### PR TITLE
Trading & Inventory Management Sync Overhaul

### DIFF
--- a/source/GameInterface/Services/Inventory/Commands/InventoryCommands.cs
+++ b/source/GameInterface/Services/Inventory/Commands/InventoryCommands.cs
@@ -1,6 +1,7 @@
 ﻿using Autofac;
 using Common;
 using Common.Logging;
+using GameInterface.Services.ObjectManager;
 using Serilog;
 using System.Collections.Generic;
 using System.Text;
@@ -13,6 +14,17 @@ namespace GameInterface.Services.Smithing.Commands;
 internal class InventoryCommands
 {
     private static readonly ILogger Logger = LogManager.GetLogger<SmithingCommands>();
+
+    /// <summary>
+    /// Attempts to get the ObjectManager
+    /// </summary>
+    private static bool TryGetObjectManager(out IObjectManager objectManager)
+    {
+        objectManager = null;
+        if (ContainerProvider.TryGetContainer(out var container) == false) return false;
+
+        return container.TryResolve(out objectManager);
+    }
 
     /// <summary>
     /// View item ids in player inventories
@@ -67,6 +79,99 @@ internal class InventoryCommands
                 {
                     stringBuilder.AppendLine(rosterElement.EquipmentElement.Item.StringId + ": " + rosterElement.EquipmentElement.Item.Value + "(" + rosterElement.EquipmentElement.ItemValue + ")");
                 }
+            }
+        }
+
+        string result = stringBuilder.ToString();
+        if (result.Length > 0)
+        {
+            return result;
+        }
+        return "Hero not found.";
+    }
+
+    /// <summary>
+    /// Output equipment ids of battle, civilian and stealth equipment for a specific hero
+    /// </summary>
+    [CommandLineArgumentFunction("heroequipment", "coop.debug.inventory")]
+    public static string HeroEquipmentCommand(List<string> strings)
+    {
+        if (strings.Count == 0)
+        {
+            return "Hero name argument required.";
+        }
+
+        StringBuilder stringBuilder = new StringBuilder();
+        foreach (var hero in Hero.AllAliveHeroes)
+        {
+            if (hero.Name.ToString() == strings[0])
+            {
+                stringBuilder.AppendLine(hero.Name.ToString());
+
+                stringBuilder.AppendLine("BattleEquipment");
+                foreach (var equipmentElement in hero.BattleEquipment._itemSlots) stringBuilder.AppendLine(equipmentElement.Item?.StringId ?? "[EMPTY]");
+
+                stringBuilder.AppendLine("CivilianEquipment");
+                foreach (var equipmentElement in hero.CivilianEquipment._itemSlots) stringBuilder.AppendLine(equipmentElement.Item?.StringId ?? "[EMPTY]");
+
+                stringBuilder.AppendLine("StealthEquipment");
+                foreach (var equipmentElement in hero.StealthEquipment._itemSlots) stringBuilder.AppendLine(equipmentElement.Item?.StringId ?? "[EMPTY]");
+            }
+        }
+
+        string result = stringBuilder.ToString();
+        if (result.Length > 0)
+        {
+            return result;
+        }
+        return "Hero not found.";
+    }
+
+    /// <summary>
+    /// Give debug animals to a hero with a given name
+    /// </summary>
+    [CommandLineArgumentFunction("giveanimals", "coop.debug.inventory")]
+    public static string GiveAnimalsCommand(List<string> strings)
+    {
+        if (ModInformation.IsClient) return "Command can only be run on the server.";
+
+        if (strings.Count == 0)
+        {
+            return "Hero name argument required.";
+        }
+
+        if (TryGetObjectManager(out var objectManager) == false)
+        {
+            return "Unable to resolve ObjectManager.";
+        }
+
+        StringBuilder stringBuilder = new StringBuilder();
+        foreach (var hero in Hero.AllAliveHeroes)
+        {
+            if (hero.Name.ToString() == strings[0])
+            {
+                var itemsToAdd = new Dictionary<string, int>()
+                {
+                    { "sheep", 5 },
+                    { "cow", 5 },
+                    { "hog", 5 },
+                    { "goose", 5 },
+                    { "chicken", 5 }
+                };
+
+                foreach (var itemId in itemsToAdd.Keys)
+                {
+                    if (!objectManager.TryGetObject(itemId, out ItemObject itemObject))
+                    {
+                        stringBuilder.AppendLine("Failed to retrieve object for ItemObject id: " + itemId);
+                    }
+                    else
+                    {
+                        hero.PartyBelongedTo.ItemRoster.AddToCounts(itemObject, itemsToAdd[itemId]);
+                    }
+                }
+
+                stringBuilder.AppendLine(strings[0] + " was given animals.");
             }
         }
 

--- a/source/GameInterface/Services/Inventory/Handlers/InventoryRefreshHandler.cs
+++ b/source/GameInterface/Services/Inventory/Handlers/InventoryRefreshHandler.cs
@@ -1,0 +1,68 @@
+﻿using Common;
+using Common.Logging;
+using Common.Messaging;
+using GameInterface.Services.Inventory.Messages;
+using GameInterface.Services.ObjectManager;
+using Serilog;
+using TaleWorlds.CampaignSystem.Inventory;
+using TaleWorlds.CampaignSystem.Roster;
+using TaleWorlds.CampaignSystem.ViewModelCollection.Inventory;
+
+namespace GameInterface.Services.Inventory.Handlers
+{
+    internal class InventoryRefreshHandler : IHandler
+    {
+        private static readonly ILogger Logger = LogManager.GetLogger<InventoryRefreshHandler>();
+        private readonly IMessageBroker messageBroker;
+        private readonly IObjectManager objectManager;
+
+        private SPInventoryVM currentInventoryVM;
+
+        public InventoryRefreshHandler(IMessageBroker messageBroker, IObjectManager objectManager)
+        {
+            this.messageBroker = messageBroker;
+            this.objectManager = objectManager;
+            messageBroker.Subscribe<InventoryVMCreated>(Handle_InventoryVMCreated);
+            messageBroker.Subscribe<RefreshOtherInventory>(Handle_RefreshOtherInventory);
+
+            currentInventoryVM = null;
+        }
+
+        public void Dispose()
+        {
+            messageBroker.Unsubscribe<InventoryVMCreated>(Handle_InventoryVMCreated);
+            messageBroker.Unsubscribe<RefreshOtherInventory>(Handle_RefreshOtherInventory);
+        }
+
+        private void Handle_InventoryVMCreated(MessagePayload<InventoryVMCreated> obj)
+        {
+            currentInventoryVM = obj.What.InventoryVM;
+        }
+
+        private void Handle_RefreshOtherInventory(MessagePayload<RefreshOtherInventory> obj)
+        {
+            if (!objectManager.TryGetObjectWithLogging<ItemRoster>(obj.What.ItemRosterId, out var itemRoster)) return;
+
+            // Only want to update if the client is looking at the changed roster
+            if (currentInventoryVM?._inventoryLogic == null || itemRoster != currentInventoryVM._inventoryLogic._rosters[0]) return;
+
+            // Rebuild LeftItemListVM only
+            GameLoopRunner.RunOnMainThread(() =>
+            {
+                currentInventoryVM.IsRefreshed = false;
+                currentInventoryVM.LeftItemListVM.Clear();
+
+                foreach (var itemRosterElement in currentInventoryVM._inventoryLogic.GetElementsInRoster(InventoryLogic.InventorySide.OtherInventory))
+                {
+                    var itemVM = new SPItemVM(currentInventoryVM._inventoryLogic, currentInventoryVM.MainCharacter.IsFemale, currentInventoryVM.CanCharacterUseItem(itemRosterElement), currentInventoryVM._usageType, itemRosterElement, InventoryLogic.InventorySide.OtherInventory, currentInventoryVM._inventoryLogic.GetCostOfItemRosterElement(itemRosterElement, InventoryLogic.InventorySide.OtherInventory), null);
+                    currentInventoryVM.UpdateFilteredStatusOfItem(itemVM);
+                    itemVM.IsLocked = (itemVM.InventorySide == InventoryLogic.InventorySide.PlayerInventory && currentInventoryVM.IsItemLocked(itemRosterElement));
+                    currentInventoryVM.LeftItemListVM.Add(itemVM);
+                }
+
+                currentInventoryVM.RefreshInformationValues();
+                currentInventoryVM.IsRefreshed = true;
+            });
+        }
+    }
+}

--- a/source/GameInterface/Services/Inventory/Handlers/InventoryRefreshHandler.cs
+++ b/source/GameInterface/Services/Inventory/Handlers/InventoryRefreshHandler.cs
@@ -4,9 +4,18 @@ using Common.Messaging;
 using GameInterface.Services.Inventory.Messages;
 using GameInterface.Services.ObjectManager;
 using Serilog;
+using System;
+using System.Collections.Generic;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Extensions;
 using TaleWorlds.CampaignSystem.Inventory;
+using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Roster;
+using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.CampaignSystem.ViewModelCollection.Inventory;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
+using static TaleWorlds.CampaignSystem.Inventory.InventoryLogic;
 
 namespace GameInterface.Services.Inventory.Handlers
 {
@@ -24,6 +33,7 @@ namespace GameInterface.Services.Inventory.Handlers
             this.objectManager = objectManager;
             messageBroker.Subscribe<InventoryVMCreated>(Handle_InventoryVMCreated);
             messageBroker.Subscribe<RefreshOtherInventory>(Handle_RefreshOtherInventory);
+            messageBroker.Subscribe<RefreshAfterTrade>(Handle_RefreshAfterTrade);
 
             currentInventoryVM = null;
         }
@@ -32,6 +42,7 @@ namespace GameInterface.Services.Inventory.Handlers
         {
             messageBroker.Unsubscribe<InventoryVMCreated>(Handle_InventoryVMCreated);
             messageBroker.Unsubscribe<RefreshOtherInventory>(Handle_RefreshOtherInventory);
+            messageBroker.Unsubscribe<RefreshAfterTrade>(Handle_RefreshAfterTrade);
         }
 
         private void Handle_InventoryVMCreated(MessagePayload<InventoryVMCreated> obj)
@@ -41,26 +52,115 @@ namespace GameInterface.Services.Inventory.Handlers
 
         private void Handle_RefreshOtherInventory(MessagePayload<RefreshOtherInventory> obj)
         {
-            if (!objectManager.TryGetObjectWithLogging<ItemRoster>(obj.What.ItemRosterId, out var itemRoster)) return;
+            if (currentInventoryVM?._inventoryLogic == null) return;
 
-            // Only want to update if the client is looking at the changed roster
-            if (currentInventoryVM?._inventoryLogic == null || itemRoster != currentInventoryVM._inventoryLogic._rosters[0]) return;
+            ItemRoster fromItemRoster = null;
+            if (obj.What.FromItemRosterId != null && !objectManager.TryGetObjectWithLogging<ItemRoster>(obj.What.FromItemRosterId, out fromItemRoster)) return;
 
-            // Rebuild LeftItemListVM only
+            ItemRoster toItemRoster = null;
+            if (obj.What.ToItemRosterId != null && !objectManager.TryGetObjectWithLogging<ItemRoster>(obj.What.ToItemRosterId, out toItemRoster)) return;
+
+            // Don't update if the client isn't looking at the changed roster
+            if (fromItemRoster != currentInventoryVM._inventoryLogic._rosters[0] && toItemRoster != currentInventoryVM._inventoryLogic._rosters[0]) return;
+
+            // Only update item costs for client who made the change
+            if (fromItemRoster == currentInventoryVM._inventoryLogic._rosters[1] || toItemRoster == currentInventoryVM._inventoryLogic._rosters[1])
+            {
+                UpdateItemCosts(obj.What.EquipmentElement);
+                return;
+            }
+
+            // Refresh the left item list for other clients looking at the same item roster
             GameLoopRunner.RunOnMainThread(() =>
             {
                 currentInventoryVM.IsRefreshed = false;
-                currentInventoryVM.LeftItemListVM.Clear();
 
-                foreach (var itemRosterElement in currentInventoryVM._inventoryLogic.GetElementsInRoster(InventoryLogic.InventorySide.OtherInventory))
+                int itemRosterElementIndex = currentInventoryVM._inventoryLogic.GetElementsInRoster(InventoryLogic.InventorySide.OtherInventory).FindIndex(rosterElement => rosterElement.EquipmentElement.Equals(obj.What.EquipmentElement));
+                bool elementWasDeleted = itemRosterElementIndex < 0;
+
+                SPItemVM targetItemVM = null;
+                foreach (var itemVM in currentInventoryVM.LeftItemListVM)
                 {
-                    var itemVM = new SPItemVM(currentInventoryVM._inventoryLogic, currentInventoryVM.MainCharacter.IsFemale, currentInventoryVM.CanCharacterUseItem(itemRosterElement), currentInventoryVM._usageType, itemRosterElement, InventoryLogic.InventorySide.OtherInventory, currentInventoryVM._inventoryLogic.GetCostOfItemRosterElement(itemRosterElement, InventoryLogic.InventorySide.OtherInventory), null);
-                    currentInventoryVM.UpdateFilteredStatusOfItem(itemVM);
-                    itemVM.IsLocked = (itemVM.InventorySide == InventoryLogic.InventorySide.PlayerInventory && currentInventoryVM.IsItemLocked(itemRosterElement));
-                    currentInventoryVM.LeftItemListVM.Add(itemVM);
+                    if (itemVM.ItemRosterElement.EquipmentElement.IsEqualTo(obj.What.EquipmentElement)) // Different amounts, can't compare ItemRosterElement directly
+                    {
+                        targetItemVM = itemVM;
+                        break;
+                    }
                 }
 
+                if (elementWasDeleted && targetItemVM != null) // Element deleted, remove VM
+                {
+                    currentInventoryVM.LeftItemListVM.Remove(targetItemVM);
+                }
+                else if (targetItemVM != null) // Existing element, update VM
+                {
+                    int amount = currentInventoryVM._inventoryLogic.GetElementsInRoster(InventoryLogic.InventorySide.OtherInventory)[itemRosterElementIndex].Amount;
+                    targetItemVM.ItemRosterElement.Amount = amount;
+                    targetItemVM.ItemCount = amount;
+                    targetItemVM.RefreshWith(targetItemVM, InventorySide.OtherInventory);
+                }
+                else if (!elementWasDeleted) // New element, add a VM
+                {
+                    ItemRosterElement itemRosterElement = currentInventoryVM._inventoryLogic.GetElementsInRoster(InventoryLogic.InventorySide.OtherInventory)[itemRosterElementIndex];
+                    var newItemVM = new SPItemVM(currentInventoryVM._inventoryLogic, currentInventoryVM.MainCharacter.IsFemale, currentInventoryVM.CanCharacterUseItem(itemRosterElement), currentInventoryVM._usageType, itemRosterElement, InventoryLogic.InventorySide.OtherInventory, currentInventoryVM._inventoryLogic.GetCostOfItemRosterElement(itemRosterElement, InventoryLogic.InventorySide.OtherInventory), null);
+                    currentInventoryVM.UpdateFilteredStatusOfItem(newItemVM);
+                    currentInventoryVM.LeftItemListVM.Add(newItemVM);
+
+                    Tuple<int, int> currentOtherInventorySort = new((int)currentInventoryVM.OtherInventorySortController.CurrentSortOption.Value, (int)currentInventoryVM.OtherInventorySortController.CurrentSortState.Value);
+                    currentInventoryVM.OtherInventorySortController.SortByOption((SPInventorySortControllerVM.InventoryItemSortOption)currentOtherInventorySort.Item1, (SPInventorySortControllerVM.InventoryItemSortState)currentOtherInventorySort.Item2);
+                }
+
+                // Update the costs in all related SPItemVMs
+                UpdateItemCosts(obj.What.EquipmentElement);
+
                 currentInventoryVM.RefreshInformationValues();
+                currentInventoryVM.RefreshValues();
+                currentInventoryVM.IsRefreshed = true;
+            });
+        }
+
+        private void UpdateItemCosts(EquipmentElement equipmentElement)
+        {
+            GameLoopRunner.RunOnMainThread(() =>
+            {
+                currentInventoryVM.UpdateCostOfItemsInCategory(new HashSet<ItemCategory> { equipmentElement.Item.GetItemCategory() });
+            });
+        }
+
+        private void Handle_RefreshAfterTrade(MessagePayload<RefreshAfterTrade> obj)
+        {
+            if (!objectManager.TryGetObjectWithLogging<ItemRoster>(obj.What.ToItemRosterId, out var toItemRoster)) return;
+            if (!objectManager.TryGetObjectWithLogging<ItemRoster>(obj.What.FromItemRosterId, out var fromItemRoster)) return;
+
+            if (currentInventoryVM?._inventoryLogic == null) return;
+
+            GameLoopRunner.RunOnMainThread(() =>
+            {
+                currentInventoryVM.IsRefreshed = false;
+
+                // Update gold count for player inventory
+                currentInventoryVM.RightInventoryOwnerGold = Hero.MainHero.Gold;
+
+                // Update gold count for other inventory
+                if (currentInventoryVM._inventoryLogic.LeftRosterName == null)
+                {
+                    Settlement settlement = currentInventoryVM._currentCharacter.HeroObject.CurrentSettlement;
+                    if (settlement != null && currentInventoryVM._inventoryLogic.InventoryListener != null)
+                    {
+                        currentInventoryVM.LeftInventoryOwnerGold = currentInventoryVM._inventoryLogic.InventoryListener.GetGold();
+                    }
+                    else
+                    {
+                        PartyBase oppositePartyFromListener = currentInventoryVM._inventoryLogic.OppositePartyFromListener;
+                        MobileParty mobileParty = oppositePartyFromListener?.MobileParty;
+                        if (mobileParty != null && (mobileParty.IsCaravan || mobileParty.IsVillager))
+                        {
+                            InventoryListener inventoryListener = currentInventoryVM._inventoryLogic.InventoryListener;
+                            currentInventoryVM.LeftInventoryOwnerGold = ((inventoryListener != null) ? inventoryListener.GetGold() : 0);
+                        }
+                    }
+                }
+
                 currentInventoryVM.IsRefreshed = true;
             });
         }

--- a/source/GameInterface/Services/Inventory/Handlers/ItemDonationHandler.cs
+++ b/source/GameInterface/Services/Inventory/Handlers/ItemDonationHandler.cs
@@ -1,0 +1,67 @@
+﻿using Common.Logging;
+using Common.Messaging;
+using Common.Network;
+using GameInterface.Services.Inventory.Messages;
+using GameInterface.Services.ObjectManager;
+using Serilog;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Roster;
+
+namespace GameInterface.Services.Inventory.Handlers;
+
+internal class ItemDonationHandler : IHandler
+{
+    private static readonly ILogger logger = LogManager.GetLogger<ItemDonationHandler>();
+
+    private readonly IMessageBroker messageBroker;
+    private readonly IObjectManager objectManager;
+    private readonly INetwork network;
+
+    public ItemDonationHandler(
+        IMessageBroker messageBroker,
+        IObjectManager objectManager,
+        INetwork network)
+    {
+        this.messageBroker = messageBroker;
+        this.objectManager = objectManager;
+        this.network = network;
+
+        messageBroker.Subscribe<ItemDonated>(Handle_ItemDonated);
+        messageBroker.Subscribe<DonateItem>(Handle_DonateItem);
+    }
+
+    public void Dispose()
+    {
+        messageBroker.Unsubscribe<ItemDonated>(Handle_ItemDonated);
+        messageBroker.Unsubscribe<DonateItem>(Handle_DonateItem);
+    }
+
+    private void Handle_ItemDonated(MessagePayload<ItemDonated> obj)
+    {
+        if (!objectManager.TryGetIdWithLogging(obj.What.TargetItemRoster, out var targetItemRosterId)) return;
+        if (!objectManager.TryGetIdWithLogging(obj.What.Party, out var partyId)) return;
+
+        var message = new DonateItem(
+            targetItemRosterId,
+            obj.What.EquipmentElement,
+            partyId,
+            obj.What.TroopRosterElement,
+            obj.What.GainedXp);
+
+        network.SendAll(message);
+    }
+
+    private void Handle_DonateItem(MessagePayload<DonateItem> obj)
+    {
+        if (!objectManager.TryGetObjectWithLogging<ItemRoster>(obj.What.TargetItemRosterId, out var targetItemRoster)) return;
+        if (!objectManager.TryGetObjectWithLogging<PartyBase>(obj.What.PartyId, out var party)) return;
+
+        targetItemRoster.AddToCounts(obj.What.EquipmentElement, -1);
+
+        if (obj.What.GainedXp > 0 && obj.What.TroopRosterElement.Character != null)
+        {
+            // TODO
+            party.MemberRoster.AddXpToTroop(obj.What.TroopRosterElement.Character, obj.What.GainedXp);
+        }
+    }
+}

--- a/source/GameInterface/Services/Inventory/Handlers/ResetEquipmentHandler.cs
+++ b/source/GameInterface/Services/Inventory/Handlers/ResetEquipmentHandler.cs
@@ -1,0 +1,110 @@
+﻿using Common.Logging;
+using Common.Messaging;
+using Common.Network;
+using GameInterface.Services.Inventory.Messages;
+using GameInterface.Services.ObjectManager;
+using Serilog;
+using System.Collections.Generic;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using static TaleWorlds.Core.Equipment;
+
+namespace GameInterface.Services.Inventory.Handlers;
+
+internal class ResetEquipmentHandler : IHandler
+{
+    private static readonly ILogger logger = LogManager.GetLogger<ResetEquipmentHandler>();
+
+    private readonly IMessageBroker messageBroker;
+    private readonly IObjectManager objectManager;
+    private readonly INetwork network;
+
+    public ResetEquipmentHandler(
+        IMessageBroker messageBroker,
+        IObjectManager objectManager,
+        INetwork network)
+    {
+        this.messageBroker = messageBroker;
+        this.objectManager = objectManager;
+        this.network = network;
+
+        messageBroker.Subscribe<EquipmentReset>(Handle_EquipmentReset);
+        messageBroker.Subscribe<ResetEquipment>(Handle_ResetEquipment);
+        messageBroker.Subscribe<ResetEquipmentClients>(Handle_ResetEquipmentClients);
+    }
+
+    public void Dispose()
+    {
+        messageBroker.Unsubscribe<EquipmentReset>(Handle_EquipmentReset);
+        messageBroker.Unsubscribe<ResetEquipment>(Handle_ResetEquipment);
+        messageBroker.Unsubscribe<ResetEquipmentClients>(Handle_ResetEquipmentClients);
+    }
+
+    private void Handle_EquipmentReset(MessagePayload<EquipmentReset> obj)
+    {
+        var characterEquipments = obj.What.CharacterEquipments;
+
+        Dictionary<string, Dictionary<EquipmentType, EquipmentElement[]>> heroIdEquipmentElements = new();
+        foreach (KeyValuePair<CharacterObject, Equipment[]> keyValuePair in characterEquipments)
+        {
+            if (!objectManager.TryGetIdWithLogging(keyValuePair.Key.HeroObject, out var heroId)) continue;
+
+            heroIdEquipmentElements[heroId] = new Dictionary<EquipmentType, EquipmentElement[]>();
+            foreach (Equipment equipment in keyValuePair.Value)
+            {
+                heroIdEquipmentElements[heroId][equipment._equipmentType] = equipment._itemSlots;
+            }
+        }
+
+        var message = new ResetEquipment(heroIdEquipmentElements);
+        network.SendAll(message);
+    }
+
+    private void Handle_ResetEquipment(MessagePayload<ResetEquipment> obj)
+    {
+        ResetEquipmentInternal(obj.What.HeroIdEquipmentElements);
+
+        var message = new ResetEquipmentClients(obj.What.HeroIdEquipmentElements);
+        network.SendAll(message);
+    }
+
+    private void Handle_ResetEquipmentClients(MessagePayload<ResetEquipmentClients> obj)
+    {
+        ResetEquipmentInternal(obj.What.HeroIdEquipmentElements);
+    }
+
+    private void ResetEquipmentInternal(Dictionary<string, Dictionary<EquipmentType, EquipmentElement[]>> dictionary)
+    {
+        foreach (KeyValuePair<string, Dictionary<EquipmentType, EquipmentElement[]>> keyValuePair in dictionary)
+        {
+            if (!objectManager.TryGetObjectWithLogging<Hero>(keyValuePair.Key, out var hero)) continue;
+
+            foreach (KeyValuePair<EquipmentType, EquipmentElement[]> equipment in keyValuePair.Value)
+            {
+                if (equipment.Key == EquipmentType.Battle)
+                {
+                    FillEquipment(hero.CharacterObject.FirstBattleEquipment, equipment.Key, equipment.Value);
+                }
+                else if (equipment.Key == EquipmentType.Civilian)
+                {
+                    FillEquipment(hero.CharacterObject.FirstCivilianEquipment, equipment.Key, equipment.Value);
+                }
+                else if (equipment.Key == EquipmentType.Stealth)
+                {
+                    FillEquipment(hero.CharacterObject.FirstStealthEquipment, equipment.Key, equipment.Value);
+                }
+            }
+
+            hero.PartyBelongedTo.Party.SetVisualAsDirty();
+        }
+    }
+
+    private void FillEquipment(Equipment equipment, EquipmentType incomingEquipmentType, EquipmentElement[] incomingEquipmentElements)
+    {
+        equipment._equipmentType = incomingEquipmentType;
+        for (int i = 0; i < 12; i++)
+        {
+            equipment[i] = incomingEquipmentElements[i];
+        }
+    }
+}

--- a/source/GameInterface/Services/Inventory/Handlers/ResetRostersHandler.cs
+++ b/source/GameInterface/Services/Inventory/Handlers/ResetRostersHandler.cs
@@ -77,6 +77,6 @@ internal class ResetRostersHandler : IHandler
             targetItemRoster2?.AddToCounts(itemRosterElement.EquipmentElement, itemRosterElement.Amount);
         }
 
