### PR TITLE
ISSUE-116 | Updated mod to work with Bannerlord v1.5.4

### DIFF
--- a/source/Coop/Mod/UI/LoadGameUI/CoopLoadUI.cs
+++ b/source/Coop/Mod/UI/LoadGameUI/CoopLoadUI.cs
@@ -71,14 +71,14 @@ namespace Coop.Mod.UI
 		private new SelectedGameVM CurrentSelectedSave;
 		public CoopLoadUI() : base(false)
 		{
-			SavedGamesList.Clear();
+			GetSavedGames().Clear();
 			SaveGameFileInfo[] saveFiles = MBSaveLoad.GetSaveFiles();
 			for (int i = 0; i < saveFiles.Length; i++)
 			{
 				SelectedGameVM item = new SelectedGameVM(saveFiles[i], this.IsSaving, new Action<SavedGameVM>(this.OnDeleteSavedGame), new Action<SavedGameVM>(OnSaveSelection), new Action(this.OnCancelLoadSave), new Action(ExecuteDone));
-				SavedGamesList.Add(item);
+				GetSavedGames().Add(item);
 			}
-			OnSaveSelection(SavedGamesList.FirstOrDefault<SavedGameVM>());
+			OnSaveSelection(GetSavedGames().FirstOrDefault<SavedGameVM>());
 			RefreshValues();
 		}
 
@@ -126,10 +126,13 @@ namespace Coop.Mod.UI
 			InformationManager.ShowInquiry(new InquiryData(titleText, text, true, true, new TextObject("{=aeouhelq}Yes", null).ToString(), new TextObject("{=8OkPHu4f}No", null).ToString(), delegate ()
 			{
 				MBSaveLoad.DeleteSaveGame(savedGame.Save.Name);
-				SavedGamesList.Remove(savedGame);
-				OnSaveSelection(SavedGamesList.FirstOrDefault());
+				GetSavedGames().Remove(savedGame);
+				OnSaveSelection(GetSavedGames().FirstOrDefault());
 			}, null, ""), false);
 		}
+
+		private MBBindingList<SavedGameVM> GetSavedGames() => SaveGroups.FirstOrDefault().SavedGamesList;
+		
 	}
 
 	class CoopLoadScreen : SaveLoadScreen


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue. -->
Project does not build because field `SavedGamesList` in `SaveLoadVM` is missing in new version v1.5.4

## What is the new behaviour?
<!-- Insert issue id after hashtag. -->
Resolves #116  
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
I noticed that field `SavedGamesList` was being wrapped inside field `SaveGroups`. That's why I created method `GetSavedGames` as to retrieve `SavedGamesList` like before v1.5.4.

Tests were not added as it's very difficult to test with static methods called from within the method I'd like to test. A DI framework would fix this issue. More about it on issue #119.

Project builds
![image](https://user-images.githubusercontent.com/30632132/100013997-80035f80-2db4-11eb-9bd2-a850e32b7a1f.png)

Game loads savefile
https://drive.google.com/file/d/10RQfGrdOzghiWB6tZxxmXMPwvhynz1tb/view?usp=sharing

Sync works
https://drive.google.com/file/d/1bpV-lxhna6VgiiW0Q46eWMrbE1DTHQUQ/view?usp=sharing

## Other information