### PR TITLE
Bump Scriban 6.0.0 -> 7.2.0 to fix 9 security advisories

### DIFF
--- a/source/GameInterface.Tests/GameInterface.Tests.csproj
+++ b/source/GameInterface.Tests/GameInterface.Tests.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="MonoMod.RuntimeDetour" Version="25.2.3" />
     <PackageReference Include="MonoMod.Utils" Version="25.0.8" />
-    <PackageReference Include="Scriban" Version="6.0.0" />
+    <PackageReference Include="Scriban" Version="7.2.0" />
     <PackageReference Include="System.Reflection.Primitives" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">

--- a/source/GameInterface/GameInterface.csproj
+++ b/source/GameInterface/GameInterface.csproj
@@ -224,7 +224,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="9.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Scriban" Version="6.0.0" />
+    <PackageReference Include="Scriban" Version="7.2.0" />
     <PackageReference Include="Scrutor" Version="6.0.1" />
   </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
## Summary
Upgrades `Scriban` from 6.0.0 to 7.2.0 in `GameInterface` and `GameInterface.Tests` to resolve **9 security advisories** (1 critical, 6 high, 2 moderate) that NuGet currently surfaces as `NU1902`/`NU1903`/`NU1904` warnings on every restore.

## Advisories fixed
| Severity | ID |
|---|---|
| Critical | GHSA-5wr9-m6jw-xx44 |
| High | GHSA-c875-h985-hvrc |
| High | GHSA-grr9-747v-xvcp |
| High | GHSA-p6q4-fgr8-vx4p |
| High | GHSA-v66j-x4hw-fv9g |
| High | GHSA-wgh7-7m3c-fx25 |
| High | GHSA-x6m9-38vm-2xhf |
| High | GHSA-xcx6-vp38-8hr5 |
| Moderate | GHSA-m2p3-hwv5-xpqw |
| Moderate | GHSA-xw6w-9jjh-p9cr |

After the upgrade, `dotnet restore Coop.sln` reports **zero** `NU190X` advisories.

## Compatibility
Production usage is a single call site (`GameInterface/DynamicSync/Templates/TemplateParser.cs`) using only `Template.Parse` and `template.Render`, which are unchanged in Scriban 7.x. No other production code imports the namespace.

The 11 `TemplateRenderTests` in `GameInterface.Tests/DynamicSync/TemplateRenderTests.cs` are all marked `[Fact(Skip = \"Need regeneration\")]`, so they cannot validate output round-trips end-to-end here, but the project compiles cleanly after the bump and the rest of the test suite is unaffected.

> Note: A `GameInterface - Backup.csproj` artifact in the repo also references Scriban 6.0.0. It is not part of `Coop.sln` and is therefore not built or restored — left untouched to keep this PR scoped to the active build graph.

## Test plan
- [x] `dotnet restore Coop.sln`: 0 NU190X warnings (was 10+)
- [x] `dotnet build Coop.sln`: no new build errors
- [x] `dotnet test source/Common.Tests`: 34/34 (unchanged)
- [x] `dotnet test source/Coop.Tests`: 87/94 (unchanged baseline)
- [x] `dotnet test source/GameInterface.Tests`: 202/215 (unchanged baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)