### PR TITLE
fix: resolve existing party on client reconnect (issue #1126)

### DIFF
--- a/source/Coop.Core/Client/Services/MobileParties/Handlers/ClientMobilePartyBehaviorHandler.cs
+++ b/source/Coop.Core/Client/Services/MobileParties/Handlers/ClientMobilePartyBehaviorHandler.cs
@@ -1,12 +1,10 @@
-﻿using Common.Logging;
-using Common.Messaging;
+﻿using Common.Messaging;
 using Common.Network;
 using Coop.Core.Client.Services.MobileParties.Messages;
 using Coop.Core.Server.Services.MobileParties.Messages;
 using Coop.Core.Server.Services.MobileParties.Packets;
 using GameInterface.Services.MobileParties.Messages;
 using GameInterface.Services.MobileParties.Messages.Behavior;
-using Serilog;
 
 namespace Coop.Core.Client.Services.MobileParties.Handlers
 {
@@ -17,8 +15,6 @@ namespace Coop.Core.Client.Services.MobileParties.Handlers
     /// <seealso cref="GameInterface.Services.MobileParties.Handlers.MobilePartyBehaviorHandler">Game Interface's Handler</seealso>
     public class ClientMobilePartyBehaviorHandler : IHandler
     {
-        private static readonly ILogger Logger = LogManager.GetLogger<ClientMobilePartyBehaviorHandler>();
-
         private readonly IMessageBroker messageBroker;
         private readonly INetwork network;
 
@@ -46,9 +42,6 @@ namespace Coop.Core.Client.Services.MobileParties.Handlers
 
         internal void Handle(MessagePayload<ControlledPartyBehaviorUpdated> obj)
         {
-            var position = obj.What.BehaviorUpdateData.PartyPosition;
-            Logger.Debug($"Attempting to update party movement X:{position.X} Y:{position.Y}");
-
             network.SendAll(new RequestMobilePartyBehaviorPacket(obj.What.BehaviorUpdateData));
         }
 

--- a/source/Coop.Core/Common/Network/CoopNetworkBase.cs
+++ b/source/Coop.Core/Common/Network/CoopNetworkBase.cs
@@ -23,6 +23,8 @@ public abstract class CoopNetworkBase : INetwork, INetEventListener
 
     private Thread UpdateThread { get; set; }
     private CancellationTokenSource CancellationTokenSource;
+    // Guard against double-dispose: finalizer calls Dispose() after explicit Dispose() on reconnect
+    private bool _disposed = false;
 
     protected readonly NetManager netManager;
 
@@ -50,11 +52,18 @@ public abstract class CoopNetworkBase : INetwork, INetEventListener
 
     public virtual void Dispose()
     {
+        // Prevent ObjectDisposedException if GC finalizer runs after explicit Dispose on reconnect
+        if (_disposed) return;
+        _disposed = true;
+
         netManager.Stop();
 
         CancellationTokenSource.Cancel();
         CancellationTokenSource.Dispose();
         UpdateThread?.Join(Configuration.ObjectCreationTimeout);
+
+        // Tell GC not to run the finalizer — Dispose() already cleaned up, avoids double-call
+        GC.SuppressFinalize(this);
     }
 
     private void UpdateThreadMethod()

--- a/source/GameInterface.Tests/Services/Heroes/Interfaces/HeroInterfaceTests.cs
+++ b/source/GameInterface.Tests/Services/Heroes/Interfaces/HeroInterfaceTests.cs
@@ -1,0 +1,182 @@
+using GameInterface.Serialization;
+using GameInterface.Services.Entity;
+using GameInterface.Services.Entity.Data;
+using GameInterface.Services.Heroes.Interfaces;
+using GameInterface.Services.ObjectManager;
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using TaleWorlds.CampaignSystem;
+using Xunit;
+
+namespace GameInterface.Tests.Services.Heroes.Interfaces;
+
+/// <summary>
+/// Tests for <see cref="HeroInterface.TryResolveHero"/>.
+///
+/// TryResolveHero is the method called by the server when a client reconnects to check
+/// whether that client already has a hero. It looks up the client's controllerId in the
+/// ControlledEntityRegistry, filters to entities that resolve to a Hero in the ObjectManager,
+/// and returns the first match.
+///
+/// These tests do not require the game to be running — all dependencies are either direct
+/// instantiations (ControlledEntityRegistry) or lightweight stubs.
+/// </summary>
+public class HeroInterfaceTests
+{
+    // HeroInterface requires IBinaryPackageFactory only for PackageMainHero/UnpackHero.
+    // TryResolveHero does not touch it, so we pass null safely.
+    private static readonly IBinaryPackageFactory? NullPackageFactory = null;
+
+    private const string ControllerId = "testclient1";
+
+    /// <summary>
+    /// Creates a Hero instance without invoking its constructor, avoiding any game
+    /// bootstrap dependency. The instance only needs to exist so the ObjectManager stub
+    /// can return it for a given ID.
+    /// </summary>
+    private static Hero CreateHeroStub() =>
+        (Hero)FormatterServices.GetUninitializedObject(typeof(Hero));
+
+    [Fact]
+    public void TryResolveHero_NoEntitiesForController_ReturnsFalse()
+    {
+        // Arrange — registry has no entries for this controllerId at all
+        var registry = new ControlledEntityRegistry();
+        var objectManager = new TestObjectManager();
+        var heroInterface = new HeroInterface(NullPackageFactory, registry, objectManager);
+
+        // Act
+        var result = heroInterface.TryResolveHero(ControllerId, out var heroId);
+
+        // Assert
+        Assert.False(result);
+        Assert.Null(heroId);
+    }
+
+    [Fact]
+    public void TryResolveHero_EntitiesExistButNoneAreHeroes_ReturnsFalse()
+    {
+        // Arrange — controllerId has a party entity registered, but no Hero
+        var registry = new ControlledEntityRegistry();
+        registry.RegisterAsControlled(ControllerId, "Coop_MobileParty_1");
+
+        // ObjectManager knows about the party but not any Hero
+        var objectManager = new TestObjectManager();
+
+        var heroInterface = new HeroInterface(NullPackageFactory, registry, objectManager);
+
+        // Act
+        var result = heroInterface.TryResolveHero(ControllerId, out var heroId);
+
+        // Assert
+        Assert.False(result);
+        Assert.Null(heroId);
+    }
+
+    [Fact]
+    public void TryResolveHero_OneHeroRegistered_ReturnsTrueWithHeroId()
+    {
+        // Arrange — the normal reconnect case: one hero registered under the controllerId
+        var registry = new ControlledEntityRegistry();
+        var heroId = "Coop_TaleWorlds.CampaignSystem.Hero_1";
+        registry.RegisterAsControlled(ControllerId, heroId);
+
+        // ObjectManager returns a Hero for that ID, matching what AutoRegistry<Hero> produces
+        var objectManager = new TestObjectManager();
+        objectManager.RegisterHero(heroId, CreateHeroStub());
+
+        var heroInterface = new HeroInterface(NullPackageFactory, registry, objectManager);
+
+        // Act
+        var result = heroInterface.TryResolveHero(ControllerId, out var resolvedId);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(heroId, resolvedId);
+    }
+
+    [Fact]
+    public void TryResolveHero_HeroAndPartyBothRegistered_ReturnsTrueWithHeroId()
+    {
+        // Arrange — realistic case: a client has both a hero entity and a mobile party
+        // entity registered under their controllerId. TryResolveHero must return only the hero.
+        var registry = new ControlledEntityRegistry();
+        var heroId = "Coop_TaleWorlds.CampaignSystem.Hero_1";
+        var partyId = "Coop_MobileParty_1";
+        registry.RegisterAsControlled(ControllerId, heroId);
+        registry.RegisterAsControlled(ControllerId, partyId);
+
+        // ObjectManager only resolves the hero entity as a Hero — the party entity is not a Hero
+        var objectManager = new TestObjectManager();
+        objectManager.RegisterHero(heroId, CreateHeroStub());
+
+        var heroInterface = new HeroInterface(NullPackageFactory, registry, objectManager);
+
+        // Act
+        var result = heroInterface.TryResolveHero(ControllerId, out var resolvedId);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(heroId, resolvedId);
+    }
+
+    [Fact]
+    public void TryResolveHero_MultipleHeroEntities_ReturnsTrueWithFirstHeroId()
+    {
+        // Arrange — defensive guard: two hero entities registered under the same controllerId.
+        // This should not happen in normal gameplay (only the player's main hero is ever
+        // registered under their controllerId), but the registry data model allows it.
+        // The method should not throw and should return the first match.
+        var registry = new ControlledEntityRegistry();
+        var heroId1 = "Coop_TaleWorlds.CampaignSystem.Hero_1";
+        var heroId2 = "Coop_TaleWorlds.CampaignSystem.Hero_2";
+        registry.RegisterAsControlled(ControllerId, heroId1);
+        registry.RegisterAsControlled(ControllerId, heroId2);
+
+        var objectManager = new TestObjectManager();
+        objectManager.RegisterHero(heroId1, CreateHeroStub());
+        objectManager.RegisterHero(heroId2, CreateHeroStub());
+
+        var heroInterface = new HeroInterface(NullPackageFactory, registry, objectManager);
+
+        // Act
+        var result = heroInterface.TryResolveHero(ControllerId, out var resolvedId);
+
+        // Assert — no exception, first hero returned
+        Assert.True(result);
+        Assert.Equal(heroId1, resolvedId);
+    }
+
+    /// <summary>
+    /// Minimal IObjectManager stub for hero resolution tests.
+    /// Only implements TryGetObject&lt;T&gt; — the sole method used by TryResolveHero.
+    /// </summary>
+    private class TestObjectManager : IObjectManager
+    {
+        private readonly Dictionary<string, Hero> _heroes = new();
+
+        public void RegisterHero(string id, Hero hero) => _heroes[id] = hero;
+
+        public bool TryGetObject<T>(string id, out T obj) where T : class
+        {
+            if (typeof(T) == typeof(Hero) && _heroes.TryGetValue(id, out var hero))
+            {
+                obj = (hero as T)!;
+                return obj != null;
+            }
+
+            obj = null!;
+            return false;
+        }
+
+        // Remaining interface members are not exercised by TryResolveHero
+        public bool AddExisting<T>(string id, T obj) => throw new NotImplementedException();
+        public bool AddNewObject<T>(T obj, out string newId) => throw new NotImplementedException();
+        public bool Contains<T>(T obj) => throw new NotImplementedException();
+        public bool Contains(string id) => throw new NotImplementedException();
+        public bool IsTypeManaged(Type type) => throw new NotImplementedException();
+        public bool Remove<T>(T obj) => throw new NotImplementedException();
+        public bool TryGetId<T>(T obj, out string id) => throw new NotImplementedException();
+    }
+}

--- a/source/GameInterface/Services/Heroes/Interfaces/HeroInterface.cs
+++ b/source/GameInterface/Services/Heroes/Interfaces/HeroInterface.cs
@@ -119,14 +119,20 @@ internal class HeroInterface : IHeroInterface
             return false;
         }
 
-        // TODO ensure works
-        var resolvedEntity = entities.SingleOrDefault(entity => entity.EntityId.StartsWith("hero"));
+        var heroEntities = entities.Where(entity => objectManager.TryGetObject<Hero>(entity.EntityId, out _)).ToList();
 
-        if (resolvedEntity == null)
+        if (heroEntities.Count == 0)
         {
             Logger.Warning("No hero was registered for {controllerId}", controllerId);
             return false;
         }
+
+        if (heroEntities.Count > 1)
+        {
+            Logger.Warning("Multiple heroes registered for {controllerId}, using first match", controllerId);
+        }
+
+        var resolvedEntity = heroEntities[0];
 
         heroId = resolvedEntity.EntityId;
 


### PR DESCRIPTION
TryResolveHero used entity.EntityId.StartsWith("hero") to find a client's hero in the ControlledEntityRegistry. Hero IDs are generated by AutoRegistry<Hero> as 'Coop_TaleWorlds.CampaignSystem.Hero_N' - they start with 'Coop_', never 'hero'. The check always returned null, so TryResolveHero always returned false, causing the server to send HeroExists=false to every reconnecting client and routing them to character creation instead of loading their save.

Fix: use objectManager.TryGetObject<Hero>(entity.EntityId) for the predicate - a type-safe registry lookup that correctly identifies hero entities regardless of naming scheme.

Also replaced SingleOrDefault with a Count check: a client's entity set legitimately contains multiple entries (hero + mobile party), and SingleOrDefault threw InvalidOperationException when more than one entity matched the predicate.

Additional changes in this commit:
- CoopNetworkBase: fix double-dispose ObjectDisposedException on reconnect by adding _disposed guard flag and GC.SuppressFinalize(this)
- ClientMobilePartyBehaviorHandler: remove per-tick movement log spam that was flooding log files and obscuring real errors
- HeroInterfaceTests: add XUnit tests for TryResolveHero (DoD requirement)

---------------------------------------------


## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
Now able to rejoin as the client and not prompted to recreate character.


## What is the new behavior?
Now able to rejoin as the client and not prompted to recreate character.
Resolves #1126
See above in commit notes


