### PR TITLE
Register RegistryModule and IControlledEntityRegistry in test containers

### DIFF
--- a/source/Coop.Tests/ClientTestComponent.cs
+++ b/source/Coop.Tests/ClientTestComponent.cs
@@ -1,6 +1,9 @@
 ﻿using Autofac;
 using Coop.Core.Client;
+using GameInterface.AutoSync;
+using GameInterface.Registry;
 using GameInterface.Services.Entity;
+using Moq;
 using Xunit.Abstractions;
 
 namespace Coop.Tests;
@@ -12,6 +15,8 @@ internal class ClientTestComponent : TestComponentBase
         var builder = new ContainerBuilder();
         builder.RegisterModule<ClientModule>();
         builder.RegisterType<ControlledEntityRegistry>().As<IControlledEntityRegistry>().InstancePerLifetimeScope();
+        builder.RegisterInstance(new Mock<IAutoSyncPatchCollector>().Object).As<IAutoSyncPatchCollector>();
+        builder.RegisterModule<RegistryModule>();
 
         Container = BuildContainer(builder);
     }

--- a/source/Coop.Tests/ClientTestComponent.cs
+++ b/source/Coop.Tests/ClientTestComponent.cs
@@ -1,5 +1,6 @@
 ﻿using Autofac;
 using Coop.Core.Client;
+using GameInterface.Services.Entity;
 using Xunit.Abstractions;
 
 namespace Coop.Tests;
@@ -10,6 +11,7 @@ internal class ClientTestComponent : TestComponentBase
     {
         var builder = new ContainerBuilder();
         builder.RegisterModule<ClientModule>();
+        builder.RegisterType<ControlledEntityRegistry>().As<IControlledEntityRegistry>().InstancePerLifetimeScope();
 
         Container = BuildContainer(builder);
     }

--- a/source/Coop.Tests/ServerTestComponent.cs
+++ b/source/Coop.Tests/ServerTestComponent.cs
@@ -1,5 +1,7 @@
 ﻿using Autofac;
 using Coop.Core.Server;
+using GameInterface.AutoSync;
+using GameInterface.Registry;
 using GameInterface.Services.Entity;
 using GameInterface.Services.Heroes.Interfaces;
 using GameInterface.Services.MobileParties.Interfaces;
@@ -17,6 +19,8 @@ internal class ServerTestComponent : TestComponentBase
         builder.RegisterModule<ServerModule>();
         builder.RegisterType<ControlledEntityRegistry>().As<IControlledEntityRegistry>().InstancePerLifetimeScope();
         builder.RegisterInstance(new Mock<IMobilePartyInterface>().Object).As<IMobilePartyInterface>().SingleInstance();
+        builder.RegisterInstance(new Mock<IAutoSyncPatchCollector>().Object).As<IAutoSyncPatchCollector>();
+        builder.RegisterModule<RegistryModule>();
         Container = BuildContainer(builder);
     }
 }


### PR DESCRIPTION
## Summary

Several Coop.Tests state-tests in both Client and Server fail because the test containers don't register dependencies that production states need. This PR adds those registrations.

### Background
- A while back, commit `73723e32` added `IControlledEntityRegistry` to `CharacterCreationState`'s constructor without updating the client test container. That broke 7 tests in `CharacterCreationStateTests`. (Original `#1176` scope.)
- The `1.3-interactions` merge (#1166) then added `IRegistryManager` to several more state constructors (`InitialServerState`, `CharacterCreationState`, `ValidateModuleState`, `LoadingState`, `RunningState`, `ReceivingSavedDataState`). That brought the total to 16 failures in both `ClientTestComponent`-based and `ServerTestComponent`-based suites.

### Fix
Both `ClientTestComponent` and `ServerTestComponent` now also:
- Register `RegistryModule` (which provides `IRegistryManager` and `IAutoRegistryFactory`)
- Mock `IAutoSyncPatchCollector` (the only dependency `RegistryManager` needs that we don't want to wire up for real in unit tests — same pattern as `SerializationTestModule`)

`IControlledEntityRegistry` is still registered explicitly in both (kept from the original PR scope; production wires it via `GameInterfaceModule` but the test containers don't include that whole module).

## Test plan

- [x] `Coop.Tests`: 78/94 -> **91/94** (3 remaining failures are pre-existing `NullReferenceException` in `AlleyRegistry.RegisterAllObjects()` that need `Campaign.Current`, and are not solvable in unit tests — separate concern)
- [x] `Common.Tests`: 34/34
- [ ] CI green

Note: `GameInterface.Tests` is currently very red (~168 failures) on `development` after the `1.3-interactions` merge; that's pre-existing and orthogonal to this PR.

New contributor — five PRs so far (#1176, #1177, #1178 merged, #1183 merged, #1186 closed-superseded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)