### PR TITLE
ISSUE-108 | Party movement doesn't affect map speed

### DIFF
--- a/source/Coop/Coop.csproj
+++ b/source/Coop/Coop.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\PropertyChanged.Fody.3.2.8\build\PropertyChanged.Fody.props" Condition="Exists('..\packages\PropertyChanged.Fody.3.2.8\build\PropertyChanged.Fody.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -291,6 +291,10 @@
     <Compile Include="Mod\Managers\ClientManager.cs" />
     <Compile Include="Mod\Managers\ServerManager.cs" />
     <Compile Include="Mod\MbLogTarget.cs" />
+    <Compile Include="Mod\Patch\MapSpeedModifier\OnTerrainClick\MapSpeedOnTerrainClickOverrider.cs" />
+    <Compile Include="Mod\Patch\MapSpeedModifier\MapSpeedResolver.cs" />
+    <Compile Include="Mod\Patch\MapSpeedModifier\OnTerrainClick\MapSpeedOnTerrainClickSaver.cs" />
+    <Compile Include="Mod\Patch\MapSpeedModifier\OnMapSpeedChange\TimeControlOverrider.cs" />
     <Compile Include="Mod\Patch\TimeSynchronization.cs" />
     <Compile Include="Mod\Patch\Debugging.cs" />
     <Compile Include="Mod\Patch\Exceptions.cs" />
@@ -416,6 +420,7 @@
   <ItemGroup>
     <Content Include="FodyWeavers.xml" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>powershell -ExecutionPolicy Unrestricted -File "$(SolutionDir)..\deploy.ps1" -SolutionDir "$(SolutionDir)\"  -TargetDir "$(TargetDir)\" -TargetFileName "$(TargetFileName) " -Libs Common.dll,Network.dll,Sync.dll,0harmony.dll,LiteNetLib.dll,Stateless.dll,RailgunNet.dll,NLog.dll,Mono.Reflection.dll,Extensions.Data.xxHash.dll,DistributedLock.dll</PostBuildEvent>

--- a/source/Coop/Mod/Patch/MapSpeedModifier/MapSpeedResolver.cs
+++ b/source/Coop/Mod/Patch/MapSpeedModifier/MapSpeedResolver.cs
@@ -1,0 +1,27 @@
+﻿using TaleWorlds.CampaignSystem;
+
+namespace Coop.Mod.Patch.MapSpeedModifier
+{
+    class MapSpeedResolver
+    {
+        public static CampaignTimeControlMode Resolve(
+            CampaignTimeControlMode currentTimeControlMode,
+            bool canStop)
+        {
+
+            switch (currentTimeControlMode)
+            {
+                case CampaignTimeControlMode.Stop:
+                    return canStop ? currentTimeControlMode : CampaignTimeControlMode.UnstoppablePlay;
+                case CampaignTimeControlMode.StoppablePlay:
+                    return CampaignTimeControlMode.UnstoppablePlay;
+                case CampaignTimeControlMode.StoppableFastForward:
+                    return CampaignTimeControlMode.UnstoppableFastForward;
+                default:
+                    return currentTimeControlMode;
+            }
+
+        }
+
+    }
+}

--- a/source/Coop/Mod/Patch/MapSpeedModifier/MapSpeedResolver.cs
+++ b/source/Coop/Mod/Patch/MapSpeedModifier/MapSpeedResolver.cs
@@ -2,26 +2,49 @@
 
 namespace Coop.Mod.Patch.MapSpeedModifier
 {
+
+    /// <summary>
+    ///     Campaign map time speed resolver class.
+    /// </summary>
     class MapSpeedResolver
     {
+        /// <summary>
+        ///     <para>
+        ///         Given a <c>CampaignTimeControlMode</c> returns a new one. It's useful to override consistently current 
+        ///         <c>CampaignTimeControlMode</c> through all method users.
+        ///     </para>
+        ///     <para>
+        ///         More about it on <see href="https://github.com/Bannerlord-Coop-Team/BannerlordCoop/issues/108">issue #108</see>
+        ///     </para>
+        /// </summary>
+        /// <param name="timeControlMode">
+        ///     Any <c>CampaignTimeControlMode</c> which method user desires will suffice. 
+        ///     Most useful being the current one.
+        /// </param>
+        /// <param name="canStop">
+        ///     Useful in cases when method user does or doesn't want the new <c>CampaignTimeControlMode</c> to be
+        ///     equal to <c>CampaignTimeControlMode.Stop</c>
+        /// </param>
+        /// <returns>Resolved <c>CampaignTimeControlMode</c></returns>
         public static CampaignTimeControlMode Resolve(
-            CampaignTimeControlMode currentTimeControlMode,
+            CampaignTimeControlMode timeControlMode,
             bool canStop)
         {
 
-            switch (currentTimeControlMode)
+            switch (timeControlMode)
             {
                 case CampaignTimeControlMode.Stop:
-                    return canStop ? currentTimeControlMode : CampaignTimeControlMode.UnstoppablePlay;
+                    return canStop ? timeControlMode : CampaignTimeControlMode.UnstoppablePlay;
                 case CampaignTimeControlMode.StoppablePlay:
                     return CampaignTimeControlMode.UnstoppablePlay;
                 case CampaignTimeControlMode.StoppableFastForward:
                     return CampaignTimeControlMode.UnstoppableFastForward;
                 default:
-                    return currentTimeControlMode;
+                    return timeControlMode;
             }
 
         }
 
     }
+
 }

--- a/source/Coop/Mod/Patch/MapSpeedModifier/OnMapSpeedChange/TimeControlOverrider.cs
+++ b/source/Coop/Mod/Patch/MapSpeedModifier/OnMapSpeedChange/TimeControlOverrider.cs
@@ -3,6 +3,19 @@ using TaleWorlds.CampaignSystem;
 
 namespace Coop.Mod.Patch.MapSpeedModifier.OnMapSpeedChange
 {
+
+    /// <summary>
+    ///     <para>
+    ///         Code patcher through Harmony which overrides new campaign map time speed on it's setter.
+    ///     </para>
+    ///     <para>
+    ///         More about it on <see href="https://github.com/Bannerlord-Coop-Team/BannerlordCoop/issues/108">issue #108</see>
+    ///     </para>
+    /// </summary>
+    /// <remarks>
+    ///     This class prefixes setter <c>Campaign::TimeControlMode::set</c> to override it's new value 
+    ///     as <c>MapSpeedResolver::Resolve</c> sees fit.
+    /// </remarks>
     [HarmonyPatch(typeof(Campaign))]
     [HarmonyPatch(nameof(Campaign.TimeControlMode), MethodType.Setter)]
     class TimeControlOverrider
@@ -17,4 +30,5 @@ namespace Coop.Mod.Patch.MapSpeedModifier.OnMapSpeedChange
         }
 
     }
