### PR TITLE
Add loading progress messages

### DIFF
--- a/source/Coop.Core/Client/States/CharacterCreationState.cs
+++ b/source/Coop.Core/Client/States/CharacterCreationState.cs
@@ -67,7 +67,9 @@ public class CharacterCreationState : ClientStateBase
     {
         // Cover the client's own (character-creation) world with a loading screen until the
         // server campaign is ready, so the local world isn't briefly visible while we join.
-        loadingInterface.ShowLoadingScreen();
+        loadingInterface.ShowLoadingScreen(
+            "Joining Coop Campaign",
+            "Sending your character to the host...");
 
         registryManager.RegisterAllGameObjects();
 

--- a/source/Coop.Core/Client/States/LoadingState.cs
+++ b/source/Coop.Core/Client/States/LoadingState.cs
@@ -6,6 +6,7 @@ using GameInterface.Services.Entity;
 using GameInterface.Services.GameState.Messages;
 using GameInterface.Services.Heroes.Interfaces;
 using GameInterface.Services.Heroes.Messages;
+using GameInterface.Services.UI.Interfaces;
 
 namespace Coop.Core.Client.States;
 
@@ -20,6 +21,7 @@ public class LoadingState : ClientStateBase
     private readonly IHeroInterface heroInterface;
     private readonly IControllerIdProvider controllerIdProvider;
     private readonly IControlledEntityRegistry controlledEntityRegistry;
+    private readonly ILoadingInterface loadingInterface;
 
     public LoadingState(
         IClientLogic logic,
@@ -28,7 +30,8 @@ public class LoadingState : ClientStateBase
         IDeferredHeroRepository deferredHeroRepo,
         IHeroInterface heroInterface,
         IControllerIdProvider controllerIdProvider,
-        IControlledEntityRegistry controlledEntityRegistry) : base(logic)
+        IControlledEntityRegistry controlledEntityRegistry,
+        ILoadingInterface loadingInterface) : base(logic)
     {
         this.messageBroker = messageBroker;
         this.registryManager = registryManager;
@@ -36,6 +39,7 @@ public class LoadingState : ClientStateBase
         this.heroInterface = heroInterface;
         this.controllerIdProvider = controllerIdProvider;
         this.controlledEntityRegistry = controlledEntityRegistry;
+        this.loadingInterface = loadingInterface;
 
         messageBroker.Subscribe<CampaignReady>(Handle_CampaignLoaded);
     }
@@ -52,15 +56,34 @@ public class LoadingState : ClientStateBase
 
     internal void Handle_CampaignLoaded(MessagePayload<CampaignReady> obj)
     {
+        loadingInterface.SetLoadingMessage(
+            "Loading Host Campaign",
+            "Registering campaign objects...");
         registryManager.RegisterAllGameObjects();
+
+        loadingInterface.SetLoadingMessage(
+            "Loading Host Campaign",
+            "Applying synced object lifetimes...");
         registryManager.PatchLifetimes();
 
+        loadingInterface.SetLoadingMessage(
+            "Loading Host Campaign",
+            "Creating remote player heroes...");
         InstantiateDeferredHeroes();
 
+        loadingInterface.SetLoadingMessage(
+            "Loading Host Campaign",
+            "Registering player control...");
         RegisterPlayerAsControlled();
 
+        loadingInterface.SetLoadingMessage(
+            "Loading Host Campaign",
+            "Switching to your hero...");
         heroInterface.SwitchToPlayer(Logic.Player);
 
+        loadingInterface.SetLoadingMessage(
+            "Loading Host Campaign",
+            "Entering campaign...");
         Logic.EnterCampaignState();
     }
 

--- a/source/Coop.Core/Client/States/MainMenuState.cs
+++ b/source/Coop.Core/Client/States/MainMenuState.cs
@@ -47,8 +47,11 @@ public class MainMenuState : ClientStateBase
     {
         loadingInterface.ShowLoadingScreen(
             "Connecting to Coop Server",
-            "Validating modules...");
+            "Applying patches...");
         gameInterface.PatchAll();
