### PR TITLE
fix all crash relate to mobile party

### DIFF
--- a/source/GameInterface/Services/Armies/Handlers/ArmyHandler.cs
+++ b/source/GameInterface/Services/Armies/Handlers/ArmyHandler.cs
@@ -67,7 +67,7 @@ public class ArmyHandler : IHandler
             return;
         }
 
-        ArmyPatches.AddMobilePartyInArmy(mobileParty, army);
+        //ArmyPatches.AddMobilePartyInArmy(mobileParty, army);
           
     }
     public void Dispose()

--- a/source/GameInterface/Services/Armies/Patches/ArmyPatches.cs
+++ b/source/GameInterface/Services/Armies/Patches/ArmyPatches.cs
@@ -22,7 +22,7 @@ namespace GameInterface.Services.Armies.Patches;
 public class ArmyPatches
 {
     private static ILogger Logger = LogManager.GetLogger<Kingdom>();
-
+/*
     [HarmonyPatch(typeof(Army), "OnAddPartyInternal")]
     [HarmonyPrefix]
     static bool OnAddPartyInternalPrefix(ref Army __instance, MobileParty mobileParty)
@@ -53,7 +53,7 @@ public class ArmyPatches
         MessageBroker.Instance.Publish(mobileParty, message);
 
         return true;
-    }
+    }*/
 
 
     [HarmonyPatch(typeof(Army), "OnRemovePartyInternal")]
@@ -98,7 +98,7 @@ public class ArmyPatches
     }
 
 
-    public static void AddMobilePartyInArmy(MobileParty mobileParty, Army army)
+    /*public static void AddMobilePartyInArmy(MobileParty mobileParty, Army army)
     {
         GameLoopRunner.RunOnMainThread(() =>
         {
@@ -107,7 +107,7 @@ public class ArmyPatches
                 army.AddPartyInternal(mobileParty);
             }
         });
-    }
+    }*/
 
     public static void RemoveMobilePartyInArmy(MobileParty mobileParty, Army army)
     {


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue. -->


## What is the new behaviour?
<!-- Insert issue id after hashtag. -->
Resolves #766 
<!-- Describe functionality added. Add images or videos to show how it works if applies -->

Mobile Party Patches => SetArmyPrefix()
Armies Patches => OnAddPartyInternalPrefix()

The mobile party is set 2 times in the object. The solution would be to choose only one of it. 

I comment for now the OnAddPartyInternalPrefix, because the SetArmyPrefix() sync well mobile parties between client and server.

I have **no crash anymore**

## Other information