### PR TITLE
Fix four client-side NullReferenceExceptions during sync transitions

### DIFF
--- a/source/GameInterface/Services/MobileParties/Patches/CalculateBaseSpeedPatch.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/CalculateBaseSpeedPatch.cs
@@ -1,5 +1,7 @@
-﻿using GameInterface.Services.MobileParties.Extensions;
+﻿using Common.Logging;
+using GameInterface.Services.MobileParties.Extensions;
 using HarmonyLib;
+using Serilog;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.GameComponents;
 using TaleWorlds.CampaignSystem.Party;
@@ -50,5 +52,29 @@ internal class GameTextsPatches
             gameTextManager.LoadGameTexts();
             GameTexts.Initialize(gameTextManager);
         }
+    }
+}
+
+/// <summary>
+/// Guards against NullReferenceException in <see cref="DefaultPartyMoraleModel.GetEffectivePartyMorale"/>
+/// when a Militia party's <see cref="TaleWorlds.CampaignSystem.Party.MobileParty.HomeSettlement"/> is null
+/// during a multiplayer sync transition on the client.
+/// </summary>
+[HarmonyPatch(typeof(DefaultPartyMoraleModel), nameof(DefaultPartyMoraleModel.GetEffectivePartyMorale))]
+internal class PartyMoraleModelRobustnessPatch
+{
+    private static readonly ILogger Logger = LogManager.GetLogger<PartyMoraleModelRobustnessPatch>();
+
+    [HarmonyPrefix]
+    private static bool Prefix(MobileParty mobileParty, bool includeDescription, ref ExplainedNumber __result)
+    {
+        if (mobileParty.IsMilitia && mobileParty.HomeSettlement == null)
+        {
+            Logger.Debug("DefaultPartyMoraleModel.GetEffectivePartyMorale: skipping militia party {Party} with null HomeSettlement",
+                mobileParty.StringId ?? "null");
+            __result = new ExplainedNumber(50f, includeDescription, null);
+            return false;
+        }
+        return true;
     }
 }

--- a/source/GameInterface/Services/MobileParties/Patches/MobilePartyRobustnessPatches.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/MobilePartyRobustnessPatches.cs
@@ -1,6 +1,10 @@
-﻿using HarmonyLib;
+﻿using Common.Logging;
+using HarmonyLib;
+using Serilog;
 using TaleWorlds.CampaignSystem.Naval;
 using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Party.PartyComponents;
+using TaleWorlds.Core;
 using TaleWorlds.Library;
 
 namespace GameInterface.Services.MobileParties.Patches;
@@ -18,5 +22,29 @@ internal class MobilePartyRobustnessPatches
             __instance.Anchor = anchor;
             __result = anchor;
         }
+    }
+}
+
+/// <summary>
+/// Guards against NullReferenceException in <see cref="WarPartyComponent.Clan"/>
+/// when <see cref="PartyComponent.MobileParty"/> is null during a multiplayer sync
+/// transition, which causes <see cref="WarPartyComponent.GetDefaultComponentBanner"/>
+/// to NRE before it can null-check the result.
+/// </summary>
+[HarmonyPatch(typeof(WarPartyComponent), nameof(WarPartyComponent.GetDefaultComponentBanner))]
+internal class WarPartyComponentBannerRobustnessPatch
+{
+    private static readonly ILogger Logger = LogManager.GetLogger<WarPartyComponentBannerRobustnessPatch>();
+
+    [HarmonyPrefix]
+    private static bool Prefix(WarPartyComponent __instance, ref Banner __result)
+    {
+        if (__instance.MobileParty == null)
+        {
+            Logger.Debug("WarPartyComponent.GetDefaultComponentBanner: MobileParty is null, returning null banner");
+            __result = null;
+            return false;
+        }
+        return true;
     }
 }

--- a/source/GameInterface/Services/MobileParties/Patches/ParallelRobustnessPatches.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/ParallelRobustnessPatches.cs
@@ -184,6 +184,18 @@ internal class ParallelRobustnessPatches
                 }
 
                 MobileParty.CachedPartyVariables localVariables = tickCachePerParty.LocalVariables;
+
+                // HasMapEvent may be stale: it was cached as true but MapEvent can become null
+                // on the client during a sync transition, causing DoUpdatePosition to NRE on
+                // this.Party.MapEvent.Position.ToVec2(). Reset the flag so the tick uses
+                // NextTargetPosition instead.
+                if (localVariables.HasMapEvent && mobileParty.Party.MapEvent == null)
+                {
+                    Logger.Warning("Resetting stale HasMapEvent for party {stringId} in ParallelTickStationaryParties: MapEvent is null",
+                        mobileParty.StringId ?? "null");
+                    localVariables.HasMapEvent = false;
+                }
+
                 mobileParty.TickForStationaryMobileParty(ref localVariables, __instance._currentDt, __instance._currentRealDt);
             }
 

--- a/source/GameInterface/Services/PartyComponents/Patches/Lifetime/LordPartyComponentLifetimePatches.cs
+++ b/source/GameInterface/Services/PartyComponents/Patches/Lifetime/LordPartyComponentLifetimePatches.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Party.PartyComponents;
+using TaleWorlds.CampaignSystem.Settlements;
 
 namespace GameInterface.Services.PartyComponents.Patches.Lifetime;
 
@@ -39,6 +40,31 @@ internal class LordPartyComponentLifetimePatches
 
         MessageBroker.Instance.Publish(__instance, message);
 