+        loadingInterface.SetLoadingMessage(
+            "Connecting to Coop Server",
+            "Validating modules...");
         Logic.ValidateModules();
     }
 

--- a/source/Coop.Core/Client/States/MainMenuState.cs
+++ b/source/Coop.Core/Client/States/MainMenuState.cs
@@ -45,7 +45,9 @@ public class MainMenuState : ClientStateBase
 
     internal void Handle_NetworkConnected(MessagePayload<NetworkConnected> obj)
     {
-        loadingInterface.ShowLoadingScreen();
+        loadingInterface.ShowLoadingScreen(
+            "Connecting to Coop Server",
+            "Validating modules...");
         gameInterface.PatchAll();
         Logic.ValidateModules();
     }

--- a/source/Coop.Core/Client/States/ReceivingSavedDataState.cs
+++ b/source/Coop.Core/Client/States/ReceivingSavedDataState.cs
@@ -18,6 +18,7 @@ public class ReceivingSavedDataState : ClientStateBase
     private NetworkGameSaveDataReceived saveDataMessage = default;
     private readonly IMessageBroker messageBroker;
     private readonly IDeferredHeroRepository deferredHeroRepo;
+    private readonly ILoadingInterface loadingInterface;
     private readonly ICoopFinalizer coopFinalizer;
 
     public ReceivingSavedDataState(
@@ -29,6 +30,7 @@ public class ReceivingSavedDataState : ClientStateBase
     {
         this.messageBroker = messageBroker;
         this.deferredHeroRepo = deferredHeroRepo;
+        this.loadingInterface = loadingInterface;
         this.coopFinalizer = coopFinalizer;
         messageBroker.Subscribe<NetworkGameSaveDataReceived>(Handle_NetworkGameSaveDataReceived);
         messageBroker.Subscribe<MainMenuEntered>(Handle_MainMenuEntered);
@@ -37,7 +39,9 @@ public class ReceivingSavedDataState : ClientStateBase
         // Keep a loading screen up while we receive and load the server world. This is the
         // common state for both new (post character-creation) and returning clients, so the
         // client's local/main-menu view isn't shown during the transition.
-        loadingInterface.ShowLoadingScreen();
+        loadingInterface.ShowLoadingScreen(
+            "Joining Coop Campaign",
+            "Waiting for host save data...");
     }
 
     public override void Dispose()
@@ -50,6 +54,9 @@ public class ReceivingSavedDataState : ClientStateBase
     internal void Handle_NetworkGameSaveDataReceived(MessagePayload<NetworkGameSaveDataReceived> obj)
     {
         saveDataMessage = obj.What;
+        loadingInterface.SetLoadingMessage(
+            "Joining Coop Campaign",
+            "Preparing host save data...");
         Logic.EnterMainMenu();
     }
 
@@ -59,6 +66,10 @@ public class ReceivingSavedDataState : ClientStateBase
 
         if (saveData == null) return;
         if (saveData.Length == 0) return;
+
+        loadingInterface.SetLoadingMessage(
+            "Loading Host Campaign",
+            "Loading host save data...");
 
         var commandLoad = new LoadGameSave(saveData);
         messageBroker.Publish(this, commandLoad);

--- a/source/Coop.Tests/Client/States/CharacterCreationStateTests.cs
+++ b/source/Coop.Tests/Client/States/CharacterCreationStateTests.cs
@@ -10,6 +10,7 @@ using GameInterface.Registry.Messages;
 using GameInterface.Services.CharacterCreation.Messages;
 using GameInterface.Services.GameState.Messages;
 using GameInterface.Services.Heroes.Messages;
+using GameInterface.Services.UI.Interfaces;
 using LiteNetLib;
 using Moq;
 using Xunit;
@@ -22,6 +23,7 @@ namespace Coop.Tests.Client.States
         private readonly IClientLogic clientLogic;
         private readonly NetPeer serverPeer;
         private readonly ClientTestComponent clientComponent;
+        private readonly Mock<ILoadingInterface> loadingInterfaceMock;
 
         private TestMessageBroker TestMessageBroker => clientComponent.TestMessageBroker;
         private TestNetwork MockNetwork => clientComponent.TestNetwork;
@@ -33,6 +35,7 @@ namespace Coop.Tests.Client.States
 
             serverPeer = MockNetwork.CreatePeer();
             clientLogic = container.Resolve<IClientLogic>()!;
+            loadingInterfaceMock = container.Resolve<Mock<ILoadingInterface>>();
         }
 
         [Fact]
