### PR TITLE
Settlement menu open twice fix

### DIFF
--- a/source/Coop/Mod/DebugUtil/ReplayEvent.cs
+++ b/source/Coop/Mod/DebugUtil/ReplayEvent.cs
@@ -24,7 +24,7 @@ namespace Coop.Mod.DebugUtil
             return obj is ReplayEvent other &&
                 this.entityId == other.entityId &&
                 this.party?.Id == other.party?.Id &&
-                this.movement.NearlyEquals(other.movement);
+                this.movement.Equals(other.movement);
         }
 
         public override int GetHashCode()

--- a/source/Coop/Mod/Persistence/Party/MovementData.cs
+++ b/source/Coop/Mod/Persistence/Party/MovementData.cs
@@ -85,14 +85,6 @@ namespace Coop.Mod.Persistence.Party
             return Values.GetEnumerator();
         }
 
-        public bool NearlyEquals(MovementData other)
-        {
-            return DefaultBehaviour == other.DefaultBehaviour &&
-                   TargetPosition.NearlyEquals(other.TargetPosition) &&
-                   TargetParty?.Id == other.TargetParty?.Id &&
-                   TargetSettlement?.Id == other.TargetSettlement?.Id;
-        }
-
         public override bool Equals(Object obj)
         {
             if (!(obj is MovementData))
@@ -101,8 +93,8 @@ namespace Coop.Mod.Persistence.Party
             }
 
             MovementData other = (MovementData)obj;
-            return DefaultBehaviour.Equals(other.DefaultBehaviour) &&
-                   TargetPosition.Equals(other.TargetPosition) &&
+            return DefaultBehaviour == other.DefaultBehaviour &&
+                   TargetPosition.NearlyEquals(other.TargetPosition, Compare.COORDINATE_PRECISION) &&
                    TargetParty?.Id == other.TargetParty?.Id &&
                    TargetSettlement?.Id == other.TargetSettlement?.Id;
         }

--- a/source/Coop/Mod/Persistence/Party/MovementData.cs
+++ b/source/Coop/Mod/Persistence/Party/MovementData.cs
@@ -93,6 +93,20 @@ namespace Coop.Mod.Persistence.Party
                    TargetSettlement?.Id == other.TargetSettlement?.Id;
         }
 
+        public override bool Equals(Object obj)
+        {
+            if (!(obj is MovementData))
+            {
+                return false;
+            }
+
+            MovementData other = (MovementData)obj;
+            return DefaultBehaviour.Equals(other.DefaultBehaviour) &&
+                   TargetPosition.Equals(other.TargetPosition) &&
+                   TargetParty?.Id == other.TargetParty?.Id &&
+                   TargetSettlement?.Id == other.TargetSettlement?.Id;
+        }
+
         private enum Field
         {
             DefaultBehavior = 0,

--- a/source/Sync/FieldChangeBuffer.cs
+++ b/source/Sync/FieldChangeBuffer.cs
@@ -100,10 +100,10 @@ namespace Sync
                 ValueAccess field = data.Access;
 
                 object newValue = data.Access.Get(data.Target);
-                bool changed = !Equals(newValue, data.Value);
+                bool changed = !newValue.Equals(data.Value);
 
                 Dictionary<object, ValueChangeRequest> fieldBuffer = BufferedChanges.Assert(field);
-                if (fieldBuffer.TryGetValue(data.Target, out ValueChangeRequest cached))
+                /*if (fieldBuffer.TryGetValue(data.Target, out ValueChangeRequest cached))
                 {
                     if (changed && cached.RequestProcessed)
                     {
@@ -113,7 +113,7 @@ namespace Sync
                     cached.RequestedValue = newValue;
                     field.Set(data.Target, cached.LatestActualValue);
                     continue;
-                }
+                }*/
 
                 if (!changed) continue;
 

--- a/source/Sync/FieldChangeBuffer.cs
+++ b/source/Sync/FieldChangeBuffer.cs
@@ -102,10 +102,12 @@ namespace Sync
                 object newValue = data.Access.Get(data.Target);
                 bool changed = !newValue.Equals(data.Value);
 
+                if (!changed) continue;
+
                 Dictionary<object, ValueChangeRequest> fieldBuffer = BufferedChanges.Assert(field);
-                /*if (fieldBuffer.TryGetValue(data.Target, out ValueChangeRequest cached))
+                if (fieldBuffer.TryGetValue(data.Target, out ValueChangeRequest cached))
                 {
-                    if (changed && cached.RequestProcessed)
+                    if (cached.RequestProcessed)
                     {
                         cached.RequestProcessed = false;
                     }
@@ -113,9 +115,7 @@ namespace Sync
                     cached.RequestedValue = newValue;
                     field.Set(data.Target, cached.LatestActualValue);
                     continue;
-                }*/
-
-                if (!changed) continue;
+                }
 
                 fieldBuffer[data.Target] = new ValueChangeRequest
                 {

--- a/source/Sync/Reflection/Extensions.cs
+++ b/source/Sync/Reflection/Extensions.cs
@@ -16,6 +16,10 @@ namespace Sync.Reflection
                 BindingFlags.Public);
         }
 
+        /// <summary>
+        /// Try to get the current value in the dictionary, if not exists, it creates a new <typeparamref name="TValue"/> and it's added to the dictionary with key <typeparamref name="TKey"/>
+        /// </summary>
+        /// <returns>Current value or the added object of type <typeparamref name="TValue"/></returns>
         public static TValue Assert<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key)
             where TValue : new()
         {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behaviour?
When leaving a settlement the menu opens again, after pressing a second time the "Leave" button the party would leave the settlement


## What is the new behaviour?
Resolves #134 

When leaving a settlement the menu opens once

## Other information