### PR TITLE
Global connection timeout

### DIFF
--- a/source/Coop.Tests/CoopClient_Test.cs
+++ b/source/Coop.Tests/CoopClient_Test.cs
@@ -16,7 +16,7 @@ namespace Coop.Tests
         public CoopClient_Test()
         {
             ServerConfiguration config = TestUtils.GetTestingConfig();
-            config.DisconnectTimeout = m_DisconnectTimeout;
+            config.NetworkConfiguration.DisconnectTimeout = m_DisconnectTimeout;
             m_Server = new Mock<Server>(Server.EType.Threaded)
             {
                 CallBase = true
@@ -36,8 +36,8 @@ namespace Coop.Tests
         private void ConnectClient()
         {
             m_Client.Connect(
-                m_Server.Object.ActiveConfig.LanAddress,
-                m_Server.Object.ActiveConfig.LanPort);
+                m_Server.Object.ActiveConfig.NetworkConfiguration.LanAddress,
+                m_Server.Object.ActiveConfig.NetworkConfiguration.LanPort);
         }
 
         private async Task WaitForClientConnect()

--- a/source/Coop.Tests/CoopClient_Test.cs
+++ b/source/Coop.Tests/CoopClient_Test.cs
@@ -29,7 +29,7 @@ namespace Coop.Tests
         private readonly LiteNetManagerServer m_NetManagerServer;
         private readonly Mock<Server> m_Server;
         private readonly Mock<ISaveData> m_WorldData = TestUtils.CreateMockSaveData();
-        private readonly CoopClient m_Client = new CoopClient();
+        private readonly CoopClient m_Client = new CoopClient(new ClientConfiguration());
         private readonly TimeSpan m_FrameTime = TimeSpan.FromMilliseconds(15);
         private readonly TimeSpan m_DisconnectTimeout = TimeSpan.FromMilliseconds(100);
 

--- a/source/Coop.Tests/Network/ClientServerCommunication_Test.cs
+++ b/source/Coop.Tests/Network/ClientServerCommunication_Test.cs
@@ -22,7 +22,7 @@ namespace Coop.Tests.Network
         {
             TestUtils.SetupLogger();
             ServerConfiguration config = TestUtils.GetTestingConfig();
-            config.KeepAliveInterval = m_keepAliveInterval;
+            config.NetworkConfiguration.KeepAliveInterval = m_keepAliveInterval;
             m_Server = new Mock<Server>(Server.EType.Threaded)
             {
                 CallBase = true
@@ -78,8 +78,8 @@ namespace Coop.Tests.Network
             // Setup client
             Client client = new Client(m_WorldData.Object);
             client.Manager.Connect(
-                m_Server.Object.ActiveConfig.LanAddress,
-                m_Server.Object.ActiveConfig.LanPort);
+                m_Server.Object.ActiveConfig.NetworkConfiguration.LanAddress,
+                m_Server.Object.ActiveConfig.NetworkConfiguration.LanPort);
 
             // Wait until the client is connected
             TestUtils.UpdateUntil(

--- a/source/Coop.Tests/Network/ClientServerCommunication_Test.cs
+++ b/source/Coop.Tests/Network/ClientServerCommunication_Test.cs
@@ -147,7 +147,7 @@ namespace Coop.Tests.Network
             public Client(ISaveData worldData)
             {
                 Session = new GameSession(worldData);
-                Manager = new LiteNetManagerClient(Session);
+                Manager = new LiteNetManagerClient(Session, new ClientConfiguration());
             }
         }
     }

--- a/source/Coop.Tests/Network/NetManager_Test.cs
+++ b/source/Coop.Tests/Network/NetManager_Test.cs
@@ -29,7 +29,7 @@ namespace Coop.Tests.Network
             public Client()
             {
                 Session = new GameSession(Mock.Of<ISaveData>());
-                Manager = new LiteNetManagerClient(Session);
+                Manager = new LiteNetManagerClient(Session, new ClientConfiguration());
             }
         }
 