@@ -65,7 +68,10 @@ namespace Coop.Tests.Client.States
             characterCreationState.Handle_CharacterCreationFinished(payload);
 
             // Assert
-            Assert.Single(TestMessageBroker.GetMessagesFromType<NetworkTransferedHero>());
+            Assert.Single(MockNetwork.GetPeerMessagesFromType<NetworkTransferedHero>(serverPeer));
+            loadingInterfaceMock.Verify(x => x.ShowLoadingScreen(
+                "Joining Coop Campaign",
+                "Sending your character to the host..."), Times.Once);
         }
 
         [Fact]

--- a/source/Coop.Tests/Client/States/LoadingStateTests.cs
+++ b/source/Coop.Tests/Client/States/LoadingStateTests.cs
@@ -5,6 +5,8 @@ using Coop.Core.Client;
 using Coop.Core.Client.States;
 using GameInterface.Registry.Messages;
 using GameInterface.Services.GameState.Messages;
+using GameInterface.Services.UI.Interfaces;
+using Moq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -14,6 +16,7 @@ namespace Coop.Tests.Client.States
     {
         private readonly IClientLogic clientLogic;
         private readonly ClientTestComponent clientComponent;
+        private readonly Mock<ILoadingInterface> loadingInterfaceMock;
 
         public LoadingStateTests(ITestOutputHelper output)
         {
@@ -21,6 +24,7 @@ namespace Coop.Tests.Client.States
             var container = clientComponent.Container;
 
             clientLogic = container.Resolve<IClientLogic>()!;
+            loadingInterfaceMock = container.Resolve<Mock<ILoadingInterface>>();
         }
 
         [Fact]
@@ -37,6 +41,24 @@ namespace Coop.Tests.Client.States
 
             // Assert
             Assert.IsType<CampaignState>(clientLogic.State);
+            loadingInterfaceMock.Verify(x => x.SetLoadingMessage(
+                "Loading Host Campaign",
+                "Registering campaign objects..."), Times.Once);
+            loadingInterfaceMock.Verify(x => x.SetLoadingMessage(
+                "Loading Host Campaign",
+                "Applying synced object lifetimes..."), Times.Once);
+            loadingInterfaceMock.Verify(x => x.SetLoadingMessage(
+                "Loading Host Campaign",
+                "Creating remote player heroes..."), Times.Once);
+            loadingInterfaceMock.Verify(x => x.SetLoadingMessage(
+                "Loading Host Campaign",
+                "Registering player control..."), Times.Once);
+            loadingInterfaceMock.Verify(x => x.SetLoadingMessage(
+                "Loading Host Campaign",
+                "Switching to your hero..."), Times.Once);
+            loadingInterfaceMock.Verify(x => x.SetLoadingMessage(
+                "Loading Host Campaign",
+                "Entering campaign..."), Times.Once);
         }
 
         [Fact]

--- a/source/Coop.Tests/Client/States/MainMenuStateTests.cs
+++ b/source/Coop.Tests/Client/States/MainMenuStateTests.cs
@@ -6,6 +6,8 @@ using Coop.Core.Client.Messages;
 using Coop.Core.Client.States;
 using Coop.Tests.Mocks;
 using GameInterface.Services.GameState.Messages;
