### PR TITLE
Fix: Leaving Settlement Pauses Game

### DIFF
--- a/source/GameInterface/Services/Time/Patches/GameStateManagerPatches.cs
+++ b/source/GameInterface/Services/Time/Patches/GameStateManagerPatches.cs
@@ -26,7 +26,7 @@ namespace GameInterface.Services.Time.Patches
                 MapState mapState = __instance.LastOrDefault<MapState>();
                 if (mapState == null) return;
 
-                MapState_OnTick.Invoke(mapState, new object[] { dt });
+                mapState.OnTick(dt);
             }
         }
 

--- a/source/GameInterface/Services/Time/Patches/TimePatches.cs
+++ b/source/GameInterface/Services/Time/Patches/TimePatches.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Encounters;
 using TaleWorlds.CampaignSystem.ViewModelCollection.Map.MapBar;
 
 namespace GameInterface.Services.Heroes.Patches;
@@ -19,7 +20,6 @@ namespace GameInterface.Services.Heroes.Patches;
 internal class TimePatches
 {
     private static CampaignTimeControlMode CurrentMode = CampaignTimeControlMode.Stop;
-
 
     private static readonly TimeControlModeConverter timeControlModeConverter = new();
 
@@ -79,24 +79,48 @@ internal class AllowTimeControlFromHotKeysPatches
 {
     static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
     {
-        var instrs = instructions.ToList();
-
         var allow = AccessTools.Method(typeof(AllowedThread), nameof(AllowedThread.AllowThisThread));
         var revoke = AccessTools.Method(typeof(AllowedThread), nameof(AllowedThread.RevokeThisThread));
 
-        // Inject allow and revoke thread for hotkey time controls
-        instrs.Insert(514, new CodeInstruction(OpCodes.Call, allow));
-        instrs.Insert(760, new CodeInstruction(OpCodes.Call, revoke));
+        var setTime = AccessTools.Method(typeof(Campaign), nameof(Campaign.SetTimeSpeed));
 
-        return instrs;
+        foreach (var instr in instructions)
+        {
+            if (instr.Calls(setTime))
+            {
+                // wrap set time speed with allow
+                yield return new CodeInstruction(OpCodes.Call, allow);
+                yield return instr;
+                yield return new CodeInstruction(OpCodes.Call, revoke);
+            }
+            else
+            {
+                yield return instr;
+            }
+        }
     }
-    private static void Prefix()
-    {
-        AllowedThread.AllowThisThread();
-    }
+}
 
-    private static void Postfix()
+[HarmonyPatch(typeof(PlayerEncounter), nameof(PlayerEncounter.Finish))]
+internal class PlayerEncouterFinishPatches
+{
+    static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
     {
-        AllowedThread.RevokeThisThread();
+        var setTimeMode = AccessTools.PropertySetter(typeof(Campaign), nameof(Campaign.TimeControlMode));
+
+        foreach (var instr in instructions)
+        {
+            if (instr.Calls(setTimeMode))
+            {
+                // Pop campaign
+                yield return new CodeInstruction(OpCodes.Pop);
+                // Pop setter value
+                yield return new CodeInstruction(OpCodes.Pop);
+            }
+            else
+            {
+                yield return instr;
+            }
+        }
     }
 }

--- a/source/GameInterface/Services/Villages/Patches/VillagePatches.cs
+++ b/source/GameInterface/Services/Villages/Patches/VillagePatches.cs
@@ -49,7 +49,6 @@ internal class VillagePatches
                 village.Settlement.Party.SetLevelMaskIsDirty();
             }
         });
-
     }
 
     // Justification:
@@ -83,8 +82,6 @@ internal class VillagePatches
                 village.Hearth = Hearth;
             }
         });
-
-
     }
 
     [HarmonyPatch(nameof(Village.TradeBound), MethodType.Setter)]
@@ -113,7 +110,6 @@ internal class VillagePatches
                 village.TradeBound = tradebound;
             }
         });
-
     }
 
 
@@ -140,7 +136,6 @@ internal class VillagePatches
                 village.TradeTaxAccumulated = tradeTaxAccumulated;
             }
         });
-
     }
 
     [HarmonyPatch(nameof(Village.LastDemandSatisfiedTime), MethodType.Setter)]
@@ -166,8 +161,5 @@ internal class VillagePatches
                 village.LastDemandSatisfiedTime = LastDemandSatisfiedTime;
             }
         });
-
     }
-
-
 }


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When leaving a settlement the game is paused because `EndPlayerSettlementEncounter` calls `PlayerEncounter.Finish` is called using allowed and `PlayerEncounter.Finish` changes the time mode

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #814
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Patched out time setting in `PlayerEncounter.Finish`

## Other information