--- a/source/Coop.Tests/Network/NetManager_Test.cs
+++ b/source/Coop.Tests/Network/NetManager_Test.cs
@@ -37,7 +37,7 @@ namespace Coop.Tests.Network
         private void ClientCanConnect()
         {
             Client client = new Client();
-            client.Manager.Connect(m_Server.ActiveConfig.LanAddress, m_Server.ActiveConfig.LanPort);
+            client.Manager.Connect(m_Server.ActiveConfig.NetworkConfiguration.LanAddress, m_Server.ActiveConfig.NetworkConfiguration.LanPort);
             TestUtils.UpdateUntil(
                 () => client.Session.Connection != null,
                 new List<IUpdateable>
@@ -50,7 +50,7 @@ namespace Coop.Tests.Network
         private void ClientCanDisconnect()
         {
             Client client = new Client();
-            client.Manager.Connect(m_Server.ActiveConfig.LanAddress, m_Server.ActiveConfig.LanPort);
+            client.Manager.Connect(m_Server.ActiveConfig.NetworkConfiguration.LanAddress, m_Server.ActiveConfig.NetworkConfiguration.LanPort);
             TestUtils.UpdateUntil(
                 () => client.Session.Connection != null,
                 new List<IUpdateable>

--- a/source/Coop.Tests/TestUtils.cs
+++ b/source/Coop.Tests/TestUtils.cs
@@ -71,7 +71,10 @@ namespace Coop.Tests
         {
             return new ServerConfiguration
             {
-                LanPort = GetPort(),
+                NetworkConfiguration = new NetworkConfiguration
+                {
+                    LanPort = GetPort()
+                },
                 MaxPlayerCount = 4,
                 TickRate = 0
             };

--- a/source/Coop/Coop.csproj
+++ b/source/Coop/Coop.csproj
@@ -374,6 +374,7 @@
     <Compile Include="Mod\UI\CoopConnectMenuVM.cs" />
     <Compile Include="Mod\UI\CoopConnectionUI.cs" />
     <Compile Include="Mod\UI\LoadGameUI\CoopLoadUI.cs" />
+    <Compile Include="NetImpl\LiteNet\DiscoveryThread.cs" />
     <Compile Include="NetImpl\LiteNet\Extensions.cs" />
     <Compile Include="NetImpl\LiteNet\LiteNetManagerClient.cs" />
     <Compile Include="NetImpl\LiteNet\LiteNetListenerClient.cs" />

--- a/source/Coop/Coop.csproj
+++ b/source/Coop/Coop.csproj
@@ -380,6 +380,7 @@
     <Compile Include="NetImpl\LiteNet\LiteNetManagerServer.cs" />
     <Compile Include="NetImpl\LiteNet\LiteNetConnection.cs" />
     <Compile Include="NetImpl\LiteNet\LiteNetListenerServer.cs" />
+    <Compile Include="NetImpl\LiteNet\NetManagerFactory.cs" />
     <Compile Include="NetImpl\LiteNet\RailNetPeerWrapper.cs" />
     <Compile Include="NetImpl\PlatformAPI.cs" />
     <Compile Include="NetImpl\Steam\NetworkSteam.cs" />

--- a/source/Coop/Mod/CoopClient.cs
+++ b/source/Coop/Mod/CoopClient.cs
@@ -39,7 +39,7 @@ namespace Coop.Mod
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
         private static readonly Lazy<CoopClient> m_Instance =
-            new Lazy<CoopClient>(() => new CoopClient());
+            new Lazy<CoopClient>(() => new CoopClient(new ClientConfiguration()));
         private readonly CoopClientSM m_CoopClientSM;
 
         [NotNull] private readonly LiteNetManagerClient m_NetManager;
@@ -59,11 +59,11 @@ namespace Coop.Mod
 
         public Action<RemoteStore> RemoteStoreCreated;
 
-        public CoopClient()
+        public CoopClient(ClientConfiguration config)
         {
             Session = new GameSession(new GameData());
             Session.OnConnectionDestroyed += ConnectionDestroyed;
-            m_NetManager = new LiteNetManagerClient(Session);
+            m_NetManager = new LiteNetManagerClient(Session, config);
             GameState = new CoopGameState();
             Events = new CoopEvents();
             m_CoopClientSM = new CoopClientSM();

--- a/source/Coop/Mod/DebugUtil/CLICommands.cs
+++ b/source/Coop/Mod/DebugUtil/CLICommands.cs
@@ -44,7 +44,7 @@ namespace Coop.Mod.DebugUtil
             if (CoopServer.Instance.StartServer() == null)
             {
                 ServerConfiguration config = CoopServer.Instance.Current.ActiveConfig;
-                CoopClient.Instance.Connect(config.LanAddress, config.LanPort);
+                CoopClient.Instance.Connect(config.NetworkConfiguration.LanAddress, config.NetworkConfiguration.LanPort);
                 return CoopServer.Instance.ToString();
             }
 

--- a/source/Coop/Mod/DebugUtil/DebugUI.cs
+++ b/source/Coop/Mod/DebugUtil/DebugUI.cs
@@ -191,7 +191,7 @@ namespace Coop.Mod.DebugUtil
                     if ((startServerResult = CoopServer.Instance.StartServer()) == null)
                     {
                         ServerConfiguration config = CoopServer.Instance.Current.ActiveConfig;
-                        connectResult = CoopClient.Instance.Connect(config.LanAddress, config.LanPort);
+                        connectResult = CoopClient.Instance.Connect(config.NetworkConfiguration.LanAddress, config.NetworkConfiguration.LanPort);
                     }
                 }
             }
@@ -203,8 +203,8 @@ namespace Coop.Mod.DebugUtil
                 {
                     ServerConfiguration defaultConfiguration = new ServerConfiguration();
                     connectResult = CoopClient.Instance.Connect(
-                        defaultConfiguration.LanAddress,
-                        defaultConfiguration.LanPort);
+                        defaultConfiguration.NetworkConfiguration.LanAddress,
+                        defaultConfiguration.NetworkConfiguration.LanPort);
                 }
             }
 
@@ -313,9 +313,9 @@ namespace Coop.Mod.DebugUtil
                 }
 
                 Imgui.Text(
-                    $"LAN:   {server.ActiveConfig.LanAddress}:{server.ActiveConfig.LanPort}");
+                    $"LAN:   {server.ActiveConfig.NetworkConfiguration.LanAddress}:{server.ActiveConfig.NetworkConfiguration.LanPort}");
                 Imgui.Text(
-                    $"WAN:   {server.ActiveConfig.WanAddress}:{server.ActiveConfig.WanPort}");
+                    $"WAN:   {server.ActiveConfig.NetworkConfiguration.WanAddress}:{server.ActiveConfig.NetworkConfiguration.WanPort}");
                 Imgui.Text("");
 
                 Imgui.Columns(3);

--- a/source/Coop/Mod/DebugUtil/DebugUI.cs
+++ b/source/Coop/Mod/DebugUtil/DebugUI.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Net;
 using Common;
 using Coop.Mod.Patch;
 using Coop.Mod.Persistence;
 using Coop.Mod.Persistence.RPC;
