### PR TITLE
Bugfix: wrong packet handler for remote store

### DIFF
--- a/source/Coop/Coop.csproj
+++ b/source/Coop/Coop.csproj
@@ -399,7 +399,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>powershell -ExecutionPolicy Unrestricted -File "$(SolutionDir)..\deploy.ps1" -SolutionDir "$(SolutionDir)\"  -TargetDir "$(TargetDir)\" -TargetFileName "$(TargetFileName) " -Libs Common.dll,Network.dll,Sync.dll,0harmony.dll,LiteNetLib.dll,Stateless.dll,RailgunNet.dll,NLog.dll,Mono.Reflection.dll</PostBuildEvent>
+    <PostBuildEvent>powershell -ExecutionPolicy Unrestricted -File "$(SolutionDir)..\deploy.ps1" -SolutionDir "$(SolutionDir)\"  -TargetDir "$(TargetDir)\" -TargetFileName "$(TargetFileName) " -Libs Common.dll,Network.dll,Sync.dll,0harmony.dll,LiteNetLib.dll,Stateless.dll,RailgunNet.dll,NLog.dll,Mono.Reflection.dll,Extensions.Data.xxHash.dll</PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\packages\Fody.6.1.1\build\Fody.targets" Condition="Exists('..\packages\Fody.6.1.1\build\Fody.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/source/Sync/Store/RemoteStore.cs
+++ b/source/Sync/Store/RemoteStore.cs
@@ -165,8 +165,8 @@ namespace Sync.Store
             Logger.Trace("[{id}] Sent ACK", id);
         }
 
-        [ConnectionClientPacketHandler(EClientConnectionState.Connected, EPacket.StoreAdd)]
-        [ConnectionServerPacketHandler(EServerConnectionState.Ready, EPacket.StoreAdd)]
+        [ConnectionClientPacketHandler(EClientConnectionState.Connected, EPacket.StoreAck)]
+        [ConnectionServerPacketHandler(EServerConnectionState.Ready, EPacket.StoreAck)]
         private void ReceiveAck(ConnectionBase connection, Packet packet)
         {
             ObjectId id = new ObjectId(new ByteReader(packet.Payload).Binary.ReadUInt32());


### PR DESCRIPTION
Slipped through in #56 . There's unit tests for that, but they're sadly not working right now #59 .

I also fixed the missing xxHash.dll not being copied again. That was a merge issue with #56 .