### PR TITLE
Patch GarrisonTroopsCampaignBehavior to avoid PlayerParties inconsistencies

### DIFF
--- a/source/Coop/Coop.csproj
+++ b/source/Coop/Coop.csproj
@@ -273,6 +273,7 @@
     <Compile Include="Mod\Patch\MobilePartyPatches\DisablePartyDecisionMaking.cs" />
     <Compile Include="Mod\Patch\MobilePartyPatches\MobilePartyUpdatable.cs" />
     <Compile Include="Mod\Patch\Party\BanditsCampaignBehavior.cs" />
+    <Compile Include="Mod\Patch\Party\GarrisonTroopsCampaignBehavior.cs" />
     <Compile Include="Mod\Patch\Party\PartiesBuyFoodCampaignBehavior.cs" />
     <Compile Include="Mod\Patch\Party\PartiesBuyHorseCampaignBehavior.cs" />
     <Compile Include="Mod\Patch\Party\PartiesSellLootCampaignBehavior.cs" />

--- a/source/Coop/Mod/Patch/Party/GarrisonTroopsCampaignBehavior.cs
+++ b/source/Coop/Mod/Patch/Party/GarrisonTroopsCampaignBehavior.cs
@@ -1,0 +1,16 @@
+﻿using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.SandBox.CampaignBehaviors;
+
+namespace Coop.Mod.Patch.Party
+{
+    [HarmonyPatch(typeof(GarrisonTroopsCampaignBehavior), "OnSettlementEntered")]
+    internal class GarrisonTroopsCampaignBehaviorPatch
+    {
+        private static bool Prefix(ref MobileParty mobileParty, ref Settlement settlement, ref Hero hero)
+        {
+            // Skip function if mobile party is player controlled
+            return !mobileParty.IsAnyPlayerMainParty();
+        }
+    }
+}


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behaviour?
Currently player parties will add or take Troops from the Garrison if the settlement belongs to the same clan on other clients.


## What is the new behaviour?
<!-- Insert issue id after hashtag. -->
Resolves #96
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
By skipping the function if the Party belongs to a player, we avoid the logic responsible for taking or adding to garrisons.

## Other information
Code this Patch skips for player parties:
```c#
// Token: 0x060030EB RID: 12523 RVA: 0x000D71E8 File Offset: 0x000D53E8
public void OnSettlementEntered(MobileParty mobileParty, Settlement settlement, Hero hero)
{
	if (!Campaign.Current.GameStarted)
	{
		return;
	}
	if (mobileParty != null && mobileParty != MobileParty.MainParty && mobileParty.IsLordParty && !mobileParty.IsDisbanding && mobileParty.LeaderHero != null && mobileParty.LeaderHero.MapFaction.IsKingdomFaction && FactionManager.IsAlliedWithFaction(mobileParty.MapFaction, settlement.MapFaction) && (settlement.OwnerClan != Clan.PlayerClan || Hero.MainHero == Hero.MainHero.MapFaction.Leader) && settlement.IsFortification)
	{
		float currentTime = Campaign.CurrentTime;
		int num = Campaign.Current.Models.SettlementGarrisonModel.FindNumberOfTroopsToLeaveToGarrison(mobileParty, mobileParty.CurrentSettlement);
		if (num > 0)
		{
			LeaveTroopsToSettlementAction.Apply(mobileParty, settlement, num, true);
			return;
		}
		if (mobileParty.LeaderHero.Clan == settlement.OwnerClan)
		{
			int num2 = Campaign.Current.Models.SettlementGarrisonModel.FindNumberOfTroopsToTakeFromGarrison(mobileParty, mobileParty.CurrentSettlement, 0f);
			if (num2 > 0)
			{
				LeaveTroopsToSettlementAction.Apply(mobileParty, settlement, -num2, false);
			}
		}
	}
}
```