### PR TITLE
feat: add DebugAutoConnect build config for one-click auto host+join

### DIFF
--- a/source/ClientDebug/ClientDebug.csproj
+++ b/source/ClientDebug/ClientDebug.csproj
@@ -30,6 +30,15 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'DebugAutoConnect|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/source/ClientDebug/ClientDebug.csproj.user
+++ b/source/ClientDebug/ClientDebug.csproj.user
@@ -11,5 +11,9 @@
     <StartProgram>..\mb2\bin\Win64_Shipping_Client\Bannerlord.exe</StartProgram>
     <StartWorkingDirectory>..\..\..\..\mb2\bin\Win64_Shipping_Client\</StartWorkingDirectory>
     <StartArguments>/singleplayer /client _MODULES_%2aNative%2aSandBoxCore%2aCustomBattle%2aSandBox%2aStoryMode%2aCoop%2a_MODULES_</StartArguments>
-  </PropertyGroup>
-</Project>
+  </PropertyGroup>  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DebugAutoConnect|AnyCPU'">
+    <StartArguments>/singleplayer /client /platformId testclient1 /autoconnect _MODULES_%2aNative%2aSandBoxCore%2aSandBox%2aStoryMode%2aCoop%2a_MODULES_</StartArguments>
+    <StartAction>Program</StartAction>
+    <StartProgram>..\mb2\bin\Win64_Shipping_Client\Bannerlord.exe</StartProgram>
+    <StartWorkingDirectory>..\..\..\..\mb2\bin\Win64_Shipping_Client\</StartWorkingDirectory>
+  </PropertyGroup></Project>

--- a/source/Coop.Core/Client/CoopClient.cs
+++ b/source/Coop.Core/Client/CoopClient.cs
@@ -33,6 +33,8 @@ public class CoopClient : CoopNetworkBase, ICoopClient
     private readonly IPacketManager packetManager;
 
     private bool isConnected = false;
+    private bool reconnectPending = false;
+    private DateTime reconnectAfter = DateTime.MinValue;
 
     public CoopClient(
         INetworkConfiguration config,
@@ -51,7 +53,9 @@ public class CoopClient : CoopNetworkBase, ICoopClient
 
     public override void OnNetworkError(IPEndPoint endPoint, SocketError socketError)
     {
-        throw new NotImplementedException();
+        // Common during auto-connect: server not yet listening when client attempts connection.
+        // Log and continue — LiteNetLib will keep retrying within the DisconnectTimeout window.
+        Logger.Warning("Network error from {EndPoint}: {SocketError}", endPoint, socketError);
     }
 
     public override void OnNetworkLatencyUpdate(NetPeer peer, int latency)
@@ -67,7 +71,7 @@ public class CoopClient : CoopNetworkBase, ICoopClient
 
     public override void OnNetworkReceiveUnconnected(IPEndPoint remoteEndPoint, NetPacketReader reader, UnconnectedMessageType messageType)
     {
-        throw new NotImplementedException();
+        Logger.Warning("Received unconnected message from {EndPoint}", remoteEndPoint);
     }
 
     public override void OnPeerConnected(NetPeer peer)
@@ -88,6 +92,14 @@ public class CoopClient : CoopNetworkBase, ICoopClient
             messageBroker.Publish(this, new SendInformationMessage(disconnectInfo.Reason.ToString()));
             messageBroker.Publish(this, new NetworkDisconnected(disconnectInfo));
         }
+        else
+        {
+            // During auto-connect, the client may attempt to connect before the server has finished
+            // registering game objects and opened joining. Schedule a retry until it's accepted.
+            Logger.Warning("Connection attempt failed ({Reason}), retrying in 3 seconds...", disconnectInfo.Reason);
+            reconnectPending = true;
+            reconnectAfter = DateTime.UtcNow.AddSeconds(3);
+        }
     }
 
     public override void Start()