-        network.SendAll(new RefreshOtherInventory(obj.What.TargetItemRoster1Id));
+        //network.SendAll(new RefreshOtherInventory(obj.What.TargetItemRoster1Id));
     }
 }

--- a/source/GameInterface/Services/Inventory/Handlers/ResetRostersHandler.cs
+++ b/source/GameInterface/Services/Inventory/Handlers/ResetRostersHandler.cs
@@ -1,0 +1,82 @@
+﻿using Common.Logging;
+using Common.Messaging;
+using Common.Network;
+using GameInterface.Services.Inventory.Messages;
+using GameInterface.Services.ObjectManager;
+using Serilog;
+using System.Linq;
+using TaleWorlds.CampaignSystem.Roster;
+using TaleWorlds.Core;
+
+namespace GameInterface.Services.Inventory.Handlers;
+
+internal class ResetRostersHandler : IHandler
+{
+    private static readonly ILogger logger = LogManager.GetLogger<ResetRostersHandler>();
+
+    private readonly IMessageBroker messageBroker;
+    private readonly IObjectManager objectManager;
+    private readonly INetwork network;
+
+    public ResetRostersHandler(
+        IMessageBroker messageBroker,
+        IObjectManager objectManager,
+        INetwork network)
+    {
+        this.messageBroker = messageBroker;
+        this.objectManager = objectManager;
+        this.network = network;
+
+        messageBroker.Subscribe<ResetRosters>(Handle_ResetRosters);
+        messageBroker.Subscribe<CompleteResetRosters>(Handle_CompleteResetRosters);
+    }
+
+    public void Dispose()
+    {
+        messageBroker.Unsubscribe<ResetRosters>(Handle_ResetRosters);
+        messageBroker.Unsubscribe<CompleteResetRosters>(Handle_CompleteResetRosters);
+    }
+
+    private void Handle_ResetRosters(MessagePayload<ResetRosters> obj)
+    {
+        string targetItemRoster1Id = null;
+        if (obj.What.TargetItemRoster1 != null && !objectManager.TryGetIdWithLogging(obj.What.TargetItemRoster1, out targetItemRoster1Id)) return;
+
+        string targetItemRoster2Id = null;
+        if (obj.What.TargetItemRoster2 != null && !objectManager.TryGetIdWithLogging(obj.What.TargetItemRoster2, out targetItemRoster2Id)) return;
+
+        var backupItemRoster1Elements = obj.What.BackupItemRoster1._data;
+        var backupItemRoster2Elements = obj.What.BackupItemRoster2._data;
+
+        var message = new CompleteResetRosters(
+            targetItemRoster1Id,
+            targetItemRoster2Id,
+            backupItemRoster1Elements,
+            backupItemRoster2Elements);
+
+        network.SendAll(message);
+    }
+
+    private void Handle_CompleteResetRosters(MessagePayload<CompleteResetRosters> obj)
+    {
+        ItemRoster targetItemRoster1 = null;
+        if (obj.What.TargetItemRoster1Id != null && !objectManager.TryGetObjectWithLogging<ItemRoster>(obj.What.TargetItemRoster1Id, out targetItemRoster1)) return;
+
+        ItemRoster targetItemRoster2 = null;
+        if (obj.What.TargetItemRoster2Id != null && !objectManager.TryGetObjectWithLogging<ItemRoster>(obj.What.TargetItemRoster2Id, out targetItemRoster2)) return;
+
+        targetItemRoster1?.Clear();
+        foreach(var itemRosterElement in obj.What.BackupItemRoster1Elements ?? Enumerable.Empty<ItemRosterElement>())
+        {
+            targetItemRoster1?.AddToCounts(itemRosterElement.EquipmentElement, itemRosterElement.Amount);
+        }
+
+        targetItemRoster2?.Clear();
+        foreach (var itemRosterElement in obj.What.BackupItemRoster2Elements ?? Enumerable.Empty<ItemRosterElement>())
+        {
+            targetItemRoster2?.AddToCounts(itemRosterElement.EquipmentElement, itemRosterElement.Amount);
+        }
+
+        network.SendAll(new RefreshOtherInventory(obj.What.TargetItemRoster1Id));
+    }
+}

