### PR TITLE
Perk Activation Sync

### DIFF
--- a/source/GameInterface/Services/CharacterDevelopers/Handlers/CharacterDeveloperHandler.cs
+++ b/source/GameInterface/Services/CharacterDevelopers/Handlers/CharacterDeveloperHandler.cs
@@ -4,25 +4,13 @@ using Common.Messaging;
 using Common.Network;
 using Common.Util;
 using GameInterface.Services.CharacterDevelopers.Messages;
-using GameInterface.Services.CharacterDevelopers.Patches;
-using GameInterface.Services.CraftingService.Messages;
-using GameInterface.Services.Heroes.Handlers;
-using GameInterface.Services.Heroes.Interfaces;
 using GameInterface.Services.ObjectManager;
 using Serilog;
 using System;
 using System.Collections.Generic;
-using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Xml.Linq;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CharacterDevelopment;
-using TaleWorlds.CampaignSystem.Extensions;
-using TaleWorlds.CampaignSystem.ViewModelCollection.CharacterDeveloper;
 using TaleWorlds.Core;
-using TaleWorlds.Diamond;
-using TaleWorlds.TwoDimension.Standalone;
 
 namespace GameInterface.Services.CharacterDevelopers.Handlers
 {
@@ -61,15 +49,9 @@ namespace GameInterface.Services.CharacterDevelopers.Handlers
         private void Handle(MessagePayload<NetworkApplyChangesServer> obj)
         {
             // Send to all clients and apply on server
-            GameLoopRunner.RunOnMainThread(() =>
-            {
-                using (new AllowedThread())
-                {
-                    NetworkApplyChangesClients changes = new(obj.What);
-                    network.SendAll(changes);
-                    ApplyChanges(changes);
-                }
-            });
+            NetworkApplyChangesClients changes = new(obj.What);
+            network.SendAll(changes);
+            ApplyChanges(changes);
         }
 
         private void Handle(MessagePayload<NetworkApplyChangesClients> obj)
@@ -153,12 +135,12 @@ namespace GameInterface.Services.CharacterDevelopers.Handlers
                 return;
             }
 
-            addPerks(obj.PerkIds, hero.HeroDeveloper);
-            addAttributes(obj.AttributeIds, obj.AttributeIncreases, hero.HeroDeveloper);
-            addFocuses(obj.SkillIds, obj.SkillFocusLevels, obj.SkillOrgFocusAmounts, hero.HeroDeveloper);
+            AddPerks(obj.PerkIds, hero.HeroDeveloper);
+            AddAttributes(obj.AttributeIds, obj.AttributeIncreases, hero.HeroDeveloper);
+            AddFocuses(obj.SkillIds, obj.SkillFocusLevels, obj.SkillOrgFocusAmounts, hero.HeroDeveloper);
         }
 
-        private void addPerks(List<string> perkIds, HeroDeveloper heroDeveloper)
+        private void AddPerks(List<string> perkIds, HeroDeveloper heroDeveloper)
         {
             if (perkIds != null)
             {
@@ -175,7 +157,7 @@ namespace GameInterface.Services.CharacterDevelopers.Handlers
             }
         }
 
-        private void addAttributes(List<string> attributeIds, List<int> attributeIncreases, HeroDeveloper heroDeveloper)
+        private void AddAttributes(List<string> attributeIds, List<int> attributeIncreases, HeroDeveloper heroDeveloper)
         {
             if (attributeIds != null)
             {
@@ -198,7 +180,7 @@ namespace GameInterface.Services.CharacterDevelopers.Handlers
             }
         }
 
