### PR TITLE
Disable AI parties joining a player map event

### DIFF
--- a/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
@@ -206,15 +206,8 @@ internal class InteractionPatches
         if (!__instance.ContainsPlayerParty())
             return;
 
-        if (!playerBattleAiJoinWindows.TryGetValue(__instance, out var debounce))
-            return;
-
-        // Prevent AI joining after 5 hours
-        if (debounce.Expired)
-        {
-            __result = false;
-            return;
-        }
+        // Prevent any AI party from joining a battle that involves a player
+        __result = false;
     }
 
     [HarmonyPatch(typeof(MapEvent), nameof(MapEvent.Initialize))]


### PR DESCRIPTION
Previously AI parties could join a player battle for a 5-hour window via CanPartyJoinBattle. Now any AI party is blocked from joining as soon as the map event involves a player party. Players can still join, and AI can still join battles with no players involved.

## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Other information
