### PR TITLE
compile fixes for game version e1.4.3

### DIFF
--- a/source/Coop/Mod/DebugUtil/DebugManager.cs
+++ b/source/Coop/Mod/DebugUtil/DebugManager.cs
@@ -33,6 +33,28 @@ namespace Coop.Mod.DebugUtil
             }
         }
 
+        public void SilentAssert(
+            bool condition,
+            string message = "",
+            bool getDump = false,
+            [CallerFilePath] string callerFile = "",
+            [CallerMemberName] string callerMethod = "",
+            [CallerLineNumber] int callerLine = 0)
+        {
+            if (!condition)
+            {
+                Logger.Debug(
+                    "Assert failure in {file}::{method}::{line}: {message}",
+                    callerFile,
+                    callerMethod,
+                    callerLine);
+                if (Debugger.IsAttached)
+                {
+                    Debugger.Break();
+                }
+            }
+        }
+
         public void BeginTelemetryScope(TelemetryLevelMask levelMask, string scopeName)
         {
         }

--- a/source/Coop/Mod/Serializers/CustomSerializers/MobilePartySerializer.cs
+++ b/source/Coop/Mod/Serializers/CustomSerializers/MobilePartySerializer.cs
@@ -99,6 +99,9 @@ namespace Coop.Mod.Serializers
                             attachedPartiesNames.Add(attachedParty.Name.ToString());
                         }
                         break;
+                    case "_actualClan":
+                        SNNSO.Add(fieldInfo, new ClanSerializer((Clan)value));
+                        break;
                     default:
                         throw new NotImplementedException("Cannot serialize " + fieldInfo.Name);
                 }

--- a/source/Coop/Mod/Serializers/CustomSerializers/MobilePartySerializer.cs
+++ b/source/Coop/Mod/Serializers/CustomSerializers/MobilePartySerializer.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Runtime.Serialization;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.Library;
+using TaleWorlds.Localization;
 
 namespace Coop.Mod.Serializers
 {
@@ -122,7 +123,10 @@ namespace Coop.Mod.Serializers
 
         public override object Deserialize()
         {
-            MobileParty newMobileParty = MobileParty.Create(name);
+            MobileParty newMobileParty = new MobileParty
+            {
+                Name = new TextObject(name)
+            };
 
             // Circular referenced object needs assignment before deserialize
             if (hero == null)

--- a/source/Coop/Mod/Serializers/CustomSerializers/PlayerHeroSerializer.cs
+++ b/source/Coop/Mod/Serializers/CustomSerializers/PlayerHeroSerializer.cs
@@ -1,14 +1,6 @@
-﻿using HarmonyLib;
-using System;
-using System.CodeDom;
+﻿using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Reflection;
-using System.Runtime.Serialization;
-using System.Runtime.Serialization.Formatters.Binary;
-using System.Text;
-using System.Threading.Tasks;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
@@ -100,6 +92,9 @@ namespace Coop.Mod.Serializers
                         SNNSO.Add(fieldInfo, new SettlementSerializer((Settlement)value));
                         break;
                     case "<HomeSettlement>k__BackingField":
+                        SNNSO.Add(fieldInfo, new SettlementSerializer((Settlement)value));
+                        break;
+                    case "_homeSettlement":
                         SNNSO.Add(fieldInfo, new SettlementSerializer((Settlement)value));
                         break;
                     case "_father":


### PR DESCRIPTION
New patch broke compilation.

@garrettluskey : Please have a look at the `MobilePartySerializer`. They removed `MobileParty.Create`, but apparently the constructor is public. Can we just use that?