### PR TITLE
add startup message for client/server mode

### DIFF
--- a/source/Coop/Mod/Main.cs
+++ b/source/Coop/Mod/Main.cs
@@ -97,6 +97,8 @@ namespace Coop.Mod
             Updateables.Add(new MobilePartyUpdatable());
         }
 
+        private static string ClientServerModeMessage = ""; 
+
         public static Main Instance { get; private set; }
         public UpdateableList Updateables { get; } = new UpdateableList();
 
@@ -146,11 +148,13 @@ namespace Coop.Mod
                         {
                             if (argument.ToLower() == "/server")
                             {
+                                ClientServerModeMessage = "Started Bannerlord Co-op in server mode";
                                 //TODO add name to args
                                 CoopServer.Instance.StartGame("MP");
                             }
                             else if (argument.ToLower() == "/client")
                             {
+                                ClientServerModeMessage = "Started Bannerlord Co-op in client mode";
                                 ServerConfiguration defaultConfiguration =
                                     new ServerConfiguration();
                                 CoopClient.Instance.Connect(
@@ -184,6 +188,12 @@ namespace Coop.Mod
         protected override void OnSubModuleUnloaded()
         {
             base.OnSubModuleUnloaded();
+        }
+
+        protected override void OnBeforeInitialModuleScreenSetAsRoot()
+        {
+            base.OnBeforeInitialModuleScreenSetAsRoot();
+            InformationManager.DisplayMessage(new InformationMessage(ClientServerModeMessage));
         }
 
         public Action<Game> OnGameInit;


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behaviour?
There is no difference visually between client and server-mode game instances.


## What is the new behaviour?
Shows a message at the main menu if the game was started with `/server` or `/client` arguments  
Resolves #188 somewhat


## Other information