### PR TITLE
Fix crashes on client connection

### DIFF
--- a/source/Common/Common.csproj
+++ b/source/Common/Common.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="LiteNetLib" Version="1.0.1.1" />
-    <PackageReference Include="protobuf-net" Version="3.1.33" />
+    <PackageReference Include="protobuf-net" Version="3.2.26" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="System.Text.Json" Version="7.0.2" />
   </ItemGroup>

--- a/source/Coop.Core/Client/CoopClient.cs
+++ b/source/Coop.Core/Client/CoopClient.cs
@@ -66,7 +66,7 @@ namespace Coop.Core.Client
 
         public void OnNetworkReceive(NetPeer peer, NetPacketReader reader, byte channelNumber, DeliveryMethod deliveryMethod)
         {
-            IPacket packet = (IPacket)ProtoBufSerializer.Deserialize(reader.GetBytesWithLength());
+            IPacket packet = (IPacket)ProtoBufSerializer.Deserialize(reader.GetRemainingBytes());
             packetManager.HandleRecieve(peer, packet);
         }
 

--- a/source/Coop.Core/Client/States/ValidateModuleState.cs
+++ b/source/Coop.Core/Client/States/ValidateModuleState.cs
@@ -65,7 +65,7 @@ public class ValidateModuleState : ClientStateBase
     public override void LoadSavedData()
     {
 #if DEBUG
-        Logic.NetworkMessageBroker.Publish(this, new LoadDebugGame());
+        Logic.MessageBroker.Publish(this, new LoadDebugGame());
         Logic.State = new LoadingState(Logic);
 #else
         Logic.State = new ReceivingSavedDataState(Logic);

--- a/source/Coop.Core/Common/Network/CoopNetworkBase.cs
+++ b/source/Coop.Core/Common/Network/CoopNetworkBase.cs
@@ -38,14 +38,11 @@ namespace Coop.Core.Common.Network
 
         public virtual void Send(NetPeer netPeer, IPacket packet)
         {
-            NetDataWriter writer = new NetDataWriter();
-
-            // Serialize and put data in writer (with length is important on receive end)
+            // Serialize data
             byte[] data = ProtoBufSerializer.Serialize(packet);
-            writer.PutBytesWithLength(data);
 
             // Send data
-            netPeer.Send(writer.Data, packet.DeliveryMethod);
+            netPeer.Send(data, packet.DeliveryMethod);
         }
 
         public void Send(NetPeer netPeer, IMessage message)

--- a/source/Coop.Core/Server/Connections/Messages/NetworkClientValidation.cs
+++ b/source/Coop.Core/Server/Connections/Messages/NetworkClientValidation.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace Coop.Core.Server.Connections.Messages
 {
-    [ProtoContract]
+    [ProtoContract(SkipConstructor = true)]
     public record NetworkClientValidate : ICommand
     {
         [ProtoMember(1)]
@@ -16,7 +16,7 @@ namespace Coop.Core.Server.Connections.Messages
         }
     }
 
-    [ProtoContract]
+    [ProtoContract(SkipConstructor = true)]
     public record NetworkClientValidated : IResponse
     {
         [ProtoMember(1)]

--- a/source/Coop.Core/Server/CoopServer.cs
+++ b/source/Coop.Core/Server/CoopServer.cs
@@ -90,7 +90,7 @@ namespace Coop.Core.Server
 
         public void OnNetworkReceive(NetPeer peer, NetPacketReader reader, byte channelNumber, DeliveryMethod deliveryMethod)
         {
-            IPacket packet = (IPacket)ProtoBufSerializer.Deserialize(reader.GetBytesWithLength());
+            IPacket packet = (IPacket)ProtoBufSerializer.Deserialize(reader.GetRemainingBytes());
             packetManager.HandleRecieve(peer, packet);
         }
 

--- a/source/Coop/AssemblyHellscape.cs
+++ b/source/Coop/AssemblyHellscape.cs
@@ -18,6 +18,7 @@ namespace Coop
             "Microsoft.Bcl.AsyncInterfaces",
             "System.Threading.Tasks.Extensions",
             "System.Text.Json",
+            "System.Buffers",
         };
 
         private static readonly Dictionary<string, Assembly> LoadedRedirects = RedirectedAssemblies

--- a/source/GameInterface/Services/Registry/Handlers/RegistryHandler.cs
+++ b/source/GameInterface/Services/Registry/Handlers/RegistryHandler.cs
@@ -4,7 +4,7 @@ using GameInterface.Services.Heroes.Messages;
 
 namespace GameInterface.Services.Registry.Handlers;
 
-internal class RegistryHandler
+internal class RegistryHandler : IHandler
 {
     private readonly IMessageBroker messageBroker;
     private readonly IHeroRegistry heroRegistry;
@@ -18,7 +18,13 @@ internal class RegistryHandler
         this.messageBroker = messageBroker;
         this.heroRegistry = heroRegistry;
         this.partyRegistry = partyRegistry;
-        this.messageBroker.Subscribe<RegisterAllGameObjects>(Handle);
+        
+        messageBroker.Subscribe<RegisterAllGameObjects>(Handle);
+    }
+
+    public void Dispose()
+    {
+        messageBroker.Unsubscribe<RegisterAllGameObjects>(Handle);
     }
 
     private void Handle(MessagePayload<RegisterAllGameObjects> obj)

--- a/source/IntroServer/IntroServer.csproj
+++ b/source/IntroServer/IntroServer.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="LiteNetLib" Version="1.0.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.3" />
-    <PackageReference Include="protobuf-net" Version="3.1.26" />
+    <PackageReference Include="protobuf-net" Version="3.2.26" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behaviour?
The client and the server are unable to connect due to:
1. `System.Buffers` version dependency conflicts
2. Deserialization issues with `NetworkClientValidation` messages
3. `RegistryHandler` not implementing the `IHandler` interface (preventing `CoopServer.AllowJoining()` from being called)
4. `NetDataWriter` limiting packet sizes

## What is the new behaviour?
The client and the server are now able to connect.

<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Other information