### PR TITLE
#440 logging corrections

### DIFF
--- a/source/ClientDebug/ClientDebug.csproj.user
+++ b/source/ClientDebug/ClientDebug.csproj.user
@@ -9,6 +9,6 @@
     <StartArguments>/singleplayer /client _MODULES_%2aNative%2aSandBoxCore%2aSandBox%2aStoryMode%2aMissionTestMod%2a_MODULES_</StartArguments>
     <StartAction>Program</StartAction>
     <StartProgram>..\mb2\bin\Win64_Shipping_Client\Bannerlord.exe</StartProgram>
-    <StartWorkingDirectory>D:\Mod Development\BannerlordCoop\mb2\bin\Win64_Shipping_Client\</StartWorkingDirectory>
+    <StartWorkingDirectory>..\..\..\..\mb2\bin\Win64_Shipping_Client\</StartWorkingDirectory>
   </PropertyGroup>
 </Project>

--- a/source/Common.Tests/Common.Tests.csproj
+++ b/source/Common.Tests/Common.Tests.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/Common/Common.csproj
+++ b/source/Common/Common.csproj
@@ -34,6 +34,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="NLog, Version=5.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.5.0.5\lib\net46\NLog.dll</HintPath>
+    </Reference>
     <Reference Include="protobuf-net, Version=3.0.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
       <HintPath>..\packages\protobuf-net.3.1.22\lib\net462\protobuf-net.dll</HintPath>
     </Reference>
@@ -47,7 +50,9 @@
     <Reference Include="System.Collections.Immutable, Version=1.2.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Collections.Immutable.1.7.1\lib\net461\System.Collections.Immutable.dll</HintPath>
     </Reference>
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
     </Reference>
@@ -87,6 +92,7 @@
     <Compile Include="Extentions.cs" />
     <Compile Include="FrameLimiter.cs" />
     <Compile Include="Globals.cs" />
+    <Compile Include="Logging\BatchLogger.cs" />
     <Compile Include="Messaging\IHandler.cs" />
     <Compile Include="Messaging\EMessageResponse.cs" />
     <Compile Include="Messaging\ICommand.cs" />
@@ -109,5 +115,6 @@
     <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/source/Common/Logging/BatchLogger.cs
