### PR TITLE
Devfred/patrol party sync and nullref fixes

### DIFF
--- a/source/GameInterface/Services/MobileParties/Patches/Disable/DisablePatrolPartiesCampaignBehavior.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/Disable/DisablePatrolPartiesCampaignBehavior.cs
@@ -1,0 +1,32 @@
+using Common;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem.CampaignBehaviors;
+
+namespace GameInterface.Services.MobileParties.Patches;
+
+/// <summary>
+/// Disables <see cref="PatrolPartiesCampaignBehavior"/> on the CLIENT only.
+///
+/// The server must run this behavior normally: it spawns patrol parties via
+/// <c>SpawnPatrolParty</c>, ticks their AI, replenishes their rosters, and destroys
+/// them when appropriate. All of those actions flow through the coop sync pipeline
+/// (party creation → <c>NetworkCreatePartyComponent</c> + <c>NetworkCreateParty</c>,
+/// destruction → <c>NetworkDestroyParty</c>, field mutations → DynamicSync).
+///
+/// The client must NOT run this behavior. If it did, it would independently spawn its
+/// own local patrol parties, duplicating the ones already synced from the server and
+/// triggering the same NullReferenceException that motivated this patch:
+/// <c>MobilePartyDataPatches.SetPartyComponentIntercept</c> would fire, find the
+/// newly constructed <c>PatrolPartyComponent</c> in the registry (it is now registered),
+/// publish a <c>PartyComponentChanged</c> event, and the client-side party would
+/// incorrectly broadcast as if it were a server-authoritative change.
+///
+/// Clients receive patrol parties exclusively through the sync pipeline; this patch
+/// simply prevents the behavior from subscribing to any campaign events on the client.
+/// </summary>
+[HarmonyPatch(typeof(PatrolPartiesCampaignBehavior))]
+internal class DisablePatrolPartiesCampaignBehavior
+{
+    [HarmonyPatch(nameof(PatrolPartiesCampaignBehavior.RegisterEvents))]
+    static bool Prefix() => !ModInformation.IsClient;
+}

--- a/source/GameInterface/Services/PartyComponents/Data/PartyComponentData.cs
+++ b/source/GameInterface/Services/PartyComponents/Data/PartyComponentData.cs
@@ -10,4 +10,20 @@ public record PartyComponentData(int TypeIndex, string Id)
 
     [ProtoMember(2)]
     public string Id { get; } = Id;
+
+    /// <summary>
+    /// Optional: the StringId of the home Settlement for a <c>PatrolPartyComponent</c>.
+    /// Null for all other component types. Bundled with creation so the client can call
+    /// <c>InitializePartyComponentProperties</c> immediately without waiting for a
+    /// separate DynamicSync field message (which may arrive in any order).
+    /// </summary>
+    [ProtoMember(3)]
+    public string HomeSettlementId { get; set; } = null;
+
+    /// <summary>
+    /// Optional: the IsNaval flag for a <c>PatrolPartyComponent</c>.
+    /// False for all other component types.
+    /// </summary>
+    [ProtoMember(4)]
+    public bool IsNaval { get; set; } = false;
 }

--- a/source/GameInterface/Services/PartyComponents/Handlers/PartyComponentHandler.cs
+++ b/source/GameInterface/Services/PartyComponents/Handlers/PartyComponentHandler.cs
@@ -9,6 +9,7 @@ using GameInterface.Services.PartyComponents.Patches;
 using HarmonyLib;
 using Serilog;
 using System;
+using System.Reflection;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Party.PartyComponents;
 using TaleWorlds.CampaignSystem.Settlements;
