### PR TITLE
RPC improvements

### DIFF
--- a/source/Common/MovingAverage.cs
+++ b/source/Common/MovingAverage.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 namespace Common
 {
@@ -36,6 +37,9 @@ namespace Common
                 return m_Max.Value;
             }
         }
+        
+        public long AllTimeMin { get; private set; } = Int64.MaxValue;
+        public long AllTimeMax { get; private set; } = Int64.MinValue;
 
         public MovingAverage(int size)
         {
@@ -67,6 +71,9 @@ namespace Common
 
             m_Min = null;
             m_Max = null;
+            
+            AllTimeMin = Math.Min(AllTimeMin, value);
+            AllTimeMax = Math.Max(AllTimeMax, value);
             
             return Average;
         }

--- a/source/Coop.Tests/Persistence/RPC/Argument_Hash_Test.cs
+++ b/source/Coop.Tests/Persistence/RPC/Argument_Hash_Test.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using Coop.Mod.Persistence.RPC;
+using Sync.Store;
+using TaleWorlds.ObjectSystem;
+using Xunit;
+
+namespace Coop.Tests.Persistence.RPC
+{
+    public class Argument_Test
+    {
+        const int numberOfTests = 2 ^ 10;
+        
+        [Fact]
+        private void StaticInstanceHashes()
+        {
+            Assert.Equal(Argument.Null.GetHashCode(), Argument.Null.GetHashCode());
+            Assert.Equal(Argument.MBObjectManager.GetHashCode(), Argument.MBObjectManager.GetHashCode());
+            Assert.Equal(Argument.CurrentCampaign.GetHashCode(), Argument.CurrentCampaign.GetHashCode());
+        }
+        
+        [Fact]
+        private void IntHash()
+        {
+            const int seed = 42;
+            Random random = new Random(seed);
+            for (int i = 0; i < numberOfTests; ++i)
+            {
+                int iNumber = random.Next();
+                Assert.Equal(new Argument(iNumber).GetHashCode(), new Argument(iNumber).GetHashCode());
+                Assert.NotEqual(new Argument(iNumber).GetHashCode(), new Argument((float)iNumber).GetHashCode());
+                for (int j = 0; j < numberOfTests; ++j)
+                {
+                    int iNumberInner = random.Next();
+                    Assert.NotEqual(new Argument(iNumber).GetHashCode(), new Argument(iNumberInner).GetHashCode());
+                }
+            }
+        }
+        
+        [Fact]
+        private void FloatHash()
+        {
+            const int seed = 43;
+            Random random = new Random(seed);
+            for (int i = 0; i < numberOfTests; ++i)
+            {
+                float fNumber = (float)random.NextDouble();
+                Assert.Equal(new Argument(fNumber).GetHashCode(), new Argument(fNumber).GetHashCode());
+                Assert.NotEqual(new Argument(fNumber).GetHashCode(), new Argument((int)fNumber).GetHashCode());
+                for (int j = 0; j < numberOfTests; ++j)
+                {
+                    float fNumberInner = (float)random.NextDouble();
+                    Assert.NotEqual(new Argument(fNumber).GetHashCode(), new Argument(fNumberInner).GetHashCode());
+                }
+            }
+        }
+        
+        [Fact]
+        private void MBGuidHash()
+        {
+            const int seed = 44;
+            Random random = new Random(seed);
+            for (int i = 0; i < numberOfTests; ++i)
+            {
+                MBGUID guid = new MBGUID((uint) random.Next());
+                Assert.Equal(new Argument(guid).GetHashCode(), new Argument(guid).GetHashCode());
+                for (int j = 0; j < numberOfTests; ++j)
+                {
+                    MBGUID guidInner = new MBGUID((uint) random.Next());
+                    Assert.NotEqual(new Argument(guid).GetHashCode(), new Argument(guidInner).GetHashCode());
+                }
+            }
+        }
+        
+        [Fact]
+        private void StoreIdHash()
+        {
+            const int seed = 45;
+            Random random = new Random(seed);
+            for (int i = 0; i < numberOfTests; ++i)
+            {
+                ObjectId guid = new ObjectId((uint) random.Next());
+                Assert.Equal(new Argument(guid).GetHashCode(), new Argument(guid).GetHashCode());
+                for (int j = 0; j < numberOfTests; ++j)
+                {
+                    ObjectId guidInner = new ObjectId((uint) random.Next());
+                    Assert.NotEqual(new Argument(guid).GetHashCode(), new Argument(guidInner).GetHashCode());
+                }
+            }
+        }
+    }
+}

