### PR TITLE
Fixed intro video still playing in the background after joining a game

### DIFF
--- a/source/GameInterface/Services/GameDebug/Patches/CharacterCreationIntroPatch.cs
+++ b/source/GameInterface/Services/GameDebug/Patches/CharacterCreationIntroPatch.cs
@@ -17,11 +17,15 @@ namespace GameInterface.Services.GameDebug.Patches
         [HarmonyPatch("OnActivate")]
         private static void OnActivate(ref TaleworldGameState __instance)
         {
-            Logger.Information("Game State is changing to: '{state}'", __instance.GetType().Name);
+            Logger.Information("Game State is changing to {state}", __instance.GetType().Name);
             if (DebugCharacterCreationInterface.InCharacterCreationIntro())
             {
-                VideoPlayerViewPatch.CurrentVideoPlayerView?.StopVideo(); // Shouldn't be null.
-                VideoPlayerViewPatch.CurrentVideoPlayerView = null;
+                if (VideoPlayerViewPatch.CurrentVideoPlayerView != null)
+                {
+                    VideoPlayerViewPatch.CurrentVideoPlayerView?.StopVideo();
+                    VideoPlayerViewPatch.CurrentVideoPlayerView = null;
+                }
+                
                 MessageBroker.Instance.Publish(__instance, new CharacterCreationStarted());
             }
         }

--- a/source/GameInterface/Services/GameDebug/Patches/CharacterCreationIntroPatch.cs
+++ b/source/GameInterface/Services/GameDebug/Patches/CharacterCreationIntroPatch.cs
@@ -2,7 +2,6 @@
 using Common.Messaging;
 using GameInterface.Services.GameDebug.Interfaces;
 using GameInterface.Services.GameDebug.Messages;
-using GameInterface.Services.Heroes.Interfaces;
 using HarmonyLib;
 using Serilog;
 using TaleworldGameState = TaleWorlds.Core.GameState;
@@ -10,17 +9,19 @@ using TaleworldGameState = TaleWorlds.Core.GameState;
 namespace GameInterface.Services.GameDebug.Patches
 {
     [HarmonyPatch(typeof(TaleworldGameState))]
-    internal class CharacterCreationIntoPatch
+    internal class CharacterCreationIntroPatch
     {
-        private static readonly ILogger Logger = LogManager.GetLogger<CharacterCreationIntoPatch>();
+        private static readonly ILogger Logger = LogManager.GetLogger<CharacterCreationIntroPatch>();
 
         [HarmonyPostfix]
         [HarmonyPatch("OnActivate")]
         private static void OnActivate(ref TaleworldGameState __instance)
         {
-            Logger.Information("Game State is changing to {state}", __instance.GetType().Name);
+            Logger.Information("Game State is changing to: '{state}'", __instance.GetType().Name);
             if (DebugCharacterCreationInterface.InCharacterCreationIntro())
             {
+                VideoPlayerViewPatch.CurrentVideoPlayerView?.StopVideo(); // Shouldn't be null.
+                VideoPlayerViewPatch.CurrentVideoPlayerView = null;
                 MessageBroker.Instance.Publish(__instance, new CharacterCreationStarted());
             }
         }

--- a/source/GameInterface/Services/GameDebug/Patches/VideoPlayerView.cs
+++ b/source/GameInterface/Services/GameDebug/Patches/VideoPlayerView.cs
@@ -8,8 +8,7 @@ namespace GameInterface.Services.GameDebug.Patches
     [HarmonyPatch(typeof(VideoPlayerView))]
     internal class VideoPlayerViewPatch
     {
-        private static readonly ILogger Logger = LogManager.GetLogger<VideoPlayerViewPatch>();
-        public static VideoPlayerView? CurrentVideoPlayerView;
+        public static VideoPlayerView CurrentVideoPlayerView;
 
         [HarmonyPatch(nameof(VideoPlayerView.CreateVideoPlayerView))]
         [HarmonyPostfix]

--- a/source/GameInterface/Services/GameDebug/Patches/VideoPlayerView.cs
+++ b/source/GameInterface/Services/GameDebug/Patches/VideoPlayerView.cs
@@ -1,0 +1,21 @@
+﻿using Common.Logging;
+using HarmonyLib;
+using Serilog;
+using TaleWorlds.Engine;
+
+namespace GameInterface.Services.GameDebug.Patches
+{
+    [HarmonyPatch(typeof(VideoPlayerView))]
+    internal class VideoPlayerViewPatch
+    {
+        private static readonly ILogger Logger = LogManager.GetLogger<VideoPlayerViewPatch>();
+        public static VideoPlayerView? CurrentVideoPlayerView;
+
+        [HarmonyPatch(nameof(VideoPlayerView.CreateVideoPlayerView))]
+        [HarmonyPostfix]
+        private static void CreateVideoPlayerViewPostfix(ref VideoPlayerView __result)
+        {
+            CurrentVideoPlayerView = __result;
+        }
+    }
+}


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behaviour?
Video player is destroyed but the video is not stopped and the audio continues to play in the background.


## What is the new behaviour?
Skips the intro video, destroys the video player and stops the video.