@@ -19,19 +20,25 @@ internal class PartyComponentHandler : IHandler
 {
     private static readonly ILogger Logger = LogManager.GetLogger<PartyComponentHandler>();
 
+    private static readonly FieldInfo HomeSettlementField =
+        AccessTools.Field(typeof(PatrolPartyComponent), "_homeSettlement");
+    private static readonly MethodInfo PatrolInitializeProperties =
+        AccessTools.Method(typeof(PatrolPartyComponent), "InitializePartyComponentProperties");
+
     private readonly IMessageBroker messageBroker;
     private readonly INetwork network;
     private readonly IObjectManager objectManager;
 
     private readonly Type[] partyTypes = new Type[]
     {
-        typeof(BanditPartyComponent),
-        typeof(CaravanPartyComponent),
-        typeof(CustomPartyComponent),
-        typeof(GarrisonPartyComponent),
-        typeof(LordPartyComponent),
-        typeof(MilitiaPartyComponent),
-        typeof(VillagerPartyComponent),
+        typeof(BanditPartyComponent),    // 0
+        typeof(CaravanPartyComponent),   // 1
+        typeof(CustomPartyComponent),    // 2
+        typeof(GarrisonPartyComponent),  // 3
+        typeof(LordPartyComponent),      // 4
+        typeof(MilitiaPartyComponent),   // 5
+        typeof(PatrolPartyComponent),    // 6
+        typeof(VillagerPartyComponent),  // 7
     };
 
     public PartyComponentHandler(IMessageBroker messageBroker, INetwork network, IObjectManager objectManager)
@@ -54,8 +61,12 @@ internal class PartyComponentHandler : IHandler
         objectManager.AddNewObject(payload.What.Instance, out var id);
 
         var typeIndex = partyTypes.IndexOf(payload.What.Instance.GetType());
-        var data = new PartyComponentData(typeIndex, id);
-        
+        var data = new PartyComponentData(typeIndex, id)
+        {
+            HomeSettlementId = payload.What.SettlementId,
+            IsNaval = payload.What.IsNaval,
+        };
+
         network.SendAll(new NetworkCreatePartyComponent(data));
     }
 
@@ -85,11 +96,35 @@ internal class PartyComponentHandler : IHandler
                 objectManager.AddExisting(data.Id, (MilitiaPartyComponent)obj);
                 break;
             case 6:
+                var patrolComponent = (PatrolPartyComponent)obj;
+                objectManager.AddExisting(data.Id, patrolComponent);
+                // Reconstitute fields that are normally set in the constructor and
+                // InitializePartyComponentProperties. These are bundled in the creation
+                // message to avoid any dependency on DynamicSync field-update ordering.
+                if (data.HomeSettlementId != null &&
+                    objectManager.TryGetObject(data.HomeSettlementId, out Settlement homeSettlement))
+                {
+                    HomeSettlementField.SetValue(patrolComponent, homeSettlement);
+                    // Reflect IsNaval through its private setter so that IsNaval is correct
+                    // before InitializePartyComponentProperties checks it.
+                    AccessTools.Property(typeof(PatrolPartyComponent), nameof(PatrolPartyComponent.IsNaval))
+                        .SetValue(patrolComponent, data.IsNaval);
+                    PatrolInitializeProperties.Invoke(patrolComponent, null);
+                }
+                else if (data.HomeSettlementId != null)
+                {
+                    Logger.Warning(
+                        "PatrolPartyComponent {Id}: could not find Settlement '{SettlementId}' in ObjectManager; " +
+                        "Settlement.PatrolParty will not be set on client",
+                        data.Id, data.HomeSettlementId);
+                }
+                break;
+            case 7:
                 objectManager.AddExisting(data.Id, (VillagerPartyComponent)obj);
                 break;
             default:
                 Logger.Error(
-                    "Invalid TypeIndex {TypeIndex}. Valid range: [0..{MaxIndex}]. PacketId: {Id}",
+                    "Invalid TypeIndex {TypeIndex}. Valid range: [0..{MaxIndex}] (0=Bandit,1=Caravan,2=Custom,3=Garrison,4=Lord,5=Militia,6=Patrol,7=Villager). PacketId: {Id}",
                     data.TypeIndex,
                     partyTypes.Length - 1,
                     data.Id);