--- a/source/GameInterface/Services/Inventory/Handlers/SlaughterHandler.cs
+++ b/source/GameInterface/Services/Inventory/Handlers/SlaughterHandler.cs
@@ -1,0 +1,60 @@
+﻿using Common.Logging;
+using Common.Messaging;
+using Common.Network;
+using GameInterface.Services.Inventory.Messages;
+using GameInterface.Services.ObjectManager;
+using Serilog;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Roster;
+
+namespace GameInterface.Services.Inventory.Handlers;
+
+internal class SlaughterHandler : IHandler
+{
+    private static readonly ILogger logger = LogManager.GetLogger<SlaughterHandler>();
+
+    private readonly IMessageBroker messageBroker;
+    private readonly IObjectManager objectManager;
+    private readonly INetwork network;
+
+    public SlaughterHandler(
+        IMessageBroker messageBroker,
+        IObjectManager objectManager,
+        INetwork network)
+    {
+        this.messageBroker = messageBroker;
+        this.objectManager = objectManager;
+        this.network = network;
+
+        messageBroker.Subscribe<ItemSlaughtered>(Handle_ItemSlaughtered);
+        messageBroker.Subscribe<SlaughterItem>(Handle_SlaughterItem);
+    }
+
+    public void Dispose()
+    {
+        messageBroker.Unsubscribe<ItemSlaughtered>(Handle_ItemSlaughtered);
+        messageBroker.Unsubscribe<SlaughterItem>(Handle_SlaughterItem);
+    }
+
+    private void Handle_ItemSlaughtered(MessagePayload<ItemSlaughtered> obj)
+    {
+        if (!objectManager.TryGetIdWithLogging(obj.What.TargetItemRoster, out var targetItemRosterId)) return;
+
+        var message = new SlaughterItem(
+            targetItemRosterId,
+            obj.What.EquipmentElement,
+            obj.What.MeatCount,
+            obj.What.HideCount);
+
+        network.SendAll(message);
+    }
+
+    private void Handle_SlaughterItem(MessagePayload<SlaughterItem> obj)
+    {
+        if (!objectManager.TryGetObjectWithLogging<ItemRoster>(obj.What.TargetItemRosterId, out var targetItemRoster)) return;
+
+        targetItemRoster.AddToCounts(DefaultItems.Meat, obj.What.MeatCount);
+        targetItemRoster.AddToCounts(obj.What.EquipmentElement, -1);
+        targetItemRoster.AddToCounts(DefaultItems.Hides, obj.What.HideCount);
+    }
+}

--- a/source/GameInterface/Services/Inventory/Handlers/TradeHandler.cs
+++ b/source/GameInterface/Services/Inventory/Handlers/TradeHandler.cs
@@ -1,4 +1,5 @@
-﻿using Common.Logging;
+﻿using Common;
+using Common.Logging;
 using Common.Messaging;
 using Common.Network;
 using Common.Util;
@@ -116,6 +117,11 @@ internal class TradeHandler : IHandler
             boughtItems,
             soldItems
         );
+
+        GameLoopRunner.RunOnMainThread(() =>
+        {
+            network.SendAll(new RefreshAfterTrade(message.ToItemRosterId, message.FromItemRosterId));
+        });
     }
 
     private (ItemRosterElementData, int)[] ResolveTradeItemIds(

--- a/source/GameInterface/Services/Inventory/Handlers/TransferHandler.cs
+++ b/source/GameInterface/Services/Inventory/Handlers/TransferHandler.cs
@@ -37,10 +37,15 @@ internal class TransferHandler : IHandler
 
     private void Handle_TransferAttempted(MessagePayload<TransferAttempted> obj)
     {
-        if (!objectManager.TryGetIdWithLogging(obj.What.TargetItemRoster, out var targetItemRosterId)) return;
+        string fromItemRosterId = null;
+        if (obj.What.FromItemRoster != null && !objectManager.TryGetIdWithLogging(obj.What.FromItemRoster, out fromItemRosterId)) return;
+
+        string toItemRosterId = null;
+        if (obj.What.ToItemRoster != null && !objectManager.TryGetIdWithLogging(obj.What.ToItemRoster, out toItemRosterId)) return;
 
         var message = new CompleteTransfer(
-            targetItemRosterId,
+            fromItemRosterId,
+            toItemRosterId,
             obj.What.EquipmentElement,
             obj.What.Count);
 
@@ -49,10 +54,25 @@ internal class TransferHandler : IHandler
 
     private void Handle_CompleteTransfer(MessagePayload<CompleteTransfer> obj)
     {
-        if (!objectManager.TryGetObjectWithLogging<ItemRoster>(obj.What.TargetItemRosterId, out var targetItemRoster)) return;
+        ItemRoster fromItemRoster = null;
+        if (obj.What.FromItemRosterId != null && !objectManager.TryGetObjectWithLogging(obj.What.FromItemRosterId, out fromItemRoster)) return;
 
-        targetItemRoster.AddToCounts(obj.What.EquipmentElement, obj.What.Count);
+        ItemRoster toItemRoster = null;
+        if (obj.What.ToItemRosterId != null && !objectManager.TryGetObjectWithLogging(obj.What.ToItemRosterId, out toItemRoster)) return;
 
-        network.SendAll(new RefreshOtherInventory(obj.What.TargetItemRosterId));
+        int fromCount = obj.What.Count;
+        if (fromItemRoster != null)
+        {
+            int equipmentElementIndex = fromItemRoster.FindIndexOfElement(obj.What.EquipmentElement);
+            if (equipmentElementIndex >= 0 && fromItemRoster[equipmentElementIndex].Amount - fromCount < 0)
+            {
+                fromCount = 0;
+            }
+        }
+
+        fromItemRoster?.AddToCounts(obj.What.EquipmentElement, -fromCount);
+        toItemRoster?.AddToCounts(obj.What.EquipmentElement, obj.What.Count);
+
+        network.SendAll(new RefreshOtherInventory(obj.What.FromItemRosterId, obj.What.ToItemRosterId, obj.What.EquipmentElement));
     }
 }

--- a/source/GameInterface/Services/Inventory/Handlers/TransferHandler.cs
+++ b/source/GameInterface/Services/Inventory/Handlers/TransferHandler.cs
@@ -1,0 +1,58 @@
+﻿using Common.Logging;
+using Common.Messaging;
+using Common.Network;
+using GameInterface.Services.Inventory.Messages;
+using GameInterface.Services.ObjectManager;
+using Serilog;
+using TaleWorlds.CampaignSystem.Roster;
+
+namespace GameInterface.Services.Inventory.Handlers;
+
+internal class TransferHandler : IHandler
+{
+    private static readonly ILogger logger = LogManager.GetLogger<TransferHandler>();
+
+    private readonly IMessageBroker messageBroker;
+    private readonly IObjectManager objectManager;
+    private readonly INetwork network;
+
+    public TransferHandler(
+        IMessageBroker messageBroker,
+        IObjectManager objectManager,
+        INetwork network)
+    {
+        this.messageBroker = messageBroker;
+        this.objectManager = objectManager;
+        this.network = network;
+
+        messageBroker.Subscribe<TransferAttempted>(Handle_TransferAttempted);
+        messageBroker.Subscribe<CompleteTransfer>(Handle_CompleteTransfer);
+    }
+
+    public void Dispose()
+    {
+        messageBroker.Unsubscribe<TransferAttempted>(Handle_TransferAttempted);
+        messageBroker.Unsubscribe<CompleteTransfer>(Handle_CompleteTransfer);
+    }
+
+    private void Handle_TransferAttempted(MessagePayload<TransferAttempted> obj)
+    {
+        if (!objectManager.TryGetIdWithLogging(obj.What.TargetItemRoster, out var targetItemRosterId)) return;
+
+        var message = new CompleteTransfer(
+            targetItemRosterId,
+            obj.What.EquipmentElement,
+            obj.What.Count);
+
+        network.SendAll(message);
+    }
+
+    private void Handle_CompleteTransfer(MessagePayload<CompleteTransfer> obj)
+    {
+        if (!objectManager.TryGetObjectWithLogging<ItemRoster>(obj.What.TargetItemRosterId, out var targetItemRoster)) return;
+
+        targetItemRoster.AddToCounts(obj.What.EquipmentElement, obj.What.Count);
+
+        network.SendAll(new RefreshOtherInventory(obj.What.TargetItemRosterId));
+    }
+}

--- a/source/GameInterface/Services/Inventory/Handlers/UpdateEquipmentHandler.cs
+++ b/source/GameInterface/Services/Inventory/Handlers/UpdateEquipmentHandler.cs
@@ -1,0 +1,106 @@
+﻿using Common;
+using Common.Logging;
+using Common.Messaging;
+using Common.Network;
+using GameInterface.Services.Inventory.Messages;
+using GameInterface.Services.ObjectManager;
+using Serilog;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using static TaleWorlds.Core.Equipment;
+
+namespace GameInterface.Services.Inventory.Handlers;
+
+internal class UpdateEquipmentHandler : IHandler
+{
+    private static readonly ILogger logger = LogManager.GetLogger<UpdateEquipmentHandler>();
+
+    private readonly IMessageBroker messageBroker;
+    private readonly IObjectManager objectManager;
+    private readonly INetwork network;
+
+    public UpdateEquipmentHandler(
+        IMessageBroker messageBroker,
+        IObjectManager objectManager,
+        INetwork network)
+    {
+        this.messageBroker = messageBroker;
+        this.objectManager = objectManager;
+        this.network = network;
+
+        messageBroker.Subscribe<EquipmentUpdated>(Handle_EquipmentUpdated);
+        messageBroker.Subscribe<UpdateEquipment>(Handle_UpdateEquipment);
+        messageBroker.Subscribe<UpdateEquipmentClients>(Handle_UpdateEquipmentClients);
+    }
+
+    public void Dispose()
+    {
+        messageBroker.Unsubscribe<EquipmentUpdated>(Handle_EquipmentUpdated);
+        messageBroker.Unsubscribe<UpdateEquipment>(Handle_UpdateEquipment);
+        messageBroker.Unsubscribe<UpdateEquipmentClients>(Handle_UpdateEquipmentClients);
+    }
+
+    private void Handle_EquipmentUpdated(MessagePayload<EquipmentUpdated> obj)
+    {
+        if (!objectManager.TryGetIdWithLogging(obj.What.Hero, out var heroId)) return;
+
+        var message = new UpdateEquipment(
+            heroId,
+            obj.What.EquipmentType,
+            obj.What.EquipmentElement,
+            obj.What.EquipmentIndex);
+
+        network.SendAll(message);
+    }
+
+    private void Handle_UpdateEquipment(MessagePayload<UpdateEquipment> obj)
+    {
+        if (!objectManager.TryGetObjectWithLogging<Hero>(obj.What.HeroId, out var hero)) return;
+
+        UpdateEquipmentInternal(hero.CharacterObject, obj.What.EquipmentType, obj.What.EquipmentIndex, obj.What.EquipmentElement);
+
+        // Message for clients because equipment isn't managed
+        var message = new UpdateEquipmentClients(
+            obj.What.HeroId,
+            obj.What.EquipmentType,
+            obj.What.EquipmentElement,
+            obj.What.EquipmentIndex);
+
+        network.SendAll(message);
+    }
+
+    private void Handle_UpdateEquipmentClients(MessagePayload<UpdateEquipmentClients> obj)
+    {
+        if (!objectManager.TryGetObjectWithLogging<Hero>(obj.What.HeroId, out var hero)) return;
+
+        // Don't run for hero that was modified by the client (already updated)
+        if (hero == Hero.MainHero) return;
+
+        UpdateEquipmentInternal(hero.CharacterObject, obj.What.EquipmentType, obj.What.EquipmentIndex, obj.What.EquipmentElement);
+    }
+
+    private void UpdateEquipmentInternal(
+        CharacterObject character,
+        EquipmentType equipmentType,
+        EquipmentIndex equipmentIndex,
+        EquipmentElement equipmentElement)
+    {
+        Equipment targetEquipment = null;
+        if (equipmentType == EquipmentType.Battle)
+        {
+            targetEquipment = character.FirstBattleEquipment;
+        }
+        else if (equipmentType == EquipmentType.Civilian)
+        {
+            targetEquipment = character.FirstCivilianEquipment;
+        }
+        else if (equipmentType == EquipmentType.Stealth)
+        {
+            targetEquipment = character.FirstStealthEquipment;
+        }
+
+        if (targetEquipment != null) targetEquipment[equipmentIndex] = equipmentElement;
+
+        character.HeroObject.PartyBelongedTo.Party.SetVisualAsDirty();
+    }
+}

--- a/source/GameInterface/Services/Inventory/Interfaces/InventoryLogicInterface.cs
+++ b/source/GameInterface/Services/Inventory/Interfaces/InventoryLogicInterface.cs
@@ -142,7 +142,7 @@ namespace GameInterface.Services.Inventory.Interfaces
                         MobilePartyHelper.PartyAddSharedXp(ownerHero.PartyBelongedTo, (float)xpBonusForDiscardingItems);
                     }
 
