### PR TITLE
Added Array and List serializers for protobuf-net support

### DIFF
--- a/source/GameInterface.Tests/GameInterface.Tests.csproj
+++ b/source/GameInterface.Tests/GameInterface.Tests.csproj
@@ -128,6 +128,8 @@
   <ItemGroup>
     <Compile Include="ModuleBuild_UnitTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Serialization\Collections\ArraySerializerTests.cs" />
+    <Compile Include="Serialization\Collections\ListSerializerTests.cs" />
     <Compile Include="Serialization\DynamicModelGeneratorTests.cs" />
     <Compile Include="Serialization\Dynamic\BodyPropertiesSerializationTests.cs" />
     <Compile Include="Serialization\Dynamic\CharacterObjectSerializationTests.cs" />

--- a/source/GameInterface.Tests/Serialization/Collections/ArraySerializerTests.cs
+++ b/source/GameInterface.Tests/Serialization/Collections/ArraySerializerTests.cs
@@ -1,0 +1,121 @@
+﻿using Coop.Serialization;
+using GameInterface.Serialization.Collections;
+using ProtoBuf;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GameInterface.Tests.Serialization.Collections
+{
+    public class ArraySerializerTests
+    {
+        [Fact]
+        public void EmptyArrayTest()
+        {
+            string[] myStings = new string[0];
+
+            ArraySerializer<string> preSer = new ArraySerializer<string>();
+
+            preSer.Pack(myStings);
+
+            ProtobufSerializer ser = new ProtobufSerializer();
+
+            byte[] bytes = ser.Serialize(preSer);
+
+            string[] newStrings = ser.Deserialize<ArraySerializer<string>>(bytes).Unpack();
+
+            Assert.Equal(myStings, newStrings);
+        }
+
+        [Fact]
+        public void AllNullArrayTest()
+        {
+            string[] myStings = new string[] { null, null, null, null };
+
+            ArraySerializer<string> preSer = new ArraySerializer<string>();
+
+            preSer.Pack(myStings);
+
+            ProtobufSerializer ser = new ProtobufSerializer();
+
+            byte[] bytes = ser.Serialize(preSer);
+
+            string[] newStrings = ser.Deserialize<ArraySerializer<string>>(bytes).Unpack();
+
+            Assert.Equal(myStings, newStrings);
+        }
+
+        [Fact]
+        public void SomeNullArrayTest()
+        {
+            string[] myStings = new string[] { null, "Hi", "Yo", null };
+
+            ArraySerializer<string> preSer = new ArraySerializer<string>();
+
+            preSer.Pack(myStings);
+
+            ProtobufSerializer ser = new ProtobufSerializer();
+
+            byte[] bytes = ser.Serialize(preSer);
+
+            string[] newStrings = ser.Deserialize<ArraySerializer<string>>(bytes).Unpack();
+
+            Assert.Equal(myStings, newStrings);
+        }
+
+        [Fact]
+        public void NoNullArrayTest()
+        {
+            string[] myStings = new string[] { "Hi", "Yo" };
+
+            ArraySerializer<string> preSer = new ArraySerializer<string>();
+
+            preSer.Pack(myStings);
+
+            ProtobufSerializer ser = new ProtobufSerializer();
+
+            byte[] bytes = ser.Serialize(preSer);
+
+            string[] newStrings = ser.Deserialize<ArraySerializer<string>>(bytes).Unpack();
+
+            Assert.Equal(myStings, newStrings);
+        }
+
+        [Fact]
+        public void JaggedArrayTest()
+        {
+            string[][] myStings = new string[2][];
+            myStings[0] = new string[] { "Hi", "Hello" };
+            myStings[1] = new string[] { "Yo" };
+
+            // This will be done using manual packing and unpacking
+            ArraySerializer<string>[] arraySerializers = new ArraySerializer<string>[myStings.Length];
+
+            for (int i = 0; i < myStings.Length; i++)
+            {
+                var arrSer = new ArraySerializer<string>();
+                arrSer.Pack(myStings[i]);
+                arraySerializers[i] = arrSer;
+            }
+
+            ProtobufSerializer ser = new ProtobufSerializer();
+
+            byte[] bytes = ser.Serialize(arraySerializers);
+
+            List<ArraySerializer<string>> newArraySerializers = ser.Deserialize<List<ArraySerializer<string>>>(bytes);
+
+            string[][] newStrings = new string[newArraySerializers.Count][];
+
+            for (int i = 0; i < newStrings.Length; i++)
+            {
+                var arrSer = newArraySerializers[i];
+                newStrings[i] = arrSer.Unpack();
+            }
+
+            Assert.Equal(myStings, newStrings);
+        }
+    }
+}