--- a/source/GameInterface/Services/PartyComponents/Messages/PartyComponentCreated.cs
+++ b/source/GameInterface/Services/PartyComponents/Messages/PartyComponentCreated.cs
@@ -2,9 +2,11 @@
 using TaleWorlds.CampaignSystem.Party.PartyComponents;
 
 namespace GameInterface.Services.PartyComponents.Messages;
-internal record PartyComponentCreated(PartyComponent Instance, string SettlementId = null) : IEvent
+internal record PartyComponentCreated(PartyComponent Instance, string SettlementId = null, bool IsNaval = false) : IEvent
 {
     public PartyComponent Instance { get; } = Instance;
 
     public string SettlementId { get; } = SettlementId;
+
+    public bool IsNaval { get; } = IsNaval;
 }

--- a/source/GameInterface/Services/PartyComponents/PartyComponentRegistry.cs
+++ b/source/GameInterface/Services/PartyComponents/PartyComponentRegistry.cs
@@ -28,6 +28,7 @@ internal class PartyComponentRegistry : RegistryBase<PartyComponent>
         typeof(GarrisonPartyComponent),
         typeof(LordPartyComponent),
         typeof(MilitiaPartyComponent),
+        typeof(PatrolPartyComponent),
         typeof(VillagerPartyComponent),
     };
 

--- a/source/GameInterface/Services/PartyComponents/Patches/Lifetime/PatrolPartyComponentLifetimePatches.cs
+++ b/source/GameInterface/Services/PartyComponents/Patches/Lifetime/PatrolPartyComponentLifetimePatches.cs
@@ -1,0 +1,50 @@
+using Common;
+using Common.Logging;
+using Common.Messaging;
+using GameInterface.Policies;
+using GameInterface.Services.PartyComponents.Messages;
+using HarmonyLib;
+using Serilog;
+using System.Collections.Generic;
+using System.Reflection;
+using TaleWorlds.CampaignSystem.Party.PartyComponents;
+using TaleWorlds.CampaignSystem.Settlements;
+
+namespace GameInterface.Services.PartyComponents.Patches.Lifetime;
+
+/// <summary>
+/// Harmony patches for the lifetime of a <see cref="PatrolPartyComponent"/> object.
+///
+/// The Prefix fires before the constructor body, so <c>_homeSettlement</c> is not yet
+/// assigned to the instance. However, Harmony delivers the constructor parameters by
+/// name, so <c>homeSettlement</c> and <c>isNaval</c> are available directly. They are
+/// bundled into <see cref="PartyComponentCreated"/> via <c>SettlementId</c> so that
+/// <see cref="Handlers.PartyComponentHandler"/> can reconstruct the full component state
+/// on the client without any dependency on DynamicSync message ordering.
+/// </summary>
+[HarmonyPatch]
+internal class PatrolPartyComponentLifetimePatches
+{
+    private static readonly ILogger Logger = LogManager.GetLogger<PatrolPartyComponentLifetimePatches>();
+
+    private static IEnumerable<MethodBase> TargetMethods() =>
+        AccessTools.GetDeclaredConstructors(typeof(PatrolPartyComponent));
+
+    private static bool Prefix(PatrolPartyComponent __instance, Settlement homeSettlement, bool isNaval)
+    {
+        if (CallOriginalPolicy.IsOriginalAllowed()) return true;
+
+        if (ModInformation.IsClient)
+        {
+            Logger.Error("Client created managed {name}", typeof(PatrolPartyComponent));
+            return true;
+        }
+
+        var message = new PartyComponentCreated(__instance,
+            SettlementId: homeSettlement?.StringId,
+            IsNaval: isNaval);
+        MessageBroker.Instance.Publish(__instance, message);
+
+        return true;
+    }
+}