+
 }

--- a/source/Coop/Mod/Patch/MapSpeedModifier/OnMapSpeedChange/TimeControlOverrider.cs
+++ b/source/Coop/Mod/Patch/MapSpeedModifier/OnMapSpeedChange/TimeControlOverrider.cs
@@ -1,0 +1,20 @@
+﻿using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+
+namespace Coop.Mod.Patch.MapSpeedModifier.OnMapSpeedChange
+{
+    [HarmonyPatch(typeof(Campaign))]
+    [HarmonyPatch(nameof(Campaign.TimeControlMode), MethodType.Setter)]
+    class TimeControlOverrider
+    {
+        static void Prefix(ref CampaignTimeControlMode value)
+        {
+
+            var newSpeed = MapSpeedResolver.Resolve(value, true);
+
+            value = newSpeed;
+
+        }
+
+    }
+}

--- a/source/Coop/Mod/Patch/MapSpeedModifier/OnTerrainClick/MapSpeedOnTerrainClickOverrider.cs
+++ b/source/Coop/Mod/Patch/MapSpeedModifier/OnTerrainClick/MapSpeedOnTerrainClickOverrider.cs
@@ -4,6 +4,19 @@ using TaleWorlds.CampaignSystem;
 
 namespace Coop.Mod.Patch.MapSpeedModifier.OnTerrainClick
 {
+
+    /// <summary>
+    ///     <para>
+    ///         Code patcher through Harmony which patches campaign map time speed on terrain click.
+    ///     </para>
+    ///     <para>
+    ///         More about it on <see href="https://github.com/Bannerlord-Coop-Team/BannerlordCoop/issues/108">issue #108</see>
+    ///     </para>
+    /// </summary>
+    /// <remarks>
+    ///     This class prefixes private method <c>MapScreen::OnTerrainClick</c> to replace current <c>TimeControlMode</c> 
+    ///     as <c>MapSpeedResolver::Resolve</c> sees fit.
+    /// </remarks>
     [HarmonyPatch(typeof(MapScreen))]
     [HarmonyPatch("OnTerrainClick")]
     class MapSpeedOnTerrainClickOverrider
@@ -18,4 +31,5 @@ namespace Coop.Mod.Patch.MapSpeedModifier.OnTerrainClick
         }
 
     }
