### PR TITLE
Refactor NetworkAgentRegistry

### DIFF
--- a/source/MissionTests/MissionTests.csproj
+++ b/source/MissionTests/MissionTests.csproj
@@ -42,11 +42,18 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.5.1.0\lib\net462\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="LiteNetLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" />
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.2.2.7\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.2.2.7\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Moq, Version=4.18.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.18.2\lib\net462\Moq.dll</HintPath>
     </Reference>
     <Reference Include="protobuf-net, Version=3.0.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
       <HintPath>..\packages\protobuf-net.3.1.22\lib\net462\protobuf-net.dll</HintPath>
@@ -61,6 +68,7 @@
     <Reference Include="System.Collections.Immutable, Version=1.2.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Collections.Immutable.1.7.1\lib\net461\System.Collections.Immutable.dll</HintPath>
     </Reference>
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
@@ -72,6 +80,9 @@
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="TaleWorlds.CampaignSystem, Version=1.0.0.0, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
@@ -81,6 +92,10 @@
     <Reference Include="TaleWorlds.Library, Version=1.0.0.0, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\mb2\bin\Win64_Shipping_Client\TaleWorlds.Library.dll</HintPath>
+    </Reference>
+    <Reference Include="TaleWorlds.MountAndBlade, Version=1.0.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\GameInterface.Tests\bin\Debug\TaleWorlds.MountAndBlade.dll</HintPath>
     </Reference>
     <Reference Include="TaleWorlds.ObjectSystem, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
@@ -99,6 +114,7 @@
   <ItemGroup>
     <Compile Include="ClientInfoTests.cs" />
     <Compile Include="NetworkMessageSerializationTest.cs" />