@@ -107,6 +119,14 @@ public class CoopClient : CoopNetworkBase, ICoopClient
     public override void Update(TimeSpan frameTime)
     {
         netManager.PollEvents();
+
+        // Auto-connect retry: fires after a rejection while the server was still loading.
+        if (reconnectPending && DateTime.UtcNow >= reconnectAfter)
+        {
+            reconnectPending = false;
+            Logger.Information("Retrying connection to {Address}:{Port}...", Configuration.Address, Configuration.Port);
+            netManager.Connect(Configuration.Address, Configuration.Port, Configuration.Token);
+        }
     }
 
     public override void SendAll(IPacket packet)

--- a/source/Coop.Core/Server/CoopServer.cs
+++ b/source/Coop.Core/Server/CoopServer.cs
@@ -93,7 +93,7 @@ public class CoopServer : CoopNetworkBase, ICoopServer
 
     public override void OnNetworkError(IPEndPoint endPoint, SocketError socketError)
     {
-        throw new NotImplementedException();
+        Logger.Warning("Network error from {EndPoint}: {SocketError}", endPoint, socketError);
     }
 
     public override void OnNetworkLatencyUpdate(NetPeer peer, int latency)
@@ -109,7 +109,7 @@ public class CoopServer : CoopNetworkBase, ICoopServer
 
     public override void OnNetworkReceiveUnconnected(IPEndPoint remoteEndPoint, NetPacketReader reader, UnconnectedMessageType messageType)
     {
-        throw new NotImplementedException();
+        Logger.Warning("Received unconnected message from {EndPoint}", remoteEndPoint);
     }
 
     public override void OnPeerConnected(NetPeer peer)

--- a/source/Coop.sln
+++ b/source/Coop.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31825.309
+# Visual Studio Version 18
+VisualStudioVersion = 18.4.11620.152 stable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6E453886-083F-4A26-84F3-7607EBACC96B}"
 	ProjectSection(SolutionItems) = preProject
@@ -38,6 +38,8 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|x64 = Debug|x64
+		DebugAutoConnect|Any CPU = DebugAutoConnect|Any CPU
+		DebugAutoConnect|x64 = DebugAutoConnect|x64
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 	EndGlobalSection
@@ -46,6 +48,10 @@ Global
 		{52CC5E00-CAA6-4B05-A713-4D387B60B138}.Debug|Any CPU.Build.0 = Debug|x64
 		{52CC5E00-CAA6-4B05-A713-4D387B60B138}.Debug|x64.ActiveCfg = Debug|x64
 		{52CC5E00-CAA6-4B05-A713-4D387B60B138}.Debug|x64.Build.0 = Debug|x64
+		{52CC5E00-CAA6-4B05-A713-4D387B60B138}.DebugAutoConnect|Any CPU.ActiveCfg = Debug|x64
+		{52CC5E00-CAA6-4B05-A713-4D387B60B138}.DebugAutoConnect|Any CPU.Build.0 = Debug|x64
+		{52CC5E00-CAA6-4B05-A713-4D387B60B138}.DebugAutoConnect|x64.ActiveCfg = Debug|x64
+		{52CC5E00-CAA6-4B05-A713-4D387B60B138}.DebugAutoConnect|x64.Build.0 = Debug|x64
 		{52CC5E00-CAA6-4B05-A713-4D387B60B138}.Release|Any CPU.ActiveCfg = Release|x64
 		{52CC5E00-CAA6-4B05-A713-4D387B60B138}.Release|Any CPU.Build.0 = Release|x64
 		{52CC5E00-CAA6-4B05-A713-4D387B60B138}.Release|x64.ActiveCfg = Release|x64
@@ -54,6 +60,10 @@ Global
 		{CD22C2AE-B9D7-4529-9081-816F4A3B778E}.Debug|Any CPU.Build.0 = Debug|x64
 		{CD22C2AE-B9D7-4529-9081-816F4A3B778E}.Debug|x64.ActiveCfg = Debug|x64
 		{CD22C2AE-B9D7-4529-9081-816F4A3B778E}.Debug|x64.Build.0 = Debug|x64