-        private void addFocuses(List<string> skillIds, List<int> skillFocusLevels, List<int> skillOrgFocusAmounts, HeroDeveloper heroDeveloper)
+        private void AddFocuses(List<string> skillIds, List<int> skillFocusLevels, List<int> skillOrgFocusAmounts, HeroDeveloper heroDeveloper)
         {
             if (skillIds != null)
             {

--- a/source/GameInterface/Services/HeroDevelopers/Handlers/PerkActivationHandler.cs
+++ b/source/GameInterface/Services/HeroDevelopers/Handlers/PerkActivationHandler.cs
@@ -62,7 +62,7 @@ namespace GameInterface.Services.HeroDevelopers.Handlers
 
         private void OnOpenedPerkInternal(Hero hero, PerkObject perk)
         {
-            if (hero != null)
+            if (hero == null) return;
             {
                 if (perk == DefaultPerks.OneHanded.Trainer || perk == DefaultPerks.OneHanded.UnwaveringDefense || perk == DefaultPerks.TwoHanded.ThickHides || perk == DefaultPerks.Athletics.WellBuilt || perk == DefaultPerks.Medicine.PreventiveMedicine)
                 {

--- a/source/GameInterface/Services/HeroDevelopers/Handlers/PerkActivationHandler.cs
+++ b/source/GameInterface/Services/HeroDevelopers/Handlers/PerkActivationHandler.cs
@@ -63,50 +63,49 @@ namespace GameInterface.Services.HeroDevelopers.Handlers
         private void OnOpenedPerkInternal(Hero hero, PerkObject perk)
         {
             if (hero == null) return;
-            {
-                if (perk == DefaultPerks.OneHanded.Trainer || perk == DefaultPerks.OneHanded.UnwaveringDefense || perk == DefaultPerks.TwoHanded.ThickHides || perk == DefaultPerks.Athletics.WellBuilt || perk == DefaultPerks.Medicine.PreventiveMedicine)
-                {
-                    hero.HitPoints += (int)perk.PrimaryBonus;
-                }
-                else if (perk == DefaultPerks.Crafting.VigorousSmith)
-                {
-                    hero.HeroDeveloper.AddAttribute(DefaultCharacterAttributes.Vigor, 1, false);
-                }
-                else if (perk == DefaultPerks.Crafting.StrongSmith)
-                {
-                    hero.HeroDeveloper.AddAttribute(DefaultCharacterAttributes.Control, 1, false);
-                }
-                else if (perk == DefaultPerks.Crafting.EnduringSmith)
-                {
-                    hero.HeroDeveloper.AddAttribute(DefaultCharacterAttributes.Endurance, 1, false);
-                }
-                else if (perk == DefaultPerks.Crafting.WeaponMasterSmith)
-                {
-                    hero.HeroDeveloper.AddFocus(DefaultSkills.OneHanded, 1, false);
-                    hero.HeroDeveloper.AddFocus(DefaultSkills.TwoHanded, 1, false);
-                }
-                else if (perk == DefaultPerks.Athletics.Durable)
-                {
-                    hero.HeroDeveloper.AddAttribute(DefaultCharacterAttributes.Endurance, 1, false);
-                }
-                else if (perk == DefaultPerks.Athletics.Steady)
-                {
-                    hero.HeroDeveloper.AddAttribute(DefaultCharacterAttributes.Control, 1, false);
-                }
-                else if (perk == DefaultPerks.Athletics.Strong)
-                {
-                    hero.HeroDeveloper.AddAttribute(DefaultCharacterAttributes.Vigor, 1, false);
-                }
 
-                // Substitute for Hero == Hero.MainHero
-                if (playerRegistry.Contains(hero.PartyBelongedTo) && (perk == DefaultPerks.OneHanded.Prestige || perk == DefaultPerks.TwoHanded.Hope || perk == DefaultPerks.Athletics.ImposingStature || perk == DefaultPerks.Bow.MerryMen || perk == DefaultPerks.Tactics.HordeLeader || perk == DefaultPerks.Scouting.MountedScouts || perk == DefaultPerks.Leadership.Authority || perk == DefaultPerks.Leadership.LeaderOfMasses || perk == DefaultPerks.Leadership.UltimateLeader))
-                {
-                    hero.PartyBelongedTo.MemberRoster.UpdateVersion();
-                }
-                if (perk.PrimaryRole == PartyRole.Captain)
-                {
-                    hero.UpdatePowerModifier();
-                }
+            if (perk == DefaultPerks.OneHanded.Trainer || perk == DefaultPerks.OneHanded.UnwaveringDefense || perk == DefaultPerks.TwoHanded.ThickHides || perk == DefaultPerks.Athletics.WellBuilt || perk == DefaultPerks.Medicine.PreventiveMedicine)
+            {
+                hero.HitPoints += (int)perk.PrimaryBonus;
+            }
+            else if (perk == DefaultPerks.Crafting.VigorousSmith)
+            {
+                hero.HeroDeveloper.AddAttribute(DefaultCharacterAttributes.Vigor, 1, false);
+            }
+            else if (perk == DefaultPerks.Crafting.StrongSmith)
+            {
+                hero.HeroDeveloper.AddAttribute(DefaultCharacterAttributes.Control, 1, false);
+            }
+            else if (perk == DefaultPerks.Crafting.EnduringSmith)
+            {
+                hero.HeroDeveloper.AddAttribute(DefaultCharacterAttributes.Endurance, 1, false);
+            }
+            else if (perk == DefaultPerks.Crafting.WeaponMasterSmith)
+            {
+                hero.HeroDeveloper.AddFocus(DefaultSkills.OneHanded, 1, false);
+                hero.HeroDeveloper.AddFocus(DefaultSkills.TwoHanded, 1, false);
+            }
+            else if (perk == DefaultPerks.Athletics.Durable)
+            {
+                hero.HeroDeveloper.AddAttribute(DefaultCharacterAttributes.Endurance, 1, false);
+            }
+            else if (perk == DefaultPerks.Athletics.Steady)
+            {
+                hero.HeroDeveloper.AddAttribute(DefaultCharacterAttributes.Control, 1, false);
+            }
+            else if (perk == DefaultPerks.Athletics.Strong)
+            {
+                hero.HeroDeveloper.AddAttribute(DefaultCharacterAttributes.Vigor, 1, false);
+            }
+
+            // Substitute for Hero == Hero.MainHero
+            if (playerRegistry.Contains(hero.PartyBelongedTo) && (perk == DefaultPerks.OneHanded.Prestige || perk == DefaultPerks.TwoHanded.Hope || perk == DefaultPerks.Athletics.ImposingStature || perk == DefaultPerks.Bow.MerryMen || perk == DefaultPerks.Tactics.HordeLeader || perk == DefaultPerks.Scouting.MountedScouts || perk == DefaultPerks.Leadership.Authority || perk == DefaultPerks.Leadership.LeaderOfMasses || perk == DefaultPerks.Leadership.UltimateLeader))
+            {
+                hero.PartyBelongedTo.MemberRoster.UpdateVersion();
+            }
+            if (perk.PrimaryRole == PartyRole.Captain)
+            {
+                hero.UpdatePowerModifier();
             }
         }
     }

--- a/source/GameInterface/Services/HeroDevelopers/Handlers/PerkActivationHandler.cs
+++ b/source/GameInterface/Services/HeroDevelopers/Handlers/PerkActivationHandler.cs
@@ -1,0 +1,113 @@
+﻿using Common;
+using Common.Logging;
+using Common.Messaging;
+using Common.Network;
+using GameInterface.Services.HeroDevelopers.Messages;
+using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Players;
+using Serilog;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.CharacterDevelopment;
+using TaleWorlds.Core;
+
+namespace GameInterface.Services.HeroDevelopers.Handlers
+{
+    internal class PerkActivationHandler : IHandler
+    {
+        private static readonly ILogger Logger = LogManager.GetLogger<PerkActivationHandler>();
+        private readonly IMessageBroker messageBroker;
+        private readonly IObjectManager objectManager;
+        private readonly INetwork network;
+        private readonly IPlayerRegistry playerRegistry;
+
+        public PerkActivationHandler(
+            IMessageBroker messageBroker,
+            IObjectManager objectManager,
+            INetwork network,
+            IPlayerRegistry playerRegistry)
+        {
+            this.messageBroker = messageBroker;
+            this.objectManager = objectManager;
+            this.network = network;
+            this.playerRegistry = playerRegistry;
+            messageBroker.Subscribe<PerkOpened>(Handle_PerkOpened);
+            messageBroker.Subscribe<OpenPerk>(Handle_OpenPerk);
+        }
+
+        public void Dispose()
+        {
+            messageBroker.Unsubscribe<PerkOpened>(Handle_PerkOpened);
+            messageBroker.Unsubscribe<OpenPerk>(Handle_OpenPerk);
+        }
+
+        private void Handle_PerkOpened(MessagePayload<PerkOpened> obj)
+        {
+            if (!objectManager.TryGetIdWithLogging(obj.What.Hero, out var heroId)) return;
+            if (!objectManager.TryGetIdWithLogging(obj.What.Perk, out var perkId)) return;
+
+            // Run on all clients
+            var message = new OpenPerk(heroId, perkId);
+            network.SendAll(message);
+
+            OnOpenedPerkInternal(obj.What.Hero, obj.What.Perk);
+        }
+
+        private void Handle_OpenPerk(MessagePayload<OpenPerk> obj)
+        {
+            if (!objectManager.TryGetObjectWithLogging<Hero>(obj.What.HeroId, out var hero)) return;
+            if (!objectManager.TryGetObjectWithLogging<PerkObject>(obj.What.PerkId, out var perk)) return;
+
+            OnOpenedPerkInternal(hero, perk);
+        }
+
+        private void OnOpenedPerkInternal(Hero hero, PerkObject perk)
+        {
+            if (hero != null)
+            {
+                if (perk == DefaultPerks.OneHanded.Trainer || perk == DefaultPerks.OneHanded.UnwaveringDefense || perk == DefaultPerks.TwoHanded.ThickHides || perk == DefaultPerks.Athletics.WellBuilt || perk == DefaultPerks.Medicine.PreventiveMedicine)
+                {
+                    hero.HitPoints += (int)perk.PrimaryBonus;
+                }
+                else if (perk == DefaultPerks.Crafting.VigorousSmith)
+                {
+                    hero.HeroDeveloper.AddAttribute(DefaultCharacterAttributes.Vigor, 1, false);
+                }
+                else if (perk == DefaultPerks.Crafting.StrongSmith)
+                {
+                    hero.HeroDeveloper.AddAttribute(DefaultCharacterAttributes.Control, 1, false);
+                }
+                else if (perk == DefaultPerks.Crafting.EnduringSmith)
+                {
+                    hero.HeroDeveloper.AddAttribute(DefaultCharacterAttributes.Endurance, 1, false);
+                }
+                else if (perk == DefaultPerks.Crafting.WeaponMasterSmith)
+                {
+                    hero.HeroDeveloper.AddFocus(DefaultSkills.OneHanded, 1, false);
+                    hero.HeroDeveloper.AddFocus(DefaultSkills.TwoHanded, 1, false);
+                }
+                else if (perk == DefaultPerks.Athletics.Durable)
+                {
+                    hero.HeroDeveloper.AddAttribute(DefaultCharacterAttributes.Endurance, 1, false);
+                }
+                else if (perk == DefaultPerks.Athletics.Steady)
+                {
+                    hero.HeroDeveloper.AddAttribute(DefaultCharacterAttributes.Control, 1, false);
+                }
+                else if (perk == DefaultPerks.Athletics.Strong)
+                {
+                    hero.HeroDeveloper.AddAttribute(DefaultCharacterAttributes.Vigor, 1, false);
+                }
+
+                // Substitute for Hero == Hero.MainHero
+                if (playerRegistry.Contains(hero.PartyBelongedTo) && (perk == DefaultPerks.OneHanded.Prestige || perk == DefaultPerks.TwoHanded.Hope || perk == DefaultPerks.Athletics.ImposingStature || perk == DefaultPerks.Bow.MerryMen || perk == DefaultPerks.Tactics.HordeLeader || perk == DefaultPerks.Scouting.MountedScouts || perk == DefaultPerks.Leadership.Authority || perk == DefaultPerks.Leadership.LeaderOfMasses || perk == DefaultPerks.Leadership.UltimateLeader))
+                {
+                    hero.PartyBelongedTo.MemberRoster.UpdateVersion();
+                }
+                if (perk.PrimaryRole == PartyRole.Captain)
+                {
+                    hero.UpdatePowerModifier();
+                }
+            }
+        }
+    }
+}

--- a/source/GameInterface/Services/HeroDevelopers/Messages/OpenPerk.cs
+++ b/source/GameInterface/Services/HeroDevelopers/Messages/OpenPerk.cs
@@ -1,0 +1,20 @@
+﻿using Common.Messaging;
+using ProtoBuf;
+
+namespace GameInterface.Services.HeroDevelopers.Messages;
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct OpenPerk : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string HeroId;
+
+    [ProtoMember(2)]
+    public readonly string PerkId;
+
+    public OpenPerk(string heroId, string perkId)
+    {
+        HeroId = heroId;
+        PerkId = perkId;
+    }
+}

--- a/source/GameInterface/Services/HeroDevelopers/Messages/PerkOpened.cs
+++ b/source/GameInterface/Services/HeroDevelopers/Messages/PerkOpened.cs
@@ -1,0 +1,18 @@
+﻿using Common.Messaging;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.CharacterDevelopment;
+using TaleWorlds.CampaignSystem.Party;
+
+namespace GameInterface.Services.HeroDevelopers.Messages;
+
+public readonly struct PerkOpened : IEvent
+{
+    public readonly Hero Hero;
+    public readonly PerkObject Perk;
+
+    public PerkOpened(Hero hero, PerkObject perk)
+    {
+        Hero = hero;
+        Perk = perk;
+    }
+}

--- a/source/GameInterface/Services/HeroDevelopers/Patches/PerkActivationPatch.cs
+++ b/source/GameInterface/Services/HeroDevelopers/Patches/PerkActivationPatch.cs
@@ -1,0 +1,35 @@
+﻿using Common;
+using Common.Logging;
+using Common.Messaging;
+using GameInterface.Policies;
+using GameInterface.Services.HeroDevelopers.Messages;
+using HarmonyLib;
+using Serilog;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.CampaignBehaviors;
+using TaleWorlds.CampaignSystem.CharacterDevelopment;
+using TaleWorlds.CampaignSystem.Inventory;
+
+namespace GameInterface.Services.HeroDevelopers.Patches
+{
+    [HarmonyPatch(typeof(PerkActivationHandlerCampaignBehavior))]
+    internal class PerkActivationPatch
+    {
+        private static readonly ILogger logger = LogManager.GetLogger<PerkActivationHandlerCampaignBehavior>();
+
+        [HarmonyPatch(nameof(PerkActivationHandlerCampaignBehavior.OnPerkOpened))]
+        [HarmonyPrefix]
+        static bool OnPerkOpenedPrefix(ref InventoryLogic __instance, Hero hero, PerkObject perk)
+        {
+            // Call original if we call this function
+            if (CallOriginalPolicy.IsOriginalAllowed()) return true;
+
+            if (ModInformation.IsClient) return false;
+
+            var message = new PerkOpened(hero, perk);
+            MessageBroker.Instance.Publish(__instance, message);
+
+            return false;
+        }
+    }
+}

--- a/source/GameInterface/Services/MobileParties/Patches/Disable/DisablePerkActivationHandlerCampaignBehavior.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/Disable/DisablePerkActivationHandlerCampaignBehavior.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using Common;
+using HarmonyLib;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
 
 namespace GameInterface.Services.MobileParties.Patches;
@@ -7,5 +8,5 @@ namespace GameInterface.Services.MobileParties.Patches;
 internal class DisablePerkActivationHandlerCampaignBehavior
 {
     [HarmonyPatch(nameof(PerkActivationHandlerCampaignBehavior.RegisterEvents))]
-    static bool Prefix() => false;
+    static bool Prefix() => ModInformation.IsServer;
 }


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
After adding perks such as those that give an extra level for an attribute, `PerkActivationHandlerCampaignBehavior.OnPerkOpened ` is not being called.


## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Adding perks now applies the appropriate extra effects with `PerkActivationHandlerCampaignBehavior.OnPerkOpened` synced for server and clients.
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Other information
