### PR TITLE
Enable nullable annotations in Coop.Core to fix CS8632 in CI build

### DIFF
--- a/source/Coop.Core/Coop.Core.csproj
+++ b/source/Coop.Core/Coop.Core.csproj
@@ -13,6 +13,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <LangVersion>10</LangVersion>
+    <Nullable>annotations</Nullable>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Platforms>x64</Platforms>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>


### PR DESCRIPTION
## Summary

CI build (`dotnet build Coop.Core -c Release`) currently fails on every branch with:

```
Coop.Core/Server/Services/ItemRosters/Handlers/ItemRosterMessageHandler.cs(34,15):
  error CS8632: The annotation for nullable reference types should only be used
  in code within a '#nullable' annotations context.

Coop.Core/Server/Services/Towns/Handlers/ServerTownHandler.cs(140,19):
  error CS8632: ...
```

Coop.Core has several files using `string?` annotations (`ItemRosterMessageHandler`, `ServerTownHandler`, `NetworkChangeTownGovernor`, `NetworkMobilePartyPropertyChanged`) but the csproj does not opt in to a `<Nullable>` context, so CS8632 fires and `TreatWarningsAsErrors=true` turns it into a build error.

Fix: add `<Nullable>annotations</Nullable>` to `Coop.Core.csproj`. This allows the existing `?` syntax without enabling full flow-analysis warnings — `<Nullable>enable</Nullable>` would surface 27 additional pre-existing issues (CS8618/CS8604/CS8625) that need a much larger code-cleanup. `annotations` is the minimal-disruption choice.

For reference, `Coop.Tests.csproj` and `ServerConsole.csproj` already opt in via `<Nullable>enable</Nullable>`; this PR is the minimal variant for code that isn't fully null-safety-clean yet.

## Test plan

- [x] `dotnet build Coop.Core -c Release` -> 0 warnings, 0 errors (the exact CI step)
- [x] `Common.Tests`: 34/34 pass
- [x] No regression in `Coop.Tests` / `GameInterface.Tests` (pre-existing failures unchanged; they wait on #1176 / #1177)
- [ ] CI green on this PR (please verify after pushing)

New contributor — four PRs in so far (#1176, #1177, #1178, this one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)