-                    toRoster.AddToCounts(rosterElement.EquipmentElement, -rosterElement.Amount);
+                    //toRoster.AddToCounts(rosterElement.EquipmentElement, -rosterElement.Amount);
                 }
             }
 
@@ -152,6 +152,7 @@ namespace GameInterface.Services.Inventory.Interfaces
                 // Sets the gold of the other party
                 currentSettlementComponent.Gold += totalAmount;
 
+                /*
                 foreach (ItemRosterElement rosterElement in boughtItems.Select(x => x.Item1))
                 {
                     toRoster.AddToCounts(rosterElement.EquipmentElement, rosterElement.Amount);
@@ -163,6 +164,7 @@ namespace GameInterface.Services.Inventory.Interfaces
                     toRoster.AddToCounts(rosterElement.EquipmentElement, -rosterElement.Amount);
                     fromRoster.AddToCounts(rosterElement.EquipmentElement, rosterElement.Amount);
                 }
+                */
             }
             else if (((currentMobileParty != null) ? currentMobileParty.Party.LeaderHero : null) != null && isTrading)
             {

--- a/source/GameInterface/Services/Inventory/Messages/CompleteResetRosters.cs
+++ b/source/GameInterface/Services/Inventory/Messages/CompleteResetRosters.cs
@@ -1,0 +1,33 @@
+﻿using Common.Messaging;
+using ProtoBuf;
+using TaleWorlds.Core;
+
+namespace GameInterface.Services.Inventory.Messages;
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct CompleteResetRosters : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string TargetItemRoster1Id;
+
+    [ProtoMember(2)]
+    public readonly string TargetItemRoster2Id;
+
+    [ProtoMember(3)]
+    public readonly ItemRosterElement[] BackupItemRoster1Elements;
+
+    [ProtoMember(4)]
+    public readonly ItemRosterElement[] BackupItemRoster2Elements;
+
+    public CompleteResetRosters(
+        string targetItemRoster1Id,
+        string targetItemRoster2Id,
+        ItemRosterElement[] backupItemRoster1Elements,
+        ItemRosterElement[] backupItemRoster2Elements)
+    {
+        TargetItemRoster1Id = targetItemRoster1Id;
+        TargetItemRoster2Id = targetItemRoster2Id;
+        BackupItemRoster1Elements = backupItemRoster1Elements;
+        BackupItemRoster2Elements = backupItemRoster2Elements;
+    }
+}

--- a/source/GameInterface/Services/Inventory/Messages/CompleteTransfer.cs
+++ b/source/GameInterface/Services/Inventory/Messages/CompleteTransfer.cs
@@ -1,0 +1,28 @@
+﻿using Common.Messaging;
+using ProtoBuf;
+using TaleWorlds.Core;
+
+namespace GameInterface.Services.Inventory.Messages;
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct CompleteTransfer : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string TargetItemRosterId;
+
+    [ProtoMember(2)]
+    public readonly EquipmentElement EquipmentElement;
+
+    [ProtoMember(3)]
+    public readonly int Count;
+
+    public CompleteTransfer(
+        string targetItemRosterId,
+        EquipmentElement equipmentElement,
+        int count)
+    {
+        TargetItemRosterId = targetItemRosterId;
+        EquipmentElement = equipmentElement;
+        Count = count;
+    }
+}

--- a/source/GameInterface/Services/Inventory/Messages/CompleteTransfer.cs
+++ b/source/GameInterface/Services/Inventory/Messages/CompleteTransfer.cs
@@ -8,20 +8,25 @@ namespace GameInterface.Services.Inventory.Messages;
 internal readonly struct CompleteTransfer : ICommand
 {
     [ProtoMember(1)]
-    public readonly string TargetItemRosterId;
+    public readonly string FromItemRosterId;
 
     [ProtoMember(2)]
-    public readonly EquipmentElement EquipmentElement;
+    public readonly string ToItemRosterId;
 
     [ProtoMember(3)]
+    public readonly EquipmentElement EquipmentElement;
+
+    [ProtoMember(4)]
     public readonly int Count;
 
     public CompleteTransfer(
-        string targetItemRosterId,
+        string fromItemRosterId,
+        string toItemRosterId,
         EquipmentElement equipmentElement,
         int count)
     {
-        TargetItemRosterId = targetItemRosterId;
+        FromItemRosterId = fromItemRosterId;
+        ToItemRosterId = toItemRosterId;
         EquipmentElement = equipmentElement;
         Count = count;
     }

--- a/source/GameInterface/Services/Inventory/Messages/DonateItem.cs
+++ b/source/GameInterface/Services/Inventory/Messages/DonateItem.cs
@@ -1,0 +1,39 @@
+﻿using Common.Messaging;
+using ProtoBuf;
+using TaleWorlds.CampaignSystem.Roster;
+using TaleWorlds.Core;
+
+namespace GameInterface.Services.Inventory.Messages;
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct DonateItem : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string TargetItemRosterId;
+
+    [ProtoMember(2)]
+    public readonly EquipmentElement EquipmentElement;
+
+    [ProtoMember(3)]
+    public readonly string PartyId;
+
+    [ProtoMember(4)]
+    public readonly TroopRosterElement TroopRosterElement;
+
+    [ProtoMember(5)]
+    public readonly int GainedXp;
+
+    public DonateItem(
+        string targetItemRosterId,
+        EquipmentElement equipmentElement,
+        string partyId,
+        TroopRosterElement troopRosterElement,
+        int gainedXp)
+    {
+        TargetItemRosterId = targetItemRosterId;
+        EquipmentElement = equipmentElement;
+        PartyId = partyId;
+        TroopRosterElement = troopRosterElement;
+        GainedXp = gainedXp;
+    }
+}

--- a/source/GameInterface/Services/Inventory/Messages/EquipmentReset.cs
+++ b/source/GameInterface/Services/Inventory/Messages/EquipmentReset.cs
@@ -1,0 +1,16 @@
+﻿using Common.Messaging;
+using System.Collections.Generic;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+
+namespace GameInterface.Services.Inventory.Messages;
+
+public readonly struct EquipmentReset : IEvent
+{
+    public readonly Dictionary<CharacterObject, Equipment[]> CharacterEquipments;
+
+    public EquipmentReset(Dictionary<CharacterObject, Equipment[]> characterEquipments)
+    {
+        CharacterEquipments = characterEquipments;
+    }
+}

--- a/source/GameInterface/Services/Inventory/Messages/EquipmentUpdated.cs
+++ b/source/GameInterface/Services/Inventory/Messages/EquipmentUpdated.cs
@@ -1,0 +1,26 @@
+﻿using Common.Messaging;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using static TaleWorlds.Core.Equipment;
+
+namespace GameInterface.Services.Inventory.Messages;
+
+public readonly struct EquipmentUpdated : IEvent
+{
+    public readonly Hero Hero;
+    public readonly EquipmentType EquipmentType;
+    public readonly EquipmentElement EquipmentElement;
+    public readonly EquipmentIndex EquipmentIndex;
+
+    public EquipmentUpdated(
+        Hero hero,
+        EquipmentType equipmentType,
+        EquipmentElement equipmentElement,
+        EquipmentIndex equipmentIndex)
+    {
+        Hero = hero;
+        EquipmentType = equipmentType;
+        EquipmentElement = equipmentElement;
+        EquipmentIndex = equipmentIndex;
+    }
+}

--- a/source/GameInterface/Services/Inventory/Messages/InventoryRefreshMessages.cs
+++ b/source/GameInterface/Services/Inventory/Messages/InventoryRefreshMessages.cs
@@ -1,0 +1,27 @@
+﻿using Common.Messaging;
+using ProtoBuf;
+using TaleWorlds.CampaignSystem.ViewModelCollection.Inventory;
+
+namespace GameInterface.Services.Inventory.Messages;
+
+public readonly struct InventoryVMCreated : IEvent
+{
+    public readonly SPInventoryVM InventoryVM;
+
+    public InventoryVMCreated(SPInventoryVM inventoryVM)
+    {
+        InventoryVM = inventoryVM;
+    }
+}
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct RefreshOtherInventory : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string ItemRosterId;
+
+    public RefreshOtherInventory(string itemRosterId)
+    {
+        ItemRosterId = itemRosterId;
+    }
+}

--- a/source/GameInterface/Services/Inventory/Messages/InventoryRefreshMessages.cs
+++ b/source/GameInterface/Services/Inventory/Messages/InventoryRefreshMessages.cs
@@ -1,6 +1,7 @@
 ﻿using Common.Messaging;
 using ProtoBuf;
 using TaleWorlds.CampaignSystem.ViewModelCollection.Inventory;
+using TaleWorlds.Core;
 
 namespace GameInterface.Services.Inventory.Messages;
 
@@ -18,10 +19,34 @@ public readonly struct InventoryVMCreated : IEvent
 internal readonly struct RefreshOtherInventory : ICommand
 {
     [ProtoMember(1)]
-    public readonly string ItemRosterId;
+    public readonly string FromItemRosterId;
 
-    public RefreshOtherInventory(string itemRosterId)
+    [ProtoMember(2)]
+    public readonly string ToItemRosterId;
+
+    [ProtoMember(3)]
+    public readonly EquipmentElement EquipmentElement;
+
+    public RefreshOtherInventory(string fromItemRosterId, string toItemRosterId, EquipmentElement equipmentElement)
     {
-        ItemRosterId = itemRosterId;
+        FromItemRosterId = fromItemRosterId;
+        ToItemRosterId = toItemRosterId;
+        EquipmentElement = equipmentElement;
+    }
+}
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct RefreshAfterTrade : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string ToItemRosterId;
+
+    [ProtoMember(2)]
+    public readonly string FromItemRosterId;
+
+    public RefreshAfterTrade(string toItemRosterId, string fromItemRosterId)
+    {
+        ToItemRosterId = toItemRosterId;
+        FromItemRosterId = fromItemRosterId;
     }
 }