+using GameInterface.Services.UI.Interfaces;
+using Moq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -15,6 +17,7 @@ namespace Coop.Tests.Client.States
     {
         private readonly IClientLogic clientLogic;
         private readonly ClientTestComponent clientComponent;
+        private readonly Mock<ILoadingInterface> loadingInterfaceMock;
 
         public MainMenuStateTests(ITestOutputHelper output)
         {
@@ -22,6 +25,7 @@ namespace Coop.Tests.Client.States
             var container = clientComponent.Container;
 
             clientLogic = container.Resolve<IClientLogic>()!;
+            loadingInterfaceMock = container.Resolve<Mock<ILoadingInterface>>();
         }
 
         [Fact]
@@ -51,6 +55,9 @@ namespace Coop.Tests.Client.States
 
             // Assert
             Assert.IsType<ValidateModuleState>(clientLogic.State);
+            loadingInterfaceMock.Verify(x => x.ShowLoadingScreen(
+                "Connecting to Coop Server",
+                "Validating modules..."), Times.Once);
         }
 
         [Fact]

--- a/source/Coop.Tests/Client/States/MainMenuStateTests.cs
+++ b/source/Coop.Tests/Client/States/MainMenuStateTests.cs
@@ -57,6 +57,9 @@ namespace Coop.Tests.Client.States
             Assert.IsType<ValidateModuleState>(clientLogic.State);
             loadingInterfaceMock.Verify(x => x.ShowLoadingScreen(
                 "Connecting to Coop Server",
+                "Applying patches..."), Times.Once);
+            loadingInterfaceMock.Verify(x => x.SetLoadingMessage(
+                "Connecting to Coop Server",
                 "Validating modules..."), Times.Once);
         }
 

--- a/source/Coop.Tests/Client/States/ReceivingSavedDataStateTests.cs
+++ b/source/Coop.Tests/Client/States/ReceivingSavedDataStateTests.cs
@@ -6,6 +6,8 @@ using Coop.Core.Client.States;
 using Coop.Tests.Mocks;
 using GameInterface.Services.GameState.Messages;
 using GameInterface.Services.Smithing;
+using GameInterface.Services.UI.Interfaces;
+using Moq;
 using System;
 using System.Linq;
 using Xunit;
@@ -17,6 +19,7 @@ namespace Coop.Tests.Client.States
     {
         private readonly IClientLogic clientLogic;
         private readonly ClientTestComponent clientComponent;
+        private readonly Mock<ILoadingInterface> loadingInterfaceMock;
 
         public ReceivingSavedDataStateTests(ITestOutputHelper output)
         {
@@ -24,6 +27,19 @@ namespace Coop.Tests.Client.States
             var container = clientComponent.Container;
 
             clientLogic = container.Resolve<IClientLogic>()!;
+            loadingInterfaceMock = container.Resolve<Mock<ILoadingInterface>>();
+        }
+
+        [Fact]
+        public void StateEntered_Shows_LoadingProgressMessage()
+        {
+            // Act
+            clientLogic.SetState<ReceivingSavedDataState>();
+
+            // Assert
+            loadingInterfaceMock.Verify(x => x.ShowLoadingScreen(
+                "Joining Coop Campaign",
+                "Waiting for host save data..."), Times.Once);
         }
 
         [Fact]
@@ -44,6 +60,9 @@ namespace Coop.Tests.Client.States
             // Assert
             var message = Assert.Single(clientComponent.TestMessageBroker.Messages);
             Assert.IsType<EnterMainMenu>(message);
+            loadingInterfaceMock.Verify(x => x.SetLoadingMessage(
+                "Joining Coop Campaign",
+                "Preparing host save data..."), Times.Once);
         }
 
         [Fact]
@@ -73,6 +92,9 @@ namespace Coop.Tests.Client.States
             Assert.Equal(gameSaveData, loadSaveMessage.SaveData);
 
             Assert.IsType<LoadingState>(clientLogic.State);
+            loadingInterfaceMock.Verify(x => x.SetLoadingMessage(
+                "Loading Host Campaign",
+                "Loading host save data..."), Times.Once);
         }
 
         [Fact]

--- a/source/Coop.Tests/TestComponentBase.cs
+++ b/source/Coop.Tests/TestComponentBase.cs
@@ -7,13 +7,18 @@ using Coop.Core;
 using Coop.Tests.Mocks;
 using GameInterface.Registry;
 using GameInterface.Services.Entity;
