### PR TITLE
added missing field serializer

### DIFF
--- a/source/Coop/Mod/Serializers/CustomSerializers/MobilePartySerializer.cs
+++ b/source/Coop/Mod/Serializers/CustomSerializers/MobilePartySerializer.cs
@@ -103,6 +103,9 @@ namespace Coop.Mod.Serializers
                     case "_actualClan":
                         SNNSO.Add(fieldInfo, new ClanSerializer((Clan)value));
                         break;
+                    case "<StationaryStartTime>k__BackingField":
+                        SNNSO.Add(fieldInfo, new CampaignTimeSerializer((CampaignTime)value));
+                        break;
                     default:
                         throw new NotImplementedException("Cannot serialize " + fieldInfo.Name);
                 }


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behaviour?
Client crashes when sending the hero party to the host because a field serializer for StationaryStartTime is missing.


## What is the new behaviour?
StationaryStartTime is serialized using `CampaignTimeSerializer`.
Resolves #130 


## Other information