### PR TITLE
Fix client crashes caused by partially-synced TroopRoster and null Mi…

### DIFF
--- a/source/GameInterface/Services/MobileParties/Patches/ParallelRobustnessPatches.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/ParallelRobustnessPatches.cs
@@ -146,6 +146,13 @@ internal class ParallelRobustnessPatches
                 continue;
             }
 
+            if (mobileParty.IsMilitia && mobileParty.HomeSettlement == null)
+            {
+                Logger.Warning("Skipping militia party {stringId} in ParallelTickMovingParties: HomeSettlement is null (Settlement not yet synced)",
+                    mobileParty.StringId);
+                continue;
+            }
+
             MobileParty.CachedPartyVariables localVariables = tickCachePerParty.LocalVariables;
             mobileParty.FillCurrentTickMoveDataForMovingArmyLeader(ref localVariables, __instance._currentDt, __instance._currentRealDt);
             mobileParty.TryToMoveThePartyWithCurrentTickMoveData(ref localVariables, ref __instance._gridChangeCount, ref __instance._gridChangeMobilePartyList);

--- a/source/GameInterface/Services/MobileParties/Patches/SkillHelperRobustnessPatches.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/SkillHelperRobustnessPatches.cs
@@ -1,0 +1,92 @@
+using Common.Logging;
+using Helpers;
+using HarmonyLib;
+using Serilog;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Roster;
+
+namespace GameInterface.Services.MobileParties.Patches;
+
+/// <summary>
+/// Guards against IndexOutOfRangeException in SkillHelper.GetEffectivePartyLeaderForSkill
+/// and PartyBaseHelper.GetVisualPartyLeader.
+///
+/// Root cause: TroopRoster has two separate counters:
+///   - TotalManCount = _totalRegulars + _totalHeroes  (sum of all soldiers)
+///   - Count         = _count                         (number of distinct character type slots)
+///
+/// During multiplayer sync, TotalManCount can be synced to non-zero before the actual
+/// character data entries (_count) are populated.  Vanilla guards only check
+/// TotalManCount > 0, then immediately call GetCharacterAtIndex(0) which throws if
+/// _count == 0.
+/// </summary>
+internal static class TroopRosterLeaderHelper
+{
+    internal static ILogger Logger = LogManager.GetLogger<SkillHelperRobustnessPatches>();
+
+    internal static bool IsSafeToGetCharacterAtIndex(PartyBase party, TroopRoster memberRoster)
+    {
+        if (memberRoster != null && memberRoster.TotalManCount > 0 && memberRoster.Count == 0)
+        {
+            Logger.Warning(
+                "TroopRoster desync on party {StringId}: TotalManCount={TotalManCount} but Count=0 - returning null leader to avoid IndexOutOfRangeException",
+                party.MobileParty?.StringId ?? party.Name?.ToString() ?? "unknown",
+                memberRoster.TotalManCount);
+            return false;
+        }
+        return true;
+    }
+}
+
+[HarmonyPatch(typeof(SkillHelper), nameof(SkillHelper.GetEffectivePartyLeaderForSkill))]
+internal class SkillHelperRobustnessPatches
+{
+    [HarmonyPrefix]
+    private static bool Prefix(PartyBase party, ref CharacterObject __result)
+    {
+        if (party == null)
+        {
+            __result = null;
+            return false;
+        }
+
+        if (party.LeaderHero != null)
+            return true;
+
+        TroopRoster memberRoster = party.MemberRoster;
+        if (memberRoster == null || memberRoster.TotalManCount <= 0 || !TroopRosterLeaderHelper.IsSafeToGetCharacterAtIndex(party, memberRoster))
+        {
+            __result = null;
+            return false;
+        }
+
+        return true;
+    }
+}
+
+[HarmonyPatch(typeof(PartyBaseHelper), nameof(PartyBaseHelper.GetVisualPartyLeader))]
+internal class PartyBaseHelperRobustnessPatches
+{
+    [HarmonyPrefix]
+    private static bool Prefix(PartyBase party, ref CharacterObject __result)
+    {
+        if (party == null)
+        {
+            __result = null;
+            return false;
+        }
+
+        if (party.LeaderHero != null)
+            return true;
+
+        TroopRoster memberRoster = party.MemberRoster;
+        if (memberRoster == null || memberRoster.TotalManCount <= 0 || !TroopRosterLeaderHelper.IsSafeToGetCharacterAtIndex(party, memberRoster))
+        {
+            __result = null;
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/source/GameInterface/Services/PartyComponents/Patches/Lifetime/MilitiaPartyComponentLifetimePatches.cs
+++ b/source/GameInterface/Services/PartyComponents/Patches/Lifetime/MilitiaPartyComponentLifetimePatches.cs
@@ -8,9 +8,12 @@ using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Party.PartyComponents;
 using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.Core;
+using TaleWorlds.Localization;
 
 namespace GameInterface.Services.PartyComponents.Patches.Lifetime;
 
@@ -40,6 +43,130 @@ internal class MilitiaPartyComponentLifetimePatches
 
         MessageBroker.Instance.Publish(__instance, message);
 
+        return true;
+    }
+
+    /// <summary>
+    /// Logs changes to <see cref="MilitiaPartyComponent.Settlement"/> so we can trace
+    /// when/why it becomes null during multiplayer sync.
+    /// </summary>
+    [HarmonyPatch(typeof(MilitiaPartyComponent), nameof(MilitiaPartyComponent.Settlement), MethodType.Setter)]
+    [HarmonyPrefix]
+    private static void SettlementSetterPrefix(MilitiaPartyComponent __instance, Settlement value)
+    {
+        var current = __instance.Settlement;
+        if (value == null)
+        {
+            Logger.Warning("MilitiaPartyComponent.Settlement being set to NULL (was: {PreviousSettlement}, MobileParty: {Party}, IsClient: {IsClient})",
+                current?.StringId ?? "null",
+                __instance.MobileParty?.StringId ?? "null",
+                ModInformation.IsClient);
+        }
+        else if (current != value)
+        {
+            Logger.Information("MilitiaPartyComponent.Settlement changed: {Previous} -> {Next} (MobileParty: {Party}, IsClient: {IsClient})",
+                current?.StringId ?? "null",
+                value.StringId,
+                __instance.MobileParty?.StringId ?? "null",
+                ModInformation.IsClient);
+        }
+    }
+
+    /// <summary>
+    /// Guards against NullReferenceException in <see cref="MilitiaPartyComponent.PartyOwner"/>
+    /// when <see cref="MilitiaPartyComponent.Settlement"/> or its <see cref="Settlement.OwnerClan"/>
+    /// is null during a multiplayer sync transition.
+    /// </summary>
+    [HarmonyPatch(typeof(MilitiaPartyComponent), nameof(MilitiaPartyComponent.PartyOwner), MethodType.Getter)]
+    [HarmonyPrefix]
+    private static bool PartyOwnerPrefix(MilitiaPartyComponent __instance, ref Hero __result)
+    {
+        if (__instance.Settlement == null || __instance.Settlement.OwnerClan == null)
+        {
+            Logger.Warning("MilitiaPartyComponent.PartyOwner accessed with null Settlement/OwnerClan (MobileParty: {Party}, Settlement: {Settlement}, IsClient: {IsClient})",
+                __instance.MobileParty?.StringId ?? "null",
+                __instance.Settlement?.StringId ?? "null",
+                ModInformation.IsClient);
+            __result = null;
+            return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Guards against NullReferenceException in <see cref="MilitiaPartyComponent.Name"/>
+    /// when <see cref="MilitiaPartyComponent.Settlement"/> is null during a multiplayer sync transition.
+    /// </summary>
+    [HarmonyPatch(typeof(MilitiaPartyComponent), nameof(MilitiaPartyComponent.Name), MethodType.Getter)]
+    [HarmonyPrefix]
+    private static bool NamePrefix(MilitiaPartyComponent __instance, ref TextObject __result)
+    {
+        if (__instance.Settlement == null)
+        {
+            Logger.Warning("MilitiaPartyComponent.Name accessed with null Settlement (MobileParty: {Party}, IsClient: {IsClient})",
+                __instance.MobileParty?.StringId ?? "null",
+                ModInformation.IsClient);
+            __result = new TextObject("{=!}Militia");
+            return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Guards against NullReferenceException in <see cref="MilitiaPartyComponent.GetDefaultComponentBanner"/>
+    /// when Settlement is null during sync.
+    /// </summary>
+    [HarmonyPatch(typeof(MilitiaPartyComponent), nameof(MilitiaPartyComponent.GetDefaultComponentBanner))]
+    [HarmonyPrefix]
+    private static bool GetDefaultComponentBannerPrefix(MilitiaPartyComponent __instance, ref Banner __result)
+    {
+        if (__instance.Settlement == null)
+        {
+            Logger.Warning("MilitiaPartyComponent.GetDefaultComponentBanner accessed with null Settlement (MobileParty: {Party}, IsClient: {IsClient})",
+                __instance.MobileParty?.StringId ?? "null",
+                ModInformation.IsClient);
+            __result = null;
+            return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Guards against NullReferenceException in <see cref="MilitiaPartyComponent.OnFinalize"/>.
+    /// The base game does <c>this.Settlement.MilitiaPartyComponent = null</c>, but on clients
+    /// <see cref="MilitiaPartyComponent.Settlement"/> may already be null when the party is
+    /// destroyed, causing the DynamicSync field intercept to crash on a null instance.
+    /// </summary>
+    [HarmonyPatch(typeof(MilitiaPartyComponent), "OnFinalize")]
+    [HarmonyPrefix]
+    private static bool OnFinalizePrefix(MilitiaPartyComponent __instance)
+    {
+        if (__instance.Settlement == null)
+        {
+            Logger.Warning("MilitiaPartyComponent.OnFinalize called with null Settlement (MobileParty: {Party}, IsClient: {IsClient}) — skipping Settlement.MilitiaPartyComponent = null",
+                __instance.MobileParty?.StringId ?? "null",
+                ModInformation.IsClient);
+            return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Guards against NullReferenceException in <see cref="MilitiaPartyComponent.OnInitialize"/>
+    /// which does <c>this.Settlement.MilitiaPartyComponent = this</c>.
+    /// Settlement may be null on clients if the sync hasn't arrived yet.
+    /// </summary>
+    [HarmonyPatch(typeof(MilitiaPartyComponent), "OnInitialize")]
+    [HarmonyPrefix]
+    private static bool OnInitializePrefix(MilitiaPartyComponent __instance)
+    {
+        if (__instance.Settlement == null)
+        {
+            Logger.Warning("MilitiaPartyComponent.OnInitialize called with null Settlement (MobileParty: {Party}, IsClient: {IsClient}) — skipping Settlement.MilitiaPartyComponent = this",
+                __instance.MobileParty?.StringId ?? "null",
+                ModInformation.IsClient);
+            return false;
+        }
         return true;
     }
 }


### PR DESCRIPTION

Three crash fixes for the client during multiplayer sync:

1. TroopRoster desync: IndexOutOfRangeException in SkillHelper.GetEffectivePartyLeaderForSkill and PartyBaseHelper.GetVisualPartyLeader (new SkillHelperRobustnessPatches.cs)
   - Root cause: TotalManCount (_totalRegulars + _totalHeroes) can arrive via sync before the character-type slot array (_count) is populated. Vanilla only checks TotalManCount > 0 before calling GetCharacterAtIndex(0), which throws when _count == 0.
   - Fix: prefix patches on both methods that also guard on memberRoster.Count > 0, with a warning log on desync so the underlying issue can be tracked.

2. Militia null Settlement: NullReferenceException in PartyOwner, Name, GetDefaultComponentBanner, OnFinalize and OnInitialize on MilitiaPartyComponent (MilitiaPartyComponentLifetimePatches.cs)
   - Root cause: Settlement can be null on clients when the party is created before its owning Settlement has been synced. All five accessors dereference Settlement unconditionally.
   - Fix: prefix patches returning safe fallbacks (null / placeholder TextObject / skip body) plus a setter patch logging when Settlement transitions to null.

3. Militia null HomeSettlement in parallel movement tick (ParallelRobustnessPatches.cs)
   - Root cause: FillCurrentTickMoveDataForMovingArmyLeader crashes when HomeSettlement is null.
   - Fix: skip the militia party in ParallelTickMovingParties when HomeSettlement is null.

## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

