### PR TITLE
additional comparison to identify player party

### DIFF
--- a/source/Coop/Mod/CoopClient.cs
+++ b/source/Coop/Mod/CoopClient.cs
@@ -53,7 +53,7 @@ namespace Coop.Mod
         private MBGameManager gameManager;
 
         private int m_ReconnectAttempts = MaxReconnectAttempts;
-        private string m_PartyName;
+        private Hero m_Hero;
         private ObjectId m_HeroId;
         public Action<PersistenceClient> OnPersistenceInitialized;
 
@@ -214,7 +214,6 @@ namespace Coop.Mod
                 {
                     if(e is HeroEventArgs args)
                     {
-                        m_PartyName = args.PartyName;
                         m_HeroId = args.HeroId;
 
                         CharacterCreationOver();
@@ -267,6 +266,10 @@ namespace Coop.Mod
                 if (id == m_HeroId)
                 {
                     m_CoopClientSM.StateMachine.Fire(ECoopClientTrigger.CharacterCreated);
+                    if (obj is Hero hero)
+                    {
+                        m_Hero = hero;
+                    }
                 }
             };
         }
@@ -313,7 +316,7 @@ namespace Coop.Mod
             if (bSuccess)
             {
                 m_CoopClientSM.StateMachine.Fire(ECoopClientTrigger.WorldDataReceived);
-                gameManager = new ClientManager(((GameData)Session.World).LoadResult, m_PartyName);
+                gameManager = new ClientManager(((GameData)Session.World).LoadResult, m_Hero);
                 MBGameManager.StartNewGame(gameManager);
                 ClientManager.OnPreLoadFinishedEvent += (source, e) => {
                     CampaignEvents.OnPlayerCharacterChangedEvent.AddNonSerializedListener(this, SendPlayerPartyChanged);

--- a/source/Coop/Mod/Managers/ClientManager.cs
+++ b/source/Coop/Mod/Managers/ClientManager.cs
@@ -8,14 +8,22 @@ using TaleWorlds.SaveSystem.Load;
 using System.Reflection;
 using TaleWorlds.CampaignSystem.Actions;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 
 namespace Coop.Mod.Managers
 {
     public class ClientManager : CampaignGameManager
     {
-        readonly string m_PartyName;
-        Hero clientPlayer;
-        public ClientManager(LoadResult saveGameData, string partyName) : base(saveGameData) { m_PartyName = partyName; }
+        /// <summary>
+        /// The clients hero as it was sent to the server. Note that the server may change some fields when introducing the hero to the campaign.
+        /// </summary>
+        [NotNull] private readonly Hero m_PlayerAsSerialized;
+
+        /// <summary>
+        /// The clients hero as it exists in the server side campaign.
+        /// </summary>
+        [CanBeNull] Hero m_PlayerInCampaign;
+        public ClientManager(LoadResult saveGameData, Hero playerAsSerialized) : base(saveGameData) { m_PlayerAsSerialized = playerAsSerialized; }
 
         public delegate void OnOnLoadFinishedEventHandler(object source, EventArgs e);
         public static event OnOnLoadFinishedEventHandler OnPreLoadFinishedEvent;
@@ -26,15 +34,13 @@ namespace Coop.Mod.Managers
             base.OnLoadFinished();
             OnPostLoadFinishedEvent?.Invoke(this, EventArgs.Empty);
 
-            // Find actual unique way to differentiate parties
-            MobileParty playerParty = MobileParty.All.AsParallel().SingleOrDefault(party => party.Name.ToString() == m_PartyName);
-
+            MobileParty playerParty = MobileParty.All.AsParallel().SingleOrDefault(IsClientPlayersParty);
             if(playerParty != null)
             {
-                clientPlayer = playerParty.LeaderHero;
+                m_PlayerInCampaign = playerParty.LeaderHero;
 
                 // Switch current player party from host to client party
-                ChangePlayerCharacterAction.Apply(clientPlayer);
+                ChangePlayerCharacterAction.Apply(m_PlayerInCampaign);
 
                 // Start player at training field
                 Settlement settlement = Settlement.Find("tutorial_training_field");
@@ -43,11 +49,10 @@ namespace Coop.Mod.Managers
             }
             else
             {
+                // Might need to adjust IsClientPlayersParty
                 throw new Exception("Transferred player party could not be found");
             }
-        } 
-
-        
+        }
 
         public new void OnTick(float dt)
         {
@@ -57,6 +62,36 @@ namespace Coop.Mod.Managers
                 entityFieldInfo.SetValue(this, new EntitySystem<GameManagerComponent>());
             }
             base.OnTick(dt);
+        }
+
+        private bool IsClientPlayersParty(MobileParty candidate)
+        {
+            // This comparison is subject to change
+            Hero candidateHero = candidate.LeaderHero;
+            if (candidateHero == null)
+            {
+                return false;
+            }
+
+            // Hero itself is always sent
+            if (candidateHero.Name.ToString() != m_PlayerAsSerialized.Name.ToString())
+            {
+                return false;
+            }
+
+            // Clan as well
+            if (candidateHero.Clan.Name.ToString() != m_PlayerAsSerialized.Clan.Name.ToString())
+            {
+                return false;
+            }
+
+            // Parents are missing for now
+            if (candidateHero.Father != null || candidateHero.Mother != null)
+            {
+                return false;
+            }
+
+            return true;
         }
     }
 }


### PR DESCRIPTION
as the player hero is randomized right now, it occasionally happens that there's a collision with an already exisiting hero in the campaign. This fix compares a few more fields to reduce the risk of that happening.