--- a/source/Coop.Tests/Persistence/RPC/MethodCall_Hash_Test.cs
+++ b/source/Coop.Tests/Persistence/RPC/MethodCall_Hash_Test.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using Coop.Mod.Persistence.RPC;
+using Sync;
+using Sync.Store;
+using TaleWorlds.ObjectSystem;
+using Xunit;
+
+namespace Coop.Tests.Persistence.RPC
+{
+    public class MethodCall_Hash_Test
+    {
+        private Argument GetRandomArgument(Random random)
+        {
+            int range = Enum.GetNames(typeof(EventArgType)).Length;
+            EventArgType eType = (EventArgType) random.Next(0, range);
+            switch (eType)
+            {
+                case EventArgType.Null:
+                    return Argument.Null;
+                case EventArgType.MBObjectManager:
+                    return Argument.MBObjectManager;
+                case EventArgType.MBObject:
+                    return new Argument(new MBGUID((uint) random.Next()));
+                case EventArgType.Int:
+                    return new Argument(random.Next());
+                case EventArgType.Float:
+                    return new Argument((float) random.NextDouble());
+                case EventArgType.StoreObjectId:
+                    return new Argument(new ObjectId((uint) random.Next()));
+                case EventArgType.CurrentCampaign:
+                    return Argument.CurrentCampaign;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        private List<Argument> GetRandomArguments(Random random, int iNumberOfArguments)
+        {
+            List<Argument> args = new List<Argument>();
+            for (int i = 0; i < iNumberOfArguments; ++i)
+            {
+                args.Add(GetRandomArgument(random));
+            }
+
+            return args;
+        }
+
+        private MethodCall GetRandomMethodCall(Random random)
+        {
+            int iNumberOfArguments = random.Next(0, 10);
+            return new MethodCall(
+                new MethodId(random.Next()),
+                GetRandomArgument(random),
+                GetRandomArguments(random, iNumberOfArguments));
+        }
+        
+        const int numberOfTests = 2 ^ 10;
+        
+        [Fact]
+        private void Hash()
+        {
+            const int seed = 42;
+            Random random = new Random(seed);
+
+            for (int i = 0; i < numberOfTests; ++i)
+            {
+                MethodCall call0 = GetRandomMethodCall(random);
+                Assert.Equal(call0.GetHashCode(), call0.GetHashCode());
+                for (int j = 0; j < numberOfTests; ++j)
+                {
+                    MethodCall call1 = GetRandomMethodCall(random);
+                    Assert.Equal(call1.GetHashCode(), call1.GetHashCode());
+                    Assert.NotEqual(call0.GetHashCode(), call1.GetHashCode());
+                }
+            }
+        }
+    }
+}

--- a/source/Coop/Coop.csproj
+++ b/source/Coop/Coop.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\PropertyChanged.Fody.3.2.8\build\PropertyChanged.Fody.props" Condition="Exists('..\packages\PropertyChanged.Fody.3.2.8\build\PropertyChanged.Fody.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -309,6 +309,7 @@
     <Compile Include="Mod\Persistence\RPC\ArgumentSerializer.cs" />
     <Compile Include="Mod\Persistence\RPC\EventMethodCall.cs" />
     <Compile Include="Mod\Persistence\RPC\MethodCallSyncHandler.cs" />
+    <Compile Include="Mod\Persistence\RPC\PendingRequests.cs" />
     <Compile Include="Mod\Persistence\RPC\RPCSyncHandlers.cs" />
     <Compile Include="Mod\Persistence\World\WorldEntityClient.cs" />
     <Compile Include="Mod\Persistence\World\WorldEntityServer.cs" />

--- a/source/Coop/Mod/DebugUtil/DebugUI.cs
+++ b/source/Coop/Mod/DebugUtil/DebugUI.cs
@@ -363,7 +363,9 @@ namespace Coop.Mod.DebugUtil
                     Imgui.Text(
                         $"Event queue {queue.Count}/{EventBroadcastingQueue.MaximumQueueSize}.");
                     Imgui.Text(
-                        $"    min {m_AverageEventsInQueue.Min} / avg {Math.Round(m_AverageEventsInQueue.Average)} / max {m_AverageEventsInQueue.Max}.");
+                        $"    min {m_AverageEventsInQueue.AllTimeMin} / avg {Math.Round(m_AverageEventsInQueue.Average)} / max {m_AverageEventsInQueue.AllTimeMax}.");
+                    Imgui.Text(
+                        $"Pending RPC: {PendingRequests.Instance.PendingRequestCount()}");
                 }
 
                 foreach (MethodCallSyncHandler handler in manager.Handlers)

--- a/source/Coop/Mod/Main.cs
+++ b/source/Coop/Mod/Main.cs
@@ -73,7 +73,8 @@ namespace Coop.Mod
                 {
                     throw new Exception("Invalid [PatchInitializer]. Has to be static.");
                 }
-
+                
+                Logger.Info("Init patch {}", initializer.DeclaringType);
                 initializer.Invoke(null, null);
             }
 

