### PR TITLE
Fixed broken time control

### DIFF
--- a/source/Coop/Mod/CoopServer.cs
+++ b/source/Coop/Mod/CoopServer.cs
@@ -40,9 +40,9 @@ namespace Coop.Mod
             new Lazy<CoopServer>(() => new CoopServer());
 
         private GameEnvironmentServer m_GameEnvironmentServer;
-        public static bool AreAllClientsPlaying =>
-            m_CoopServerSMs.All(clientSM => clientSM.Key.State.Equals(ECoopServerState.Playing));
-        private static readonly Dictionary<ConnectionServer, CoopServerSM> m_CoopServerSMs = new Dictionary<ConnectionServer, CoopServerSM>();
+        public bool AreAllClientsPlaying =>
+            m_CoopServerSMs.All(clientSM => clientSM.Key.State.Equals(EServerConnectionState.Ready));
+        private readonly Dictionary<ConnectionServer, CoopServerSM> m_CoopServerSMs = new Dictionary<ConnectionServer, CoopServerSM>();
 
         private LiteNetManagerServer m_NetManager;
 

--- a/source/Coop/Mod/GameEnvironmentServer.cs
+++ b/source/Coop/Mod/GameEnvironmentServer.cs
@@ -17,7 +17,7 @@ namespace Coop.Mod
         public FieldAccessGroup<MobileParty, MovementData> TargetPosition =>
             CampaignMapMovement.Movement;
 
-        public bool CanChangeTimeControlMode => CoopServer.AreAllClientsPlaying;
+        public bool CanChangeTimeControlMode => CoopServer.Instance.AreAllClientsPlaying;
 
         public EventBroadcastingQueue EventQueue => CoopServer.Instance.Persistence?.EventQueue;
 

--- a/source/Coop/Mod/Persistence/World/WorldEntityServer.cs
+++ b/source/Coop/Mod/Persistence/World/WorldEntityServer.cs
@@ -22,13 +22,22 @@ namespace Coop.Mod.Persistence.World
 
         protected override void UpdateAuthoritative()
         {
-            if ((RequestedTimeControlMode.HasValue || RequestedTimeControlModeLock.HasValue) && m_Environment.CanChangeTimeControlMode)
+            if (!RequestedTimeControlMode.HasValue && !RequestedTimeControlModeLock.HasValue)
             {
-                Logger.Trace("Changing time control to {request}.", RequestedTimeControlMode.Value);
-                State.TimeControlMode = (RequestedTimeControlMode.Value , RequestedTimeControlModeLock.Value);
-                RequestedTimeControlMode = null;
-                RequestedTimeControlModeLock = null;
+                // No pending requests
+                return;
             }
+
+            if (!m_Environment.CanChangeTimeControlMode)
+            {
+                Logger.Trace("Time control request ignored: Cannot change time control mode right now.");
+                return;
+            }
+                
+            Logger.Trace("Changing time control to {request}.", RequestedTimeControlMode.Value);
+            State.TimeControlMode = (RequestedTimeControlMode.Value , RequestedTimeControlModeLock.Value);
+            RequestedTimeControlMode = null;
+            RequestedTimeControlModeLock = null;
         }
 
         public override string ToString()


### PR DESCRIPTION
Timecontrol was always locked as the server compared against the wrong enum type to evaluate of all clients are playing.