+using Coop.NetImpl.LiteNet;
+using JetBrains.Annotations;
 using Network.Infrastructure;
 using NLog;
 using RailgunNet.Connection;
@@ -12,6 +15,7 @@ using RailgunNet.Connection.Client;
 using RailgunNet.Connection.Server;
 using RailgunNet.Logic;
 using Sync;
+using TaleWorlds.Core;
 using TaleWorlds.Engine;
 
 namespace Coop.Mod.DebugUtil
@@ -29,6 +33,7 @@ namespace Coop.Mod.DebugUtil
             {
                 Begin();
                 AddButtons();
+                DisplayDiscovery();
                 DisplayConnectionInfo();
                 DisplayMethodRegistry();
                 DisplayPersistenceMenu();
@@ -260,6 +265,33 @@ namespace Coop.Mod.DebugUtil
 
                 Imgui.Columns();
             }
+
+            Imgui.TreePop();
+        }
+
+        [CanBeNull] private static DiscoveryThread m_discoveryThread = null;
+        private static void DisplayDiscovery()
+        {
+            if (!Imgui.TreeNode("LAN server discovery"))
+            {
+                m_discoveryThread = null;
+                return;
+            }
+
+            if (m_discoveryThread == null)
+            {
+                m_discoveryThread = new DiscoveryThread(new NetworkConfiguration());
+            }
+
+            List<IPEndPoint> servers = m_discoveryThread.ServerList;
+            if (!servers.IsEmpty())
+            {
+                foreach (IPEndPoint ipEndPoint in servers)
+                {
+                    Imgui.Text($"{ipEndPoint}");
+                }
+            }
+            Imgui.Text("Scanning...");
 
             Imgui.TreePop();
         }

--- a/source/Coop/Mod/Main.cs
+++ b/source/Coop/Mod/Main.cs
@@ -113,8 +113,8 @@ namespace Coop.Mod
                                     ServerConfiguration defaultConfiguration =
                                         new ServerConfiguration();
                                     CoopClient.Instance.Connect(
-                                        defaultConfiguration.LanAddress,
-                                        defaultConfiguration.LanPort);
+                                        defaultConfiguration.NetworkConfiguration.LanAddress,
+                                        defaultConfiguration.NetworkConfiguration.LanPort);
                                 }
                             }
                         }

