### PR TITLE
Fix player character deletion on re-join with empty/wounded party

### DIFF
--- a/source/Coop.Core/Client/States/LoadingState.cs
+++ b/source/Coop.Core/Client/States/LoadingState.cs
@@ -2,6 +2,7 @@
 using Coop.Core.Client.Services.Heroes.Data;
 using GameInterface;
 using GameInterface.Registry;
+using GameInterface.Services.Entity;
 using GameInterface.Services.GameState.Messages;
 using GameInterface.Services.Heroes.Interfaces;
 using GameInterface.Services.Heroes.Messages;
@@ -17,18 +18,24 @@ public class LoadingState : ClientStateBase
     private readonly IRegistryManager registryManager;
     private readonly IDeferredHeroRepository deferredHeroRepo;
     private readonly IHeroInterface heroInterface;
+    private readonly IControllerIdProvider controllerIdProvider;
+    private readonly IControlledEntityRegistry controlledEntityRegistry;
 
     public LoadingState(
         IClientLogic logic,
         IMessageBroker messageBroker,
         IRegistryManager registryManager,
         IDeferredHeroRepository deferredHeroRepo,
-        IHeroInterface heroInterface) : base(logic)
+        IHeroInterface heroInterface,
+        IControllerIdProvider controllerIdProvider,
+        IControlledEntityRegistry controlledEntityRegistry) : base(logic)
     {
         this.messageBroker = messageBroker;
         this.registryManager = registryManager;
         this.deferredHeroRepo = deferredHeroRepo;
         this.heroInterface = heroInterface;
+        this.controllerIdProvider = controllerIdProvider;
+        this.controlledEntityRegistry = controlledEntityRegistry;
 
         messageBroker.Subscribe<CampaignReady>(Handle_CampaignLoaded);
     }
@@ -49,6 +56,8 @@ public class LoadingState : ClientStateBase
         registryManager.PatchLifetimes();
 
         InstantiateDeferredHeroes();
+
+        RegisterPlayerAsControlled();
 
         heroInterface.SwitchToPlayer(Logic.Player);
 
@@ -87,6 +96,22 @@ public class LoadingState : ClientStateBase
 
     public override void ValidateModules()
     {
+    }
+
+    /// <summary>
+    /// Registers the client's own hero and party as controlled by this client so that
+    /// the client owns its party's movement/AI once it switches to it. Mirrors the
+    /// server registering all parties as controlled when its save loads.
+    /// </summary>
+    private void RegisterPlayerAsControlled()
+    {
+        var player = Logic.Player;
+        if (player == null) return;
+
+        var controllerId = controllerIdProvider.ControllerId;
+
+        controlledEntityRegistry.RegisterAsControlled(controllerId, player.HeroId);
+        controlledEntityRegistry.RegisterAsControlled(controllerId, player.MobilePartyId);
     }
 
     private void InstantiateDeferredHeroes()

--- a/source/GameInterface/Services/Heroes/Patches/ChangePlayerCharacterActionPatches.cs
+++ b/source/GameInterface/Services/Heroes/Patches/ChangePlayerCharacterActionPatches.cs
@@ -19,6 +19,12 @@ internal class ChangePlayerCharacterActionPatches
 
         Hero mainHero = Hero.MainHero;
         MobileParty mainParty = MobileParty.MainParty;
+        // The party belonging to the hero we are switching INTO. In coop, SwitchToPlayer
+        // pre-points MobileParty.MainParty at this same party before calling Apply, so the
+        // "abandoned old party" cleanup below must never target it — otherwise a (re)joining
+        // player whose party is empty (0 members) or only holds a wounded leader would have
+        // their party destroyed and the character deleted.
+        MobileParty targetHeroParty = hero.PartyBelongedTo;
         CampaignVec2 position = MobileParty.MainParty.Anchor.Position;
         CampaignVec2 lastUsedDisembarkPosition = MobileParty.MainParty.Anchor.GetLastUsedDisembarkPosition();
         bool isCurrentlyAtSea = MobileParty.MainParty.IsCurrentlyAtSea;
@@ -53,7 +59,7 @@ internal class ChangePlayerCharacterActionPatches
             MobileParty.MainParty.Anchor.SetLastUsedDisembarkPosition(lastUsedDisembarkPosition);
         }
 
-        if (mainParty != MobileParty.MainParty && mainParty.IsActive)
+        if (mainParty != MobileParty.MainParty && mainParty.IsActive && mainParty != targetHeroParty)
         {
             if (mainParty.MemberRoster.TotalManCount == 0)
             {


### PR DESCRIPTION
ChangePlayerCharacterAction.Apply is reimplemented in a Harmony prefix that copies native single-player cleanup of the previously-controlled (abandoned) party: if that party is empty it is destroyed. During a coop (re)join, HeroInterface.SwitchToPlayer pre-points MobileParty.MainParty at the joining hero's own party before calling Apply, so the cleanup evaluated the party being switched INTO. When a re-joining player's party had 0 troops (or only a wounded leader, TotalManCount == 0), it was destroyed and the character deleted.

Capture the target hero party (hero.PartyBelongedTo) and guard the cleanup so it never destroys/reassigns that party, preserving native behavior for genuinely abandoned parties.

## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves https://github.com/Bannerlord-Coop-Team/Bannerlord-Coop-Issues/issues/20
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Other information