--- a/source/GameInterface/Services/Inventory/Messages/ItemDonated.cs
+++ b/source/GameInterface/Services/Inventory/Messages/ItemDonated.cs
@@ -1,0 +1,29 @@
+﻿using Common.Messaging;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Roster;
+using TaleWorlds.Core;
+
+namespace GameInterface.Services.Inventory.Messages;
+
+public readonly struct ItemDonated : IEvent
+{
+    public readonly ItemRoster TargetItemRoster;
+    public readonly EquipmentElement EquipmentElement;
+    public readonly PartyBase Party;
+    public readonly TroopRosterElement TroopRosterElement;
+    public readonly int GainedXp;
+
+    public ItemDonated(
+        ItemRoster targetItemRoster,
+        EquipmentElement equipmentElement,
+        PartyBase party,
+        TroopRosterElement troopRosterElement,
+        int gainedXp)
+    {
+        TargetItemRoster = targetItemRoster;
+        EquipmentElement = equipmentElement;
+        Party = party;
+        TroopRosterElement = troopRosterElement;
+        GainedXp = gainedXp;
+    }
+}

--- a/source/GameInterface/Services/Inventory/Messages/ItemSlaughtered.cs
+++ b/source/GameInterface/Services/Inventory/Messages/ItemSlaughtered.cs
@@ -1,0 +1,24 @@
+﻿using Common.Messaging;
+using TaleWorlds.CampaignSystem.Roster;
+using TaleWorlds.Core;
+
+namespace GameInterface.Services.Inventory.Messages;
+
+public readonly struct ItemSlaughtered : IEvent
+{
+    public readonly ItemRoster TargetItemRoster;
+    public readonly EquipmentElement EquipmentElement;
+    public readonly int MeatCount;
+    public readonly int HideCount;
+
+    public ItemSlaughtered(
+        ItemRoster targetItemRoster,
+        EquipmentElement equipmentElement,
+        int meatCount, int hideCount)
+    {
+        TargetItemRoster = targetItemRoster;
+        EquipmentElement = equipmentElement;
+        MeatCount = meatCount;
+        HideCount = hideCount;
+    }
+}

--- a/source/GameInterface/Services/Inventory/Messages/ResetEquipment.cs
+++ b/source/GameInterface/Services/Inventory/Messages/ResetEquipment.cs
@@ -1,0 +1,33 @@
+﻿using Common.Messaging;
+using ProtoBuf;
+using System.Collections.Generic;
+using TaleWorlds.Core;
+using static TaleWorlds.Core.Equipment;
+
+namespace GameInterface.Services.Inventory.Messages;
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct ResetEquipment : ICommand
+{
+    [ProtoMember(1)]
+    public readonly Dictionary<string, Dictionary<EquipmentType, EquipmentElement[]>> HeroIdEquipmentElements;
+
+    public ResetEquipment(
+        Dictionary<string, Dictionary<EquipmentType, EquipmentElement[]>> heroIdEquipmentElements)
+    {
+        HeroIdEquipmentElements = heroIdEquipmentElements;
+    }
+}
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct ResetEquipmentClients : ICommand
+{
+    [ProtoMember(1)]
+    public readonly Dictionary<string, Dictionary<EquipmentType, EquipmentElement[]>> HeroIdEquipmentElements;
+
+    public ResetEquipmentClients(
+        Dictionary<string, Dictionary<EquipmentType, EquipmentElement[]>> heroIdEquipmentElements)
+    {
+        HeroIdEquipmentElements = heroIdEquipmentElements;
+    }
+}

--- a/source/GameInterface/Services/Inventory/Messages/ResetRosters.cs
+++ b/source/GameInterface/Services/Inventory/Messages/ResetRosters.cs
@@ -1,0 +1,31 @@
+﻿using Common.Messaging;
+using TaleWorlds.CampaignSystem.Inventory;
+using TaleWorlds.CampaignSystem.Roster;
+
+namespace GameInterface.Services.Inventory.Messages;
+
+public readonly struct ResetRosters : IEvent
+{
+    public readonly ItemRoster TargetItemRoster1;
+    public readonly ItemRoster BackupItemRoster1;
+    public readonly ItemRoster TargetItemRoster2;
+    public readonly ItemRoster BackupItemRoster2;
+    public readonly InventoryLogic InventoryLogic;
+    public readonly bool FromCancel;
+
+    public ResetRosters(
+        ItemRoster targetItemRoster1,
+        ItemRoster backupItemRoster1,
+        ItemRoster targetItemRoster2,
+        ItemRoster backupItemRoster2,
+        InventoryLogic inventoryLogic,
+        bool fromCancel)
+    {
+        TargetItemRoster1 = targetItemRoster1;
+        BackupItemRoster1 = backupItemRoster1;
+        TargetItemRoster2 = targetItemRoster2;
+        BackupItemRoster2 = backupItemRoster2;
+        InventoryLogic = inventoryLogic;
+        FromCancel = fromCancel;
+    }
+}

--- a/source/GameInterface/Services/Inventory/Messages/SlaughterItem.cs
+++ b/source/GameInterface/Services/Inventory/Messages/SlaughterItem.cs
@@ -1,0 +1,32 @@
+﻿using Common.Messaging;
+using ProtoBuf;
+using TaleWorlds.Core;
+
+namespace GameInterface.Services.Inventory.Messages;
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct SlaughterItem : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string TargetItemRosterId;
+
+    [ProtoMember(2)]
+    public readonly EquipmentElement EquipmentElement;
+
+    [ProtoMember(3)]
+    public readonly int MeatCount;
+
+    [ProtoMember(4)]
+    public readonly int HideCount;
+
+    public SlaughterItem(
+        string targetItemRosterId,
+        EquipmentElement equipmentElement,
+        int meatCount, int hideCount)
+    {
+        TargetItemRosterId = targetItemRosterId;
+        EquipmentElement = equipmentElement;
+        MeatCount = meatCount;
+        HideCount = hideCount;
+    }
+}

--- a/source/GameInterface/Services/Inventory/Messages/TransferAttempted.cs
+++ b/source/GameInterface/Services/Inventory/Messages/TransferAttempted.cs
@@ -6,16 +6,19 @@ namespace GameInterface.Services.Inventory.Messages;
 
 public readonly struct TransferAttempted : IEvent
 {
-    public readonly ItemRoster TargetItemRoster;
+    public readonly ItemRoster FromItemRoster;
+    public readonly ItemRoster ToItemRoster;
     public readonly EquipmentElement EquipmentElement;
     public readonly int Count;
 
     public TransferAttempted(
-        ItemRoster targetItemRoster,
+        ItemRoster fromItemRoster,
+        ItemRoster toItemRoster,
         EquipmentElement equipmentElement,
         int count)
     {
-        TargetItemRoster = targetItemRoster;
+        FromItemRoster = fromItemRoster;
+        ToItemRoster = toItemRoster;
         EquipmentElement = equipmentElement;
         Count = count;
     }

--- a/source/GameInterface/Services/Inventory/Messages/TransferAttempted.cs
+++ b/source/GameInterface/Services/Inventory/Messages/TransferAttempted.cs
@@ -1,0 +1,22 @@
+﻿using Common.Messaging;
+using TaleWorlds.CampaignSystem.Roster;
+using TaleWorlds.Core;
+
+namespace GameInterface.Services.Inventory.Messages;
+
+public readonly struct TransferAttempted : IEvent
+{
+    public readonly ItemRoster TargetItemRoster;
+    public readonly EquipmentElement EquipmentElement;
+    public readonly int Count;
+
+    public TransferAttempted(
+        ItemRoster targetItemRoster,
+        EquipmentElement equipmentElement,
+        int count)
+    {
+        TargetItemRoster = targetItemRoster;
+        EquipmentElement = equipmentElement;
+        Count = count;
+    }
+}

--- a/source/GameInterface/Services/Inventory/Messages/UpdateEquipment.cs
+++ b/source/GameInterface/Services/Inventory/Messages/UpdateEquipment.cs
@@ -1,0 +1,62 @@
+﻿using Common.Messaging;
+using ProtoBuf;
+using TaleWorlds.Core;
+using static TaleWorlds.Core.Equipment;
+
+namespace GameInterface.Services.Inventory.Messages;
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct UpdateEquipment : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string HeroId;
+
+    [ProtoMember(2)]
+    public readonly EquipmentType EquipmentType;
+
+    [ProtoMember(3)]
+    public readonly EquipmentElement EquipmentElement;
+
+    [ProtoMember(4)]
+    public readonly EquipmentIndex EquipmentIndex;
+
+    public UpdateEquipment(
+        string heroId,
+        EquipmentType equipmentType,
+        EquipmentElement equipmentElement,
+        EquipmentIndex equipmentIndex)
+    {
+        HeroId = heroId;
+        EquipmentType = equipmentType;
+        EquipmentElement = equipmentElement;
+        EquipmentIndex = equipmentIndex;
+    }
+}
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct UpdateEquipmentClients : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string HeroId;
+
+    [ProtoMember(2)]
+    public readonly EquipmentType EquipmentType;
+
+    [ProtoMember(3)]
+    public readonly EquipmentElement EquipmentElement;
+
+    [ProtoMember(4)]
+    public readonly EquipmentIndex EquipmentIndex;
+
+    public UpdateEquipmentClients(
+        string heroId,
+        EquipmentType equipmentType,
+        EquipmentElement equipmentElement,
+        EquipmentIndex equipmentIndex)
+    {
+        HeroId = heroId;
+        EquipmentType = equipmentType;
+        EquipmentElement = equipmentElement;
+        EquipmentIndex = equipmentIndex;
+    }
+}

--- a/source/GameInterface/Services/Inventory/Patches/InventoryConstructorPatches.cs
+++ b/source/GameInterface/Services/Inventory/Patches/InventoryConstructorPatches.cs
@@ -1,0 +1,26 @@
+﻿using Common.Logging;
+using Common.Messaging;
+using GameInterface.Services.Inventory.Messages;
+using HarmonyLib;
+using Serilog;
+using System;
+using TaleWorlds.CampaignSystem.Inventory;
+using TaleWorlds.CampaignSystem.ViewModelCollection.Inventory;
+using TaleWorlds.Core;
+
+namespace GameInterface.Services.Inventory.Patches
+{
+    [HarmonyPatch(typeof(SPInventoryVM))]
+    internal class SPInventoryVMConstructorPatch
+    {
+        private static readonly ILogger Logger = LogManager.GetLogger<SPInventoryVM>();
+
+        [HarmonyPatch(MethodType.Constructor)]
+        [HarmonyPatch(new Type[] { typeof(InventoryLogic), typeof(bool), typeof(Func<WeaponComponentData, ItemObject.ItemUsageSetFlags>) })]
+        [HarmonyPostfix]
+        public static void SPInventoryVMConstructorPostfix(SPInventoryVM __instance, InventoryLogic inventoryLogic, bool isInCivilianModeByDefault, Func<WeaponComponentData, ItemObject.ItemUsageSetFlags> getItemUsageSetFlags)
+        {
+            MessageBroker.Instance.Publish(__instance, new InventoryVMCreated(__instance));
+        }
+    }
+}

--- a/source/GameInterface/Services/Inventory/Patches/InventoryEquipmentPatches.cs
+++ b/source/GameInterface/Services/Inventory/Patches/InventoryEquipmentPatches.cs
@@ -1,0 +1,45 @@
+﻿using Common.Logging;
+using Common.Messaging;
+using GameInterface.Services.Inventory.Messages;
+using HarmonyLib;
+using Serilog;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Inventory;
+using TaleWorlds.CampaignSystem.ViewModelCollection.Inventory;
+using TaleWorlds.Core;
+using static TaleWorlds.Core.Equipment;
+
+namespace GameInterface.Services.Inventory.Patches
+{
+    [HarmonyPatch(typeof(InventoryLogic.PartyEquipment))]
+    internal class InventoryLogicPartyEquipmentPatches
+    {
+        private static readonly ILogger Logger = LogManager.GetLogger<InventoryLogic.PartyEquipment>();
+
+        [HarmonyPatch(nameof(InventoryLogic.PartyEquipment.ResetEquipment))]
+        [HarmonyPostfix]
+        public static void ResetEquipmentPostfix(ref InventoryLogic.PartyEquipment __instance)
+        {
+            var message = new EquipmentReset(__instance.CharacterEquipments);
+            MessageBroker.Instance.Publish(__instance, message);
+        }
+    }
+
+    [HarmonyPatch(typeof(SPInventoryVM))]
+    internal class SPInventoryVMPatches
+    {
+        private static readonly ILogger Logger = LogManager.GetLogger<SPInventoryVM>();
+
+        [HarmonyPatch(nameof(SPInventoryVM.UpdateEquipment))]
+        [HarmonyPostfix]
+        public static void UpdateEquipmentPostfix(ref SPInventoryVM __instance, Equipment equipment, SPItemVM itemVM, EquipmentIndex itemType)
+        {
+            Hero hero = __instance._currentCharacter.HeroObject;
+            EquipmentType equipmentType = equipment._equipmentType;
+            EquipmentElement equipmentElement = (itemVM == null) ? default(EquipmentElement) : itemVM.ItemRosterElement.EquipmentElement;
+
+            var message = new EquipmentUpdated(hero, equipmentType, equipmentElement, itemType);
+            MessageBroker.Instance.Publish(__instance, message);
+        }
+    }
+}

--- a/source/GameInterface/Services/Inventory/Patches/InventoryLogicPatches.cs
+++ b/source/GameInterface/Services/Inventory/Patches/InventoryLogicPatches.cs
@@ -1,13 +1,20 @@
-﻿using Common.Logging;
+﻿using Common;
+using Common.Logging;
 using Common.Messaging;
 using Common.Util;
 using GameInterface.Services.Inventory.Messages;
 using HarmonyLib;