--- a/source/Coop/Mod/Managers/ServerManager.cs
+++ b/source/Coop/Mod/Managers/ServerManager.cs
@@ -27,7 +27,7 @@ namespace Coop.Mod.Managers
             if (CoopServer.Instance.StartServer() == null)
             {
                 ServerConfiguration config = CoopServer.Instance.Current.ActiveConfig;
-                CoopClient.Instance.Connect(config.LanAddress, config.LanPort);
+                CoopClient.Instance.Connect(config.NetworkConfiguration.LanAddress, config.NetworkConfiguration.LanPort);
             }
 
             CoopClient.Instance.RemoteStoreCreated += (remoteStore) => {

--- a/source/Coop/Mod/UI/CoopConnectMenuVM.cs
+++ b/source/Coop/Mod/UI/CoopConnectMenuVM.cs
@@ -23,9 +23,9 @@ namespace Coop.Mod.UI
         public string PortText => "Port:";
         public string PasswordText => "Password:";
 
-        public string connectIP = new ServerConfiguration().LanAddress.ToString();
+        public string connectIP = new ServerConfiguration().NetworkConfiguration.LanAddress.ToString();
 
-        public string connectPort = new ServerConfiguration().LanPort.ToString();
+        public string connectPort = new ServerConfiguration().NetworkConfiguration.LanPort.ToString();
 
         public string connectPassword = "";
 

--- a/source/Coop/NetImpl/LiteNet/DiscoveryThread.cs
+++ b/source/Coop/NetImpl/LiteNet/DiscoveryThread.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using Common;
+using JetBrains.Annotations;
+using LiteNetLib;
+using Network;
+using Network.Infrastructure;
+using Network.Protocol;
+using NLog;
+
+namespace Coop.NetImpl.LiteNet
+{
+    /// <summary>
+    ///     Thread to discovery coop servers in LAN.
+    /// </summary>
+    public class DiscoveryThread
+    {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+        private readonly object m_AvailableServerLock = new object();
+
+        private readonly HashSet<IPEndPoint> m_AvailableServers = new HashSet<IPEndPoint>();
+
+        private readonly NetworkConfiguration m_Config;
+
+        private readonly NetManager m_NetManager;
+        private readonly object m_StopRequestLock = new object();
+        [CanBeNull] private FrameLimiter m_FrameLimiter;
+        private bool m_IsStopRequest;
+        private Thread m_Thread;
+
+        /// <summary>
+        ///     Will immediately spawn a new thread and start listing for discovery packets from
+        ///     bannerlord coop servers.
+        /// </summary>
+        /// <param name="config"></param>
+        public DiscoveryThread([NotNull] NetworkConfiguration config)
+        {
+            m_Config = config;
+
+            // Setup network listener
+            EventBasedNetListener listener = new EventBasedNetListener();
+            listener.NetworkReceiveUnconnectedEvent += (remoteEndPoint, reader, type) =>
+            {
+                if (type == UnconnectedMessageType.Broadcast)
+                {
+                    ArraySegment<byte> buffer = reader.GetRemainingBytesSegment();
+                    bool isDiscoveryPacket = Discovery.TryDeserialize(new ByteReader(buffer));
+                    if (isDiscoveryPacket)
+                    {
+                        lock (m_AvailableServerLock)
+                        {
+                            if (m_AvailableServers.Add(remoteEndPoint))
+                            {
+                                Logger.Info("Server discovered: {peer}", remoteEndPoint);
+                            }
+                        }
+                    }
+                }
+            };
+            m_NetManager = new NetManager(listener)
+            {
+                BroadcastReceiveEnabled = true,
+                ReuseAddress = true
+            };
+            m_NetManager.Start(m_Config.LanDiscoveryPort);
+
+            // Start thread
+            m_Thread = new Thread(Run);
+            lock (m_StopRequestLock)
+            {
+                m_IsStopRequest = false;
+            }
+
+            m_Thread.Start();
+        }
+
+        /// <summary>
+        ///     Retrieve all found server. There is no guarantee that the servers are still available.
+        /// </summary>
+        public List<IPEndPoint> ServerList
+        {
+            get
+            {
+                lock (m_AvailableServers)
+                {
+                    return m_AvailableServers.ToList();
+                }
+            }
+        }
+
+        ~DiscoveryThread()
+        {
+            Stop();
+            m_NetManager.Stop();
+        }
+
+        private void Stop()
+        {
+            if (m_Thread == null)
+            {
+                return;
+            }
+
+            lock (m_StopRequestLock)
+            {
+                m_IsStopRequest = false;
+            }
+
+            m_Thread.Join();
+            m_Thread = null;
+        }
+
+        private void Run()
+        {
+            m_FrameLimiter = new FrameLimiter(TimeSpan.FromMilliseconds(500));
+            bool bRunning = true;
+            while (bRunning)
+            {
+                m_NetManager.PollEvents();
+                m_FrameLimiter.Throttle();
+                lock (m_StopRequestLock)
+                {
+                    bRunning = !m_IsStopRequest;
+                }
+            }
+
+            m_FrameLimiter = null;
+        }
+    }
+}

--- a/source/Coop/NetImpl/LiteNet/LiteNetListenerClient.cs
+++ b/source/Coop/NetImpl/LiteNet/LiteNetListenerClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using System.Net.Sockets;
 using LiteNetLib;
 using Network;
@@ -67,11 +68,24 @@ namespace Coop.NetImpl.LiteNet
             NetPacketReader reader,
             UnconnectedMessageType messageType)
         {
-            Logger.Warn(
-                "OnNetworkReceiveUnconnected({remoteEndPoint}, {reader}, {messageType}).",
-                remoteEndPoint,
-                reader,
-                messageType);
+            if (messageType == UnconnectedMessageType.Broadcast)
+            {
+                ArraySegment<byte> buffer = reader.GetRemainingBytesSegment();
+                bool isDiscoveryPacket = Network.Protocol.Discovery.TryDeserialize(new ByteReader(buffer));
+                if (isDiscoveryPacket)
+                {
+                    Logger.Info("Server discovered: {peer}", remoteEndPoint);
+                    // TODO: Maybe connect to it if we are not already connected?
+                }
+            }
+            else
+            {
+                Logger.Debug(
+                    "Unknown broadcast: OnNetworkReceiveUnconnected({remoteEndPoint}, {reader}, {messageType}).",
+                    remoteEndPoint,
+                    reader,
+                    messageType);
+            }
         }
 
         public void OnConnectionRequest(ConnectionRequest request)

--- a/source/Coop/NetImpl/LiteNet/LiteNetManagerClient.cs
+++ b/source/Coop/NetImpl/LiteNet/LiteNetManagerClient.cs
@@ -68,7 +68,7 @@ namespace Coop.NetImpl.LiteNet
             m_NetManager = NetManagerFactory.Create(
                 new LiteNetListenerClient(m_Session),
                 m_Configuration.NetworkConfiguration);
