### PR TITLE
Added check if the field value is different from the currently assign…

### DIFF
--- a/source/GameInterface.Tests/AutoSync/TranspilerTests.cs
+++ b/source/GameInterface.Tests/AutoSync/TranspilerTests.cs
@@ -92,7 +92,7 @@ public class TranspilerTests
         var testClass = new SwitchTestClass();
 
         const string instanceId = "MyObj";
-        const int newValue = 1001;
+        int newValue = 1001;
         objManager.AddExisting(instanceId, testClass);
 
         
@@ -100,12 +100,12 @@ public class TranspilerTests
         {
             ModInformation.IsServer = true;
             testClass.SetMyInt(newValue);
+            testClass.SetMyInt(newValue);
 
             Assert.Equal(newValue, testClass.MyInt);
         }
-
         var packet = Assert.IsType<FieldAutoSyncPacket>(network.SentPackets.First());
-
+        Assert.Single(network.SentPackets);
         Assert.Equal(typeId, packet.typeId);
         Assert.Equal(0, packet.fieldId);
         Assert.Equal(instanceId, packet.instanceId);

--- a/source/GameInterface/AutoSync/Fields/FieldTranspilerCreator.cs
+++ b/source/GameInterface/AutoSync/Fields/FieldTranspilerCreator.cs
@@ -13,6 +13,7 @@ using System.Collections;
 using System.Linq;
 using ProtoBuf;
 using ProtoBuf.Meta;
+using Newtonsoft.Json.Linq;
 
 namespace GameInterface.AutoSync.Fields;
 public class FieldTranspilerCreator
@@ -437,6 +438,8 @@ public class FieldTranspilerCreator
 
         IsClientCheck(il, field);
 
+        HasValueChanged(il, field);
+
         var networkLocal = TryResolve<INetwork>(il);
 
         var objectManagerLocal = TryResolve<IObjectManager>(il);
@@ -463,6 +466,8 @@ public class FieldTranspilerCreator
         return methodBuilder;
     }
 
+
+
     private MethodBuilder CreateInterceptByRef(int typeId, int propId, FieldInfo field)
     {
         var methodBuilder = typeBuilder.DefineMethod($"{field.DeclaringType.Name}_{field.Name}_intercept",
@@ -475,6 +480,8 @@ public class FieldTranspilerCreator
         var il = methodBuilder.GetILGenerator();
 
         IsClientCheck(il, field);
+
+        HasValueChanged(il, field);
 
         var networkLocal = TryResolve<INetwork>(il);
         var objectManagerLocal = TryResolve<IObjectManager>(il);
@@ -524,6 +531,31 @@ public class FieldTranspilerCreator
         il.MarkLabel(validLabel);
 
         return local;
+    }
+
+    private void HasValueChanged(ILGenerator il, FieldInfo field)
+    {
+        var fieldType = field.GetUnderlyingType();
+        var valueNotChangedLabel = il.DefineLabel();
+        var method = typeof(object).GetMethod("Equals", new[] { typeof(object), typeof(object) });
+        
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, field);
+        il.Emit(OpCodes.Box, fieldType);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Box, fieldType);
+        il.Emit(OpCodes.Call, method);        
+        il.Emit(OpCodes.Brfalse_S, valueNotChangedLabel);
+
+        // Log error
+        il.Emit(OpCodes.Ldsfld, loggerField);
+        il.Emit(OpCodes.Ldstr, $"Repeating assignment");
+        il.Emit(OpCodes.Call, AccessTools.Method(typeof(ILogger), nameof(ILogger.Error), new Type[] { typeof(string) }));
+
+        // Return
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(valueNotChangedLabel);
     }
 
     private LocalBuilder TryGetId(ILGenerator il, OpCode argOpcode, LocalBuilder objectManagerLocal)


### PR DESCRIPTION
…ed value

## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Other information
@garrettluskey only the changes in [FieldTranspilerCreator.cs](https://github.com/Bannerlord-Coop-Team/BannerlordCoop/compare/autosync-safety?expand=1#diff-9658174eacc9ad3e5e7a1e134e0fe13687184fccba26192daacaa0896487ca6b) are relevant the test class is only changed to test if the function is working for now.