--- a/source/Coop/Mod/Persistence/RPC/ArgumentFactory.cs
+++ b/source/Coop/Mod/Persistence/RPC/ArgumentFactory.cs
@@ -5,6 +5,7 @@ using JetBrains.Annotations;
 using NLog;
 using RailgunNet.Logic;
 using Sync.Store;
+using TaleWorlds.CampaignSystem;
 using TaleWorlds.ObjectSystem;
 
 namespace Coop.Mod.Persistence.RPC
@@ -61,6 +62,8 @@ namespace Coop.Mod.Persistence.RPC
                         resolvedObject.GetType());
                     store.Remove(arg.StoreObjectId.Value);
                     return resolvedObject;
+                case EventArgType.CurrentCampaign:
+                    return Campaign.Current;
                 default:
                     throw new ArgumentOutOfRangeException();
             }
@@ -111,7 +114,13 @@ namespace Coop.Mod.Persistence.RPC
                     return bTransferByValue ?
                         new Argument(store.Insert(obj)) :
                         new Argument(mbobj.Id);
-
+                case Campaign campaign:
+                    if (campaign == Campaign.Current)
+                    {
+                        return Argument.CurrentCampaign;
+                    }
+                    // New campaign? Send by value
+                    return new Argument(store.Insert(obj));
                 default:
                     return new Argument(store.Insert(obj));
             }

--- a/source/Coop/Mod/Persistence/RPC/ArgumentSerializer.cs
+++ b/source/Coop/Mod/Persistence/RPC/ArgumentSerializer.cs
@@ -43,6 +43,9 @@ namespace Coop.Mod.Persistence.RPC
                 case EventArgType.StoreObjectId:
                     buffer.WriteUInt(arg.StoreObjectId.Value.Value);
                     break;
+                case EventArgType.CurrentCampaign:
+                    // Empty
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }
@@ -68,6 +71,8 @@ namespace Coop.Mod.Persistence.RPC
                     return new Argument(f);
                 case EventArgType.StoreObjectId:
                     return new Argument(new ObjectId(buffer.ReadUInt()));
+                case EventArgType.CurrentCampaign:
+                    return Argument.CurrentCampaign;
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/source/Coop/Mod/Persistence/RPC/EventBroadcastingQueue.cs
+++ b/source/Coop/Mod/Persistence/RPC/EventBroadcastingQueue.cs
@@ -23,7 +23,7 @@ namespace Coop.Mod.Persistence.RPC
         ///     DEBUG to identify situations where events are starving in the queue. Might need
         ///     to be adjusted depending on how much is done using events.
         /// </summary>
-        public static readonly int MaximumQueueSize = Main.DEBUG ? 128 : 8192;
+        public static readonly int MaximumQueueSize = Main.DEBUG ? 512 : 8192;
 
         private readonly OrderedHashSet<ObjectId> m_DistributedObjects =
             new OrderedHashSet<ObjectId>();
@@ -174,8 +174,8 @@ namespace Coop.Mod.Persistence.RPC
             public bool TryBroadcast()
             {
                 if (!IsReadyToBeSent()) return false;
+                Logger.Trace("Broadcast: {event}", RPC.Call);
                 Room.BroadcastEvent(RPC);
-                Logger.Trace("[{event}] Broadcast", RPC);
                 return true;
             }
         }

--- a/source/Coop/Mod/Persistence/RPC/EventMethodCall.cs
+++ b/source/Coop/Mod/Persistence/RPC/EventMethodCall.cs
@@ -60,6 +60,7 @@ namespace Coop.Mod.Persistence.RPC
                     method.CallOriginal(
                         ArgumentFactory.Resolve(m_EnvironmentClient.Store, Call.Instance),
                         ArgumentFactory.Resolve(m_EnvironmentClient.Store, Call.Arguments));