--- a/source/GameInterface.Tests/Serialization/Collections/ListSerializerTests.cs
+++ b/source/GameInterface.Tests/Serialization/Collections/ListSerializerTests.cs
@@ -1,0 +1,87 @@
+﻿using Coop.Serialization;
+using GameInterface.Serialization.Collections;
+using ProtoBuf;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GameInterface.Tests.Serialization.Collections
+{
+    public class ListSerializerTests
+    {
+        [Fact]
+        public void EmptyListTest()
+        {
+            List<string> myStings = new List<string>();
+
+            ListSerializer<string> preSer = new ListSerializer<string>();
+
+            preSer.Pack(myStings);
+
+            ProtobufSerializer ser = new ProtobufSerializer();
+
+            byte[] bytes = ser.Serialize(preSer);
+
+            List<string> newStrings = ser.Deserialize<ListSerializer<string>>(bytes).Unpack();
+
+            Assert.Equal(myStings, newStrings);
+        }
+
+        [Fact]
+        public void AllNullListTest()
+        {
+            List<string> myStings = new List<string> { null, null, null, null };
+
+            ListSerializer<string> preSer = new ListSerializer<string>();
+
+            preSer.Pack(myStings);
+
+            ProtobufSerializer ser = new ProtobufSerializer();
+
+            byte[] bytes = ser.Serialize(preSer);
+
+            List<string> newStrings = ser.Deserialize<ListSerializer<string>>(bytes).Unpack();
+
+            Assert.Equal(myStings, newStrings);
+        }
+
+        [Fact]
+        public void SomeNullListTest()
+        {
+            List<string> myStings = new List<string> { null, "Hi", "Yo", null };
+
+            ListSerializer<string> preSer = new ListSerializer<string>();
+
+            preSer.Pack(myStings);
+
+            ProtobufSerializer ser = new ProtobufSerializer();
+
+            byte[] bytes = ser.Serialize(preSer);
+
+            List<string> newStrings = ser.Deserialize<ListSerializer<string>>(bytes).Unpack();
+
+            Assert.Equal(myStings, newStrings);
+        }
+
+        [Fact]
+        public void NoNullListTest()
+        {
+            List<string> myStings = new List<string> { "Hi", "Yo" };
+
+            ListSerializer<string> preSer = new ListSerializer<string>();
+
+            preSer.Pack(myStings);
+
+            ProtobufSerializer ser = new ProtobufSerializer();
+
+            byte[] bytes = ser.Serialize(preSer);
+
+            List<string> newStrings = ser.Deserialize<ListSerializer<string>>(bytes).Unpack();
+
+            Assert.Equal(myStings, newStrings);
+        }
+    }
+}

--- a/source/GameInterface/GameInterface.csproj
+++ b/source/GameInterface/GameInterface.csproj
@@ -296,6 +296,9 @@
     <Compile Include="Patch\World\SaveManager.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Helpers\SaveLoadHelper.cs" />
+    <Compile Include="Serialization\Collections\ArraySerializer.cs" />
+    <Compile Include="Serialization\Collections\ICollectionSerializer.cs" />
+    <Compile Include="Serialization\Collections\ListSerializer.cs" />
     <Compile Include="Serialization\Dynamic\MetaTypeContainer.cs" />
     <Compile Include="Serialization\ISerializer.cs" />
     <Compile Include="Serialization\SerializationService.cs" />