+        return true;
+    }
+
+}
+
+/// <summary>
+/// Guards against NullReferenceException in <see cref="LordPartyComponent.HomeSettlement"/>
+/// when <see cref="LordPartyComponent.Owner"/> is null during a multiplayer sync transition.
+/// </summary>
+[HarmonyPatch(typeof(LordPartyComponent), nameof(LordPartyComponent.HomeSettlement), MethodType.Getter)]
+internal class LordPartyComponentHomeSettlementPatch
+{
+    private static readonly ILogger Logger = LogManager.GetLogger<LordPartyComponentHomeSettlementPatch>();
+
+    [HarmonyPrefix]
+    private static bool Prefix(LordPartyComponent __instance, ref Settlement __result)
+    {
+        if (__instance.Owner == null)
+        {
+            Logger.Debug("LordPartyComponent.HomeSettlement accessed with null Owner (MobileParty: {Party}, IsClient: {IsClient})",
+                __instance.MobileParty?.StringId ?? "null",
+                ModInformation.IsClient);
+            __result = null;
+            return false;
+        }
         return true;
     }
 }


### PR DESCRIPTION
During extended multiplayer sessions, four distinct NullReferenceExceptions were observed on the client crashing the game, all stemming from the same root pattern: game UI or simulation code accessing properties on partially-synced objects whose dependent data had not yet arrived from the server. Each fix follows the established mod pattern of a Harmony prefix that guards the crash site and returns a safe default, matching how MilitiaPartyComponentLifetimePatches already guards MilitiaPartyComponent.

---- Fix 1: LordPartyComponent.HomeSettlement with null Owner ----
Stack: LordPartyComponent.get_HomeSettlement -> MobileParty.get_HomeSettlement ->
       MobileParty.get_MapFaction -> PartyNameplateVM.RefreshDynamicProperties

LordPartyComponent.HomeSettlement returns 'this.Owner.HomeSettlement' with no null check on Owner. On the client, a LordPartyComponent can be registered in the object manager before its Owner Hero has been synced, making Owner null. This propagated through MobileParty.MapFaction (which also calls HomeSettlement) and crashed the nameplate refresh UI.

Fix: Added LordPartyComponentHomeSettlementPatch in LordPartyComponentLifetimePatches.cs as a separate Harmony class (required because the existing class uses TargetMethods() which cannot be combined with individual [HarmonyPatch] attribute annotations in the same class). When Owner is null the prefix returns null and skips the original.

---- Fix 2: DefaultPartyMoraleModel.GetEffectivePartyMorale with null HomeSettlement ----
Stack: DefaultPartyMoraleModel.GetEffectivePartyMorale ->
       DefaultPartySpeedCalculatingModel.CalculateLandBaseSpeed ->
       PartyNameplateVM.RefreshDynamicProperties

DefaultPartyMoraleModel.GetEffectivePartyMorale does 'mobileParty.HomeSettlement.IsStarving' when IsMilitia is true, with no null check on HomeSettlement. MobileParty.HomeSettlement delegates to MilitiaPartyComponent.Settlement, which can be null on the client during sync (the existing MilitiaPartyComponentLifetimePatches already logs this). The morale result was then fed into the speed model which also crashed.

Fix: Added PartyMoraleModelRobustnessPatch in CalculateBaseSpeedPatch.cs. When a militia party has a null HomeSettlement the prefix skips the original and returns a neutral baseline ExplainedNumber of 50 (the game's own base morale value), meaning no starvation penalty is applied until the settlement data arrives.

---- Fix 3: Stale HasMapEvent flag in ParallelTickStationaryParties ----
Stack: ParallelRobustnessPatches.ParallelTickStationaryParties ->
       MobileParty.TickForStationaryMobileParty -> MobileParty.DoUpdatePosition

MobileParty.CachedPartyVariables.HasMapEvent is set at frame-start cache time ('this.MapEvent != null'). By the time ParallelTickStationaryParties runs, Party.MapEvent can have become null on the client due to sync lag. DoUpdatePosition trusts the cached flag and calls 'this.Party.MapEvent.Position.ToVec2()' with no null check, producing the NRE. The crashing party was a lord party with HasMapEvent=true and an actual null MapEvent at tick time.

Fix: In ParallelRobustnessPatches.cs, before calling TickForStationaryMobileParty, check whether localVariables.HasMapEvent is true but mobileParty.Party.MapEvent is actually null. If so, reset the cached flag to false so DoUpdatePosition falls back to NextTargetPosition harmlessly for that tick.

---- Fix 4: WarPartyComponent.GetDefaultComponentBanner with null MobileParty ----
Stack: WarPartyComponent.get_Clan -> WarPartyComponent.GetDefaultComponentBanner ->
       PartyNameplateVM.RefreshDynamicProperties

WarPartyComponent.Clan returns 'base.Party.MobileParty.ActualClan'. PartyComponent.Party is implemented as 'this.MobileParty.Party', so if MobileParty itself is null the Clan getter NREs on line 8, before GetDefaultComponentBanner even reaches its own null check on the returned Clan value. This occurred for a lord party whose component was partially constructed during sync.

Fix: Added WarPartyComponentBannerRobustnessPatch in MobilePartyRobustnessPatches.cs. The prefix guards GetDefaultComponentBanner before the Clan getter is ever invoked: if MobileParty is null it returns a null banner and skips the original, which is the same result the base game intends when Clan is null.

## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Other information