+		{CD22C2AE-B9D7-4529-9081-816F4A3B778E}.DebugAutoConnect|Any CPU.ActiveCfg = Debug|x64
+		{CD22C2AE-B9D7-4529-9081-816F4A3B778E}.DebugAutoConnect|Any CPU.Build.0 = Debug|x64
+		{CD22C2AE-B9D7-4529-9081-816F4A3B778E}.DebugAutoConnect|x64.ActiveCfg = Debug|x64
+		{CD22C2AE-B9D7-4529-9081-816F4A3B778E}.DebugAutoConnect|x64.Build.0 = Debug|x64
 		{CD22C2AE-B9D7-4529-9081-816F4A3B778E}.Release|Any CPU.ActiveCfg = Release|x64
 		{CD22C2AE-B9D7-4529-9081-816F4A3B778E}.Release|Any CPU.Build.0 = Release|x64
 		{CD22C2AE-B9D7-4529-9081-816F4A3B778E}.Release|x64.ActiveCfg = Release|x64
@@ -62,6 +72,10 @@ Global
 		{D22CB8FA-40CC-4F47-986F-1C5A4415980B}.Debug|Any CPU.Build.0 = Debug|x64
 		{D22CB8FA-40CC-4F47-986F-1C5A4415980B}.Debug|x64.ActiveCfg = Debug|x64
 		{D22CB8FA-40CC-4F47-986F-1C5A4415980B}.Debug|x64.Build.0 = Debug|x64
+		{D22CB8FA-40CC-4F47-986F-1C5A4415980B}.DebugAutoConnect|Any CPU.ActiveCfg = Debug|x64
+		{D22CB8FA-40CC-4F47-986F-1C5A4415980B}.DebugAutoConnect|Any CPU.Build.0 = Debug|x64
+		{D22CB8FA-40CC-4F47-986F-1C5A4415980B}.DebugAutoConnect|x64.ActiveCfg = Debug|x64
+		{D22CB8FA-40CC-4F47-986F-1C5A4415980B}.DebugAutoConnect|x64.Build.0 = Debug|x64
 		{D22CB8FA-40CC-4F47-986F-1C5A4415980B}.Release|Any CPU.ActiveCfg = Release|x64
 		{D22CB8FA-40CC-4F47-986F-1C5A4415980B}.Release|Any CPU.Build.0 = Release|x64
 		{D22CB8FA-40CC-4F47-986F-1C5A4415980B}.Release|x64.ActiveCfg = Release|x64
@@ -70,6 +84,10 @@ Global
 		{AFD76C22-8732-44C1-834B-059AE2097ED7}.Debug|Any CPU.Build.0 = Debug|x64
 		{AFD76C22-8732-44C1-834B-059AE2097ED7}.Debug|x64.ActiveCfg = Debug|x64
 		{AFD76C22-8732-44C1-834B-059AE2097ED7}.Debug|x64.Build.0 = Debug|x64
+		{AFD76C22-8732-44C1-834B-059AE2097ED7}.DebugAutoConnect|Any CPU.ActiveCfg = Debug|x64
+		{AFD76C22-8732-44C1-834B-059AE2097ED7}.DebugAutoConnect|Any CPU.Build.0 = Debug|x64
+		{AFD76C22-8732-44C1-834B-059AE2097ED7}.DebugAutoConnect|x64.ActiveCfg = Debug|x64
+		{AFD76C22-8732-44C1-834B-059AE2097ED7}.DebugAutoConnect|x64.Build.0 = Debug|x64
 		{AFD76C22-8732-44C1-834B-059AE2097ED7}.Release|Any CPU.ActiveCfg = Release|x64
 		{AFD76C22-8732-44C1-834B-059AE2097ED7}.Release|Any CPU.Build.0 = Release|x64
 		{AFD76C22-8732-44C1-834B-059AE2097ED7}.Release|x64.ActiveCfg = Release|x64
@@ -78,6 +96,10 @@ Global
 		{442B73F2-B103-4EF6-8B4B-A2F36F169515}.Debug|Any CPU.Build.0 = Debug|x64
 		{442B73F2-B103-4EF6-8B4B-A2F36F169515}.Debug|x64.ActiveCfg = Debug|x64
 		{442B73F2-B103-4EF6-8B4B-A2F36F169515}.Debug|x64.Build.0 = Debug|x64