+using GameInterface.Services.Heroes.Interaces;
 using GameInterface.Services.Heroes.Interfaces;
 using GameInterface.Services.Modules;
 using GameInterface.Services.Modules.Validators;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Players;
+using GameInterface.Services.Time.Interfaces;
+using GameInterface.Services.UI.Interfaces;
 using Moq;
 using Serilog;
 using System.Collections.Generic;
+using IGameInterface = GameInterface.IGameInterface;
 using Xunit.Abstractions;
 
 namespace Coop.Tests;
@@ -74,9 +79,15 @@ internal abstract class TestComponentBase
         builder.RegisterInstance(new Mock<ILogger>().Object).As<ILogger>().SingleInstance();
 
         RegisterMock<ILogger>(builder);
+        RegisterMock<IGameInterface>(builder);
         RegisterMock<IControlledEntityRegistry>(builder);
         RegisterMock<IHeroInterface>(builder);
         RegisterMock<IModuleInfoProvider>(builder);
+        RegisterMock<IRegistryManager>(builder);
+        RegisterMock<IPlayerRegistry>(builder);
+        RegisterMock<ITimeControlInterface>(builder);
+        RegisterMock<IMapTimeTrackerInterface>(builder);
+        RegisterMock<ILoadingInterface>(builder);
 
         return builder;
     }

--- a/source/GameInterface/Services/UI/Interfaces/LoadingInterface.cs
+++ b/source/GameInterface/Services/UI/Interfaces/LoadingInterface.cs
@@ -1,5 +1,8 @@
 ﻿using GameInterface.Services.UI.Patches;
+using HarmonyLib;
+using System.Reflection;
 using TaleWorlds.Engine;
+using TaleWorlds.MountAndBlade.GauntletUI;
 
 namespace GameInterface.Services.UI.Interfaces;
 
@@ -7,10 +10,19 @@ public interface ILoadingInterface : IGameAbstraction
 {
     void HideLoadingScreen();
     void ShowLoadingScreen();
+    void ShowLoadingScreen(string titleText, string descriptionText = "");
+    void SetLoadingMessage(string titleText, string descriptionText = "");
 }
 
 internal class LoadingInterface : ILoadingInterface
 {
+    private const string GameModeText = "Coop";
+    private static string currentTitleText = string.Empty;
+    private static string currentDescriptionText = string.Empty;
+
+    private static readonly FieldInfo LoadingWindowViewModelField =
+        AccessTools.Field(typeof(GauntletDefaultLoadingWindowManager), "_loadingWindowViewModel");
+
     public void ShowLoadingScreen()
     {
         LoadingWindowPatches.ForceLoadingWindow = true;
@@ -23,10 +35,52 @@ internal class LoadingInterface : ILoadingInterface
         LoadingWindow.EnableGlobalLoadingWindow();
     }
 
+    public void ShowLoadingScreen(string titleText, string descriptionText = "")
+    {
+        ShowLoadingScreen();
+        SetLoadingMessage(titleText, descriptionText);
+    }
+
+    public void SetLoadingMessage(string titleText, string descriptionText = "")
+    {
+        currentTitleText = titleText ?? string.Empty;
+        currentDescriptionText = descriptionText ?? string.Empty;
+
+        ApplyCurrentLoadingMessage();
+    }
+
+    internal static void ApplyCurrentLoadingMessage()
+    {
+        if (string.IsNullOrEmpty(currentTitleText) &&
+            string.IsNullOrEmpty(currentDescriptionText))
+        {
+            return;
+        }
+
+        var viewModel = GetLoadingWindowViewModel();
+        if (viewModel == null) return;
+
+        viewModel.GameModeText = GameModeText;
+        viewModel.TitleText = currentTitleText;
+        viewModel.DescriptionText = currentDescriptionText;
+    }
+
     public void HideLoadingScreen()
     {
         LoadingWindowPatches.ForceLoadingWindow = false;
+        currentTitleText = string.Empty;
+        currentDescriptionText = string.Empty;
 
         LoadingWindow.DisableGlobalLoadingWindow();
+    }
+
+    private static LoadingWindowViewModel GetLoadingWindowViewModel()
+    {
+        if (LoadingWindow.LoadingWindowManager is not GauntletDefaultLoadingWindowManager manager)
+        {
+            return null;
+        }
+
+        return LoadingWindowViewModelField?.GetValue(manager) as LoadingWindowViewModel;
     }
 }