+                    PendingRequests.Instance.Remove(Call);
                 }
             }
             else

--- a/source/Coop/Mod/Persistence/RPC/MethodCall.cs
+++ b/source/Coop/Mod/Persistence/RPC/MethodCall.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Sync;
 
 namespace Coop.Mod.Persistence.RPC
@@ -8,13 +9,20 @@ namespace Coop.Mod.Persistence.RPC
     ///     pointer, instance and arguments have to resolved before execution. In order to resolve
     ///     a method call refer to <see cref="MethodRegistry" /> and <see cref="ArgumentFactory" />.
     /// </summary>
-    public class MethodCall
+    public readonly struct MethodCall
     {
-        public List<Argument> Arguments = new List<Argument>();
+        public readonly List<Argument> Arguments;
 
-        public MethodId Id = MethodId.Invalid;
-        public Argument Instance = Argument.Null; // Instance to call the method on.
+        public readonly MethodId Id;
+        public readonly Argument Instance; // Instance to call the method on.
 
+        public MethodCall(MethodId id, Argument instance, List<Argument> arguments)
+        {
+            Arguments = arguments;
+            Id = id;
+            Instance = instance;
+        }
+        
         public override string ToString()
         {
             string sRet = Instance.EventType == EventArgType.Null ? "static " : $"{Instance} ";
@@ -24,11 +32,35 @@ namespace Coop.Mod.Persistence.RPC
             }
             else
             {
-                sRet += $"[UNREGISTRED] {Id.InternalValue}";
+                sRet += $"[UNREGISTERED] {Id.InternalValue}";
             }
 
             sRet += "(" + string.Join(", ", Arguments) + ")";
             return sRet;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is MethodCall call && this.Equals(call);
+        }
+
+        private bool Equals(MethodCall other)
+        {
+            return Equals(Arguments, other.Arguments) && Id.Equals(other.Id) && Instance.Equals(other.Instance);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = Id.GetHashCode();
+                foreach (Argument argument in Arguments)
+                {
+                    hashCode = (hashCode * 397) ^ argument.GetHashCode();
+                }
+                hashCode = (hashCode * 397) ^ Instance.GetHashCode();
+                return hashCode;
+            }
         }
     }
 }

--- a/source/Coop/Mod/Persistence/RPC/PendingRequests.cs
+++ b/source/Coop/Mod/Persistence/RPC/PendingRequests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Coop.Mod.Persistence.RPC
+{
+    public class PendingRequests
+    {
+        private static readonly Lazy<PendingRequests> m_Instance =
+            new Lazy<PendingRequests>(() => new PendingRequests());
+        public static PendingRequests Instance => m_Instance.Value;
+        
+        private readonly Dictionary<int, MethodCall> m_Pending = new Dictionary<int, MethodCall>();
+
+        public void Add(MethodCall call)
+        {
+            m_Pending.Add(call.GetHashCode(), call);
+        }
+
+        public bool IsPending(MethodCall call)
+        {
+            return m_Pending.ContainsKey(call.GetHashCode());
+        }
+
+        public void Remove(MethodCall call)
+        {
+            m_Pending.Remove(call.GetHashCode());
+        }
+
+        public int PendingRequestCount()
+        {
+            return m_Pending.Count;
+            
+        }
+    }
+}

--- a/source/Sync/EMethodPatchFlag.cs
+++ b/source/Sync/EMethodPatchFlag.cs
@@ -16,6 +16,11 @@ namespace Sync
         ///     using the <see cref="Sync.Store.RemoteStore" />.
         ///     Unset if by-reference should be preferred.
         /// </summary>
-        TransferArgumentsByValue = 1 << 1
+        TransferArgumentsByValue = 1 << 1,
+        
+        /// <summary>
+        ///     Bit 2: If set, multiple calls to this function with the same arguments are ignored.
+        /// </summary>
+        DebounceCalls = 1 << 2
     }
 }


### PR DESCRIPTION
- RPC will now check if a call is already in the queue to be executed. Will skip sending it out again if the corresponding flag is set in the patch. This is helpful because the game will call actions repeatedly.
- Campaign.Current can now be used as instance or argument for the auto generated RPC

Related to #93. But i did not include any of the actual patches, i'll split that into a separate PR.