### PR TITLE
Enable AutoSync for Hero.HitPoints (#1049 partial)

### DIFF
--- a/source/GameInterface/Services/Heroes/HeroSync.cs
+++ b/source/GameInterface/Services/Heroes/HeroSync.cs
@@ -53,7 +53,7 @@ namespace GameInterface.Services.Heroes
             autoSyncBuilder.AddProperty(AccessTools.Property(typeof(Hero), nameof(Hero.DeathMark)));
             autoSyncBuilder.AddProperty(AccessTools.Property(typeof(Hero), nameof(Hero.DeathMarkKillerHero)));
             autoSyncBuilder.AddProperty(AccessTools.Property(typeof(Hero), nameof(Hero.LastKnownClosestSettlement)));
-            //autoSyncBuilder.AddProperty(AccessTools.Property(typeof(Hero), nameof(Hero.HitPoints)));
+            autoSyncBuilder.AddProperty(AccessTools.Property(typeof(Hero), nameof(Hero.HitPoints)));
             autoSyncBuilder.AddProperty(AccessTools.Property(typeof(Hero), nameof(Hero.DeathDay)));
             autoSyncBuilder.AddProperty(AccessTools.Property(typeof(Hero), nameof(Hero.LastExaminedLogEntryID)));
             autoSyncBuilder.AddProperty(AccessTools.Property(typeof(Hero), nameof(Hero.Clan)));


### PR DESCRIPTION
Partial implementation of #1049 (Remaining Hero Properties). Only enables `Hero.HitPoints` for now — see the issue comment for the analysis of why the other two properties in the issue are not addressed here.

## Why only `HitPoints`?
Detailed reasoning is in [my comment on #1049](https://github.com/Bannerlord-Coop-Team/BannerlordCoop/issues/1049#issuecomment-4466824393). Short version:

- **`HitPoints`** — public setter, no special blocker, follows the same registration pattern as the already-synced `HeroState`, `Gold`, `Weight`, etc. **Enabled in this PR.**
- **`BannerItem`** — pass-through to `BattleEquipment[EquipmentIndex.ExtraWeaponSlot]`, already covered by the existing `_battleEquipment` sync + `EquipmentCollectionPatches`. Adding it would duplicate traffic. Recommended to move to the issue's *Deferred* list.
- **`Issue`** — `IssueBase` reference; blocked by the absence of `IssueBase` lifecycle sync (no `IssueRegistry` / `IssueLifetimeHandler` in `GameInterface/Services` today). Should be split into its own issue.

## Change
One line in `source/GameInterface/Services/Heroes/HeroSync.cs`: uncomment the existing `AddProperty(... Hero.HitPoints ...)` call.

## Test plan
- [x] `dotnet build Coop.sln`: no new errors
- [x] `dotnet test source/Common.Tests`: 34/34 (unchanged)
- [x] `dotnet test source/Coop.Tests`: 87/94 (unchanged baseline)
- [x] `dotnet test source/GameInterface.Tests`: 202/215 (unchanged baseline)
- [ ] **Not done:** multi-client in-game verification. I am on a Linux dev box without a usable Bannerlord MP session. Would appreciate a manual sanity check by someone with a working two-client setup before merging — confirm that a wound on one client mirrors on the others and that `OnHeroWounded` doesn't double-fire anything user-visible (UI prompt, quest reward, etc.).

If the team prefers to gate this behind that manual check, happy to mark the PR as Draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)