-
+            m_NetManager.BroadcastReceiveEnabled = true;
             if (m_NetManager.Start())
             {
                 m_Peer = m_NetManager.Connect(address.ToString(), iPort, "");

--- a/source/Coop/NetImpl/LiteNet/LiteNetManagerClient.cs
+++ b/source/Coop/NetImpl/LiteNet/LiteNetManagerClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net;
 using Common;
+using JetBrains.Annotations;
 using LiteNetLib;
 using Network;
 using Network.Infrastructure;
@@ -10,14 +11,16 @@ namespace Coop.NetImpl.LiteNet
 {
     public class LiteNetManagerClient : IUpdateable
     {
+        private readonly ClientConfiguration m_Configuration;
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
         private readonly GameSession m_Session;
         private NetManager m_NetManager;
         private NetPeer m_Peer;
 
-        public LiteNetManagerClient(GameSession session)
+        public LiteNetManagerClient([NotNull] GameSession session, [NotNull] ClientConfiguration config)
         {
             m_Session = session ?? throw new ArgumentNullException(nameof(session));
+            m_Configuration = config ?? throw new ArgumentNullException(nameof(config));
         }
 
         public bool Connected =>
@@ -62,12 +65,9 @@ namespace Coop.NetImpl.LiteNet
                 Disconnect(EDisconnectReason.ClientJoinedAnotherServer);
             }
 
-            m_NetManager = new NetManager(new LiteNetListenerClient(m_Session))
-            {
-                ReconnectDelay = 2000,
-                MaxConnectAttempts = 20,
-                DisconnectTimeout = (int) TimeSpan.FromSeconds(60).TotalMilliseconds
-            };
+            m_NetManager = NetManagerFactory.Create(
+                new LiteNetListenerClient(m_Session),
+                m_Configuration.NetworkConfiguration);
 
             if (m_NetManager.Start())
             {

--- a/source/Coop/NetImpl/LiteNet/LiteNetManagerServer.cs
+++ b/source/Coop/NetImpl/LiteNet/LiteNetManagerServer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net;
+using System.Text;
 using Common;
 using LiteNetLib;
 using Network;
@@ -58,8 +59,7 @@ namespace Coop.NetImpl.LiteNet
 
             if (m_lanManager != null && m_SinceLastDiscovery > m_Config.NetworkConfiguration.LanDiscoveryInterval)
             {
-                // TODO: LiteNetLib removed SendDiscoveryRequest in 0.9. Replacement?
-                // m_lanManager.SendDiscoveryRequest(Encoding.UTF8.GetBytes(Globals.LanDiscoveryString), Globals.LanDiscoveryPort);
+                m_lanManager.SendBroadcast(Network.Protocol.Discovery.GetPayload(), m_Config.NetworkConfiguration.LanDiscoveryPort);
                 m_SinceLastDiscovery = TimeSpan.Zero;
             }
 

--- a/source/Coop/NetImpl/LiteNet/LiteNetManagerServer.cs
+++ b/source/Coop/NetImpl/LiteNet/LiteNetManagerServer.cs
@@ -73,10 +73,9 @@ namespace Coop.NetImpl.LiteNet
 
         private NetManager CreateNetManager(ISaveData worldData)
         {
-            return new NetManager(new LiteNetListenerServer(m_Server, worldData))
-            {
-                DisconnectTimeout = (int) m_Config.NetworkConfiguration.DisconnectTimeout.TotalMilliseconds
-            };
+            return NetManagerFactory.Create(
+                new LiteNetListenerServer(m_Server, worldData),
+                m_Config.NetworkConfiguration);
         }
 
         public void StartListening()

--- a/source/Coop/NetImpl/LiteNet/LiteNetManagerServer.cs
+++ b/source/Coop/NetImpl/LiteNet/LiteNetManagerServer.cs
@@ -27,19 +27,19 @@ namespace Coop.NetImpl.LiteNet
             }
 
             m_Config = server.ActiveConfig;
-            if (m_Config.WanAddress == null && m_Config.LanAddress == null)
+            if (m_Config.NetworkConfiguration.WanAddress == null && m_Config.NetworkConfiguration.LanAddress == null)
             {
                 throw new InvalidServerConfiguration(
                     $"Invalid server configuration {m_Server}. Unable to attach NetAdapter.");
             }
 
             m_Server = server;
-            if (m_Config.WanAddress != null)
+            if (m_Config.NetworkConfiguration.WanAddress != null)
             {
                 m_wanManager = CreateNetManager(worldData);
             }
 
-            if (m_Config.LanAddress != null)
+            if (m_Config.NetworkConfiguration.LanAddress != null)
             {
                 m_lanManager = CreateNetManager(worldData);
             }
@@ -56,14 +56,14 @@ namespace Coop.NetImpl.LiteNet
             m_lanManager?.PollEvents();
             m_wanManager?.PollEvents();
 
-            if (m_lanManager != null && m_SinceLastDiscovery > m_Config.LanDiscoveryInterval)
+            if (m_lanManager != null && m_SinceLastDiscovery > m_Config.NetworkConfiguration.LanDiscoveryInterval)
             {
                 // TODO: LiteNetLib removed SendDiscoveryRequest in 0.9. Replacement?
                 // m_lanManager.SendDiscoveryRequest(Encoding.UTF8.GetBytes(Globals.LanDiscoveryString), Globals.LanDiscoveryPort);
                 m_SinceLastDiscovery = TimeSpan.Zero;
             }
 
-            if (m_SinceLastKeepAlive > m_Config.KeepAliveInterval)
+            if (m_SinceLastKeepAlive > m_Config.NetworkConfiguration.KeepAliveInterval)
             {
                 m_Server.SendToAll(
                     new Packet(EPacket.KeepAlive, new KeepAlive(++m_iKeepAliveID).Serialize()));
@@ -75,14 +75,14 @@ namespace Coop.NetImpl.LiteNet
         {
             return new NetManager(new LiteNetListenerServer(m_Server, worldData))
             {
-                DisconnectTimeout = (int) m_Config.DisconnectTimeout.TotalMilliseconds
+                DisconnectTimeout = (int) m_Config.NetworkConfiguration.DisconnectTimeout.TotalMilliseconds
             };
         }
 
         public void StartListening()
         {
-            m_wanManager?.Start(m_Config.WanAddress, IPAddress.IPv6Any, m_Config.WanPort);
-            m_lanManager?.Start(m_Config.LanAddress, IPAddress.IPv6Any, m_Config.LanPort);
+            m_wanManager?.Start(m_Config.NetworkConfiguration.WanAddress, IPAddress.IPv6Any, m_Config.NetworkConfiguration.WanPort);
+            m_lanManager?.Start(m_Config.NetworkConfiguration.LanAddress, IPAddress.IPv6Any, m_Config.NetworkConfiguration.LanPort);
             m_Server.Updateables.Add(this);
         }
 

--- a/source/Coop/NetImpl/LiteNet/NetManagerFactory.cs
+++ b/source/Coop/NetImpl/LiteNet/NetManagerFactory.cs
@@ -1,0 +1,19 @@
+﻿using LiteNetLib;
+using Network.Infrastructure;
+
+namespace Coop.NetImpl.LiteNet
+{
+    public static class NetManagerFactory
+    {
+        public static NetManager Create(INetEventListener listener, NetworkConfiguration config)
+        {
+            return new NetManager(listener)
+            {
+                MaxConnectAttempts = 20,
+                ReconnectDelay = (int) config.ReconnectDelay.TotalMilliseconds,
+                DisconnectTimeout = (int) config.DisconnectTimeout.TotalMilliseconds,
+                UpdateTime = (int) config.UpdateTime.TotalMilliseconds
+            };
+        }
+    }
+}

--- a/source/Network/ByteReader.cs
+++ b/source/Network/ByteReader.cs
@@ -34,5 +34,12 @@ namespace Network
             m_Stream.Position -= 1;
             return val;
         }
+        
+        public int PeekInt32()
+        {
+            int i = Binary.ReadInt32();
+            m_Stream.Position -= 4;
+            return i;
+        }
     }
 }