+using Helpers;
 using Serilog;
+using System.Collections.Generic;
+using System.Reflection;
+using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Inventory;
 using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Roster;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Core;
+using TaleWorlds.Localization;
 
 namespace GameInterface.Services.Inventory.Patches;
 
@@ -54,6 +61,12 @@ internal class InventoryLogicPatches
             }
         }
 
+        __instance._partyInitialEquipment = new InventoryLogic.PartyEquipment(__instance.OwnerParty);
+        if (__instance.IsOtherPartyFromPlayerClan && __instance.LeftMemberRoster != null)
+        {
+            __instance._otherPartyInitialEquipment = new InventoryLogic.PartyEquipment(__instance.OtherParty.MobileParty);
+        }
+
         var message = new TradeAttempted(
             __instance._rosters[0],
             __instance._rosters[1],
@@ -72,12 +85,157 @@ internal class InventoryLogicPatches
         MessageBroker.Instance.Publish(__instance, message);
 
         // Reset rosters so they are set on the server side
-        using (new AllowedThread())
-        {
-            __instance.Reset(true);
-        }
+        //using (new AllowedThread())
+        //{
+        //    __instance.Reset(true);
+        //}
 
         __result = true;
+        return false;
+    }
+
+    [HarmonyPatch(nameof(InventoryLogic.ResetLogic))]
+    [HarmonyPrefix]
+    public static bool ResetLogicPrefix(ref InventoryLogic __instance, bool fromCancel)
+    {
+        AllowedThread.AllowThisThread();
+        for (int i = 0; i < 2; i++)
+        {
+            __instance._rosters[i].Clear();
+            __instance._rosters[i].Add(__instance._rostersBackup[i]);
+        }
+        AllowedThread.RevokeThisThread();
+
+        var message = new ResetRosters(
+            __instance._rosters[0],
+            __instance._rostersBackup[0],
+            __instance._rosters[1],
+            __instance._rostersBackup[1],
+            __instance, fromCancel
+        );
+        MessageBroker.Instance.Publish(__instance, message);
+
+        __instance.TransactionDebt = 0;
+        __instance._transactionHistory.Clear();
+        __instance.InitializeXpGainFromDonations();
+        __instance._partyInitialEquipment.ResetEquipment();
+        InventoryLogic.PartyEquipment otherPartyInitialEquipment = __instance._otherPartyInitialEquipment;
+        if (otherPartyInitialEquipment != null)
+        {
+            otherPartyInitialEquipment.ResetEquipment();
+        }
+
+        FieldInfo field = typeof(InventoryLogic).GetField("AfterReset", BindingFlags.Instance | BindingFlags.NonPublic);
+        InventoryLogic.AfterResetDelegate del = (InventoryLogic.AfterResetDelegate)field.GetValue(__instance);
+
+        InventoryLogic.AfterResetDelegate afterReset = del;
+        if (afterReset != null)
+        {
+            afterReset(__instance, fromCancel);
+        }
+
+        List<TransferCommandResult> resultList = new List<TransferCommandResult>();
+        if (!fromCancel)
+        {
+            __instance.OnAfterTransfer(resultList);
+        }
+
+        return false;
+    }
+
+    [HarmonyPatch(nameof(InventoryLogic.TransferItem))]
+    [HarmonyPostfix]
+    public static void TransferItemPostfix(ref InventoryLogic __instance, ref TransferCommand transferCommand)
+    {
+        EquipmentElement equipmentElement = transferCommand.ElementToTransfer.EquipmentElement;
+        bool shouldManageOtherInventory = ShouldManageOtherInventory(ref __instance);
+
+        // Both of these can be true, send messages for each
+        AllowedThread.AllowThisThread();
+        if (transferCommand.FromSide == InventoryLogic.InventorySide.PlayerInventory || (transferCommand.FromSide == InventoryLogic.InventorySide.OtherInventory && shouldManageOtherInventory))
+        {
+            // Reverse operation needs to be performed in main body to avoid crashing, add back so the server can manage from here
+            __instance._rosters[(int)transferCommand.FromSide].AddToCounts(transferCommand.ElementToTransfer.EquipmentElement, transferCommand.Amount);
+
+            var message = new TransferAttempted(__instance._rosters[(int)transferCommand.FromSide], equipmentElement, -transferCommand.Amount);
+            MessageBroker.Instance.Publish(__instance, message);
+        }
+
+        if (transferCommand.ToSide == InventoryLogic.InventorySide.PlayerInventory || (transferCommand.ToSide == InventoryLogic.InventorySide.OtherInventory && shouldManageOtherInventory))
+        {
+            // Reverse operation needs to be performed in main body to avoid crashing, remove so the server can manage from here
+            __instance._rosters[(int)transferCommand.ToSide].AddToCounts(transferCommand.ElementToTransfer.EquipmentElement, -transferCommand.Amount);
+
+            var message = new TransferAttempted(__instance._rosters[(int)transferCommand.ToSide], equipmentElement, transferCommand.Amount);
+            MessageBroker.Instance.Publish(__instance, message);
+        }
+        AllowedThread.RevokeThisThread();
+    }
+
+    // Some inventory modes such as the default don't need the other item roster to be managed on the server
+    // For example, the default inventory mode's other roster is for discarding items and is always cleared when the SPInventoryVM is closed
+    private static bool ShouldManageOtherInventory(ref InventoryLogic logic)
+    {
+        // Expand as needed for other inventory modes
+        return logic._inventoryMode != InventoryScreenHelper.InventoryMode.Default;
+    }
+
+    [HarmonyPatch(nameof(InventoryLogic.SlaughterItem))]
+    [HarmonyPostfix]
+    public static void SlaughterItemPostfix(ref InventoryLogic __instance, ItemRosterElement itemRosterElement)
+    {
+        EquipmentElement equipmentElement = itemRosterElement.EquipmentElement;
+        int meatCount = equipmentElement.Item.HorseComponent.MeatCount;
+        int hideCount = equipmentElement.Item.HorseComponent.HideCount;
+
+        // Undo AddToCounts operations so server can manage
+        __instance._rosters[1].AddToCounts(DefaultItems.Meat, -meatCount);
+        __instance._rosters[1].AddToCounts(itemRosterElement.EquipmentElement, 1);
+        __instance._rosters[1].AddToCounts(DefaultItems.Hides, -hideCount);
+
+        // Send data to server
+        var message = new ItemSlaughtered(__instance._rosters[1], equipmentElement, meatCount, hideCount);
+        MessageBroker.Instance.Publish(__instance, message);
+    }
+
+    [HarmonyPatch(nameof(InventoryLogic.DonateItem))]
+    [HarmonyPrefix]
+    public static bool DonateItemPrefix(ref InventoryLogic __instance, ItemRosterElement itemRosterElement)
+    {
+        List<TransferCommandResult> list = new List<TransferCommandResult>();
+        int tier = (int)itemRosterElement.EquipmentElement.Item.Tier;
+        int num = 100 * (tier + 1);
+        InventoryLogic.InventorySide inventorySide = InventoryLogic.InventorySide.PlayerInventory;
+        int index = __instance._rosters[(int)inventorySide].AddToCounts(itemRosterElement.EquipmentElement, -1);
+        ItemRosterElement elementCopyAtIndex = __instance._rosters[(int)inventorySide].GetElementCopyAtIndex(index);
+        list.Add(new TransferCommandResult(InventoryLogic.InventorySide.PlayerInventory, elementCopyAtIndex, -1, elementCopyAtIndex.Amount, EquipmentIndex.None, null));
+
+        TroopRosterElement randomElementWithPredicate = PartyBase.MainParty.MemberRoster.GetTroopRoster().GetRandomElementWithPredicate((TroopRosterElement m) => !m.Character.IsHero && m.Character.UpgradeTargets.Length != 0);
+        if (num > 0)
+        {
+            if (randomElementWithPredicate.Character != null)
+            {
+                // Manage on server instead, still need this block to display notification
+                //PartyBase.MainParty.MemberRoster.AddXpToTroop(randomElementWithPredicate.Character, num);
+                TextObject textObject = new TextObject("{=Kwja0a4s}Added {XPAMOUNT} amount of xp to {TROOPNAME}", null);
+                textObject.SetTextVariable("XPAMOUNT", num);
+                textObject.SetTextVariable("TROOPNAME", randomElementWithPredicate.Character.Name.ToString());
+                MBInformationManager.AddQuickInformation(textObject, 0, null, null, "");
+            }
+        }
+        __instance.SetCurrentStateAsInitial();
+        __instance.OnAfterTransfer(list);
+
+        // Undo AddToCounts action to let server manage from here. Previously run to get the index and also to update the client's VM correctly
+        __instance._rosters[(int)inventorySide].AddToCounts(itemRosterElement.EquipmentElement, 1);
+
+        var message = new ItemDonated(
+            __instance._rosters[(int)inventorySide],
+            itemRosterElement.EquipmentElement,
+            PartyBase.MainParty, randomElementWithPredicate, num);
+
+        MessageBroker.Instance.Publish(__instance, message);
+
         return false;
     }
 }

--- a/source/GameInterface/Services/Inventory/Patches/InventoryLogicPatches.cs
+++ b/source/GameInterface/Services/Inventory/Patches/InventoryLogicPatches.cs
@@ -1,20 +1,25 @@
 ﻿using Common;
 using Common.Logging;
+using Common.LogicStates;
 using Common.Messaging;
 using Common.Util;
 using GameInterface.Services.Inventory.Messages;
 using HarmonyLib;
 using Helpers;
 using Serilog;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.GameComponents;
 using TaleWorlds.CampaignSystem.Inventory;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Roster;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Core;
+using TaleWorlds.Library;
 using TaleWorlds.Localization;
+using TaleWorlds.MountAndBlade.View;
 
 namespace GameInterface.Services.Inventory.Patches;
 
@@ -32,6 +37,11 @@ internal class InventoryLogicPatches
             __result = false;
             return false;
         }
+
+        // Don't want to run done logic here for trading as trading transactions managed instantly
+        if (__instance._inventoryMode == InventoryScreenHelper.InventoryMode.Trade) return true;
+
+        /*
         SettlementComponent currentSettlementComponent = __instance.CurrentSettlementComponent;
         MobileParty currentMobileParty = __instance.CurrentMobileParty;
         PartyBase partyBase = null;
@@ -43,13 +53,16 @@ internal class InventoryLogicPatches
         {
             partyBase = currentSettlementComponent.Owner;
         }
+        */
 
