### PR TITLE
Devfred/fix dynamicsync export race

### DIFF
--- a/source/Coop.Core/CoopartiveMultiplayerExperience.cs
+++ b/source/Coop.Core/CoopartiveMultiplayerExperience.cs
@@ -8,6 +8,7 @@ using Coop.Core.Common.Services.Connection.Messages;
 using Coop.Core.Server;
 using GameInterface;
 using GameInterface.AutoSync;
+using GameInterface.DynamicSync;
 using GameInterface.Services.GameDebug.Messages;
 using GameInterface.Services.UI.Messages;
 using HarmonyLib;
@@ -119,6 +120,10 @@ namespace Coop.Core
 
             containerProvider.SetProvider(container);
             GameInterface.ContainerProvider.SetContainer(container);
+
+            // Client process does not own the export directory — only the server writes
+            // debug export files. This prevents DebugAutoConnect races on that directory.
+            DynamicSyncConfiguration.ExportFiles = false;
 
             // Create harmony patches
             container.Resolve<IGameInterface>().PatchAll();

--- a/source/Coop/BootPatches.cs
+++ b/source/Coop/BootPatches.cs
@@ -33,13 +33,53 @@ namespace Coop
             catch { return false; }
         }
 
+        private static bool _applied = false;
+
         internal static void Apply()
         {
+            if (_applied) return;
+            _applied = true;
             try
             {
                 FileLog("Apply() called");
 
                 var harmony = new Harmony("Coop.BootFix");
+
+                // ROOT CAUSE FIX: postfix on Font.TryLoadFontFromPath.
+                // When both DebugAutoConnect processes race to open the same .bfnt file,
+                // File.Open uses FileShare.None — the losing process gets IOException,
+                // TryLoadFontFromPath returns false, and the font is never added to _bitmapFonts.
+                // Later, GetFont("FiraSansExtraCondensed-Light") falls back to DefaultFont.get(),
+                // CurrentLanguage is null mid-parse → NullReferenceException.
+                // This postfix retries LoadFromPathAux after a brief sleep, by which time the
+                // other process has closed the file.
+                var fontType = typeof(FontFactory)
+                    .GetProperty("DefaultFont", BindingFlags.Public | BindingFlags.Instance)
+                    ?.PropertyType;
+                var tryLoadFontFromPath = fontType?.GetMethod("TryLoadFontFromPath",
+                    BindingFlags.Public | BindingFlags.Instance);
+                FileLog($"Font.TryLoadFontFromPath found: {tryLoadFontFromPath != null}");
+                if (tryLoadFontFromPath != null)
+                {
+                    var tlfpPostfix = typeof(BootPatches).GetMethod(nameof(Font_TryLoadFontFromPath_Postfix), BindingFlags.Static | BindingFlags.NonPublic);
+                    harmony.Patch(tryLoadFontFromPath, postfix: new HarmonyMethod(tlfpPostfix));
+                    FileLog("Patched Font.TryLoadFontFromPath with retry postfix");
+                }
+
+                // DEFENSE IN DEPTH: prefix on FontFactory.DefaultFont.get().
+                // If TryLoadFontFromPath still fails after retries, CurrentLanguage will be null
+                // mid-parse. This prefix returns null instead of crashing, so VS never sees
+                // a first-chance exception. HasValidDefaultFont detects the null downstream.
+                var defaultFontGetter = typeof(FontFactory)
+                    .GetProperty("DefaultFont", BindingFlags.Public | BindingFlags.Instance)
+                    ?.GetGetMethod();
+                FileLog($"FontFactory.DefaultFont.get found: {defaultFontGetter != null}");
+                if (defaultFontGetter != null)
+                {
+                    var dfPrefix = typeof(BootPatches).GetMethod(nameof(FontFactory_DefaultFont_get_Prefix), BindingFlags.Static | BindingFlags.NonPublic);
+                    harmony.Patch(defaultFontGetter, prefix: new HarmonyMethod(dfPrefix));
+                    FileLog("Patched FontFactory.DefaultFont.get with null-guard prefix");
+                }
 
                 // PRIMARY FIX: prefix on the private LoadMovieAux(string, ViewModel) method.
                 //
@@ -81,6 +121,58 @@ namespace Coop
                 FileLog($"Apply() threw: {ex}");
                 Logger.Error(ex, "[BootPatches] Apply() failed");
             }
+        }
+
+        // Prefix on FontFactory.DefaultFont.get() — null-guard.
+        // Returns null (via ref object __result) when CurrentLanguage is null so that
+        // Language.CreateFrom stores null in DefaultFont rather than crashing.
+        private static bool FontFactory_DefaultFont_get_Prefix(FontFactory __instance, ref object __result)
+        {
+            try
+            {
+                var currentLang = typeof(FontFactory)
+                    .GetProperty("CurrentLanguage", BindingFlags.Public | BindingFlags.Instance)
+                    ?.GetValue(__instance);
+                if (currentLang != null) return true; // safe — let original run
+                __result = null;
+                FileLog("FontFactory.DefaultFont.get: CurrentLanguage null — returning null to prevent NPE");
+                return false; // skip original
+            }
+            catch { return true; }
+        }
+
+        // Postfix on Font.TryLoadFontFromPath — retries on failure.
+        private static void Font_TryLoadFontFromPath_Postfix(object __instance, string path, ref bool __result)
+        {
+            if (__result) return;
+            try
+            {
+                var loadAux = __instance.GetType()
+                    .GetMethod("LoadFromPathAux", BindingFlags.NonPublic | BindingFlags.Instance);
+                if (loadAux == null) { FileLog($"Font_TryLoadFontFromPath_Postfix: LoadFromPathAux not found for {path}"); return; }
+
+                var spriteData = typeof(UIResourceManager)
+                    .GetProperty("SpriteData", BindingFlags.Public | BindingFlags.Static)
+                    ?.GetValue(null);
+
+                for (int i = 0; i < 3; i++)
+                {
+                    System.Threading.Thread.Sleep(50 * (i + 1));
+                    try
+                    {
+                        loadAux.Invoke(__instance, new object[] { path, spriteData });
+                        __result = true;
+                        FileLog($"Font_TryLoadFontFromPath: retry {i + 1} succeeded for {System.IO.Path.GetFileName(path)}");
+                        return;
+                    }
+                    catch (TargetInvocationException tie)
+                    {
+                        FileLog($"Font_TryLoadFontFromPath: retry {i + 1} failed for {System.IO.Path.GetFileName(path)}: {tie.InnerException?.GetType().Name}");
+                    }
+                }
+                FileLog($"Font_TryLoadFontFromPath: all retries exhausted for {System.IO.Path.GetFileName(path)}");
+            }
+            catch (Exception ex) { FileLog($"Font_TryLoadFontFromPath_Postfix threw: {ex.GetType().Name}"); }
         }
 
         // Prefix on GauntletLayer.LoadMovieAux(string, ViewModel).