+++ b/source/Common/Logging/BatchLogger.cs
@@ -6,15 +6,30 @@ using NLog;
 
 namespace Common.Logging
 {
+	/// <summary>
+	/// A class for logging batches of messages of type T.
+	/// </summary>
+	/// <typeparam name="T">The type of object you want to be counted</typeparam>
 	public sealed class BatchLogger<T> : IDisposable
 	{
+		// A concurrent dictionary to store messages of type T and their counts.
 		private readonly ConcurrentDictionary<T, int> _messages = new ConcurrentDictionary<T, int>();
+		// A logger to log the messages.
 		private readonly Logger _logger = LogManager.GetCurrentClassLogger();
+		// The log level to use when logging the messages.
 		private readonly LogLevel _level;
+		// A cancellation token source to cancel the poller task.
 		private readonly CancellationTokenSource _cancellation = new CancellationTokenSource();
+		// A task to poll for messages to log.
 		private readonly Task _poller;
+		// The number of milliseconds to wait between polls.
 		private readonly int _waitMilliseconds;
 
+		/// <summary>
+		/// Constructs a BatchLogger.
+		/// </summary>
+		/// <param name="level">The log level to use when logging the messages.</param>
+		/// <param name="waitMilliseconds">The number of milliseconds to wait between polls (optional, default is 1000).</param>
 		public BatchLogger(LogLevel level, int waitMilliseconds = 1000)
 		{
 			_level = level;
@@ -22,16 +37,25 @@ namespace Common.Logging
 			_poller = Task.Factory.StartNew(Poll, _cancellation.Token);
 		}
 
+		/// <summary>
+		/// Logs a message of type T.
+		/// </summary>
+		/// <param name="value">The message to log.</param>
 		public void Log(T value) => _messages.AddOrUpdate(value,
 			1, (_, i) => ++i);
 
+		// A method to poll for messages to log.
 		private void Poll()
 		{
+			// Keep polling until cancellation is requested.
 			while (!_cancellation.IsCancellationRequested)
 			{
+				// Sleep for the specified number of milliseconds.
 				Thread.Sleep(_waitMilliseconds);
+				// Iterate through the keys in the messages dictionary.
 				foreach (var key in _messages.Keys)
 				{
+					// If the message can be removed from the dictionary, log it.
 					if (_messages.TryRemove(key, out var value))
 						_logger.Log(_level, "{Type} received {Times} times in last {WaitMilliseconds}ms",
 							key, value, _waitMilliseconds);
@@ -39,13 +63,19 @@ namespace Common.Logging
 			}
 		}
 
+		/// <summary>
+		/// Disposes of the BatchLogger.
+		/// </summary>
 		public void Dispose()
 		{
+			// Cancel the poller task.
 			_cancellation.Cancel();
+			// Wait for the poller task to complete.
 			while (!_poller.IsCompleted)
 			{
 				Thread.Sleep(1);
 			}
+			// Dispose of the cancellation token source.
 			_cancellation?.Dispose();
 		}
 	}

--- a/source/Common/Logging/BatchLogger.cs
+++ b/source/Common/Logging/BatchLogger.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using NLog;
+
+namespace Common.Logging
+{
+	public sealed class BatchLogger<T> : IDisposable
+	{
+		private readonly ConcurrentDictionary<T, int> _messages = new ConcurrentDictionary<T, int>();
+		private readonly Logger _logger = LogManager.GetCurrentClassLogger();
+		private readonly LogLevel _level;
+		private readonly CancellationTokenSource _cancellation = new CancellationTokenSource();
+		private readonly Task _poller;
+		private readonly int _waitMilliseconds;
+
+		public BatchLogger(LogLevel level, int waitMilliseconds = 1000)
+		{
+			_level = level;
+			_waitMilliseconds = waitMilliseconds;
+			_poller = Task.Factory.StartNew(Poll, _cancellation.Token);
+		}
+
+		public void Log(T value) => _messages.AddOrUpdate(value,
+			1, (_, i) => ++i);
+
+		private void Poll()
+		{
+			while (!_cancellation.IsCancellationRequested)
+			{
+				Thread.Sleep(_waitMilliseconds);
+				foreach (var key in _messages.Keys)
+				{
+					if (_messages.TryRemove(key, out var value))
+						_logger.Log(_level, "{Type} received {Times} times in last {WaitMilliseconds}ms",
+							key, value, _waitMilliseconds);
+				}
+			}
+		}
+
+		public void Dispose()
+		{
+			_cancellation.Cancel();
+			while (!_poller.IsCompleted)
+			{
+				Thread.Sleep(1);
+			}
+			_cancellation?.Dispose();
+		}
+	}
+}

--- a/source/Common/packages.config
+++ b/source/Common/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="NLog" version="5.0.5" targetFramework="net472" />
   <package id="protobuf-net" version="3.1.22" targetFramework="net472" />
   <package id="protobuf-net.Core" version="3.1.22" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />

--- a/source/GameInterface.Tests/GameInterface.Tests.csproj
+++ b/source/GameInterface.Tests/GameInterface.Tests.csproj
@@ -64,10 +64,10 @@
       <HintPath>..\packages\Moq.4.18.2\lib\net462\Moq.dll</HintPath>
     </Reference>
     <Reference Include="protobuf-net, Version=3.0.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
-      <HintPath>..\packages\protobuf-net.3.1.17\lib\net461\protobuf-net.dll</HintPath>
+      <HintPath>..\packages\protobuf-net.3.1.22\lib\net462\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="protobuf-net.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
-      <HintPath>..\packages\protobuf-net.Core.3.1.17\lib\net461\protobuf-net.Core.dll</HintPath>
+      <HintPath>..\packages\protobuf-net.Core.3.1.22\lib\net462\protobuf-net.Core.dll</HintPath>
     </Reference>
     <Reference Include="SandBox, Version=1.0.0.0, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>

--- a/source/GameInterface.Tests/packages.config
+++ b/source/GameInterface.Tests/packages.config
@@ -7,8 +7,8 @@
   <package id="Moq" version="4.18.2" targetFramework="net472" />
   <package id="MSTest.TestAdapter" version="2.2.7" targetFramework="net472" />
   <package id="MSTest.TestFramework" version="2.2.7" targetFramework="net472" />
-  <package id="protobuf-net" version="3.1.17" targetFramework="net472" />
-  <package id="protobuf-net.Core" version="3.1.17" targetFramework="net472" />
+  <package id="protobuf-net" version="3.1.22" targetFramework="net472" />
+  <package id="protobuf-net.Core" version="3.1.22" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
   <package id="System.Collections.Immutable" version="1.7.1" targetFramework="net472" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.7.1" targetFramework="net472" />

--- a/source/GameInterface/GameInterface.csproj
+++ b/source/GameInterface/GameInterface.csproj
@@ -43,13 +43,13 @@
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=5.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.5.0.1\lib\net46\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.5.0.5\lib\net46\NLog.dll</HintPath>
     </Reference>
     <Reference Include="protobuf-net, Version=3.0.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
-      <HintPath>..\packages\protobuf-net.3.1.17\lib\net461\protobuf-net.dll</HintPath>
+      <HintPath>..\packages\protobuf-net.3.1.22\lib\net462\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="protobuf-net.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
-      <HintPath>..\packages\protobuf-net.Core.3.1.17\lib\net461\protobuf-net.Core.dll</HintPath>
+      <HintPath>..\packages\protobuf-net.Core.3.1.22\lib\net462\protobuf-net.Core.dll</HintPath>
     </Reference>
     <Reference Include="SandBox">
       <HintPath>..\..\mb2\Modules\SandBox\bin\Win64_Shipping_Client\SandBox.dll</HintPath>
@@ -92,8 +92,8 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.2\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/source/GameInterface/app.config
+++ b/source/GameInterface/app.config
@@ -10,6 +10,10 @@
         <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/source/GameInterface/packages.config
+++ b/source/GameInterface/packages.config
@@ -3,9 +3,9 @@
   <package id="Autofac" version="6.4.0" targetFramework="net472" />
   <package id="Lib.Harmony" version="2.2.2" targetFramework="net472" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net472" />
-  <package id="NLog" version="5.0.1" targetFramework="net472" />
-  <package id="protobuf-net" version="3.1.17" targetFramework="net472" />
-  <package id="protobuf-net.Core" version="3.1.17" targetFramework="net472" />
+  <package id="NLog" version="5.0.5" targetFramework="net472" />
+  <package id="protobuf-net" version="3.1.22" targetFramework="net472" />
+  <package id="protobuf-net.Core" version="3.1.22" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
   <package id="System.Collections.Immutable" version="1.7.1" targetFramework="net472" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.7.1" targetFramework="net472" />
@@ -13,5 +13,5 @@
   <package id="System.Memory" version="4.5.4" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net472" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.2" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
 </packages>

--- a/source/IntroServer/Config/NetworkConfiguration.cs
+++ b/source/IntroServer/Config/NetworkConfiguration.cs
@@ -22,10 +22,12 @@ namespace IntroServer.Config
         ///     port of the server in LAN.
         /// </summary>
         public int LanPort { get; } = 4201;
+
+        private string WanAddressText { get; set; }
         /// <summary>
         ///     ip address of the server in WAN.
         /// </summary>
-        public IPAddress WanAddress { get; } = IPAddress.Parse("144.202.53.18");
+        public IPAddress WanAddress => IPAddress.Parse(WanAddressText);
         /// <summary>
         ///     port of the server in WAN.
         /// </summary>

--- a/source/MissionTestMod/MissionTestMod.csproj
+++ b/source/MissionTestMod/MissionTestMod.csproj
@@ -42,6 +42,9 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="NLog, Version=5.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.5.0.5\lib\net46\NLog.dll</HintPath>
+    </Reference>
     <Reference Include="protobuf-net, Version=3.0.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
       <HintPath>..\packages\protobuf-net.3.1.22\lib\net462\protobuf-net.dll</HintPath>
     </Reference>

--- a/source/MissionTestMod/app.config
+++ b/source/MissionTestMod/app.config
@@ -10,6 +10,10 @@
         <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/source/MissionTestMod/packages.config
+++ b/source/MissionTestMod/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="NLog" version="5.0.5" targetFramework="net472" />
   <package id="protobuf-net" version="3.1.22" targetFramework="net472" />
   <package id="protobuf-net.Core" version="3.1.22" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />

--- a/source/MissionTests/app.config
+++ b/source/MissionTests/app.config
@@ -10,6 +10,10 @@
         <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/source/Missions/Missions.csproj
+++ b/source/Missions/Missions.csproj
@@ -46,7 +46,7 @@
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=5.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.5.0.2\lib\net46\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.5.0.5\lib\net46\NLog.dll</HintPath>
     </Reference>
     <Reference Include="protobuf-net, Version=3.0.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
       <HintPath>..\packages\protobuf-net.3.1.22\lib\net462\protobuf-net.dll</HintPath>
@@ -92,8 +92,8 @@
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
-    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.2\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/source/Missions/app.config
+++ b/source/Missions/app.config
@@ -10,6 +10,10 @@
         <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/source/Missions/packages.config
+++ b/source/Missions/packages.config
@@ -4,7 +4,7 @@
   <package id="Lib.Harmony" version="2.2.2" targetFramework="net472" />
   <package id="LiteNetLib" version="0.9.5.2" targetFramework="net472" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net472" />
-  <package id="NLog" version="5.0.2" targetFramework="net472" />
+  <package id="NLog" version="5.0.5" targetFramework="net472" />
   <package id="protobuf-net" version="3.1.22" targetFramework="net472" />
   <package id="protobuf-net.Core" version="3.1.22" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
@@ -13,5 +13,5 @@
   <package id="System.Memory" version="4.5.4" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net472" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.2" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
 </packages>

--- a/source/ServerConsole/Program.cs
+++ b/source/ServerConsole/Program.cs
@@ -1,40 +1,97 @@
-﻿using IntroServer.Config;
+﻿using System.Net;
+using System.Reflection;
+using IntroServer.Config;
 using IntroServer.Server;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NLog;
+using NLog.Extensions.Logging;
+using NLog.Targets;
+using LogLevel = NLog.LogLevel;
 
-namespace IntroducationServer
+namespace ServerConsole
 {
     internal class Program
     {
-        static int TicksPerSecond = 120;
-        static MissionTestServer? testServer;
-        static Task? pollTask;
+        private const int TicksPerSecond = 120;
+        private static readonly CancellationTokenSource ServerCancellation = new();
+        private static MissionTestServer? TestServer;
+        private static Task? PollTask;
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        private static void Main(string[] args)
+        private static async Task Main()
         {
-            var config = new NetworkConfiguration();
-            testServer = new MissionTestServer(config);
-
-            if (config.NATType == NATType.Internal)
+            try
             {
-                Console.WriteLine($"Server started on port: {config.LanPort}");
+                var logTarget = new ColoredConsoleTarget
+                {
+	                Layout = "${date:format=HH\\:MM\\:ss} [${logger}] : ${message} ${exception}",
+                };
+                NLog.Config.SimpleConfigurator.ConfigureForTargetLogging(logTarget, LogLevel.Trace);
+                Logger.Trace("Building Network Configuration");
+                var configurationBuilder = new ConfigurationBuilder()
+                    .SetBasePath(Directory.GetCurrentDirectory())
+                    .AddJsonFile("appsettings.json", optional: true)
+                    .AddUserSecrets<Program>();
+    
+                var config = configurationBuilder
+                    .Build()
+                    .Get<NetworkConfiguration>(options => 
+                        options.BindNonPublicProperties = true)!;
+
+                await using var provider = new ServiceCollection()
+                    .AddTransient<MissionTestServer>()
+                    .AddLogging(builder =>
+                    {
+                        builder.ClearProviders();
+                        builder.AddNLog();
+                    })
+                    .AddSingleton(config)
+                    .BuildServiceProvider();
+                
+                TestServer = provider.GetRequiredService<MissionTestServer>();
+
+                Logger.Info(config.NATType == NATType.Internal
+                    ? $"Server started on port: {config.LanPort}"
+                    : $"Server started on port: {config.WanPort}");
+
+                Logger.Warn($"Type STOP to stop the server.");
+                PollTask = Task.Factory
+                    .StartNew(PollServer, ServerCancellation.Token);
+
+                while (Console.ReadLine() != "STOP")
+                {
+                }
+
+                ServerCancellation.Cancel();
             }
-            else
+            catch (Exception ex)
             {
-                Console.WriteLine($"Server started on port: {config.WanPort}");
+                Logger.Fatal(ex, "Error occurred while trying to run server");
+                return;
             }
 
-            Console.WriteLine($"Type STOP to stop the server.");
-
-            pollTask = Task.Factory.StartNew(PollServer);
-
-            while (true) { Thread.Sleep(1000); };
+            try
+            {
+                await PollTask;
+            }
+            catch (TaskCanceledException)
+            {
+                // expected
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Failed to gracefully stop server");
+            }
         }
 
-        static async void PollServer()
+        private static async void PollServer()
         {
-            while (true)
+            Logger.Trace("Started Update Polling Loop");
+            while (!ServerCancellation.IsCancellationRequested)
             {
-                testServer?.Update();
+                TestServer?.Update();
                 await Task.Delay(1000 / TicksPerSecond);
             }
         }

--- a/source/ServerConsole/ServerConsole.csproj
+++ b/source/ServerConsole/ServerConsole.csproj
@@ -5,10 +5,25 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <UserSecretsId>0eb23bf1-4971-419c-9fc0-dce446b4b2f2</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\IntroServer\IntroServer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="5.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/source/ServerConsole/appsettings.json
+++ b/source/ServerConsole/appsettings.json
@@ -1,0 +1,10 @@
+﻿{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Debug",
+            "System": "Information",
+            "Microsoft": "Information"
+        }
+    },
+    "WanAddressText": "144.202.53.18"
+}


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [X] All new classes have class-level documentation comments, if there are any at all
- [X] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue. -->
Log output is hidden or tucked away in files.

## What is the new behaviour?
<!-- Insert issue id after hashtag. -->
Adds coloured console log output to the server application, and outputs client logging to the debug console in Visual Studio (behind `#if DEBUG`).

Resolves #440
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Other information
Also consolidates nuget packages, fixes the "type 'STOP'" on server, and allows [user-secrets](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-7.0&tabs=windows#secret-manager) to be used for the WanIpAddress

Log output for server looks like thus:
![image](https://user-images.githubusercontent.com/2247869/210121933-019e79b7-b2ee-4881-b5fd-dac2385d62f9.png)

Log output for client looks like thus:
![image](https://user-images.githubusercontent.com/2247869/210121937-81cfa9ee-dc96-4a11-b641-89a7ffa45f11.png)