--- a/source/GameInterface/Services/PartyComponents/PatrolPartyComponentSync.cs
+++ b/source/GameInterface/Services/PartyComponents/PatrolPartyComponentSync.cs
@@ -1,0 +1,24 @@
+using GameInterface.AutoSync;
+using GameInterface.DynamicSync;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem.Party.PartyComponents;
+
+namespace GameInterface.Services.PartyComponents;
+
+/// <summary>
+/// Registers <see cref="PatrolPartyComponent"/> fields and properties with the DynamicSync
+/// system so that changes made during construction (and later mutations) are automatically
+/// broadcast from the server to all clients.
+///
+/// Synced members:
+/// - <c>_homeSettlement</c>  — the settlement this patrol party belongs to.
+/// - <c>IsNaval</c>          — whether the party is a naval patrol.
+/// </summary>
+internal class PatrolPartyComponentSync : IDynamicSync
+{
+    public PatrolPartyComponentSync(DynamicSyncRegistry autoSyncBuilder)
+    {
+        autoSyncBuilder.AddField(AccessTools.Field(typeof(PatrolPartyComponent), "_homeSettlement"));
+        autoSyncBuilder.AddProperty(AccessTools.Property(typeof(PatrolPartyComponent), nameof(PatrolPartyComponent.IsNaval)));
+    }
+}

--- a/source/GameInterface/Services/Settlements/Handlers/SettlementHandler.cs
+++ b/source/GameInterface/Services/Settlements/Handlers/SettlementHandler.cs
@@ -4,6 +4,7 @@ using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Settlements.Messages;
 using GameInterface.Services.Settlements.Patches;
 using Serilog;
+using System.Linq;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Settlements;
@@ -218,7 +219,7 @@ public class SettlementHandler : IHandler
             return;
         }
 