+    <Compile Include="Network\NetworkAgentRegistryTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/source/MissionTests/Network/NetworkAgentRegistryTests.cs
+++ b/source/MissionTests/Network/NetworkAgentRegistryTests.cs
@@ -1,0 +1,337 @@
+﻿using Common.Messaging;
+using LiteNetLib;
+using Missions.Services.Network;
+using Moq;
+using System;
+using System.Runtime.Serialization;
+using TaleWorlds.MountAndBlade;
+using Xunit;
+
+namespace IntroductionServerTests.Network
+{
+    /// <summary>
+    /// Test class for <see cref="INetworkAgentRegistry"/>.
+    /// </summary>
+    public class NetworkAgentRegistryTests
+    {
+        INetworkAgentRegistry _agentRegistry;
+
+        public NetworkAgentRegistryTests()
+        {
+            var messageBroker = new Mock<IMessageBroker>();
+
+            _agentRegistry = new NetworkAgentRegistry(messageBroker.Object);
+        }
+
+        [Fact]
+        public void RegisterControlledAgent_AddToEmptyDictionary()
+        {
+            // Arrange
+            var guid = Guid.NewGuid();
+            var agent = CreateAgent();
+
+            // Act
+            var result = _agentRegistry.RegisterControlledAgent(guid, agent);
+
+            // Assert
+            Assert.True(result);
+            Assert.NotEmpty(_agentRegistry.AgentToId);
+            Assert.NotEmpty(_agentRegistry.ControlledAgents);
+            Assert.Empty(_agentRegistry.PlayerAgents);
+            Assert.True(_agentRegistry.AgentToId.ContainsKey(agent));
+            Assert.True(_agentRegistry.ControlledAgents.ContainsKey(guid));
+        }
+
+        [Fact]
+        public void RegisterControlledAgent_TryAddAlreadyExistingAgent()
+        {
+            // Arrange
+            var guid = Guid.NewGuid();
+            var agent = CreateAgent();
+
+            // Act
+            _agentRegistry.RegisterControlledAgent(guid, agent);
+
+            Assert.NotEmpty(_agentRegistry.AgentToId);
+            Assert.NotEmpty(_agentRegistry.ControlledAgents);
+            Assert.Empty(_agentRegistry.PlayerAgents);
+
+            var result = _agentRegistry.RegisterControlledAgent(guid, agent);
+
+            // Assert
+            Assert.False(result);
+            Assert.True(_agentRegistry.AgentToId.ContainsKey(agent));
+            Assert.True(_agentRegistry.ControlledAgents.ContainsKey(guid));
+            Assert.NotEmpty(_agentRegistry.AgentToId);
+            Assert.NotEmpty(_agentRegistry.ControlledAgents);
+            Assert.Empty(_agentRegistry.PlayerAgents);
+        }
+
+        [Fact]
+        public void RegisterNetworkControlledAgent_AddToEmptyDictionary()
+        {
+            // Arrange
+            var guid = Guid.NewGuid();
+            var agent = CreateAgent();
+            var peer = CreateNetPeer();
+
+            // Act
+            var result = _agentRegistry.RegisterNetworkControlledAgent(peer, guid, agent);
+
+            // Assert
+            Assert.True(result);
+            Assert.NotEmpty(_agentRegistry.OtherAgents);
+            Assert.NotEmpty(_agentRegistry.AgentToId);
+            Assert.Empty(_agentRegistry.PlayerAgents);
+            Assert.True(_agentRegistry.AgentToId.ContainsKey(agent));
+        }
+
+        [Fact]
+        public void RegisterNetworkControlledAgent_AddAgentToAlreadyExistingPeer()
+        {
+            // Arrange
+            var guid = Guid.NewGuid();
+            var agent = CreateAgent();
+            var peer = CreateNetPeer();
+
+            var otherGuid = Guid.NewGuid();
+            var otherAgent = CreateAgent();
+
+            // Act
+            _agentRegistry.RegisterNetworkControlledAgent(peer, guid, agent);
+            var result = _agentRegistry.RegisterNetworkControlledAgent(peer, otherGuid, otherAgent);
+
+            // Assert
+            Assert.True(result);
+            Assert.NotEmpty(_agentRegistry.OtherAgents);
+            Assert.NotEmpty(_agentRegistry.AgentToId);
+            Assert.Empty(_agentRegistry.PlayerAgents);
+            Assert.True(_agentRegistry.AgentToId.ContainsKey(agent));
+            Assert.True(_agentRegistry.AgentToId.ContainsKey(otherAgent));
+        }
+
+        [Fact]
+        public void RegisterNetworkControlledAgent_TryAddAlreadyExistingAgent()
+        {
+            // Arrange
+            var guid = Guid.NewGuid();
+            var agent = CreateAgent();
+            var peer = CreateNetPeer();
+
+            // Act
+            _agentRegistry.RegisterNetworkControlledAgent(peer, guid, agent);
+            var result = _agentRegistry.RegisterNetworkControlledAgent(peer, guid, agent);
+
+            // Assert
+            Assert.False(result);
+            Assert.NotEmpty(_agentRegistry.OtherAgents);
+            Assert.NotEmpty(_agentRegistry.AgentToId);
+            Assert.Empty(_agentRegistry.PlayerAgents);
+            Assert.True(_agentRegistry.AgentToId.ContainsKey(agent));
+        }
+
+        [Fact]
+        public void RegisterPlayerAgent_AddToEmptyDictionary()
+        {
+            // Arrange
+            var guid = Guid.NewGuid();
+            var agent = CreateAgent();
+
+            // Act
+            var result = _agentRegistry.RegisterPlayerAgent(guid, agent);
+
+            // Assert
+            Assert.True(result);
+            Assert.NotEmpty(_agentRegistry.AgentToId);
+            Assert.NotEmpty(_agentRegistry.ControlledAgents);
+            Assert.NotEmpty(_agentRegistry.PlayerAgents);
+            Assert.True(_agentRegistry.AgentToId.ContainsKey(agent));
+            Assert.True(_agentRegistry.ControlledAgents.ContainsKey(guid));
+            Assert.True(_agentRegistry.PlayerAgents.ContainsKey(guid));
+        }
+
+        [Fact]
+        public void RegisterPlayerAgent_TryAddAlreadyExistingAgent()
+        {
+            // Arrange
+            var guid = Guid.NewGuid();
+            var agent = CreateAgent();
+
+            // Act
+            _agentRegistry.RegisterPlayerAgent(guid, agent);
+
+            Assert.NotEmpty(_agentRegistry.AgentToId);
+            Assert.NotEmpty(_agentRegistry.ControlledAgents);
+            Assert.NotEmpty(_agentRegistry.PlayerAgents);
+            Assert.True(_agentRegistry.AgentToId.ContainsKey(agent));
+            Assert.True(_agentRegistry.ControlledAgents.ContainsKey(guid));
+            Assert.True(_agentRegistry.PlayerAgents.ContainsKey(guid));
+
+            var result = _agentRegistry.RegisterPlayerAgent(guid, agent);
+
+            // Assert
+            Assert.False(result);
+
+            Assert.NotEmpty(_agentRegistry.AgentToId);
+            Assert.NotEmpty(_agentRegistry.ControlledAgents);
+            Assert.NotEmpty(_agentRegistry.PlayerAgents);
+            Assert.True(_agentRegistry.AgentToId.ContainsKey(agent));
+            Assert.True(_agentRegistry.ControlledAgents.ContainsKey(guid));
+            Assert.True(_agentRegistry.PlayerAgents.ContainsKey(guid));
+        }
+
+        [Fact]
+        public void RegisterNetworkPlayerAgent_AddToEmptyDictionary()
+        {
+            // Arrange
+            var guid = Guid.NewGuid();
+            var agent = CreateAgent();
+            var peer = CreateNetPeer();
+
+            // Act
+            var result = _agentRegistry.RegisterNetworkPlayerAgent(peer, guid, agent);
+
+            // Assert
+            Assert.True(result);
+            Assert.NotEmpty(_agentRegistry.OtherAgents);
+            Assert.NotEmpty(_agentRegistry.AgentToId);
+            Assert.NotEmpty(_agentRegistry.PlayerAgents);
+            Assert.True(_agentRegistry.AgentToId.ContainsKey(agent));
+            Assert.True(_agentRegistry.PlayerAgents.ContainsKey(guid));
+        }
+
+        [Fact]
+        public void RegisterNetworkPlayerAgent_AddAgentToAlreadyExistingPeer()
+        {
+            // Arrange
+            var guid = Guid.NewGuid();
+            var agent = CreateAgent();
+            var peer = CreateNetPeer();
+
+            var otherGuid = Guid.NewGuid();
+            var otherAgent = CreateAgent();
+
+            // Act
+            _agentRegistry.RegisterNetworkPlayerAgent(peer, guid, agent);
+            var result = _agentRegistry.RegisterNetworkPlayerAgent(peer, otherGuid, otherAgent);
+
+            // Assert
+            Assert.True(result);
+            Assert.NotEmpty(_agentRegistry.OtherAgents);
+            Assert.NotEmpty(_agentRegistry.AgentToId);
+            Assert.NotEmpty(_agentRegistry.PlayerAgents);
+            Assert.True(_agentRegistry.AgentToId.ContainsKey(agent));
+            Assert.True(_agentRegistry.AgentToId.ContainsKey(otherAgent));
+            Assert.True(_agentRegistry.PlayerAgents.ContainsKey(guid));
+            Assert.True(_agentRegistry.PlayerAgents.ContainsKey(otherGuid));
+        }
+
+        [Fact]
+        public void RegisterNetworkPlayerAgent_TryAddAlreadyExistingAgent()
+        {
+            // Arrange
+            var guid = Guid.NewGuid();
+            var agent = CreateAgent();
+            var peer = CreateNetPeer();
+
+            // Act
+            _agentRegistry.RegisterNetworkPlayerAgent(peer, guid, agent);
+            var result = _agentRegistry.RegisterNetworkPlayerAgent(peer, guid, agent);
+
+            // Assert
+            Assert.False(result);
+            Assert.NotEmpty(_agentRegistry.OtherAgents);
+            Assert.NotEmpty(_agentRegistry.AgentToId);
+            Assert.NotEmpty(_agentRegistry.PlayerAgents);
+            Assert.True(_agentRegistry.AgentToId.ContainsKey(agent));
+            Assert.True(_agentRegistry.PlayerAgents.ContainsKey(guid));
+        }
+
+        [Fact]
+        public void RemoveControlledAgent_NoneExists()
+        {
+            // Arrange
+            var guid = Guid.NewGuid();
+
+            // Act
+            var result = _agentRegistry.RemoveControlledAgent(guid);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void RemoveControlledAgent_OneExists()
+        {
+            // Arrange
+            var guid = Guid.NewGuid();
+            var agent = CreateAgent();
+
+            _agentRegistry.RegisterControlledAgent(guid, agent);
+
+            // Act
+            var result = _agentRegistry.RemoveControlledAgent(guid);
+
+            // Assert
+            Assert.True(result);
+            Assert.Empty(_agentRegistry.AgentToId);
+            Assert.NotEmpty(_agentRegistry.ControlledAgents);
+        }
+
+        [Fact]
+        public void RemovePeer_NoneExists()
+        {
+            // Arrange
+            var peer = CreateNetPeer();
+
+            // Act
+            var result = _agentRegistry.RemovePeer(peer);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void RemovePeer_ControlledAgentExists()
+        {
+            // Arrange
+            var guid = Guid.NewGuid();
+            var agent = CreateAgent();
+            var peer = CreateNetPeer();
+
+            _agentRegistry.RegisterNetworkControlledAgent(peer, guid, agent);
+
+            // Act
+            var result = _agentRegistry.RemovePeer(peer);
+
+            // Assert
+            Assert.True(result);
+            Assert.Empty(_agentRegistry.AgentToId);
+            Assert.Empty(_agentRegistry.OtherAgents);
+            Assert.Empty(_agentRegistry.PlayerAgents);
+        }
+
+        [Fact]
+        public void RemovePeer_PlayerAgentExists()
+        {
+            // Arrange
+            var guid = Guid.NewGuid();
+            var agent = CreateAgent();
+            var peer = CreateNetPeer();
+
+            _agentRegistry.RegisterNetworkPlayerAgent(peer, guid, agent);
+
+            // Act
+            var result = _agentRegistry.RemovePeer(peer);
+
+            // Assert
+            Assert.True(result);
+            Assert.Empty(_agentRegistry.AgentToId);
+            Assert.Empty(_agentRegistry.OtherAgents);
+            Assert.Empty(_agentRegistry.PlayerAgents);
+        }
+
+        private Agent CreateAgent() => FormatterServices.GetSafeUninitializedObject(typeof(Agent)) as Agent;
+        private NetPeer CreateNetPeer() => FormatterServices.GetSafeUninitializedObject(typeof(NetPeer)) as NetPeer;
+    }
+}

--- a/source/MissionTests/packages.config
+++ b/source/MissionTests/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Castle.Core" version="5.1.0" targetFramework="net472" />
+  <package id="Moq" version="4.18.2" targetFramework="net472" />
   <package id="MSTest.TestAdapter" version="2.2.7" targetFramework="net472" />
   <package id="MSTest.TestFramework" version="2.2.7" targetFramework="net472" />
   <package id="protobuf-net" version="3.1.22" targetFramework="net472" />
@@ -9,6 +11,7 @@
   <package id="System.Memory" version="4.5.4" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
   <package id="xunit" version="2.4.2" targetFramework="net472" />
   <package id="xunit.abstractions" version="2.0.3" targetFramework="net472" />
   <package id="xunit.analyzers" version="1.0.0" targetFramework="net472" />

--- a/source/Missions/Services/Agents/Extensions/AgentExtensions.cs
+++ b/source/Missions/Services/Agents/Extensions/AgentExtensions.cs
@@ -1,6 +1,6 @@
-﻿using TaleWorlds.MountAndBlade;
-using Missions.Services.Network;
-using System.Linq;
+﻿using Missions.Services.Network;
+using System;
+using TaleWorlds.MountAndBlade;
 
 namespace Missions.Services.Agents.Extensions
 {
@@ -13,7 +13,12 @@ namespace Missions.Services.Agents.Extensions
 
         public static bool IsPlayerAgent(this Agent agent)
         {
-            return NetworkAgentRegistry.Instance.PlayerAgents.Any(kvp => kvp.Value == agent);
+            if (NetworkAgentRegistry.Instance.AgentToId.TryGetValue(agent, out Guid id))
+            {
+                return NetworkAgentRegistry.Instance.PlayerAgents.ContainsKey(id);
+            }
+
+            return false;
         }
     }
 }

--- a/source/Missions/Services/Agents/Extensions/AgentExtensions.cs
+++ b/source/Missions/Services/Agents/Extensions/AgentExtensions.cs
@@ -1,13 +1,19 @@
 ﻿using TaleWorlds.MountAndBlade;
 using Missions.Services.Network;
+using System.Linq;
 
 namespace Missions.Services.Agents.Extensions
 {
     public static class AgentExtensions
     {
-        public static bool IsNetworkAgent(this Agent agent)
+        public static bool IsNetworkAgent(this Agent agent) 
         {
             return NetworkAgentRegistry.Instance.AgentToId.ContainsKey(agent);
+        }
+
+        public static bool IsPlayerAgent(this Agent agent)
+        {
+            return NetworkAgentRegistry.Instance.PlayerAgents.Any(kvp => kvp.Value == agent);
         }
     }
 }

--- a/source/Missions/Services/Agents/Patches/AgentInteractionPatches.cs
+++ b/source/Missions/Services/Agents/Patches/AgentInteractionPatches.cs
@@ -17,7 +17,7 @@ namespace Missions.Services.Agents.Patches
     {
         public static bool Prefix(ref Agent userAgent, ref Agent agent)
         {
-            if (!agent.IsNetworkAgent())
+            if (!agent.IsPlayerAgent())
             {
                 ProcessSentencePatch.SetInteractedAgents(null, null);
                 return true;

--- a/source/Missions/Services/Network/MissionClient.cs
+++ b/source/Missions/Services/Network/MissionClient.cs
@@ -71,7 +71,7 @@ namespace Missions.Services.Network
         private void SendJoinInfo(NetPeer peer)
         {
             Logger.Debug("Sending join request");
-            _agentRegistry.RegisterControlledAgent(_playerId, Agent.Main);
+            _agentRegistry.RegisterPlayerAgent(_playerId, Agent.Main);
 
             CharacterObject characterObject = CharacterObject.PlayerCharacter;
             MissionJoinInfo request = new MissionJoinInfo(characterObject, _playerId, Agent.Main.Position);
@@ -96,7 +96,7 @@ namespace Missions.Services.Network
                 joinInfo.CharacterObject.Name, newAgentId, netPeer.EndPoint);
             // TODO remove test code
             Agent newAgent = MissionTestGameManager.SpawnAgent(startingPos, joinInfo.CharacterObject);
-            _agentRegistry.RegisterNetworkControlledAgent(netPeer, newAgentId, newAgent);
+            _agentRegistry.RegisterNetworkPlayerAgent(netPeer, newAgentId, newAgent);
         }
     }
 }

--- a/source/Missions/Services/Network/NetworkAgentRegistry.cs
+++ b/source/Missions/Services/Network/NetworkAgentRegistry.cs
@@ -79,11 +79,7 @@ namespace Missions.Services.Network
                 if (agent != null)
                 {
                     var result = m_AgentToId.Remove(agent);
-
-                    if (m_PlayerAgents.ContainsKey(agentId))
-                    {
-                        result &= m_PlayerAgents.Remove(agentId);
-                    }
+                    RemovePlayerAgent(agentId);
 
                     return result;
                 }
@@ -96,8 +92,8 @@ namespace Missions.Services.Network
 
         public bool RegisterControlledAgent(Guid agentId, Agent agent)
         {
-            if (m_AgentToId.ContainsKey(agent) ||
-                m_ControlledAgents.ContainsKey(agentId)) return false;
+            if (m_AgentToId.ContainsKey(agent)) return false;
+            if (m_ControlledAgents.ContainsKey(agentId)) return false;
 
             m_ControlledAgents.Add(agentId, agent);
             m_AgentToId.Add(agent, agentId);
@@ -109,7 +105,8 @@ namespace Missions.Services.Network
         {
             if (m_OtherAgents.TryGetValue(peer, out AgentGroupController controller))
             {
-                if (controller.Contains(agent) || controller.Contains(agentId)) return false;
+                if (controller.Contains(agent)) return false;
+                if (controller.Contains(agentId)) return false;
 
                 controller.AddAgent(agentId, agent);
                 m_AgentToId.Add(agent, agentId);
@@ -127,11 +124,11 @@ namespace Missions.Services.Network
 
         public bool RegisterPlayerAgent(Guid agentId, Agent agent)
         {
-            if (m_AgentToId.ContainsKey(agent) ||
-                m_PlayerAgents.ContainsKey(agentId)) return false;
+            if (m_AgentToId.ContainsKey(agent)) return false;
+            if (m_PlayerAgents.ContainsKey(agentId)) return false;
 
             m_PlayerAgents.Add(agentId, agent);
-            m_AgentToId.Add(agent, agentId);
+            RegisterControlledAgent(agentId, agent);
 
             return true;
         }
@@ -140,7 +137,8 @@ namespace Missions.Services.Network
         {
             if (m_OtherAgents.TryGetValue(peer, out AgentGroupController controller))
             {
-                if (controller.Contains(agent) || controller.Contains(agentId)) return false;
+                if (controller.Contains(agent)) return false;
+                if (controller.Contains(agentId)) return false;
 
                 controller.AddAgent(agentId, agent);
                 m_AgentToId.Add(agent, agentId);
@@ -169,12 +167,7 @@ namespace Missions.Services.Network
 
         public bool RemovePlayerAgent(Guid agentId)
         {
-            if (m_PlayerAgents.TryGetValue(agentId, out Agent agent))
-            {
-                return m_AgentToId.Remove(agent);
-            }
-
-            return false;
+            return m_PlayerAgents.Remove(agentId);
         }
 
         public bool RemovePeer(NetPeer peer)
@@ -186,10 +179,7 @@ namespace Missions.Services.Network
                 {
                     var innerResult = m_AgentToId.Remove(kvp.Value);
 
-                    if (kvp.Value.IsPlayerAgent())
-                    {
-                        innerResult &= m_PlayerAgents.Remove(kvp.Key);
-                    }
+                    RemovePlayerAgent(kvp.Key);
 
                     return innerResult;
                 });

--- a/source/Missions/Services/Network/NetworkAgentRegistry.cs
+++ b/source/Missions/Services/Network/NetworkAgentRegistry.cs
@@ -124,34 +124,20 @@ namespace Missions.Services.Network
 
         public bool RegisterPlayerAgent(Guid agentId, Agent agent)
         {
-            if (m_AgentToId.ContainsKey(agent)) return false;
+            if (RegisterControlledAgent(agentId, agent) == false) return false;
             if (m_PlayerAgents.ContainsKey(agentId)) return false;
 
             m_PlayerAgents.Add(agentId, agent);
-            RegisterControlledAgent(agentId, agent);
 
             return true;
         }
 
         public bool RegisterNetworkPlayerAgent(NetPeer peer, Guid agentId, Agent agent)
         {
-            if (m_OtherAgents.TryGetValue(peer, out AgentGroupController controller))
-            {
-                if (controller.Contains(agent)) return false;
-                if (controller.Contains(agentId)) return false;
-
-                controller.AddAgent(agentId, agent);
-                m_AgentToId.Add(agent, agentId);
-                m_PlayerAgents.Add(agentId, agent);
-            }
-            else
-            {
-                AgentGroupController newGroupController = new AgentGroupController();
-                newGroupController.AddAgent(agentId, agent);
-                m_AgentToId.Add(agent, agentId);
-                m_OtherAgents.Add(peer, newGroupController);
-                m_PlayerAgents.Add(agentId, agent);
-            }
+            if (RegisterNetworkControlledAgent(peer, agentId, agent) == false) return false;
+            if (m_PlayerAgents.ContainsKey(agentId)) return false;
+            
+            m_PlayerAgents.Add(agentId, agent);
 
             return true;
         }


### PR DESCRIPTION
- Added IsPlayerAgent extension-method using this dictionary
- Added methods to register PlayerAgents and NetworkPlayerAgents
- Adjusted AgentInteractionPatches to use IsPlayerAgent instead of IsNetworkAgent

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behaviour?
Currently only all controlled agents of players are stored.

## What is the new behaviour?
Resolves #432
- Added new Dictionary and methods to store PlayerAgents.
- Added new extension method `IsPlayerAgent`
- Adjusted AgentInteractionPatches to use `IsPlayerAgent` instead of `IsNetworkAgent`
- 
PlayerAgents can be registered in the NetworkAgentRegistry both locally and remotely.
`IsPlayerAgent` can be used to check whether an agent is directly controlled by a player.
Behaviour of `IsNetworkAgent` remains unchanged.

Resolves: #485 
- Replaced Dictionary with ConcurrentDictionary
- Added tests to cover functionality

## Other information
Used VS feature to detect and automatically remove unused using directives.