### PR TITLE
Bump Scriban 7.1.0 -> 7.2.0 in Coop.Core to match GameInterface

### DIFF
--- a/source/Coop.Core/Coop.Core.csproj
+++ b/source/Coop.Core/Coop.Core.csproj
@@ -61,7 +61,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Scriban" Version="7.1.0" />
+    <PackageReference Include="Scriban" Version="7.2.0" />
     <PackageReference Include="System.Collections.Immutable" Version="9.0.2" />
     <PackageReference Include="System.Reflection.Primitives" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

The 1.3-interactions merge (#1166) added a direct `Scriban 7.1.0` reference to `Coop.Core.csproj`. But `GameInterface.csproj` already requires `Scriban 7.2.0` (set by #1178 to fix nine security advisories). NuGet now refuses to restore with:

```
error NU1605: Warning As Error: Detected package downgrade:
  Scriban from 7.2.0 to 7.1.0.
error NU1903: Warning As Error: Package 'Scriban' 7.1.0 has a known
  high severity vulnerability, GHSA-24c8-4792-22hx
```

This breaks `dotnet restore` on `Coop.Tests` and `GameInterface.Tests`, which blocks every PR that touches those projects (including my own #1176 and #1177).

Fix: bump the direct reference to 7.2.0 so it matches GameInterface and clears the advisory.

## Test plan

- [x] `dotnet build Coop.Core -c Release` — no longer reports the Scriban NU1605/NU1903 errors (only the pre-existing CS8632 in `ItemRosterMessageHandler.cs`/`ServerTownHandler.cs` remains, which is fixed by #1183).
- [x] No code changes — only a package version bump, same as #1178 was for GameInterface.
- [ ] CI green on this PR.

New contributor — five PRs in so far (#1176, #1177, #1178, #1183, this one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)