### PR TITLE
added event broadcasting queue to debug ui

### DIFF
--- a/source/Common/MovingAverage.cs
+++ b/source/Common/MovingAverage.cs
@@ -1,18 +1,46 @@
-﻿namespace Common
+﻿using System.Linq;
+
+namespace Common
 {
     public class MovingAverage
     {
-        private readonly int m_iSize;
+        public int Size { get; }
 
         private readonly long[] m_Values;
         private int m_iBack;
         private int m_iCount;
         private int m_iFront;
 
-        public MovingAverage(int iSize)
+        private long? m_Min;
+        private long? m_Max;
+
+        public long Min
         {
-            m_iSize = iSize;
-            m_Values = new long[iSize];
+            get
+            {
+                if (!m_Min.HasValue)
+                {
+                    m_Min = m_Values.Min();
+                }
+                return m_Min.Value;
+            }
+        }
+        public long Max
+        {
+            get
+            {
+                if (!m_Max.HasValue)
+                {
+                    m_Max = m_Values.Max();
+                }
+                return m_Max.Value;
+            }
+        }
+
+        public MovingAverage(int size)
+        {
+            Size = size;
+            m_Values = new long[size];
             m_iCount = 0;
             m_iFront = 0;
             m_iBack = 0;
@@ -23,9 +51,9 @@
 
         public double Push(long value)
         {
-            if (m_iCount == m_iSize)
+            if (m_iCount == Size)
             {
-                Average = (Average * m_iSize - m_Values[m_iBack] + value) / m_iSize;
+                Average = (Average * Size - m_Values[m_iBack] + value) / Size;
                 m_Values[m_iBack] = value;
                 m_iFront = NextIndex(m_iFront);
                 m_iBack = NextIndex(m_iBack);
@@ -37,12 +65,15 @@
                 m_iBack = NextIndex(m_iBack);
             }
 
+            m_Min = null;
+            m_Max = null;
+            
             return Average;
         }
 
         private int NextIndex(int index)
         {
-            return (index + 1) % m_iSize;
+            return (index + 1) % Size;
         }
     }
 }

--- a/source/Coop/Mod/CoopServer.cs
+++ b/source/Coop/Mod/CoopServer.cs
@@ -40,6 +40,7 @@ namespace Coop.Mod
             new Lazy<CoopServer>(() => new CoopServer());
 
         private GameEnvironmentServer m_GameEnvironmentServer;
+        public IEnvironmentServer Environment => m_GameEnvironmentServer;
         public static bool AreAllClientsPlaying =>
             m_CoopServerSMs.All(clientSM => clientSM.Key.State.Equals(ECoopServerState.Playing));
         private static readonly Dictionary<ConnectionServer, CoopServerSM> m_CoopServerSMs = new Dictionary<ConnectionServer, CoopServerSM>();

--- a/source/Coop/Mod/DebugUtil/DebugUI.cs
+++ b/source/Coop/Mod/DebugUtil/DebugUI.cs
@@ -333,6 +333,8 @@ namespace Coop.Mod.DebugUtil
             Imgui.TreePop();
         }
 
+        private static readonly MovingAverage m_AverageEventsInQueue = new MovingAverage(60);
+
         private static void DisplayClientRpcInfo()
         {
             if (!Imgui.TreeNode("Client synchronized method calls"))
@@ -347,6 +349,17 @@ namespace Coop.Mod.DebugUtil
             else
             {
                 RPCSyncHandlers manager = CoopClient.Instance?.Persistence?.RpcSyncHandlers;
+
+                EventBroadcastingQueue queue = CoopServer.Instance.Environment?.EventQueue;
+                if (queue != null)
+                {
+                    int currentQueueSize = queue.Count;
+                    double avgSize = m_AverageEventsInQueue.Push(currentQueueSize);
+                    Imgui.Text(
+                        $"Event queue {queue.Count}/{EventBroadcastingQueue.MaximumQueueSize}.");
+                    Imgui.Text(
+                        $"    min {m_AverageEventsInQueue.Min} / avg {Math.Round(m_AverageEventsInQueue.Average)} / max {m_AverageEventsInQueue.Max}.");
+                }
 
                 foreach (MethodCallSyncHandler handler in manager.Handlers)
                 {

--- a/source/Coop/Mod/Persistence/RPC/EventBroadcastingQueue.cs
+++ b/source/Coop/Mod/Persistence/RPC/EventBroadcastingQueue.cs
@@ -23,7 +23,7 @@ namespace Coop.Mod.Persistence.RPC
         ///     DEBUG to identify situations where events are starving in the queue. Might need
         ///     to be adjusted depending on how much is done using events.
         /// </summary>
-        private static readonly int MaximumQueueSize = Main.DEBUG ? 128 : 8192;
+        public static readonly int MaximumQueueSize = Main.DEBUG ? 128 : 8192;
 
         private readonly OrderedHashSet<ObjectId> m_DistributedObjects =
             new OrderedHashSet<ObjectId>();


### PR DESCRIPTION
For easier debugging. It's nested under Persistence->Client synchronized method calls ![Debug UI](https://i.imgur.com/jp6QQRs.png)

Only available on the host since the broadcasting is always done by the server.