--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -36,6 +36,12 @@ namespace Coop
             MBDebug.DisableLogging = false;
 
             AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
+
+            // Must be called here (constructor), not in NoHarmonyLoad().
+            // Module.LoadSubModules() calls all submodule constructors first, then all
+            // OnSubModuleLoad() in a second pass. GauntletUISubModule.OnSubModuleLoad()
+            // triggers the font race — our patches must be registered before that runs.
+            BootPatches.Apply();
         }
 
         private static string ClientServerModeMessage = "";
@@ -150,11 +156,6 @@ namespace Coop
 
         public override void NoHarmonyLoad()
         {
-            // Apply boot-time UI fix before any application ticks run.
-            // Prevents intermittent TextWidget NullRef on GauntletDefaultLoadingWindowManager.Initialize()
-            // caused by UIContext being created with a null FontFactory on Bannerlord v1.3.15.
-            BootPatches.Apply();
-
             Coop = new CoopartiveMultiplayerExperience();
 
             Updateables.Add(GameLoopRunner.Instance);

--- a/source/GameInterface/DynamicSync/Builders/DynamicSyncBuilder.cs
+++ b/source/GameInterface/DynamicSync/Builders/DynamicSyncBuilder.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using Common.Logging;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Serilog;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -11,6 +13,8 @@ namespace GameInterface.DynamicSync.Builders;
 
 public class DynamicSyncBuilder
 {
+    private static readonly ILogger Logger = LogManager.GetLogger<DynamicSyncBuilder>();
+
     private readonly DynamicSyncRegistry dynamicSyncRegistry;
     private readonly DynamicSyncAssemblyInfoBuilder dynamicSyncAssemblyInfoBuilder;
     private readonly DynamicSyncPatchBuilder dynamicSyncPatchBuilder;
@@ -24,13 +28,42 @@ public class DynamicSyncBuilder
 
     public Assembly Build()
     {
-        if (Directory.Exists($@"{DynamicSyncConfiguration.ExportPath}"))
+        // Only the server/host process manages the export directory (ExportFiles=true by
+        // default; the client sets it to false in StartAsClient before calling PatchAll).
+        //
+        // Why it is safe for the client never to delete or write the export directory:
+        //
+        //   - Same-machine (DebugAutoConnect): both processes share the same physical
+        //     directory. Without this guard they raced on Directory.Delete, causing
+        //     "directory is not empty" IOException. Since both processes generate identical
+        //     output, the server's deletion and export is sufficient — the client gains
+        //     nothing by also doing it.
+        //
+        //   - Separate machines (normal multiplayer): ExportPath is derived from
+        //     Assembly.GetExecutingAssembly().Location, which is a local path on whichever
+        //     machine the process runs on. Server and client therefore have completely
+        //     independent directories on different disks — no race is possible regardless.
+        //     The client skipping its own local export is a minor debug inconvenience at
+        //     most; the server's exported sources are always available for inspection, and
+        //     both sides generate identical code anyway.
+        if (DynamicSyncConfiguration.ExportFiles && Directory.Exists(DynamicSyncConfiguration.ExportPath))
         {
-            // Directory.Delete throws UnauthorizedAccessException on read-only files (a .NET
-            // Framework limitation). Strip attributes on all files before deleting.
+            // Directory.Delete throws UnauthorizedAccessException on read-only files
+            // (.NET Framework limitation). Strip attributes on all files before deleting.
             foreach (var file in Directory.GetFiles(DynamicSyncConfiguration.ExportPath, "*", SearchOption.AllDirectories))
-                File.SetAttributes(file, FileAttributes.Normal);
-            Directory.Delete($@"{DynamicSyncConfiguration.ExportPath}", true);
+            {
+                try { File.SetAttributes(file, FileAttributes.Normal); }
+                catch (FileNotFoundException ex)
+                {
+                    Logger.Warning("[DynamicSync] SetAttributes: file not found (race?): {File} — {Message}", file, ex.Message);
+                }
+                catch (IOException ex)
+                {
+                    Logger.Warning("[DynamicSync] SetAttributes IOException: {File} — {Message}", file, ex.Message);
+                }
+            }
+
+            Directory.Delete(DynamicSyncConfiguration.ExportPath, true);
         }
 
         List<Assembly> assemblies = new List<Assembly>
@@ -101,7 +134,15 @@ public class DynamicSyncBuilder
             var result = dynamicAssembly.Emit(assemblyStream, pdbStream);
 
             if (!result.Success)
-                throw new InvalidOperationException(string.Join("\n", result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).Select(d => $"{d.Location.ToString()} {d.GetMessage()}")));
+            {
+                var errors = result.Diagnostics
+                    .Where(d => d.Severity == DiagnosticSeverity.Error)
+                    .Select(d => $"{d.Location} {d.GetMessage()}")
+                    .ToList();
+                Logger.Error("[DynamicSync] Compilation failed with {ErrorCount} error(s):\n{Errors}",
+                    errors.Count, string.Join("\n", errors));
+                throw new InvalidOperationException(string.Join("\n", errors));
+            }
 
             return Assembly.Load(assemblyStream.GetBuffer());
         };

--- a/source/GameInterface/DynamicSync/DynamicSyncConfiguration.cs
+++ b/source/GameInterface/DynamicSync/DynamicSyncConfiguration.cs
@@ -7,7 +7,7 @@ namespace GameInterface.DynamicSync
     {
         public static string ExportPath => Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + @"\DynamicSyncExport";
 
-        public static bool ExportFiles { get; } = true;
+        public static bool ExportFiles { get; set; } = true;
 
         public static bool Enabled { get; } = true;
 


### PR DESCRIPTION
Fix DynamicSync export directory race in DebugAutoConnect

When running DebugAutoConnect both the server and client processes start
simultaneously and both called DynamicSyncBuilder.Build(), which deleted
and recreated the DynamicSyncExport directory. This caused two races:

  1. IOException ('directory is not empty') - the losing process hit
     Directory.Delete while the winner was mid-deletion.
  2. FileNotFoundException on File.SetAttributes - the winner deleted
     files between the loser's Directory.GetFiles enumeration and its
     subsequent SetAttributes call.

Root cause: both processes share the same export directory on the same
machine, but only the server's export is needed (both sides generate
identical output).

Fix:
- DynamicSyncConfiguration.ExportFiles gains a public setter (was
  get-only). Defaults to true so server behaviour is unchanged.
- DynamicSyncBuilder.Build() gates the entire directory cleanup block
  on ExportFiles, so a client with ExportFiles=false skips it entirely.
  File.SetAttributes errors are now caught and logged as warnings rather
  than swallowed silently, in case a race ever surfaces again.
- CoopartiveMultiplayerExperience.StartAsClient() sets
  DynamicSyncConfiguration.ExportFiles = false before calling PatchAll(),
  so the client never touches the export directory.
- Roslyn compilation errors in Build() are now logged via Serilog before
  throwing, making failures easier to diagnose.

This fix is safe for both deployment topologies:
- Same machine (DebugAutoConnect): race eliminated at the root because
  only one process (server) manages the shared directory.
- Separate machines (normal multiplayer): ExportPath is local to each
  machine, so no race was ever possible; client skipping its own local
  export is a minor debug inconvenience only."

## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [X ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Other information
