### PR TITLE
Fix Switching to Wrong Party

### DIFF
--- a/source/GameInterface/Services/GameDebug/Interfaces/GameDebugInterface.cs
+++ b/source/GameInterface/Services/GameDebug/Interfaces/GameDebugInterface.cs
@@ -64,11 +64,14 @@ namespace GameInterface.Services.GameDebug.Interfaces
         {
             PartyVisibilityPatch.AllPartiesVisible = true;
 
-            foreach(var party in Campaign.Current.MobileParties)
+            GameLoopRunner.RunOnMainThread(() =>
             {
-                party.IsVisible = true;
-                party.Party.SetVisualAsDirty();
-            }
+                foreach (var party in Campaign.Current.MobileParties)
+                {
+                    party.IsVisible = true;
+                    party.Party.SetVisualAsDirty();
+                }
+            });
         }
 
         public void LoadGame(string saveName)

--- a/source/GameInterface/Services/GameDebug/Patches/PartyVisibilityPatch.cs
+++ b/source/GameInterface/Services/GameDebug/Patches/PartyVisibilityPatch.cs
@@ -23,7 +23,7 @@ namespace GameInterface.Services.GameDebug.Patches
         {
             if (AllPartiesVisible == false) return true;
 
-            __instance.IsVisible = true;
+            __instance._isVisible = true;
             __instance.Party.OnVisibilityChanged(true);
 
             return false;

--- a/source/GameInterface/Services/Heroes/Interfaces/HeroInterface.cs
+++ b/source/GameInterface/Services/Heroes/Interfaces/HeroInterface.cs
@@ -61,8 +61,8 @@ internal class HeroInterface : IHeroInterface
     {
         Hero.MainHero.StringId = string.Empty;
         Hero.MainHero.PartyBelongedTo.StringId = string.Empty;
-        //Hero.MainHero.Clan.StringId = $"CoopClan_{Guid.NewGuid()}";
         Hero.MainHero.Clan.StringId = string.Empty;
+        Hero.MainHero.CharacterObject.StringId = string.Empty;
 
         HeroBinaryPackage package = binaryPackageFactory.GetBinaryPackage<HeroBinaryPackage>(Hero.MainHero);
 
@@ -134,9 +134,6 @@ internal class HeroInterface : IHeroInterface
             Logger.Information("Switching to new hero: {heroName}", resolvedHero.Name.ToString());
 
             ChangePlayerCharacterAction.Apply(resolvedHero);
-            Campaign.Current.MainParty = resolvedHero.PartyBelongedTo;
-
-            Campaign.Current.PlayerDefaultFaction = resolvedHero.Clan;
         }
         else
         {


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue. -->
When a new player is created, the character object was resolved using a StringId rather than the new one from the client.

## What is the new behaviour?
<!-- Insert issue id after hashtag. -->
Resolves #812
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Setting the new heros character object to an empty string in HeroInterface.PackageMainHero forces the serializer to use the new character object instead of trying to resolve one while deserializing.


## Other information