+
 }

--- a/source/Coop/Mod/Patch/MapSpeedModifier/OnTerrainClick/MapSpeedOnTerrainClickOverrider.cs
+++ b/source/Coop/Mod/Patch/MapSpeedModifier/OnTerrainClick/MapSpeedOnTerrainClickOverrider.cs
@@ -1,0 +1,21 @@
+﻿using HarmonyLib;
+using SandBox.View.Map;
+using TaleWorlds.CampaignSystem;
+
+namespace Coop.Mod.Patch.MapSpeedModifier.OnTerrainClick
+{
+    [HarmonyPatch(typeof(MapScreen))]
+    [HarmonyPatch("OnTerrainClick")]
+    class MapSpeedOnTerrainClickOverrider
+    {
+        static void Prefix()
+        {
+            
+            var currentTimeControlMode = MapSpeedOnTerrainClickSaver.currentCampaignTimeControlMode;
+
+            Campaign.Current.TimeControlMode = MapSpeedResolver.Resolve(currentTimeControlMode, false);
+            
+        }
+
+    }
+}

--- a/source/Coop/Mod/Patch/MapSpeedModifier/OnTerrainClick/MapSpeedOnTerrainClickSaver.cs
+++ b/source/Coop/Mod/Patch/MapSpeedModifier/OnTerrainClick/MapSpeedOnTerrainClickSaver.cs
@@ -1,0 +1,20 @@
+﻿using HarmonyLib;
+using SandBox.View.Map;
+using TaleWorlds.CampaignSystem;
+
+namespace Coop.Mod.Patch.MapSpeedModifier.OnTerrainClick
+{
+    [HarmonyPatch(typeof(MapScreen))]
+    [HarmonyPatch("HandleLeftMouseButtonClick")]
+    class MapSpeedOnTerrainClickSaver
+    {
+
+        public static CampaignTimeControlMode currentCampaignTimeControlMode;
+
+        static void Prefix()
+        {
+            currentCampaignTimeControlMode = Campaign.Current.TimeControlMode;
+        }
+
+    }
+}

--- a/source/Coop/Mod/Patch/MapSpeedModifier/OnTerrainClick/MapSpeedOnTerrainClickSaver.cs
+++ b/source/Coop/Mod/Patch/MapSpeedModifier/OnTerrainClick/MapSpeedOnTerrainClickSaver.cs
@@ -4,6 +4,19 @@ using TaleWorlds.CampaignSystem;
 
 namespace Coop.Mod.Patch.MapSpeedModifier.OnTerrainClick
 {
+
+    /// <summary>
+    ///     <para>
+    ///         Code patcher through Harmony which saves current campaign map time speed on left mouse button click.
+    ///     </para>
+    ///     <para>
+    ///         More about it on <see href="https://github.com/Bannerlord-Coop-Team/BannerlordCoop/issues/108">issue #108</see>
+    ///     </para>
+    /// </summary>
+    /// <remarks>
+    ///     This class prefixes private method <c>MapScreen::HandleLeftMouseButtonClick</c> to save 
+    ///     current <c>TimeControlMode</c>.
+    /// </remarks>
     [HarmonyPatch(typeof(MapScreen))]
     [HarmonyPatch("HandleLeftMouseButtonClick")]
     class MapSpeedOnTerrainClickSaver
@@ -17,4 +30,5 @@ namespace Coop.Mod.Patch.MapSpeedModifier.OnTerrainClick
         }
 
     }
+
 }


### PR DESCRIPTION
Solves #108

Code patches the following cases:

- On party movement: Explained in issue #108
- When player sets the map speed while party already moved: It's useful in cases where the user departed with map speed `UnstoppablePlay` because party movement speed is patched, but then they want to travel a bit faster so they fast forward, but the thing is, the game raises a `StoppableFastForward`. That's why the code patches it to `UnstoppableFastForward`

Prefixed code from Campaign
![image](https://user-images.githubusercontent.com/30632132/99893179-baa5b480-2c5b-11eb-8d26-fd69284fade8.png)

Prefixed code from MapScreen
![image](https://user-images.githubusercontent.com/30632132/99893216-14a67a00-2c5c-11eb-9ea1-f61c1d2cab12.png)
and HandleLeftMouseButtonClick but that's a bit larger 😅 

Proof
https://drive.google.com/file/d/1C1dq9DPKb8B6UZRDz52RoKy-3-AVDuHQ/view?usp=sharing