--- a/source/GameInterface/Serialization/Collections/ArraySerializer.cs
+++ b/source/GameInterface/Serialization/Collections/ArraySerializer.cs
@@ -1,0 +1,60 @@
+﻿using ProtoBuf;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GameInterface.Serialization.Collections
+{
+    [ProtoContract]
+    public class ArraySerializer<T> : ICollectionSerializer<T[]>
+    {
+        [ProtoMember(1)]
+        protected Queue<T> Values { get; }
+
+        [ProtoMember(2)]
+        protected List<bool> NullElements { get; }
+
+        public ArraySerializer()
+        {
+            Values = new Queue<T>();
+            NullElements = new List<bool>();
+        }
+
+        public void Pack(T[] values)
+        {
+            foreach (var value in values)
+            {
+                if (value == null)
+                {
+                    NullElements.Add(true);
+                }
+                else
+                {
+                    Values.Enqueue(value);
+                    NullElements.Add(false);
+                }
+            }
+        }
+
+        public T[] Unpack()
+        {
+            List<T> newList = new List<T>();
+
+            foreach (var isNull in NullElements)
+            {
+                if (isNull)
+                {
+                    newList.Add(default);
+                }
+                else
+                {
+                    newList.Add(Values.Dequeue());
+                }
+            }
+
+            return newList.ToArray();
+        }
+    }
+}