--- a/source/Network/Infrastructure/ClientConfiguration.cs
+++ b/source/Network/Infrastructure/ClientConfiguration.cs
@@ -1,0 +1,7 @@
+﻿namespace Network.Infrastructure
+{
+    public class ClientConfiguration
+    {
+        public NetworkConfiguration NetworkConfiguration { get; set; } = new NetworkConfiguration();
+    }
+}

--- a/source/Network/Infrastructure/ConnectionBase.cs
+++ b/source/Network/Infrastructure/ConnectionBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using Common;
 using JetBrains.Annotations;
 using Network.Protocol;
 

--- a/source/Network/Infrastructure/ConnectionBase.cs
+++ b/source/Network/Infrastructure/ConnectionBase.cs
@@ -105,7 +105,8 @@ namespace Network.Infrastructure
 
         /// <summary>
         ///     Closes the connection.
-        ///     Postcondition: <see cref="State" /> is equal to <see cref="EConnectionState.Disconnected" />.
+        ///     Post condition: <see cref="State" /> is equal to <see cref="EClientConnectionState.Disconnected"/>
+        ///     or <see cref="EServerConnectionState.Terminated"/>.
         /// </summary>
         /// <param name="eReason">Reason that caused the disconnect.</param>
         public abstract void Disconnect(EDisconnectReason eReason);

--- a/source/Network/Infrastructure/ConnectionClient.cs
+++ b/source/Network/Infrastructure/ConnectionClient.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using Network.Protocol;
-using NLog;
-using Stateless;
 using Version = Network.Protocol.Version;
 
 namespace Network.Infrastructure

--- a/source/Network/Infrastructure/ConnectionClientSM.cs
+++ b/source/Network/Infrastructure/ConnectionClientSM.cs
@@ -1,8 +1,5 @@
 ﻿using Common;
-using NLog;
 using Stateless;
-using System;
-using System.Collections.Generic;
 
 namespace Network.Infrastructure
 {

--- a/source/Network/Infrastructure/ConnectionServer.cs
+++ b/source/Network/Infrastructure/ConnectionServer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Network.Protocol;
 using NLog;
-using Stateless;
 using Version = Network.Protocol.Version;
 
 namespace Network.Infrastructure

--- a/source/Network/Infrastructure/ConnectionServerSM.cs
+++ b/source/Network/Infrastructure/ConnectionServerSM.cs
@@ -1,8 +1,5 @@
 ﻿using Common;
-using NLog;
 using Stateless;
-using System;
-using System.Collections.Generic;
 
 namespace Network.Infrastructure
 {

--- a/source/Network/Infrastructure/Globals.cs
+++ b/source/Network/Infrastructure/Globals.cs
@@ -1,8 +1,0 @@
-﻿namespace Network.Infrastructure
-{
-    public static class Globals
-    {
-        public const int LanDiscoveryPort = 4200;
-        public const string LanDiscoveryString = "bannerlord-coop-server";
-    }
-}

--- a/source/Network/Infrastructure/NetworkConfiguration.cs
+++ b/source/Network/Infrastructure/NetworkConfiguration.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Net;
+
+namespace Network.Infrastructure
+{
+    public class NetworkConfiguration
+    {
+        public IPAddress LanAddress { get; set; } = IPAddress.Parse("127.0.0.1");
+        public int LanPort { get; set; } = 4201;
+        public IPAddress WanAddress { get; set; } = null;
+        public int WanPort { get; set; } = 4200;
+        public TimeSpan KeepAliveInterval { get; set; } = TimeSpan.FromSeconds(1);
+        public TimeSpan LanDiscoveryInterval { get; } = TimeSpan.FromSeconds(2);
+        public TimeSpan DisconnectTimeout { get; set; } = TimeSpan.FromSeconds(5);
+    }
+}

--- a/source/Network/Infrastructure/NetworkConfiguration.cs
+++ b/source/Network/Infrastructure/NetworkConfiguration.cs
@@ -11,6 +11,9 @@ namespace Network.Infrastructure
         public int WanPort { get; set; } = 4200;
         public TimeSpan KeepAliveInterval { get; set; } = TimeSpan.FromSeconds(1);
         public TimeSpan LanDiscoveryInterval { get; } = TimeSpan.FromSeconds(2);
-        public TimeSpan DisconnectTimeout { get; set; } = TimeSpan.FromSeconds(5);
+        public TimeSpan DisconnectTimeout { get; set; } = TimeSpan.FromSeconds(60);
+        public TimeSpan ReconnectDelay { get; set; } = TimeSpan.FromSeconds(2);
+        
+        public TimeSpan UpdateTime { get; set; } = TimeSpan.FromMilliseconds(15);
     }
 }

