### PR TITLE
Fix PartyBehaviorPatchTests after ObjectManager-based id lookup

### DIFF
--- a/source/GameInterface.Tests/Services/Parties/Patches/PartyBehaviorPatchTests.cs
+++ b/source/GameInterface.Tests/Services/Parties/Patches/PartyBehaviorPatchTests.cs
@@ -3,6 +3,7 @@ using Common.Messaging;
 using Common.Util;
 using GameInterface.Services.Entity;
 using GameInterface.Services.MapEvents.Patches;
+using GameInterface.Services.ObjectManager;
 using GameInterface.Tests.Bootstrap;
 using System;
 using TaleWorlds.CampaignSystem.Party;
@@ -29,6 +30,9 @@ public class PartyBehaviorPatchTests : IDisposable
         var party = ObjectHelper.SkipConstructor<MobileParty>();
         party.StringId = "TestEntityId";
 
+        var objectManager = Container.Resolve<IObjectManager>();
+        objectManager.AddExisting(party.StringId, party);
+
         var dt = 0.1f;
 
         // Act
@@ -48,9 +52,13 @@ public class PartyBehaviorPatchTests : IDisposable
 
         var idProvider = Container.Resolve<IControllerIdProvider>();
         var entityRegistry = Container.Resolve<IControlledEntityRegistry>();
+        var objectManager = Container.Resolve<IObjectManager>();
+
+        objectManager.AddExisting(party.StringId, party);
+        objectManager.TryGetId(party, out var partyId);
 
         idProvider.SetControllerId(controllerId);
-        entityRegistry.RegisterAsControlled(controllerId, party.StringId);
+        entityRegistry.RegisterAsControlled(controllerId, partyId);
 
         var dt = 0.1f;
 

--- a/source/GameInterface/Services/MobileParties/Extensions/PartyExtensions.cs
+++ b/source/GameInterface/Services/MobileParties/Extensions/PartyExtensions.cs
@@ -60,7 +60,7 @@ internal static class PartyExtensions
 
         if (!objectManager.TryGetId(party, out var partyId))
         {
-            Logger.Error("Unable to resolve id for {name}", party.Name);
+            Logger.Error("Unable to resolve id for party with StringId {stringId}", party.StringId);
             return false;
         }
 


### PR DESCRIPTION
## Summary
- Aligns `PartyBehaviorPatchTests` with the new `IObjectManager`-based id lookup introduced in commit 73723e32
- Replaces `party.Name` with `party.StringId` in the `IsPartyControlled` error log to avoid a `NullReferenceException` on partially-initialised parties

## Root cause
Commit 73723e32 (\"fixed old sting ids\") changed `PartyExtensions.IsPartyControlled` from using `party.StringId` directly to calling `objectManager.TryGetId(party, out var partyId)`. The existing `PartyBehaviorPatchTests` were not updated for the new flow:

- The test party is created via `ObjectHelper.SkipConstructor<MobileParty>()` and only has `StringId` assigned; it is never added to the `IObjectManager`.
- `TryGetId` therefore returns false and the failure branch executes `Logger.Error(\"...\", party.Name)`. The `MobileParty.Name` getter touches uninitialised internal state on a `SkipConstructor` instance, throwing `NullReferenceException`.

Both `UncontrolledParty_SkipsMethod` and `ControlledParty_RunsMethod` fail with the same NRE for this reason.

## Changes
1. `PartyBehaviorPatchTests` now register the test party with `IObjectManager.AddExisting(party.StringId, party)` and resolve the id back through `TryGetId` to feed `IControlledEntityRegistry.RegisterAsControlled`. This mirrors the production flow in `MobilePartyRegistry.RegisterAllObjects`.
2. `PartyExtensions.IsPartyControlled` logs `party.StringId` instead of `party.Name`, matching the defensive style of `MobilePartyAuditData` and `SkillHelperRobustnessPatches`.

## Test plan
- [x] `dotnet test source/GameInterface.Tests --filter PartyBehaviorPatchTests`: 0/2 -> 2/2
- [x] `dotnet test source/GameInterface.Tests` (full suite): 202/215 -> 204/215 (no regression)
- [x] `dotnet test source/Common.Tests`: 34/34 (unchanged)
- [x] `dotnet build Coop.sln`: no new errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)