### PR TITLE
Coop Server is shutdown when game ends

### DIFF
--- a/source/Coop/Mod/Main.cs
+++ b/source/Coop/Mod/Main.cs
@@ -141,8 +141,13 @@ namespace Coop.Mod
 
         protected override void OnSubModuleUnloaded()
         {
-            CoopServer.Instance.ShutDownServer();
             base.OnSubModuleUnloaded();
+        }
+
+        public override void OnGameEnd(Game game)
+        {
+            base.OnGameEnd(game);
+            CoopServer.Instance.ShutDownServer();
         }
 
         protected override void OnApplicationTick(float dt)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behaviour?
When the server is running and the host exit the campaign map, either pressing "Save And Exit" or "Exit to Main Manu" crashes the game.


## What is the new behaviour?
Resolves #132 
Coop server is being shutdown when the game is unloaded instead of unloading it when the Coop module mod is unloaded.


## Other information
Server is being shutdown after the game ends on purpose to avoid any interference with the game itself.