### PR TITLE
Enable view data tracker campaign behavior

### DIFF
--- a/source/GameInterface/Services/CampaignService/Patches/DisableViewDataTrackerCampaignBehavior.cs
+++ b/source/GameInterface/Services/CampaignService/Patches/DisableViewDataTrackerCampaignBehavior.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using Common;
+using HarmonyLib;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
 
 namespace GameInterface.Services.CampaignService.Patches;
@@ -7,5 +8,5 @@ namespace GameInterface.Services.CampaignService.Patches;
 internal class DisableViewDataTrackerCampaignBehavior
 {
     [HarmonyPatch(nameof(ViewDataTrackerCampaignBehavior.RegisterEvents))]
-    static bool Prefix() => true;
+    static bool Prefix() => ModInformation.IsClient;
 }

--- a/source/GameInterface/Services/CampaignService/Patches/DisableViewDataTrackerCampaignBehavior.cs
+++ b/source/GameInterface/Services/CampaignService/Patches/DisableViewDataTrackerCampaignBehavior.cs
@@ -7,5 +7,5 @@ namespace GameInterface.Services.CampaignService.Patches;
 internal class DisableViewDataTrackerCampaignBehavior
 {
     [HarmonyPatch(nameof(ViewDataTrackerCampaignBehavior.RegisterEvents))]
-    static bool Prefix() => false;
+    static bool Prefix() => true;
 }


### PR DESCRIPTION
ViewDataTrackerCampaignBehavior is needed for clients to see updates to their UI on certain events. For example, when unlocking perks or levelling up a red icon should appear above the button in the bottom left.

## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Other information