+		{442B73F2-B103-4EF6-8B4B-A2F36F169515}.DebugAutoConnect|Any CPU.ActiveCfg = Debug|x64
+		{442B73F2-B103-4EF6-8B4B-A2F36F169515}.DebugAutoConnect|Any CPU.Build.0 = Debug|x64
+		{442B73F2-B103-4EF6-8B4B-A2F36F169515}.DebugAutoConnect|x64.ActiveCfg = Debug|x64
+		{442B73F2-B103-4EF6-8B4B-A2F36F169515}.DebugAutoConnect|x64.Build.0 = Debug|x64
 		{442B73F2-B103-4EF6-8B4B-A2F36F169515}.Release|Any CPU.ActiveCfg = Release|x64
 		{442B73F2-B103-4EF6-8B4B-A2F36F169515}.Release|Any CPU.Build.0 = Release|x64
 		{442B73F2-B103-4EF6-8B4B-A2F36F169515}.Release|x64.ActiveCfg = Release|x64
@@ -86,6 +108,10 @@ Global
 		{E474A5B5-3F73-46CB-B68C-E8FA5199950B}.Debug|Any CPU.Build.0 = Debug|x64
 		{E474A5B5-3F73-46CB-B68C-E8FA5199950B}.Debug|x64.ActiveCfg = Debug|x64
 		{E474A5B5-3F73-46CB-B68C-E8FA5199950B}.Debug|x64.Build.0 = Debug|x64
+		{E474A5B5-3F73-46CB-B68C-E8FA5199950B}.DebugAutoConnect|Any CPU.ActiveCfg = Debug|x64
+		{E474A5B5-3F73-46CB-B68C-E8FA5199950B}.DebugAutoConnect|Any CPU.Build.0 = Debug|x64
+		{E474A5B5-3F73-46CB-B68C-E8FA5199950B}.DebugAutoConnect|x64.ActiveCfg = Debug|x64
+		{E474A5B5-3F73-46CB-B68C-E8FA5199950B}.DebugAutoConnect|x64.Build.0 = Debug|x64
 		{E474A5B5-3F73-46CB-B68C-E8FA5199950B}.Release|Any CPU.ActiveCfg = Release|x64
 		{E474A5B5-3F73-46CB-B68C-E8FA5199950B}.Release|Any CPU.Build.0 = Release|x64
 		{E474A5B5-3F73-46CB-B68C-E8FA5199950B}.Release|x64.ActiveCfg = Release|x64
@@ -94,6 +120,10 @@ Global
 		{B24413E5-4371-47EE-BBFF-947E13EE6CCC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B24413E5-4371-47EE-BBFF-947E13EE6CCC}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{B24413E5-4371-47EE-BBFF-947E13EE6CCC}.Debug|x64.Build.0 = Debug|Any CPU
+		{B24413E5-4371-47EE-BBFF-947E13EE6CCC}.DebugAutoConnect|Any CPU.ActiveCfg = Debug|Any CPU
+		{B24413E5-4371-47EE-BBFF-947E13EE6CCC}.DebugAutoConnect|Any CPU.Build.0 = Debug|Any CPU
+		{B24413E5-4371-47EE-BBFF-947E13EE6CCC}.DebugAutoConnect|x64.ActiveCfg = Debug|Any CPU
+		{B24413E5-4371-47EE-BBFF-947E13EE6CCC}.DebugAutoConnect|x64.Build.0 = Debug|Any CPU
 		{B24413E5-4371-47EE-BBFF-947E13EE6CCC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B24413E5-4371-47EE-BBFF-947E13EE6CCC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B24413E5-4371-47EE-BBFF-947E13EE6CCC}.Release|x64.ActiveCfg = Release|Any CPU