--- a/source/GameInterface/Serialization/Collections/ArraySerializer.cs
+++ b/source/GameInterface/Serialization/Collections/ArraySerializer.cs
@@ -1,4 +1,5 @@
-﻿using ProtoBuf;
+﻿using GameInterface.Utils;
+using ProtoBuf;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,19 +16,25 @@ namespace GameInterface.Serialization.Collections
     public class ArraySerializer<T> : ICollectionSerializer<T[]>
     {
         [ProtoMember(1)]
-        protected Queue<T> Values { get; }
+        Queue<T> Values { get; }
 
         [ProtoMember(2)]
-        protected List<bool> NullElements { get; }
+        List<bool> NullElements { get; }
+
+        [ProtoMember(3)]
+        bool IsNull;
 
         public ArraySerializer()
         {
             Values = new Queue<T>();
             NullElements = new List<bool>();
+            IsNull = true;
         }
 
         public void Pack(T[] values)
         {
+            if (values == null) return;
+
             foreach (var value in values)
             {
                 if (value == null)
@@ -40,10 +47,14 @@ namespace GameInterface.Serialization.Collections
                     NullElements.Add(false);
                 }
             }
+
+            IsNull = false;
         }
 
         public T[] Unpack()
         {
+            if (IsNull) return null;
+
             List<T> newList = new List<T>();
 
             foreach (var isNull in NullElements)

--- a/source/GameInterface/Serialization/Collections/ArraySerializer.cs
+++ b/source/GameInterface/Serialization/Collections/ArraySerializer.cs
@@ -7,6 +7,10 @@ using System.Threading.Tasks;
 
 namespace GameInterface.Serialization.Collections
 {
+    /// <summary>
+    /// Custom array serializer for protobuf-net support
+    /// </summary>
+    /// <typeparam name="T">Array's underlying type</typeparam>
     [ProtoContract]
     public class ArraySerializer<T> : ICollectionSerializer<T[]>
     {

--- a/source/GameInterface/Serialization/Collections/ICollectionSerializer.cs
+++ b/source/GameInterface/Serialization/Collections/ICollectionSerializer.cs
@@ -7,7 +7,10 @@ using System.Threading.Tasks;
 
 namespace GameInterface.Serialization.Collections
 {
-
+    /// <summary>
+    /// Interface for collection serialization
+    /// </summary>
+    /// <typeparam name="T">Type of collection</typeparam>
     [ProtoContract]
     public interface ICollectionSerializer<T>
     {

--- a/source/GameInterface/Serialization/Collections/ICollectionSerializer.cs
+++ b/source/GameInterface/Serialization/Collections/ICollectionSerializer.cs
@@ -1,0 +1,17 @@
+﻿using ProtoBuf;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GameInterface.Serialization.Collections
+{
+
+    [ProtoContract]
+    public interface ICollectionSerializer<T>
+    {
+        void Pack(T values);
+        T Unpack();
+    }
+}

--- a/source/GameInterface/Serialization/Collections/ListSerializer.cs
+++ b/source/GameInterface/Serialization/Collections/ListSerializer.cs
@@ -15,19 +15,25 @@ namespace GameInterface.Serialization.Collections
     public class ListSerializer<T> : ICollectionSerializer<List<T>>
     {
         [ProtoMember(1)]
-        protected Queue<T> Values { get; }
+        Queue<T> Values { get; }
+
+        [ProtoMember(2)]
+        List<bool> NullElements { get; }
 
         [ProtoMember(3)]
-        protected List<bool> NullElements { get; }
+        bool IsNull;
 
         public ListSerializer()
         {
             Values = new Queue<T>();
             NullElements = new List<bool>();
+            IsNull = true;
         }
 
         public void Pack(List<T> values)
         {
+            if (values == null) return;
+
             foreach (var value in values)
             {
                 if (value == null)
@@ -40,10 +46,14 @@ namespace GameInterface.Serialization.Collections
                     NullElements.Add(false);
                 }
             }
+
+            IsNull = false;
         }
 
         public List<T> Unpack()
         {
+            if (IsNull) return null;
+
             List<T> newList = new List<T>();
 
             foreach (var isNull in NullElements)

--- a/source/GameInterface/Serialization/Collections/ListSerializer.cs
+++ b/source/GameInterface/Serialization/Collections/ListSerializer.cs
@@ -1,0 +1,60 @@
+﻿using ProtoBuf;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GameInterface.Serialization.Collections
+{
+    [ProtoContract]
+    public class ListSerializer<T> : ICollectionSerializer<List<T>>
+    {
+        [ProtoMember(1)]
+        protected Queue<T> Values { get; }
+
+        [ProtoMember(3)]
+        protected List<bool> NullElements { get; }
+
+        public ListSerializer()
+        {
+            Values = new Queue<T>();
+            NullElements = new List<bool>();
+        }
+
+        public void Pack(List<T> values)
+        {
+            foreach (var value in values)
+            {
+                if (value == null)
+                {
+                    NullElements.Add(true);
+                }
+                else
+                {
+                    Values.Enqueue(value);
+                    NullElements.Add(false);
+                }
+            }
+        }
+
+        public List<T> Unpack()
+        {
+            List<T> newList = new List<T>();
+
+            foreach (var isNull in NullElements)
+            {
+                if (isNull)
+                {
+                    newList.Add(default);
+                }
+                else
+                {
+                    newList.Add(Values.Dequeue());
+                }
+            }
+
+            return newList;
+        }
+    }
+}

--- a/source/GameInterface/Serialization/Collections/ListSerializer.cs
+++ b/source/GameInterface/Serialization/Collections/ListSerializer.cs
@@ -7,6 +7,10 @@ using System.Threading.Tasks;
 
 namespace GameInterface.Serialization.Collections
 {
+    /// <summary>
+    /// Custom list serializer for protobuf-net support
+    /// </summary>
+    /// <typeparam name="T">List's underlying type</typeparam>
     [ProtoContract]
     public class ListSerializer<T> : ICollectionSerializer<List<T>>
     {

--- a/source/GameInterface/Serialization/ProtobufSerializer.cs
+++ b/source/GameInterface/Serialization/ProtobufSerializer.cs
@@ -27,7 +27,7 @@ namespace Coop.Serialization
                 return memoryStream.ToArray();
             }
         }
-        
+
         /// <summary>
         ///     Deserializes the message into the represented object.
         /// </summary>


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue. -->
List and array values that are null currently cannot be serialized by the protobuf-net library.


## What is the new behaviour?
ListSerializer and ArraySerializer have been created to add functionality for null values in lists.


## Other information
N/A