--- a/source/Network/Infrastructure/NetworkConfiguration.cs
+++ b/source/Network/Infrastructure/NetworkConfiguration.cs
@@ -1,19 +1,55 @@
 ﻿using System;
 using System.Net;
+using Network.Protocol;
 
 namespace Network.Infrastructure
 {
+    /// <summary>
+    ///     Network settings for both client & server.
+    /// </summary>
     public class NetworkConfiguration
     {
+        /// <summary>
+        ///     ip address of the server in LAN.
+        /// </summary>
         public IPAddress LanAddress { get; set; } = IPAddress.Parse("127.0.0.1");
+        /// <summary>
+        ///     port of the server in LAN.
+        /// </summary>
         public int LanPort { get; set; } = 4201;
+        /// <summary>
+        ///     ip address of the server in WAN.
+        /// </summary>
         public IPAddress WanAddress { get; set; } = null;
+        /// <summary>
+        ///     port of the server in WAN.
+        /// </summary>
         public int WanPort { get; set; } = 4200;
-        public TimeSpan KeepAliveInterval { get; set; } = TimeSpan.FromSeconds(1);
+        /// <summary>
+        ///     Interval in which the server will send out LAN discovery messages.
+        /// </summary>
         public TimeSpan LanDiscoveryInterval { get; } = TimeSpan.FromSeconds(2);
+        /// <summary>
+        ///     port the server will broadcast a LAN discovery message.
+        /// </summary>
+        public int LanDiscoveryPort { get; set; } = 4202;
+        /// <summary>
+        ///     Interval in which the server will send out <see cref="EPacket.KeepAlive"/>
+        ///     packets.
+        /// </summary>
+        public TimeSpan KeepAliveInterval { get; set; } = TimeSpan.FromSeconds(1);
+        /// <summary>
+        ///     If a connection is inactive (no requests or response) for longer than this time
+        ///     frame, it will be disconnected.
+        /// </summary>
         public TimeSpan DisconnectTimeout { get; set; } = TimeSpan.FromSeconds(60);
+        /// <summary>
+        ///     Delay after a failed connection attempt until it is tried again.
+        /// </summary>
         public TimeSpan ReconnectDelay { get; set; } = TimeSpan.FromSeconds(2);
-        
+        /// <summary>
+        ///     Update cycle time for the network receiver.
+        /// </summary>
         public TimeSpan UpdateTime { get; set; } = TimeSpan.FromMilliseconds(15);
     }
 }

--- a/source/Network/Infrastructure/Server.cs
+++ b/source/Network/Infrastructure/Server.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using Common;
 using JetBrains.Annotations;