@@ -102,6 +132,10 @@ Global
 		{08184158-2865-4481-AD38-9E82F1A44FD5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{08184158-2865-4481-AD38-9E82F1A44FD5}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{08184158-2865-4481-AD38-9E82F1A44FD5}.Debug|x64.Build.0 = Debug|Any CPU
+		{08184158-2865-4481-AD38-9E82F1A44FD5}.DebugAutoConnect|Any CPU.ActiveCfg = Debug|Any CPU
+		{08184158-2865-4481-AD38-9E82F1A44FD5}.DebugAutoConnect|Any CPU.Build.0 = Debug|Any CPU
+		{08184158-2865-4481-AD38-9E82F1A44FD5}.DebugAutoConnect|x64.ActiveCfg = Debug|Any CPU
+		{08184158-2865-4481-AD38-9E82F1A44FD5}.DebugAutoConnect|x64.Build.0 = Debug|Any CPU
 		{08184158-2865-4481-AD38-9E82F1A44FD5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{08184158-2865-4481-AD38-9E82F1A44FD5}.Release|Any CPU.Build.0 = Release|Any CPU
 		{08184158-2865-4481-AD38-9E82F1A44FD5}.Release|x64.ActiveCfg = Release|Any CPU
@@ -110,6 +144,10 @@ Global
 		{2C1C41C6-591A-4092-A01A-FEEE1B53185F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2C1C41C6-591A-4092-A01A-FEEE1B53185F}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{2C1C41C6-591A-4092-A01A-FEEE1B53185F}.Debug|x64.Build.0 = Debug|Any CPU
+		{2C1C41C6-591A-4092-A01A-FEEE1B53185F}.DebugAutoConnect|Any CPU.ActiveCfg = DebugAutoConnect|Any CPU
+		{2C1C41C6-591A-4092-A01A-FEEE1B53185F}.DebugAutoConnect|Any CPU.Build.0 = DebugAutoConnect|Any CPU
+		{2C1C41C6-591A-4092-A01A-FEEE1B53185F}.DebugAutoConnect|x64.ActiveCfg = DebugAutoConnect|Any CPU
+		{2C1C41C6-591A-4092-A01A-FEEE1B53185F}.DebugAutoConnect|x64.Build.0 = DebugAutoConnect|Any CPU
 		{2C1C41C6-591A-4092-A01A-FEEE1B53185F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2C1C41C6-591A-4092-A01A-FEEE1B53185F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{2C1C41C6-591A-4092-A01A-FEEE1B53185F}.Release|x64.ActiveCfg = Release|Any CPU
@@ -118,6 +156,10 @@ Global
 		{470498AB-91E4-419A-9E59-5E9E97264D99}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{470498AB-91E4-419A-9E59-5E9E97264D99}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{470498AB-91E4-419A-9E59-5E9E97264D99}.Debug|x64.Build.0 = Debug|Any CPU
+		{470498AB-91E4-419A-9E59-5E9E97264D99}.DebugAutoConnect|Any CPU.ActiveCfg = DebugAutoConnect|Any CPU
+		{470498AB-91E4-419A-9E59-5E9E97264D99}.DebugAutoConnect|Any CPU.Build.0 = DebugAutoConnect|Any CPU
+		{470498AB-91E4-419A-9E59-5E9E97264D99}.DebugAutoConnect|x64.ActiveCfg = DebugAutoConnect|Any CPU
+		{470498AB-91E4-419A-9E59-5E9E97264D99}.DebugAutoConnect|x64.Build.0 = DebugAutoConnect|Any CPU
 		{470498AB-91E4-419A-9E59-5E9E97264D99}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{470498AB-91E4-419A-9E59-5E9E97264D99}.Release|Any CPU.Build.0 = Release|Any CPU
 		{470498AB-91E4-419A-9E59-5E9E97264D99}.Release|x64.ActiveCfg = Release|Any CPU
@@ -126,6 +168,10 @@ Global
 		{DF3D47B3-487A-48AE-A10B-FDCE9D46D782}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DF3D47B3-487A-48AE-A10B-FDCE9D46D782}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{DF3D47B3-487A-48AE-A10B-FDCE9D46D782}.Debug|x64.Build.0 = Debug|Any CPU
+		{DF3D47B3-487A-48AE-A10B-FDCE9D46D782}.DebugAutoConnect|Any CPU.ActiveCfg = Debug|Any CPU
+		{DF3D47B3-487A-48AE-A10B-FDCE9D46D782}.DebugAutoConnect|Any CPU.Build.0 = Debug|Any CPU
+		{DF3D47B3-487A-48AE-A10B-FDCE9D46D782}.DebugAutoConnect|x64.ActiveCfg = Debug|Any CPU
+		{DF3D47B3-487A-48AE-A10B-FDCE9D46D782}.DebugAutoConnect|x64.Build.0 = Debug|Any CPU
 		{DF3D47B3-487A-48AE-A10B-FDCE9D46D782}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DF3D47B3-487A-48AE-A10B-FDCE9D46D782}.Release|Any CPU.Build.0 = Release|Any CPU
 		{DF3D47B3-487A-48AE-A10B-FDCE9D46D782}.Release|x64.ActiveCfg = Release|Any CPU
@@ -134,6 +180,10 @@ Global
 		{BCBF501F-2A56-40B7-B328-9C0E15CEDBC1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BCBF501F-2A56-40B7-B328-9C0E15CEDBC1}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{BCBF501F-2A56-40B7-B328-9C0E15CEDBC1}.Debug|x64.Build.0 = Debug|Any CPU
+		{BCBF501F-2A56-40B7-B328-9C0E15CEDBC1}.DebugAutoConnect|Any CPU.ActiveCfg = Debug|Any CPU
+		{BCBF501F-2A56-40B7-B328-9C0E15CEDBC1}.DebugAutoConnect|Any CPU.Build.0 = Debug|Any CPU
+		{BCBF501F-2A56-40B7-B328-9C0E15CEDBC1}.DebugAutoConnect|x64.ActiveCfg = Debug|Any CPU
+		{BCBF501F-2A56-40B7-B328-9C0E15CEDBC1}.DebugAutoConnect|x64.Build.0 = Debug|Any CPU
 		{BCBF501F-2A56-40B7-B328-9C0E15CEDBC1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BCBF501F-2A56-40B7-B328-9C0E15CEDBC1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{BCBF501F-2A56-40B7-B328-9C0E15CEDBC1}.Release|x64.ActiveCfg = Release|Any CPU
@@ -142,6 +192,10 @@ Global
 		{239E3ABE-646A-4DCE-AD4C-AD102DC014C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{239E3ABE-646A-4DCE-AD4C-AD102DC014C0}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{239E3ABE-646A-4DCE-AD4C-AD102DC014C0}.Debug|x64.Build.0 = Debug|Any CPU
+		{239E3ABE-646A-4DCE-AD4C-AD102DC014C0}.DebugAutoConnect|Any CPU.ActiveCfg = Debug|Any CPU
+		{239E3ABE-646A-4DCE-AD4C-AD102DC014C0}.DebugAutoConnect|Any CPU.Build.0 = Debug|Any CPU
+		{239E3ABE-646A-4DCE-AD4C-AD102DC014C0}.DebugAutoConnect|x64.ActiveCfg = Debug|Any CPU
+		{239E3ABE-646A-4DCE-AD4C-AD102DC014C0}.DebugAutoConnect|x64.Build.0 = Debug|Any CPU
 		{239E3ABE-646A-4DCE-AD4C-AD102DC014C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{239E3ABE-646A-4DCE-AD4C-AD102DC014C0}.Release|Any CPU.Build.0 = Release|Any CPU
 		{239E3ABE-646A-4DCE-AD4C-AD102DC014C0}.Release|x64.ActiveCfg = Release|Any CPU

--- a/source/Coop/Coop.csproj
+++ b/source/Coop/Coop.csproj
@@ -32,6 +32,15 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'DebugAutoConnect|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
   <PropertyGroup>
     <RunPostBuildEvent>Always</RunPostBuildEvent>
   </PropertyGroup>

--- a/source/Coop/Coop.csproj.user
+++ b/source/Coop/Coop.csproj.user
@@ -12,4 +12,10 @@
     <StartWorkingDirectory>..\..\..\..\mb2\bin\Win64_Shipping_Client\</StartWorkingDirectory>
     <StartArguments>/singleplayer /server _MODULES_%2aNative%2aSandBoxCore%2aCustomBattle%2aSandBox%2aStoryMode%2aCoop%2a_MODULES_</StartArguments>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DebugAutoConnect|AnyCPU'">
+    <StartAction>Program</StartAction>
+    <StartProgram>..\mb2\bin\Win64_Shipping_Client\Bannerlord.exe</StartProgram>
+    <StartArguments>/singleplayer /server /autoconnect _MODULES_%2aNative%2aSandBoxCore%2aSandBox%2aStoryMode%2aCoop%2a_MODULES_</StartArguments>
+    <StartWorkingDirectory>..\..\..\..\mb2\bin\Win64_Shipping_Client\</StartWorkingDirectory>
+  </PropertyGroup>
 </Project>

--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -41,22 +41,32 @@ namespace Coop
         private static string ClientServerModeMessage = "";
 
         private bool isServer = false;
+        private bool isAutoConnect = false;
         public override void NoHarmonyInit() 
         {
             AssemblyHellscape.CreateAssemblyBindingRedirects();
 
-            var args = Utilities.GetFullCommandLineString().Split(' ').ToList();
+            var fullCommandLine = Utilities.GetFullCommandLineString();
+            var args = fullCommandLine.Split(' ').ToList();
             
-            if (args.Contains("/server"))
+            if (args.Any(a => a.Equals("/server", StringComparison.OrdinalIgnoreCase)))
             {
                 isServer = true;
             }
-            else if (args.Contains("/client"))
+            else if (args.Any(a => a.Equals("/client", StringComparison.OrdinalIgnoreCase)))
             {
                 isServer = false;
             }
 
+            isAutoConnect = args.Any(a => a.Equals("/autoconnect", StringComparison.OrdinalIgnoreCase));
+
             SetupLogging();
+
+            if (isAutoConnect)
+            {
+                Logger.Information("[AutoConnect] Full command line: {CommandLine}", fullCommandLine);
+                Logger.Information("[AutoConnect] isServer={IsServer} isAutoConnect={IsAutoConnect}", isServer, isAutoConnect);
+            }
 
             GameLoopRunner.Instance.SetGameLoopThread();
         }
@@ -170,6 +180,7 @@ namespace Coop
         }
 
         private bool m_IsFirstTick = true;
+        private bool _autoStarted = false;
         protected override void OnApplicationTick(float dt)
         {
             if(m_IsFirstTick)
@@ -180,6 +191,37 @@ namespace Coop
             }    
             TimeSpan frameTime = TimeSpan.FromSeconds(dt);
             Updateables.UpdateAll(frameTime);
+
+#if DEBUG
+            TryAutoConnect();
+#endif
+        }
+
+        private void TryAutoConnect()
+        {
+            if (isAutoConnect && !_autoStarted && GameStateManager.Current?.ActiveState is InitialState)
+            {
+                _autoStarted = true;
+                try
+                {
+                    if (isServer)
+                    {
+                        Logger.Information("[AutoConnect] InitialState active — auto-starting as server...");
+                        Coop.StartAsServer();
+                        Logger.Information("[AutoConnect] StartAsServer() completed");
+                    }
+                    else
+                    {
+                        Logger.Information("[AutoConnect] InitialState active — auto-starting as client...");
+                        Coop.StartAsClient();
+                        Logger.Information("[AutoConnect] StartAsClient() completed");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, "[AutoConnect] Exception during auto-start");
+                }
+            }
         }
 
         private static void OnUnhandledException(object sender, UnhandledExceptionEventArgs e)


### PR DESCRIPTION


## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
Always have to launch in visual studio, then click host on the host client, then minute later click join on the player client. 


## What is the new behavior?
New option in visual studio when launching game "DebugAutoConnect". Essentially enables the host client first once it get initialized to start loading into the game on the "MP" save. Then it because the player client is polling waiting for the host to come online, when it does the player client automatically starts entering the game. So just press start in visual studio and minutes later automatically both clients will be logged into the game. (baring the colliding font issue which I'm going to take a look at next)
<img width="590" height="204" alt="image" src="https://github.com/user-attachments/assets/2a8408e0-f8a8-421c-b17b-c63d90a79589" />


