### PR TITLE
Add high-level TroopRoster sync routing tests

### DIFF
--- a/source/E2E.Tests/Services/TroopRosters/TroopRosterHandlerTests.cs
+++ b/source/E2E.Tests/Services/TroopRosters/TroopRosterHandlerTests.cs
@@ -239,6 +239,154 @@ namespace E2E.Tests.Services.TroopRosters
         }
         #endregion
 
+        #region High-level routing: public mutators that delegate to the patched primitives
+        // These exercise the higher-level TroopRoster API rather than the patched primitives
+        // directly, locking in that they continue to route through synced primitives
+        // (AddNewElement / AddToCountsAtIndex / SetElementXp / ...) rather than mutating the
+        // backing data array. If a future game version bypasses the primitives, these regress.
+
+        [Fact]
+        public void Server_AddToCounts_NewTroop_SyncsToClients()
+        {
+            // Act: AddToCounts on an empty roster routes through AddNewElement + AddToCountsAtIndex
+            Server.Call(() =>
+            {
+                Assert.True(Server.ObjectManager.TryGetObject<TroopRoster>(TroopRosterId, out var roster));
+                Assert.True(Server.ObjectManager.TryGetObject<CharacterObject>(CharacterId1, out var character));
+
+                roster.AddToCounts(character, 5);
+            });
+
+            // Assert
+            foreach (var client in Clients)
+            {
+                Assert.True(client.ObjectManager.TryGetObject<TroopRoster>(TroopRosterId, out var roster));
+                Assert.True(client.ObjectManager.TryGetObject<CharacterObject>(CharacterId1, out var character));
+
+                Assert.Equal(1, roster.Count);
+                Assert.Same(character, roster.GetElementCopyAtIndex(0).Character);
+                Assert.Equal(5, roster.GetElementCopyAtIndex(0).Number);
+            }
+        }
+
+        [Fact]
+        public void Server_AddToCounts_ExistingTroop_SyncsToClients()
+        {
+            // Arrange
+            SeedTroopOnAll(CharacterId1, count: 5);
+
+            // Act: AddToCounts on an existing element routes through AddToCountsAtIndex
+            Server.Call(() =>
+            {
+                Assert.True(Server.ObjectManager.TryGetObject<TroopRoster>(TroopRosterId, out var roster));
+                Assert.True(Server.ObjectManager.TryGetObject<CharacterObject>(CharacterId1, out var character));
+
+                roster.AddToCounts(character, 3);
+            });
+
+            // Assert
+            foreach (var client in Clients)
+            {
+                Assert.True(client.ObjectManager.TryGetObject<TroopRoster>(TroopRosterId, out var roster));
+                Assert.Equal(8, roster.GetElementCopyAtIndex(0).Number);
+            }
+        }
+
+        [Fact]
+        public void Server_Clear_SyncsToClients()
+        {
+            // Arrange: two populated elements
+            SeedTroopOnAll(CharacterId1, count: 3);
+            SeedTroopOnAll(CharacterId2, count: 4);
+
+            // Act: Clear routes through AddToCountsAtIndex per element
+            Server.Call(() =>
+            {
+                Assert.True(Server.ObjectManager.TryGetObject<TroopRoster>(TroopRosterId, out var roster));
+                Assert.Equal(2, roster.Count);
+
+                roster.Clear();
+            });
+
+            // Assert
+            foreach (var client in Clients)
+            {
+                Assert.True(client.ObjectManager.TryGetObject<TroopRoster>(TroopRosterId, out var roster));
+                Assert.Equal(0, roster.Count);
+                Assert.Equal(0, roster.TotalManCount);
+            }
+        }
+
+        [Fact]
+        public void Server_RemoveTroop_SyncsToClients()
+        {
+            // Arrange
+            SeedTroopOnAll(CharacterId1, count: 5);
+
+            // Act: RemoveTroop routes through AddToCountsAtIndex (negative count)
+            Server.Call(() =>
+            {
+                Assert.True(Server.ObjectManager.TryGetObject<TroopRoster>(TroopRosterId, out var roster));
+                Assert.True(Server.ObjectManager.TryGetObject<CharacterObject>(CharacterId1, out var character));
+
+                roster.RemoveTroop(character, 2, default, 0);
+            });
+
+            // Assert
+            foreach (var client in Clients)
+            {
+                Assert.True(client.ObjectManager.TryGetObject<TroopRoster>(TroopRosterId, out var roster));
+                Assert.Equal(3, roster.GetElementCopyAtIndex(0).Number);
+            }
+        }
+
+        [Fact]
+        public void Server_AddXpToTroop_SyncsToClients()
+        {
+            // Arrange
+            SeedTroopOnAll(CharacterId1, count: 5);
+
+            // Act: AddXpToTroop routes through AddXpToTroopAtIndex -> SetElementXp
+            Server.Call(() =>
+            {
+                Assert.True(Server.ObjectManager.TryGetObject<TroopRoster>(TroopRosterId, out var roster));
+                Assert.True(Server.ObjectManager.TryGetObject<CharacterObject>(CharacterId1, out var character));
+
+                roster.AddXpToTroop(character, 100);
+            });
+
+            // Assert
+            foreach (var client in Clients)
+            {
+                Assert.True(client.ObjectManager.TryGetObject<TroopRoster>(TroopRosterId, out var roster));
+                Assert.Equal(100, roster.GetElementCopyAtIndex(0).Xp);
+            }
+        }
+
+        [Fact]
+        public void Server_WoundTroop_SyncsToClients()
+        {
+            // Arrange
+            SeedTroopOnAll(CharacterId1, count: 5);
+
+            // Act: WoundTroop routes through AddToCountsAtIndex (wounded count change)
+            Server.Call(() =>
+            {
+                Assert.True(Server.ObjectManager.TryGetObject<TroopRoster>(TroopRosterId, out var roster));
+                Assert.True(Server.ObjectManager.TryGetObject<CharacterObject>(CharacterId1, out var character));
+
+                roster.WoundTroop(character, 2, default);
+            });
+
+            // Assert
+            foreach (var client in Clients)
+            {
+                Assert.True(client.ObjectManager.TryGetObject<TroopRoster>(TroopRosterId, out var roster));
+                Assert.Equal(2, roster.GetElementCopyAtIndex(0).WoundedNumber);
+            }
+        }
+        #endregion
+
         #region Helpers
         /// <summary>
         /// Adds <paramref name="count"/> of <paramref name="characterId"/> to the roster on the


### PR DESCRIPTION
Adds 6 E2E tests exercising the higher-level TroopRoster API (AddToCounts for new and existing troops, Clear, RemoveTroop, AddXpToTroop, WoundTroop) rather than the patched primitives directly. These confirm the public mutators still delegate to synced primitives (AddNewElement / AddToCountsAtIndex / SetElementXp / ...) instead of mutating the backing data array, and act as regression guards if a future game version bypasses them.

## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Other information