--- a/source/Network/Infrastructure/Server.cs
+++ b/source/Network/Infrastructure/Server.cs
@@ -53,8 +53,8 @@ namespace Network.Infrastructure
             string sDump = string.Join(
                 Environment.NewLine,
                 $"Server is '{State.ToString()}' with '{ActiveConnections.Count}/{ActiveConfig.MaxPlayerCount}' players.",
-                $"LAN:   {ActiveConfig.LanAddress}:{ActiveConfig.LanPort}",
-                $"WAN:   {ActiveConfig.WanAddress}:{ActiveConfig.WanPort}");
+                $"LAN:   {ActiveConfig.NetworkConfiguration.LanAddress}:{ActiveConfig.NetworkConfiguration.LanPort}",
+                $"WAN:   {ActiveConfig.NetworkConfiguration.WanAddress}:{ActiveConfig.NetworkConfiguration.WanPort}");
 
             if (ActiveConnections.Count > 0)
             {

--- a/source/Network/Infrastructure/ServerConfiguration.cs
+++ b/source/Network/Infrastructure/ServerConfiguration.cs
@@ -1,25 +1,18 @@
 ﻿using System;
-using System.Net;
 
 namespace Network.Infrastructure
 {
     public class ServerConfiguration
     {
+        public NetworkConfiguration NetworkConfiguration { get; set; } = new NetworkConfiguration();
+        public uint MaxPlayerCount { get; set; } = 8;
+        public uint TickRate { get; set; } = 120; // in [Hz]. 0 for no limit.
+        
         /// <summary>
         ///     Defines the maximum amount of time after which an event will be dropped if it was not yet
         ///     delivered successfully. Do not set this too low, as the time it takes to transfer any arguments
         ///     is included in this.
         /// </summary>
         public TimeSpan EventBroadcastTimeout = TimeSpan.FromSeconds(20);
-
-        public IPAddress LanAddress { get; set; } = IPAddress.Parse("127.0.0.1");
-        public int LanPort { get; set; } = 4201;
-        public IPAddress WanAddress { get; set; } = null;
-        public int WanPort { get; set; } = 4200;
-        public TimeSpan KeepAliveInterval { get; set; } = TimeSpan.FromSeconds(1);
-        public TimeSpan LanDiscoveryInterval { get; } = TimeSpan.FromSeconds(2);
-        public TimeSpan DisconnectTimeout { get; set; } = TimeSpan.FromSeconds(5);
-        public uint MaxPlayerCount { get; set; } = 8;
-        public uint TickRate { get; set; } = 120; // in [Hz]. 0 for no limit.
     }
 }

--- a/source/Network/Infrastructure/ServerConfiguration.cs
+++ b/source/Network/Infrastructure/ServerConfiguration.cs
@@ -4,9 +4,18 @@ namespace Network.Infrastructure
 {
     public class ServerConfiguration
     {
-        public NetworkConfiguration NetworkConfiguration { get; set; } = new NetworkConfiguration();
+        public ServerConfiguration()
+        {
+            // Initialize the UpdateTime to be roughly once per server tick.
+            NetworkConfiguration = new NetworkConfiguration()
+            {
+                UpdateTime = TimeSpan.FromMilliseconds(1000 / (float) TickRate)
+            };
+        }
         public uint MaxPlayerCount { get; set; } = 8;
         public uint TickRate { get; set; } = 120; // in [Hz]. 0 for no limit.
+        
+        public NetworkConfiguration NetworkConfiguration { get; set; }
         
         /// <summary>
         ///     Defines the maximum amount of time after which an event will be dropped if it was not yet

--- a/source/Network/Infrastructure/ServerSM.cs
+++ b/source/Network/Infrastructure/ServerSM.cs
@@ -1,10 +1,5 @@
 ﻿using Common;
 using Stateless;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Network.Infrastructure
 {

--- a/source/Network/Network.csproj
+++ b/source/Network/Network.csproj
@@ -77,6 +77,7 @@
   <ItemGroup>
     <Compile Include="ByteReader.cs" />
     <Compile Include="ByteWriter.cs" />
+    <Compile Include="Infrastructure\ClientConfiguration.cs" />
     <Compile Include="Infrastructure\ConnectionClient.cs" />
     <Compile Include="Infrastructure\ConnectionClientSM.cs" />
     <Compile Include="Infrastructure\ConnectionServer.cs" />

--- a/source/Network/Network.csproj
+++ b/source/Network/Network.csproj
@@ -83,7 +83,6 @@
     <Compile Include="Infrastructure\ConnectionServer.cs" />
     <Compile Include="Infrastructure\ConnectionServerSM.cs" />
     <Compile Include="Infrastructure\GameSession.cs" />
-    <Compile Include="Infrastructure\Globals.cs" />
     <Compile Include="Infrastructure\ConnectionBase.cs" />
     <Compile Include="Exceptions.cs" />
     <Compile Include="Infrastructure\IGameStatePersistence.cs" />

--- a/source/Network/Network.csproj
+++ b/source/Network/Network.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Infrastructure\NetworkConfiguration.cs" />
     <Compile Include="Infrastructure\ServerSM.cs" />
     <Compile Include="MemoryStreamSegment.cs" />
+    <Compile Include="Protocol\Discovery.cs" />
     <Compile Include="Protocol\Packet.cs" />
     <Compile Include="Protocol\PacketDispatcher.cs" />
     <Compile Include="Protocol\PacketHandler.cs" />
@@ -105,6 +106,10 @@
     <ProjectReference Include="..\Common\Common.csproj">
       <Project>{9cdd9c4e-92cd-4f19-a4d9-d68cf975480c}</Project>
       <Name>Common</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\LiteNetLib\LiteNetLib\LiteNetLib.csproj">
+      <Project>{d8f65198-a926-4c46-9599-2d5d4349486f}</Project>
+      <Name>LiteNetLib</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/source/Network/Network.csproj
+++ b/source/Network/Network.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Infrastructure\INetwork.cs" />
     <Compile Include="Infrastructure\INetworkConnection.cs" />
     <Compile Include="Infrastructure\ISaveData.cs" />
+    <Compile Include="Infrastructure\NetworkConfiguration.cs" />
     <Compile Include="Infrastructure\ServerSM.cs" />
     <Compile Include="MemoryStreamSegment.cs" />
     <Compile Include="Protocol\Packet.cs" />

--- a/source/Network/Protocol/Discovery.cs
+++ b/source/Network/Protocol/Discovery.cs
@@ -1,0 +1,42 @@
+﻿namespace Network.Protocol
+{
+    /// <summary>
+    ///     Payload serializer for a discovery packet.
+    /// </summary>
+    public static class Discovery
+    {
+        private const int MagicNumber = 0x13376ED6;
+        private static readonly byte[] Payload;
+
+        static Discovery()
+        {
+            ByteWriter writer = new ByteWriter();
+            writer.Binary.Write(MagicNumber);
+            Payload = writer.ToArray();
+        }
+
+        /// <summary>
+        ///     Get the payload that is being broadcast by the server.
+        /// </summary>
+        /// <returns>Payload</returns>
+        public static byte[] GetPayload()
+        {
+            return Payload;
+        }
+
+        /// <summary>
+        ///     Check if the <see cref="reader"/> contains a discovery packet. If so, deserialize
+        ///     it. Otherwise leave the reader as it is.
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <returns>Was a discovery packet read?</returns>
+        public static bool TryDeserialize(ByteReader reader)
+        {
+            int i = reader.PeekInt32();
+            if (i != MagicNumber) return false;
+            
+            reader.Binary.ReadInt32();
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
closes #104

Things done:
1. New class `NetworkConfiguration` that contains all network related options.
2. `ServerConfiguration` and `ClientConfiguration` now contain a `NetworkConfiguration` instance.
3. Implemented LAN server discovery. See `Coop.NetImpl.LiteNet.DiscoveryThread`, currently only used in DebugUI:
![](https://i.imgur.com/eCogy8b.png)
4. Updated LiteNetLib to 0.9.3.2.
5. Patched RailgunNet to prevent a ton of unnecessary allocations.