### PR TITLE
Adjust Project-Setup Documentation to mention submodule initialization

### DIFF
--- a/docs-source/overview/project_setup.md
+++ b/docs-source/overview/project_setup.md
@@ -1,6 +1,6 @@
 # Project Setup
 1. Clone the [repository](https://github.com/Bannerlord-Coop-Team/BannerlordCoop) somewhere on your machine.<br/>
-2. Submodules will have to be updated using the command `git submodule update --recursive --force`.<br/>
+2. Submodules will have to be initialized and updated using the command `git submodule init && git submodule update --recursive --force`.<br/>
 3. Run the `runmefirst.cmd` to dynamically attach your Bannerlord path and resolve references.<br/>
 4. If references in projects did not resolved automatically do the following. This can be done in Visual Studio by right-clicking references, going to browse, navigating to your Bannerlord directory through the mb2 shortcut, and selecting all TaleWorld.* .dlls. There are additional .dlls in the Modules folder, being the Native and StoryMode.<br/>
 5. Go to project settings for the Coop project and click debug. <br/>


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation update
- [ ] Other... Please describe:


## What is the current behaviour?
The Project Setup documentation was missing a step of initilizing submodules causing someone to follow the steps to end up with empty submodule folders and a project that can't be build.


## What is the new behaviour?
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
I added the `git submodule init` command before the update command. This way there should be no issues related to the submodules anymore (once #176 is merged).

## Other information
This required for #176 to be merged, otherwise the `git submodule init` command will error out complaining about LiteNetLib.