--- a/source/GameInterface/Services/UI/Patches/LoadingWindowPatches.cs
+++ b/source/GameInterface/Services/UI/Patches/LoadingWindowPatches.cs
@@ -42,7 +42,6 @@ internal static class LoadingWindowPatches
     {
         LoadingInterface.ApplyCurrentLoadingMessage();
     }
-
 }
 
 /// <summary>

--- a/source/GameInterface/Services/UI/Patches/LoadingWindowPatches.cs
+++ b/source/GameInterface/Services/UI/Patches/LoadingWindowPatches.cs
@@ -1,6 +1,8 @@
+using GameInterface.Services.UI.Interfaces;
 using HarmonyLib;
 using System.Reflection;
 using TaleWorlds.Engine;
+using TaleWorlds.MountAndBlade.GauntletUI;
 
 namespace GameInterface.Services.UI.Patches;
 
@@ -26,15 +28,35 @@ internal static class LoadingWindowPatches
     /// </summary>
     public static bool ForceLoadingWindow { get; set; }
 
-    // Setter is non-public on the engine type; resolve it once via reflection.
-    private static readonly MethodInfo SetIsLoadingWindowActive =
-        AccessTools.PropertySetter(typeof(LoadingWindow), nameof(LoadingWindow.IsLoadingWindowActive));
-
     [HarmonyPatch(nameof(LoadingWindow.DisableGlobalLoadingWindow))]
     [HarmonyPrefix]
     private static bool DisableGlobalLoadingWindowPrefix()
     {
         // Skip the disable entirely while we are forcing the window to remain visible.
         return !ForceLoadingWindow;
+    }
+
+    [HarmonyPatch(nameof(LoadingWindow.EnableGlobalLoadingWindow))]
+    [HarmonyPostfix]
+    private static void EnableGlobalLoadingWindowPostfix()
+    {
+        LoadingInterface.ApplyCurrentLoadingMessage();
+    }
+
+}
+
+[HarmonyPatch]
+internal static class GauntletDefaultLoadingWindowManagerPatches
+{
+    private static MethodBase TargetMethod()
+    {
+        return AccessTools.Method(
+            typeof(GauntletDefaultLoadingWindowManager),
+            "TaleWorlds.Engine.ILoadingWindowManager.EnableLoadingWindow");
+    }
+
+    private static void Postfix()
+    {
+        LoadingInterface.ApplyCurrentLoadingMessage();
     }
 }

--- a/source/GameInterface/Services/UI/Patches/LoadingWindowPatches.cs
+++ b/source/GameInterface/Services/UI/Patches/LoadingWindowPatches.cs
@@ -45,6 +45,10 @@ internal static class LoadingWindowPatches
 
 }
 
+/// <summary>
+/// Reapplies coop loading text when the engine directly re-enables a recreated
+/// loading window manager.
+/// </summary>
 [HarmonyPatch]
 internal static class GauntletDefaultLoadingWindowManagerPatches
 {


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Clients do not get coop-specific loading progress text while joining a host campaign.


## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #1276
<!-- Describe functionality added. Add images or videos to show how it works if applies -->

Adds coop loading title and description updates during the client join flow:

- Shows module validation progress after connecting to the coop server.
- Keeps a loading screen visible while the client sends character data and waits for host save data.
- Updates the loading message while the host save is prepared, loaded, and applied.
- Reapplies the saved coop loading text when Bannerlord recreates and directly re-enables the loading window manager.
- Adds focused state tests for the new loading progress calls.


https://github.com/user-attachments/assets/7ad942e9-a43d-4410-bcb1-b82b8da5b409