-        foreach (string heroStringId in obj.NotablesCache) {
+        foreach (string heroStringId in obj.NotablesCache ?? Enumerable.Empty<string>()) {
             if (objectManager.TryGetObject<Hero>(heroStringId, out var hero) == false)
             {
                 Logger.Error("Unable to find Hero ({HeroStringId})", heroStringId);


### PR DESCRIPTION
fix: NullReferenceException in SettlementHandler.HandleCollectNotablesToCache
Root cause:
  Protobuf omits empty repeated fields on the wire and deserializes them as
  null rather than an empty collection. SettlementHandler.HandleCollectNotablesToCache
  received a CollectNotablesToCache message whose NotablesCache list was null
  (the settlement had no notables), then iterated it with a plain foreach,
  producing a NullReferenceException at runtime.

Stack trace location:
  SettlementHandler.cs:221 - foreach (string heroStringId in obj.NotablesCache)

Fix:
  Changed the foreach to use the null-coalescing fallback:
    foreach (string heroStringId in obj.NotablesCache ?? Enumerable.Empty<string>())
  Added 'using System.Linq' for Enumerable.Empty<string>().

Behavior fixed:
  Clients no longer crash when a settlement sync message arrives for a
  settlement that has an empty notables cache. The loop simply executes
  zero iterations, matching the intended no-op behavior.


---------------

feat: full PatrolPartyComponent sync between server and client
Background:
  PatrolPartiesCampaignBehavior spawns, ticks, replenishes, and destroys
  patrol parties on behalf of settlements. Previously PatrolPartyComponent
  was completely absent from the coop sync infrastructure, causing two
  distinct failures and leaving patrol parties invisible/broken on clients.

--- NullReferenceException (server crash) ---

Root cause:
  MobilePartyDataPatches.SetPartyComponentIntercept intercepts the
  MobileParty._partyComponent field assignment inside MobileParty.CreateParty.
  It calls PartyComponentRegistry.TryGetId(value, out componentId). Because
  PatrolPartyComponent was not in PartyComponentRegistry.ManagedTypes, TryGetId
  returned false and the interceptor returned WITHOUT assigning _partyComponent.
  Back in PatrolPartyComponent.CreatePatrolParty, the next line called
  mobileParty.PatrolPartyComponent.SortRoster(). PatrolPartyComponent casts
  _partyComponent to PatrolPartyComponent - which was still null - causing
  NullReferenceException at line 62.

  Server log confirmed this with:
    'Component was not registered with PartyComponentRegistry'
  immediately before the fatal exception.

--- Sync implementation ---

Files added:

  PatrolPartyComponentLifetimePatches.cs
    Harmony prefix on all PatrolPartyComponent constructors. Fires before the
    constructor body and publishes PartyComponentCreated, registering the new
    instance in the coop ObjectManager. Constructor parameters homeSettlement
    and isNaval are captured directly from the Harmony prefix signature (by
    parameter name matching) and bundled into the message. This avoids any
    dependency on DynamicSync field-update ordering when the client
    reconstructs the component.

  PatrolPartyComponentSync.cs
    Registers _homeSettlement (field) and IsNaval (property) with DynamicSync
    so that any post-construction mutations are automatically broadcast to all
    clients, matching the pattern used by CaravanPartyComponentSync et al.

Files modified:

  PartyComponentRegistry.cs
    Added typeof(PatrolPartyComponent) to ManagedTypes so that
    SetPartyComponentIntercept can find registry IDs for patrol components,
    and RegisterAll correctly registers patrol parties loaded from save games.

  PartyComponentHandler.cs
    - Added PatrolPartyComponent at index 6 in partyTypes[] (VillagerPartyComponent
      shifted to index 7). Index is the wire-format type discriminator used by
      NetworkCreatePartyComponent.
    - In Handle(PartyComponentCreated): populates new PartyComponentData fields
      HomeSettlementId and IsNaval from the creation message.
    - In Handle(NetworkCreatePartyComponent) case 6: creates a SkipConstructor
      shell, registers it with the ObjectManager, then atomically reconstructs
      its state - sets _homeSettlement via reflection, sets IsNaval via the
      private property setter, and calls InitializePartyComponentProperties via
      reflection. InitializePartyComponentProperties sets the _name cache and
      calls Settlement.SetPatrolParty(this), which populates Settlement.PatrolParty
      on the client so patrol party UI and queries work correctly.
      If the settlement cannot be found in the ObjectManager a warning is logged
      but the component is still registered (graceful degradation).

  PartyComponentCreated.cs
    Added IsNaval property (default false) so the lifetime patch can forward
    the constructor parameter to the handler without losing information.

  PartyComponentData.cs
    Added optional ProtoMember(3) HomeSettlementId and ProtoMember(4) IsNaval.
    Null/false for all non-patrol component types; populated only for index 6.
    Bundling these in the creation packet eliminates the race condition where
    a previous implementation called InitializePartyComponentProperties in
    MobilePartyDataHandler and relied on DynamicSync messages having already
    delivered _homeSettlement - which was not guaranteed.

  DisablePatrolPartiesCampaignBehavior.cs (new file, client-side gate)
    Prefixes PatrolPartiesCampaignBehavior.RegisterEvents with
    !ModInformation.IsClient. The server runs the behavior normally (spawning,
    ticking, replenishing, destroying patrol parties). The client must not run
    it independently - doing so would cause it to spawn its own local patrol
    parties that fight the server-authoritative synced ones and re-trigger the
    PartyComponentRegistry error on the client side.

Destruction path:
  When the server destroys a patrol party, PartyLifetimeHandler sends
  NetworkDestroyParty to clients. The client calls party.RemoveParty() inside
  AllowedThread, which invokes PatrolPartyComponent.OnFinalize(), which calls
  Settlement.SetPatrolParty(null). The settlement link is correctly cleaned up.

Save-game compatibility:
  Patrol parties loaded from an existing save go through the normal
  MBObjectManager load path which calls OnInitialize() directly, setting
  Settlement.PatrolParty as usual. RegisterAll() now includes them because
  PatrolPartyComponent is in ManagedTypes.


-----------------------


## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Other information