+        /*
         if (__instance.InventoryListener != null && __instance.IsTrading && __instance.OwnerCharacter.HeroObject.Gold - __instance.TotalAmount < 0)
         {
             MBInformationManager.AddQuickInformation(GameTexts.FindText("str_warning_you_dont_have_enough_money", null), 0, null, null, "");
             __result = false;
             return false;
         }
+        */
 
         if (__instance._playerAcceptsTraderOffer)
         {
@@ -98,6 +111,9 @@ internal class InventoryLogicPatches
     [HarmonyPrefix]
     public static bool ResetLogicPrefix(ref InventoryLogic __instance, bool fromCancel)
     {
+        // Don't want reset to run for trading as trading transactions managed instantly
+        if (__instance._inventoryMode == InventoryScreenHelper.InventoryMode.Trade) return false;
+
         AllowedThread.AllowThisThread();
         for (int i = 0; i < 2; i++)
         {
@@ -144,32 +160,116 @@ internal class InventoryLogicPatches
     }
 
     [HarmonyPatch(nameof(InventoryLogic.TransferItem))]
+    [HarmonyPrefix]
+    public static bool TransferItemPrefix(ref InventoryLogic __instance, ref List<TransferCommandResult> __result, ref TransferCommand transferCommand)
+    {
+        // Ensure the player has enough gold if trading to transfer the item
+        if (__instance._inventoryMode != InventoryScreenHelper.InventoryMode.Trade) return true;
+
+        bool isSell = __instance.IsSell(transferCommand.FromSide, transferCommand.ToSide);
+        bool isBuy = __instance.IsBuy(transferCommand.FromSide, transferCommand.ToSide);
+
+        int transactionDebt = 0;
+        int itemPrice = __instance.GetItemPrice(transferCommand.ElementToTransfer.EquipmentElement, isBuy);
+        if (isSell)
+        {
+            transactionDebt -= itemPrice;
+        }
+        else if (isBuy)
+        {
+            transactionDebt += itemPrice;
+        }
+
+        if (__instance.InventoryListener != null && __instance.OwnerCharacter.HeroObject.Gold - transactionDebt < 0)
+        {
+            __result = new List<TransferCommandResult>();
+
+            MBInformationManager.AddQuickInformation(GameTexts.FindText("str_warning_you_dont_have_enough_money", null), 0, null, null, "");
+            return false;
+        }
+
+        return true;
+    }
+
+    [HarmonyPatch(nameof(InventoryLogic.TransferItem))]
     [HarmonyPostfix]
     public static void TransferItemPostfix(ref InventoryLogic __instance, ref TransferCommand transferCommand)
     {
+        if (__instance._inventoryMode == InventoryScreenHelper.InventoryMode.Trade && __instance.TransactionDebt == 0) return;
+
         EquipmentElement equipmentElement = transferCommand.ElementToTransfer.EquipmentElement;
         bool shouldManageOtherInventory = ShouldManageOtherInventory(ref __instance);
+        int amount = transferCommand.Amount;
+
+        ItemRoster fromItemRoster = null;
+        ItemRoster toItemRoster = null;
 
         // Both of these can be true, send messages for each
         AllowedThread.AllowThisThread();
         if (transferCommand.FromSide == InventoryLogic.InventorySide.PlayerInventory || (transferCommand.FromSide == InventoryLogic.InventorySide.OtherInventory && shouldManageOtherInventory))
         {
             // Reverse operation needs to be performed in main body to avoid crashing, add back so the server can manage from here
-            __instance._rosters[(int)transferCommand.FromSide].AddToCounts(transferCommand.ElementToTransfer.EquipmentElement, transferCommand.Amount);
-
-            var message = new TransferAttempted(__instance._rosters[(int)transferCommand.FromSide], equipmentElement, -transferCommand.Amount);
-            MessageBroker.Instance.Publish(__instance, message);
+            fromItemRoster = __instance._rosters[(int)transferCommand.FromSide];
+            GameLoopRunner.RunOnMainThread(() =>
+            {
+                fromItemRoster.AddToCounts(equipmentElement, amount);
+            });
         }
 
         if (transferCommand.ToSide == InventoryLogic.InventorySide.PlayerInventory || (transferCommand.ToSide == InventoryLogic.InventorySide.OtherInventory && shouldManageOtherInventory))
         {
             // Reverse operation needs to be performed in main body to avoid crashing, remove so the server can manage from here
-            __instance._rosters[(int)transferCommand.ToSide].AddToCounts(transferCommand.ElementToTransfer.EquipmentElement, -transferCommand.Amount);
-
-            var message = new TransferAttempted(__instance._rosters[(int)transferCommand.ToSide], equipmentElement, transferCommand.Amount);
-            MessageBroker.Instance.Publish(__instance, message);
+            toItemRoster = __instance._rosters[(int)transferCommand.ToSide];
+            GameLoopRunner.RunOnMainThread(() =>
+            {
+                toItemRoster.AddToCounts(equipmentElement, -amount);
+            });
         }
         AllowedThread.RevokeThisThread();
+
+        var transferMessage = new TransferAttempted(
+            fromItemRoster,
+            toItemRoster,
+            equipmentElement,
+            transferCommand.Amount
+        );
+
+        MessageBroker.Instance.Publish(__instance, transferMessage);
+
+        // Make trade instant by implementing DoneLogic here
+        if (__instance._inventoryMode == InventoryScreenHelper.InventoryMode.Trade)
+        {
+            var tradeMessage = new TradeAttempted(
+            __instance._rosters[0],
+            __instance._rosters[1],
+            __instance.IsTrading,
+            __instance.CanGainXpFromDiscarding,
+            __instance.OwnerParty.LeaderHero,
+            __instance.TotalAmount,
+            __instance.InventoryListener.GetGold(),
+            __instance.OwnerParty,
+            __instance.CurrentMobileParty,
+            __instance.CurrentSettlementComponent,
+            __instance.GetBoughtItems(),
+            __instance.GetSoldItems()
+            );
+
+            MessageBroker.Instance.Publish(__instance, tradeMessage);
+
+            // Play coin change sound cues
+            if (__instance.TransactionDebt > 0)
+            {
+                InformationManager.DisplayMessage(new InformationMessage("", "event:/ui/notification/coins_negative"));
+            }
+            else if (__instance.TransactionDebt < 0)
+            {
+                InformationManager.DisplayMessage(new InformationMessage("", "event:/ui/notification/coins_positive"));
+            }
+
+            // Clear transaction history for next transfer
+            __instance.TransactionDebt = 0;
+            __instance._transactionHistory.Clear();
+        }
     }
 
     // Some inventory modes such as the default don't need the other item roster to be managed on the server
@@ -177,7 +277,8 @@ internal class InventoryLogicPatches
     private static bool ShouldManageOtherInventory(ref InventoryLogic logic)
     {
         // Expand as needed for other inventory modes
-        return logic._inventoryMode != InventoryScreenHelper.InventoryMode.Default;
+        return logic._inventoryMode != InventoryScreenHelper.InventoryMode.Default 
+            && logic._inventoryMode != InventoryScreenHelper.InventoryMode.Loot;
     }
 
     [HarmonyPatch(nameof(InventoryLogic.SlaughterItem))]
@@ -189,12 +290,16 @@ internal class InventoryLogicPatches
         int hideCount = equipmentElement.Item.HorseComponent.HideCount;
 
         // Undo AddToCounts operations so server can manage
-        __instance._rosters[1].AddToCounts(DefaultItems.Meat, -meatCount);
-        __instance._rosters[1].AddToCounts(itemRosterElement.EquipmentElement, 1);
-        __instance._rosters[1].AddToCounts(DefaultItems.Hides, -hideCount);
+        ItemRoster itemRoster = __instance._rosters[1];
+        GameLoopRunner.RunOnMainThread(() =>
+        {
+            itemRoster.AddToCounts(DefaultItems.Meat, -meatCount);
+            itemRoster.AddToCounts(itemRosterElement.EquipmentElement, 1);
+            itemRoster.AddToCounts(DefaultItems.Hides, -hideCount);
+        });
 
         // Send data to server
-        var message = new ItemSlaughtered(__instance._rosters[1], equipmentElement, meatCount, hideCount);
+        var message = new ItemSlaughtered(itemRoster, equipmentElement, meatCount, hideCount);
         MessageBroker.Instance.Publish(__instance, message);
     }
 

--- a/source/GameInterface/Services/Inventory/Patches/InventoryScreenHelperPatches.cs
+++ b/source/GameInterface/Services/Inventory/Patches/InventoryScreenHelperPatches.cs
@@ -14,7 +14,8 @@ internal class InventoryScreenHelperPatches
     {
         AccessTools.Method(typeof(InventoryScreenHelper), nameof(InventoryScreenHelper.OpenScreenAsTrade)),
         AccessTools.Method(typeof(InventoryScreenHelper), nameof(InventoryScreenHelper.OpenInventoryPresentation)),
-        AccessTools.Method(typeof(InventoryLogic), nameof(InventoryLogic.ResetLogic)),
+        AccessTools.Method(typeof(InventoryLogic), nameof(InventoryLogic.TransferItem)),
+        AccessTools.Method(typeof(InventoryLogic), nameof(InventoryLogic.SlaughterItem))
     };
 
     static void Prefix()

--- a/source/GameInterface/Services/Inventory/Patches/InventorySliderDisable.cs
+++ b/source/GameInterface/Services/Inventory/Patches/InventorySliderDisable.cs
@@ -1,0 +1,23 @@
+﻿using HarmonyLib;
+using TaleWorlds.CampaignSystem.ViewModelCollection.Inventory;
+
+namespace GameInterface.Services.Inventory.Patches
+{
+    [HarmonyPatch(typeof(InventoryTradeVM))]
+    internal class InventoryTradeVMPatches
+    {
+        [HarmonyPatch(nameof(InventoryTradeVM.ThisStockUpdated))]
+        [HarmonyPrefix]
+        public static bool ThisStockUpdatedPrefix(InventoryTradeVM __instance)
+        {
+            // Button to handle this instead?
+            //__instance.ExecuteApplyTransaction();
+            __instance.OtherStock = __instance.TotalStock - __instance.ThisStock;
+            __instance.IsThisStockIncreasable = (__instance.OtherStock > 0);
+            __instance.IsOtherStockIncreasable = (__instance.OtherStock < __instance.TotalStock);
+            __instance.UpdateProperties();
+
+            return false;
+        }
+    }
+}

--- a/source/GameInterface/Services/Inventory/Patches/InventoryTradePatches.cs
+++ b/source/GameInterface/Services/Inventory/Patches/InventoryTradePatches.cs
@@ -1,0 +1,59 @@
+﻿using Common.Logging;
+using HarmonyLib;
+using Serilog;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.ViewModelCollection.Inventory;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
+
+namespace GameInterface.Services.Inventory.Patches
+{
+    [HarmonyPatch(typeof(SPInventoryVM))]
+    internal class InventoryTradePatches
+    {
+        private static readonly ILogger Logger = LogManager.GetLogger<SPInventoryVM>();
+
+        [HarmonyPatch(nameof(SPInventoryVM.ExecuteBuyAllItems))]
+        [HarmonyPrefix]
+        public static bool ExecuteBuyAllItems(ref SPInventoryVM __instance)
+        {
+            if (!__instance._inventoryLogic.IsTrading) return true;
+
+            int availableHeroGold = Hero.MainHero.Gold;
+            int cost = 0;
+
+            // Only approximate, might not be the best estimate as it doesn't factor in changing costs as items are bought
+            foreach (SPItemVM itemVM in __instance.LeftItemListVM)
+            {
+                if (itemVM != null && !itemVM.IsFiltered && !itemVM.IsLocked && itemVM.IsTransferable)
+                {
+                    cost += itemVM.TotalCost * itemVM.ItemCount;
+                }
+            }
+
+            if (availableHeroGold - cost < 0)
+            {
+                MBInformationManager.AddQuickInformation(GameTexts.FindText("str_warning_you_dont_have_enough_money", null), 0, null, null, "");
+                return false;
+            }
+
+            return true;
+        }
+
+        [HarmonyPatch(nameof(SPInventoryVM.ExecuteResetTranstactions))]
+        [HarmonyPrefix]
+        public static bool ExecuteResetTranstactionsPrefix(ref SPInventoryVM __instance)
+        {
+            __instance._inventoryLogic.Reset(false);
+
+            // Reset is disabled for live trading, don't show message
+            if (!__instance._inventoryLogic.IsTrading)
+            {
+                InformationManager.DisplayMessage(new InformationMessage(GameTexts.FindText("str_inventory_reset_message", null).ToString()));
+            }
+            __instance.CurrentFocusedItem = null;
+
+            return false;
+        }
+    }
+}

--- a/source/GameInterface/Services/Inventory/Patches/InventoryTradePatches.cs
+++ b/source/GameInterface/Services/Inventory/Patches/InventoryTradePatches.cs
@@ -1,5 +1,8 @@
 ﻿using Common.Logging;
+using Common.Messaging;
+using GameInterface.Services.Inventory.Messages;
 using HarmonyLib;
+using Helpers;
 using Serilog;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.ViewModelCollection.Inventory;
@@ -15,7 +18,7 @@ namespace GameInterface.Services.Inventory.Patches
 
         [HarmonyPatch(nameof(SPInventoryVM.ExecuteBuyAllItems))]
         [HarmonyPrefix]
-        public static bool ExecuteBuyAllItems(ref SPInventoryVM __instance)
+        public static bool ExecuteBuyAllItemsPrefix(ref SPInventoryVM __instance)
         {
             if (!__instance._inventoryLogic.IsTrading) return true;
 
@@ -54,6 +57,37 @@ namespace GameInterface.Services.Inventory.Patches
             __instance.CurrentFocusedItem = null;
 
             return false;
+        }
+
+        [HarmonyPatch(nameof(SPInventoryVM.TransferAllForSettlement))]
+        [HarmonyPrefix]
+        public static bool TransferAllForSettlementPrefix(ref SPInventoryVM __instance)
+        {
+            if (!__instance._inventoryLogic.IsTrading) return true;
+
+            int availableSettlementGold = __instance.LeftInventoryOwnerGold;
+            int cost = 0;
+
+            // Only approximate, might not be the best estimate as it doesn't factor in changing costs as items are bought
+            foreach (SPItemVM itemVM in __instance.RightItemListVM)
+            {
+                if (itemVM != null && !itemVM.IsFiltered && !itemVM.IsLocked && itemVM.IsTransferable)
+                {
+                    cost += itemVM.TotalCost * itemVM.ItemCount;
+                }
+            }
+
+            if (availableSettlementGold - cost < 0)
+            {
+                //MBInformationManager.AddQuickInformation(GameTexts.FindText("str_trader_doesnt_have_enough_money", null), 0, null, null, "");
+                InformationManager.ShowInquiry(new InquiryData("", GameTexts.FindText("str_trader_doesnt_have_enough_money", null).ToString(), false, true, GameTexts.FindText("str_yes", null).ToString(), GameTexts.FindText("str_no", null).ToString(), delegate ()
+                {
+                    InventoryScreenHelper.CloseScreen(false);
+                }, null, "", 0f, null, null, null), false, false);
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/source/GameInterface/Services/ItemRosters/Patches/ItemRosterPatch.cs
+++ b/source/GameInterface/Services/ItemRosters/Patches/ItemRosterPatch.cs
@@ -78,10 +78,13 @@ namespace GameInterface.Services.ItemRosters.Patches
 
         public static void AddToCountsOverride(ItemRoster itemRoster, EquipmentElement rosterElement, int amount)
         {
-            using (new AllowedThread())
+            GameLoopRunner.RunOnMainThread(() =>
             {
-                itemRoster?.AddToCounts(rosterElement, amount);
-            }
+                using (new AllowedThread())
+                {
+                    itemRoster?.AddToCounts(rosterElement, amount);
+                }
+            });
         }
 
         public static void ClearOverride(ItemRoster itemRoster)

--- a/source/GameInterface/Services/MobileParties/Patches/RecruitmentCampaignBehavior.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/RecruitmentCampaignBehavior.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using GameInterface.Services.MobileParties.Extensions;
+using HarmonyLib;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Settlements;
@@ -12,6 +13,9 @@ internal class RecruitmentCampaignBehaviorPatch
     [HarmonyPatch("CheckRecruiting")]
     private static bool CheckRecruitingPrefix(ref MobileParty mobileParty, ref Settlement settlement)
     {
+        // Let players handle recruiting for their own parties
+        if (mobileParty.IsPlayerParty()) return false;
+
         // TODO only allow for server and broadcast when it happens
         return true;
     }

--- a/source/GameInterface/Services/Smithing/Handlers/SmithingRefreshHandler.cs
+++ b/source/GameInterface/Services/Smithing/Handlers/SmithingRefreshHandler.cs
@@ -128,7 +128,7 @@ namespace GameInterface.Services.Smithing.Handlers
 
         private void RefreshWeaponDesignVM(Town town)
         {
-            if (Settlement.CurrentSettlement?.Town != town || currentCraftingVM?.IsInCraftingMode == false) return;
+            if (Settlement.CurrentSettlement?.Town != town || currentCraftingVM == null || currentCraftingVM.IsInCraftingMode == false) return;
 
             // Have to run on main thread to avoid UI related crashes
             GameLoopRunner.RunOnMainThread(() =>

--- a/source/GameInterface/Services/Smithing/Handlers/SmithingRefreshHandler.cs
+++ b/source/GameInterface/Services/Smithing/Handlers/SmithingRefreshHandler.cs
@@ -86,27 +86,33 @@ namespace GameInterface.Services.Smithing.Handlers
 
         private void Handle(MessagePayload<NetworkRefreshSmelting> obj)
         {
-            currentSmeltingVM?.RefreshValues();
-            currentSmeltingVM?.RefreshList();
-
-            if (currentSmeltingVM?.CurrentSelectedItem != null)
+            GameLoopRunner.RunOnMainThread(() =>
             {
-                int num = (int)(currentSmeltingVM?.SmeltableItemList.FindIndex((SmeltingItemVM i) => i.EquipmentElement.Item == currentSmeltingVM?.CurrentSelectedItem.EquipmentElement.Item));
-                SmeltingItemVM newItem = (num != -1) ? currentSmeltingVM?.SmeltableItemList[num] : currentSmeltingVM?.SmeltableItemList.FirstOrDefault<SmeltingItemVM>();
-                currentSmeltingVM?.OnItemSelection(newItem);
-            }
+                currentSmeltingVM?.RefreshValues();
+                currentSmeltingVM?.RefreshList();
 
-            RefreshCraftingVM();
+                if (currentSmeltingVM?.CurrentSelectedItem != null)
+                {
+                    int num = (int)(currentSmeltingVM?.SmeltableItemList.FindIndex((SmeltingItemVM i) => i.EquipmentElement.Item == currentSmeltingVM?.CurrentSelectedItem.EquipmentElement.Item));
+                    SmeltingItemVM newItem = (num != -1) ? currentSmeltingVM?.SmeltableItemList[num] : currentSmeltingVM?.SmeltableItemList.FirstOrDefault<SmeltingItemVM>();
+                    currentSmeltingVM?.OnItemSelection(newItem);
+                }
+
+                RefreshCraftingVM();
+            });
         }
 
         private void Handle(MessagePayload<NetworkRefreshRefinement> obj)
         {
             if (!objectManager.TryGetObjectWithLogging(obj.What.CraftingHeroId, out Hero craftingHero)) return;
 
-            currentRefinementVM?.RefreshRefinementActionsList(craftingHero);
-            currentCraftingVM?.OnRefinementSelectionChange();
+            GameLoopRunner.RunOnMainThread(() =>
+            {
+                currentRefinementVM?.RefreshRefinementActionsList(craftingHero);
+                currentCraftingVM?.OnRefinementSelectionChange();
 
-            RefreshCraftingVM();
+                RefreshCraftingVM();
+            });
         }
 
         private void Handle(MessagePayload<RefreshCraftingVM> obj)
@@ -122,7 +128,7 @@ namespace GameInterface.Services.Smithing.Handlers
 
         private void RefreshWeaponDesignVM(Town town)
         {
-            if (Settlement.CurrentSettlement?.Town == town && (bool)(currentCraftingVM?.IsInCraftingMode)) return;
+            if (Settlement.CurrentSettlement?.Town != town || (bool)(!currentCraftingVM?.IsInCraftingMode)) return;
                 
             // Have to run on main thread to avoid UI related crashes
             GameLoopRunner.RunOnMainThread(() =>

--- a/source/GameInterface/Surrogates/EquipmentElementSurrogate.cs
+++ b/source/GameInterface/Surrogates/EquipmentElementSurrogate.cs
@@ -27,7 +27,9 @@ internal struct EquipmentElementSurrogate
 
     public static implicit operator EquipmentElement(EquipmentElementSurrogate surrogate)
     {
-        var item = MBObjectManager.Instance.GetObject<ItemObject>(surrogate.ItemId);
+        var item = string.IsNullOrEmpty(surrogate.ItemId)
+            ? null
+            : MBObjectManager.Instance.GetObject<ItemObject>(surrogate.ItemId);
         var modifier = string.IsNullOrEmpty(surrogate.ItemModifierId)
             ? null
             : MBObjectManager.Instance.GetObject<ItemModifier>(surrogate.ItemModifierId);

--- a/source/GameInterface/Surrogates/ItemRosterElementSurrogate.cs
+++ b/source/GameInterface/Surrogates/ItemRosterElementSurrogate.cs
@@ -1,0 +1,44 @@
+﻿using ProtoBuf;
+using TaleWorlds.Core;
+using TaleWorlds.ObjectSystem;
+
+
+namespace GameInterface.Surrogates;
+
+[ProtoContract]
+internal struct ItemRosterElementSurrogate
+{
+    [ProtoMember(1)]
+    public string ItemObjectId { get; set; }
+
+    [ProtoMember(2)]
+    public int Amount { get; set; }
+
+    [ProtoMember(3)]
+    public string ItemModifierId { get; set; }
+
+    public ItemRosterElementSurrogate(ItemRosterElement itemRosterElement)
+    {
+        ItemObjectId = itemRosterElement.EquipmentElement.Item?.StringId;
+        Amount = itemRosterElement.Amount;
+        ItemModifierId = itemRosterElement.EquipmentElement.ItemModifier?.StringId;
+
+    }
+    public static implicit operator ItemRosterElementSurrogate(ItemRosterElement itemRosterElement)
+    {
+        return new ItemRosterElementSurrogate(itemRosterElement);
+    }
+
+    public static implicit operator ItemRosterElement(ItemRosterElementSurrogate surrogate)
+    {
+        var item = string.IsNullOrEmpty(surrogate.ItemObjectId)
+            ? null
+            : MBObjectManager.Instance.GetObject<ItemObject>(surrogate.ItemObjectId);
+        var modifier = string.IsNullOrEmpty(surrogate.ItemModifierId)
+            ? null
+            : MBObjectManager.Instance.GetObject<ItemModifier>(surrogate.ItemModifierId);
+
+        return new ItemRosterElement(item, surrogate.Amount, modifier);
+    }
+}
+

--- a/source/GameInterface/Surrogates/ItemRosterElementSurrogate.cs
+++ b/source/GameInterface/Surrogates/ItemRosterElementSurrogate.cs
@@ -2,7 +2,6 @@
 using TaleWorlds.Core;
 using TaleWorlds.ObjectSystem;
 
-
 namespace GameInterface.Surrogates;
 
 [ProtoContract]

--- a/source/GameInterface/Surrogates/ItemRosterElementSurrogate.cs
+++ b/source/GameInterface/Surrogates/ItemRosterElementSurrogate.cs
@@ -22,8 +22,8 @@ internal struct ItemRosterElementSurrogate
         ItemObjectId = itemRosterElement.EquipmentElement.Item?.StringId;
         Amount = itemRosterElement.Amount;
         ItemModifierId = itemRosterElement.EquipmentElement.ItemModifier?.StringId;
-
     }
+
     public static implicit operator ItemRosterElementSurrogate(ItemRosterElement itemRosterElement)
     {
         return new ItemRosterElementSurrogate(itemRosterElement);

--- a/source/GameInterface/Surrogates/SurrogateCollection.cs
+++ b/source/GameInterface/Surrogates/SurrogateCollection.cs
@@ -1,5 +1,6 @@
 ﻿using ProtoBuf.Meta;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Roster;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
 using TaleWorlds.Localization;
@@ -23,6 +24,8 @@ internal class SurrogateCollection : ISurrogateCollection
             AddSurrogate<ItemModifier, ItemModifierSurrogate>();
             AddSurrogate<TextObject, TextObjectSurrogate>();
             AddSurrogate<EquipmentElement, EquipmentElementSurrogate>();
+            AddSurrogate<ItemRosterElement, ItemRosterElementSurrogate>();
+            AddSurrogate<TroopRosterElement, TroopRosterElementSurrogate>();
 
             AddSurrogate<ExplainedNumber, ExplainedNumberSurrogate>();
             AddSurrogate<ExplainedNumber.StatExplainer, StatExplainerSurrogate>();

--- a/source/GameInterface/Surrogates/TroopRosterElementSurrogate.cs
+++ b/source/GameInterface/Surrogates/TroopRosterElementSurrogate.cs
@@ -44,7 +44,7 @@ internal struct TroopRosterElementSurrogate
             _number = surrogate.Number,
             _woundedNumber = surrogate.WoundedNumber,
             _xp = surrogate.Xp
-        }; ;
+        };
     }
 }
 

--- a/source/GameInterface/Surrogates/TroopRosterElementSurrogate.cs
+++ b/source/GameInterface/Surrogates/TroopRosterElementSurrogate.cs
@@ -26,8 +26,8 @@ internal struct TroopRosterElementSurrogate
         Number = troopRosterElement.Number;
         WoundedNumber = troopRosterElement.WoundedNumber;
         Xp = troopRosterElement.Xp;
-
     }
+
     public static implicit operator TroopRosterElementSurrogate(TroopRosterElement troopRosterElement)
     {
         return new TroopRosterElementSurrogate(troopRosterElement);

--- a/source/GameInterface/Surrogates/TroopRosterElementSurrogate.cs
+++ b/source/GameInterface/Surrogates/TroopRosterElementSurrogate.cs
@@ -1,0 +1,52 @@
+﻿using ProtoBuf;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Roster;
+using TaleWorlds.ObjectSystem;
+
+namespace GameInterface.Surrogates;
+
+[ProtoContract]
+internal struct TroopRosterElementSurrogate
+{
+    [ProtoMember(1)]
+    public string CharacterObjectId { get; set; }
+
+    [ProtoMember(2)]
+    public int Number { get; set; }
+
+    [ProtoMember(3)]
+    public int WoundedNumber { get; set; }
+
+    [ProtoMember(3)]
+    public int Xp { get; set; }
+
+    public TroopRosterElementSurrogate(TroopRosterElement troopRosterElement)
+    {
+        CharacterObjectId = troopRosterElement.Character.StringId;
+        Number = troopRosterElement.Number;
+        WoundedNumber = troopRosterElement.WoundedNumber;
+        Xp = troopRosterElement.Xp;
+
+    }
+    public static implicit operator TroopRosterElementSurrogate(TroopRosterElement troopRosterElement)
+    {
+        return new TroopRosterElementSurrogate(troopRosterElement);
+    }
+
+    public static implicit operator TroopRosterElement(TroopRosterElementSurrogate surrogate)
+    {
+        var character = string.IsNullOrEmpty(surrogate.CharacterObjectId)
+            ? null
+            : MBObjectManager.Instance.GetObject<CharacterObject>(surrogate.CharacterObjectId);
+
+        var troopRosterElement = new TroopRosterElement(character)
+        {
+            _number = surrogate.Number,
+            _woundedNumber = surrogate.WoundedNumber,
+            _xp = surrogate.Xp
+        };
+
+        return troopRosterElement;
+    }
+}
+

--- a/source/GameInterface/Surrogates/TroopRosterElementSurrogate.cs
+++ b/source/GameInterface/Surrogates/TroopRosterElementSurrogate.cs
@@ -39,14 +39,12 @@ internal struct TroopRosterElementSurrogate
             ? null
             : MBObjectManager.Instance.GetObject<CharacterObject>(surrogate.CharacterObjectId);
 
-        var troopRosterElement = new TroopRosterElement(character)
+        return new TroopRosterElement(character)
         {
             _number = surrogate.Number,
             _woundedNumber = surrogate.WoundedNumber,
             _xp = surrogate.Xp
-        };
-
-        return troopRosterElement;
+        }; ;
     }
 }
 


### PR DESCRIPTION
## Done
- Synced equipping items (with updated map visuals for other clients and server)
- Synced transferring items between rosters
- Synced discarding items
- Synced slaughtering items
- Synced donating items (theoretically)
- Synced instant trading so that multiple players can trade in a settlement at the same time. Available items and costs change in real time as other players sell and buy items.

## To-do
- The item transfer slider needs to be re-worked. Currently there are far too many messages being sent at once causing major issues such as item duplication and crashing.
- Buy and sell all while trading is not really functioning as intended. Buy all is not calculated with changing cost of trade goods in mind and sell all will randomly sell through the player's ItemRoster until the settlement is out of money.

## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe: