### PR TITLE
Hold and protect AI parties in conversation with a player

### DIFF
--- a/source/Coop.Tests/GameInterface/Services/MapEvents/ConversationPartyTrackerTests.cs
+++ b/source/Coop.Tests/GameInterface/Services/MapEvents/ConversationPartyTrackerTests.cs
@@ -1,0 +1,150 @@
+using GameInterface.Services.MapEvents;
+using Xunit;
+
+namespace Coop.Tests.GameInterface.Services.MapEvents;
+
+public class ConversationPartyTrackerTests
+{
+    private readonly ConversationPartyTracker tracker = new ConversationPartyTracker(objectManager: null);
+
+    private readonly object firstPlayer = new object();
+    private readonly object secondPlayer = new object();
+
+    [Fact]
+    public void TryBeginEngagement_WhenPartyUnengaged_BeginsEngagement()
+    {
+        var began = tracker.TryBeginEngagement(firstPlayer, "player1", "lord1", wasAiDisabled: false);
+
+        Assert.True(began);
+        Assert.True(tracker.TryGetEngagement("lord1", out var engagement));
+        Assert.Equal(firstPlayer, engagement.EngagerKey);
+        Assert.Equal("player1", engagement.EngagerPartyId);
+        Assert.False(engagement.WasAiDisabled);
+    }
+
+    [Fact]
+    public void TryBeginEngagement_WhenPartyEngagedByOtherPlayer_Fails()
+    {
+        tracker.TryBeginEngagement(firstPlayer, "player1", "lord1", wasAiDisabled: false);
+
+        var began = tracker.TryBeginEngagement(secondPlayer, "player2", "lord1", wasAiDisabled: false);
+
+        Assert.False(began);
+        Assert.True(tracker.TryGetEngagement("lord1", out var engagement));
+        Assert.Equal(firstPlayer, engagement.EngagerKey);
+    }
+
+    [Fact]
+    public void TryBeginEngagement_WhileEngagedWithDifferentParty_Fails()
+    {
+        // First approval wins: a player's live engagement must not be superseded by a later request, whose
+        // approval could otherwise release the first party while its conversation is still opening.
+        tracker.TryBeginEngagement(firstPlayer, "player1", "lord1", wasAiDisabled: false);
+
+        var began = tracker.TryBeginEngagement(firstPlayer, "player1", "lord2", wasAiDisabled: false);
+
+        Assert.False(began);
+        Assert.True(tracker.TryGetEngagement("lord1", out _));
+        Assert.False(tracker.TryGetEngagement("lord2", out _));
+    }
+
+    [Fact]
+    public void TryBeginEngagement_AfterEndingPreviousEngagement_Succeeds()
+    {
+        tracker.TryBeginEngagement(firstPlayer, "player1", "lord1", wasAiDisabled: false);
+        tracker.TryEndEngagement(firstPlayer, out _, out _);
+
+        var began = tracker.TryBeginEngagement(firstPlayer, "player1", "lord2", wasAiDisabled: false);
+
+        Assert.True(began);
+        Assert.False(tracker.TryGetEngagement("lord1", out _));
+        Assert.True(tracker.TryGetEngagement("lord2", out _));
+    }
+
+    [Fact]
+    public void TryBeginEngagement_WhenSamePlayerReengagesSameParty_KeepsOriginalAiDisabledState()
+    {
+        tracker.TryBeginEngagement(firstPlayer, "player1", "lord1", wasAiDisabled: false);
+
+        // The refresh passes true because the party is disabled by the hold itself by now.
+        var began = tracker.TryBeginEngagement(firstPlayer, "player1", "lord1", wasAiDisabled: true);
+
+        Assert.True(began);
+        Assert.True(tracker.TryGetEngagement("lord1", out var engagement));
+        Assert.False(engagement.WasAiDisabled);
+    }
+
+    [Fact]
+    public void TryEndEngagement_WhenEngaged_ReturnsHeldParty()
+    {
+        tracker.TryBeginEngagement(firstPlayer, "player1", "lord1", wasAiDisabled: false);
+
+        var ended = tracker.TryEndEngagement(firstPlayer, out var partyId, out var engagement);
+
+        Assert.True(ended);
+        Assert.Equal("lord1", partyId);
+        Assert.False(engagement.WasAiDisabled);
+        Assert.False(tracker.TryGetEngagement("lord1", out _));
+    }
+
+    [Fact]
+    public void TryEndEngagement_WhenNotEngaged_Fails()
+    {
+        Assert.False(tracker.TryEndEngagement(firstPlayer, out _, out _));
+    }
+
+    [Fact]
+    public void TryEndEngagement_DoesNotAffectOtherPlayersEngagement()
+    {
+        tracker.TryBeginEngagement(firstPlayer, "player1", "lord1", wasAiDisabled: false);
+        tracker.TryBeginEngagement(secondPlayer, "player2", "lord2", wasAiDisabled: false);
+
+        tracker.TryEndEngagement(firstPlayer, out _, out _);
+
+        Assert.False(tracker.TryGetEngagement("lord1", out _));
+        Assert.True(tracker.TryGetEngagement("lord2", out _));
+        Assert.False(tracker.IsEmpty);
+    }
+
+    [Fact]
+    public void IsEngagedByOther_TrueOnlyForDifferentEngager()
+    {
+        tracker.TryBeginEngagement(firstPlayer, "player1", "lord1", wasAiDisabled: false);
+
+        Assert.False(tracker.IsEngagedByOther("lord1", firstPlayer));
+        Assert.True(tracker.IsEngagedByOther("lord1", secondPlayer));
+        Assert.False(tracker.IsEngagedByOther("lord2", secondPlayer));
+    }
+
+    [Fact]
+    public void IsEmpty_TracksEngagementLifecycle()
+    {
+        Assert.True(tracker.IsEmpty);
+
+        tracker.TryBeginEngagement(firstPlayer, "player1", "lord1", wasAiDisabled: false);
+        Assert.False(tracker.IsEmpty);
+
+        tracker.TryEndEngagement(firstPlayer, out _, out _);
+        Assert.True(tracker.IsEmpty);
+    }
+
+    [Fact]
+    public void TryBeginEngagement_WithNullPartyOrEngager_Fails()
+    {
+        Assert.False(tracker.TryBeginEngagement(firstPlayer, "player1", null, wasAiDisabled: false));
+        Assert.False(tracker.TryBeginEngagement(null, "player1", "lord1", wasAiDisabled: false));
+        Assert.True(tracker.IsEmpty);
+    }
+
+    [Fact]
+    public void Dispose_ReleasesAndClearsEngagements()
+    {
+        tracker.TryBeginEngagement(firstPlayer, "player1", "lord1", wasAiDisabled: false);
+
+        // With no object manager the release is a no-op, but the state must still be fully cleared.
+        tracker.Dispose();
+
+        Assert.True(tracker.IsEmpty);
+        Assert.False(tracker.TryGetEngagement("lord1", out _));
+    }
+}

--- a/source/GameInterface/Services/MapEvents/ConversationPartyHold.cs
+++ b/source/GameInterface/Services/MapEvents/ConversationPartyHold.cs
@@ -1,7 +1,5 @@
-using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Services.ObjectManager;
 using System;
-using TaleWorlds.CampaignSystem.Encounters;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.Library;
 
@@ -73,58 +71,6 @@ internal static class ConversationPartyHold
     }
 
     /// <summary>
-    /// [Server] Guard for the host's encounter restart: false when the targeted AI party is already in a
-    /// conversation with another player, so the restart must not run.
-    /// </summary>
-    public static bool CanHostRestartEncounter(PartyBase attackerParty, PartyBase defenderParty)
-    {
-        var tracker = ConversationPartyTracker.Instance;
-        if (tracker == null || tracker.IsEmpty) return true;
-
-        var aiParty = GetAiMobileSide(attackerParty, defenderParty);
-        if (aiParty == null) return true;
-
-        // Battle flow: an engagement outlives a conversation that escalated into a battle (it is released at the
-        // engager's encounter finish), and battle-related restarts must keep running for such parties.
-        if (aiParty.MapEvent != null) return true;
-
-        var objectManager = tracker.ObjectManager;
-        if (objectManager == null) return true;
-        if (!objectManager.TryGetId(aiParty.Party, out var partyId)) return true;
-
-        return !tracker.IsEngagedByOther(partyId, ConversationPartyTracker.HostEngagerKey);
-    }
-
-    /// <summary>
-    /// [Server] Marks and holds the AI party of the host's freshly (re)started encounter. Runs after the restart so
-    /// the restart's internal <c>PlayerEncounter.Finish</c> (which releases the previous engagement) cannot undo it.
-    /// </summary>
-    public static void EngageHostEncounteredParty()
-    {
-        var tracker = ConversationPartyTracker.Instance;
-        if (tracker == null) return;
-
-        var party = PlayerEncounter.EncounteredMobileParty;
-        if (party == null || party.IsPlayerParty()) return;
-
-        // Battle flow: the map-event rules take over once the party is in a battle.
-        if (party.MapEvent != null) return;
-
-        var objectManager = tracker.ObjectManager;
-        if (objectManager == null) return;
-        if (!objectManager.TryGetId(party.Party, out var partyId)) return;
-        if (!objectManager.TryGetId(PartyBase.MainParty, out var hostPartyId)) return;
-
-        TryEngage(tracker, ConversationPartyTracker.HostEngagerKey, hostPartyId, party, partyId);
-    }
-
-    /// <summary>[Server] Releases the AI party held for the host's conversation, if any.</summary>
-    public static void EndHostEngagement()
-    {
-        EndEngagement(ConversationPartyTracker.Instance, ConversationPartyTracker.HostEngagerKey);
-    }
-
-    /// <summary>
     /// [Server] True when the target party is held in a player's conversation and the interacting party is not the
     /// engaging player's own party, so the map interaction must be blocked.
     /// </summary>
@@ -181,17 +127,5 @@ internal static class ConversationPartyHold
 
         ai.EnableAi();
         ai.RethinkAtNextHourlyTick = true;
-    }
-
-    /// <summary>The non-player mobile side of an encounter, or null when there is none (e.g. a settlement side).</summary>
-    private static MobileParty GetAiMobileSide(PartyBase attackerParty, PartyBase defenderParty)
-    {
-        var attackerMobile = attackerParty?.MobileParty;
-        if (attackerMobile != null && !attackerMobile.IsPlayerParty()) return attackerMobile;
-
-        var defenderMobile = defenderParty?.MobileParty;
-        if (defenderMobile != null && !defenderMobile.IsPlayerParty()) return defenderMobile;
-
-        return null;
     }
 }

--- a/source/GameInterface/Services/MapEvents/ConversationPartyHold.cs
+++ b/source/GameInterface/Services/MapEvents/ConversationPartyHold.cs
@@ -1,0 +1,197 @@
+using GameInterface.Services.MobileParties.Extensions;
+using GameInterface.Services.ObjectManager;
+using System;
+using TaleWorlds.CampaignSystem.Encounters;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.Library;
+
+namespace GameInterface.Services.MapEvents;
+
+/// <summary>
+/// Applies and reverts the server-side hold on an AI party that is in a conversation/encounter with a player,
+/// keeping the bookkeeping in <see cref="ConversationPartyTracker"/> and the party's AI state in step.
+/// </summary>
+/// <remarks>
+/// Holding stops the party's current movement (<see cref="MobileParty.SetMoveModeHold"/>) and freezes its decision
+/// making (<see cref="MobilePartyAi.DisableAi"/>) so it stays in place while campaign time keeps running for the
+/// other players. <c>MobilePartyAi._isDisabled</c> is dynamically synced, so clients see the held state too. A
+/// party whose AI was already disabled (e.g. by a quest) is tracked but left untouched. All methods must run on
+/// the game's main thread.
+/// </remarks>
+internal static class ConversationPartyHold
+{
+    private static readonly TimeSpan BlockedMessageCooldown = TimeSpan.FromSeconds(5);
+
+    private static DateTime lastBlockedMessageUtc = DateTime.MinValue;
+
+    /// <summary>
+    /// Shows the local player why their interaction with an engaged party did nothing, at most once per cooldown
+    /// so the per-frame blocked checks do not flood the message log. Must run on the game's main thread.
+    /// </summary>
+    public static void ShowInteractionBlockedMessage()
+    {
+        var now = DateTime.UtcNow;
+        if (now - lastBlockedMessageUtc < BlockedMessageCooldown) return;
+        lastBlockedMessageUtc = now;
+
+        InformationManager.DisplayMessage(new InformationMessage(
+            "You cannot interact with the party while another player is interacting with it"));
+    }
+
+    /// <summary>
+    /// Marks the party as engaged by the given player and holds it in place. Fails when another player already
+    /// engages the party, or when this player still holds an engagement with a different party (first approval
+    /// wins; that hold is released when its conversation ends).
+    /// </summary>
+    public static bool TryEngage(ConversationPartyTracker tracker, object engagerKey, string engagerPartyId, MobileParty party, string partyId)
+    {
+        if (tracker == null || party == null) return false;
+
+        var wasAiDisabled = party.Ai?.IsDisabled != false;
+
+        if (!tracker.TryBeginEngagement(engagerKey, engagerPartyId, partyId, wasAiDisabled))
+            return false;
+
+        if (!wasAiDisabled)
+        {
+            party.SetMoveModeHold();
+            party.Ai.DisableAi();
+        }
+
+        return true;
+    }
+
+    /// <summary>Ends the given player's engagement and releases the held party, if any.</summary>
+    public static void EndEngagement(ConversationPartyTracker tracker, object engagerKey)
+    {
+        if (tracker == null) return;
+
+        if (!tracker.TryEndEngagement(engagerKey, out var partyId, out var engagement))
+            return;
+
+        ReleaseParty(tracker.ObjectManager, partyId, engagement.WasAiDisabled);
+    }
+
+    /// <summary>
+    /// [Server] Guard for the host's encounter restart: false when the targeted AI party is already in a
+    /// conversation with another player, so the restart must not run.
+    /// </summary>
+    public static bool CanHostRestartEncounter(PartyBase attackerParty, PartyBase defenderParty)
+    {
+        var tracker = ConversationPartyTracker.Instance;
+        if (tracker == null || tracker.IsEmpty) return true;
+
+        var aiParty = GetAiMobileSide(attackerParty, defenderParty);
+        if (aiParty == null) return true;
+
+        // Battle flow: an engagement outlives a conversation that escalated into a battle (it is released at the
+        // engager's encounter finish), and battle-related restarts must keep running for such parties.
+        if (aiParty.MapEvent != null) return true;
+
+        var objectManager = tracker.ObjectManager;
+        if (objectManager == null) return true;
+        if (!objectManager.TryGetId(aiParty.Party, out var partyId)) return true;
+
+        return !tracker.IsEngagedByOther(partyId, ConversationPartyTracker.HostEngagerKey);
+    }
+
+    /// <summary>
+    /// [Server] Marks and holds the AI party of the host's freshly (re)started encounter. Runs after the restart so
+    /// the restart's internal <c>PlayerEncounter.Finish</c> (which releases the previous engagement) cannot undo it.
+    /// </summary>
+    public static void EngageHostEncounteredParty()
+    {
+        var tracker = ConversationPartyTracker.Instance;
+        if (tracker == null) return;
+
+        var party = PlayerEncounter.EncounteredMobileParty;
+        if (party == null || party.IsPlayerParty()) return;
+
+        // Battle flow: the map-event rules take over once the party is in a battle.
+        if (party.MapEvent != null) return;
+
+        var objectManager = tracker.ObjectManager;
+        if (objectManager == null) return;
+        if (!objectManager.TryGetId(party.Party, out var partyId)) return;
+        if (!objectManager.TryGetId(PartyBase.MainParty, out var hostPartyId)) return;
+
+        TryEngage(tracker, ConversationPartyTracker.HostEngagerKey, hostPartyId, party, partyId);
+    }
+
+    /// <summary>[Server] Releases the AI party held for the host's conversation, if any.</summary>
+    public static void EndHostEngagement()
+    {
+        EndEngagement(ConversationPartyTracker.Instance, ConversationPartyTracker.HostEngagerKey);
+    }
+
+    /// <summary>
+    /// [Server] True when the target party is held in a player's conversation and the interacting party is not the
+    /// engaging player's own party, so the map interaction must be blocked.
+    /// </summary>
+    public static bool IsInteractionBlocked(PartyBase targetParty, MobileParty interactor)
+    {
+        var tracker = ConversationPartyTracker.Instance;
+        if (tracker == null || tracker.IsEmpty) return false;
+
+        var targetMobileParty = targetParty?.MobileParty;
+        if (targetMobileParty == null || targetMobileParty.MapEvent != null) return false;
+
+        var objectManager = tracker.ObjectManager;
+        if (objectManager == null) return false;
+        if (!objectManager.TryGetId(targetParty, out var targetPartyId)) return false;
+        if (!tracker.TryGetEngagement(targetPartyId, out var engagement)) return false;
+
+        if (interactor?.Party != null
+            && objectManager.TryGetId(interactor.Party, out var interactorId)
+            && interactorId == engagement.EngagerPartyId)
+            return false;
+
+        return true;
+    }
+
+    /// <summary>True when the party is held in a player's conversation (and not already in a battle).</summary>
+    public static bool IsInPlayerConversation(MobileParty party)
+    {
+        var tracker = ConversationPartyTracker.Instance;
+        if (tracker == null || tracker.IsEmpty) return false;
+
+        if (party?.Party == null || party.MapEvent != null) return false;
+
+        var objectManager = tracker.ObjectManager;
+        if (objectManager == null) return false;
+        if (!objectManager.TryGetId(party.Party, out var partyId)) return false;
+
+        return tracker.TryGetEngagement(partyId, out _);
+    }
+
+    /// <summary>
+    /// Reverts a hold so the party resumes normal AI at its next behavior re-evaluation. Called on engagement end
+    /// and by <see cref="ConversationPartyTracker.Dispose"/> for holds that outlive the session.
+    /// </summary>
+    public static void ReleaseParty(IObjectManager objectManager, string partyId, bool wasAiDisabled)
+    {
+        if (wasAiDisabled) return;
+        if (objectManager == null) return;
+
+        // The party may no longer resolve, e.g. it was destroyed in a battle the conversation escalated into.
+        if (!objectManager.TryGetObject(partyId, out PartyBase partyBase)) return;
+
+        var ai = partyBase.MobileParty?.Ai;
+        if (ai == null) return;
+
+        ai.EnableAi();
+        ai.RethinkAtNextHourlyTick = true;
+    }
+
+    /// <summary>The non-player mobile side of an encounter, or null when there is none (e.g. a settlement side).</summary>
+    private static MobileParty GetAiMobileSide(PartyBase attackerParty, PartyBase defenderParty)
+    {
+        var attackerMobile = attackerParty?.MobileParty;
+        if (attackerMobile != null && !attackerMobile.IsPlayerParty()) return attackerMobile;
+
+        var defenderMobile = defenderParty?.MobileParty;
+        if (defenderMobile != null && !defenderMobile.IsPlayerParty()) return defenderMobile;
+
+        return null;
+    }
+}

--- a/source/GameInterface/Services/MapEvents/ConversationPartyTracker.cs
+++ b/source/GameInterface/Services/MapEvents/ConversationPartyTracker.cs
@@ -1,0 +1,169 @@
+using Common.Messaging;
+using GameInterface.Services.ObjectManager;
+using System.Collections.Generic;
+
+namespace GameInterface.Services.MapEvents;
+
+/// <summary>
+/// Server-side registry of AI parties currently held in a conversation/encounter with a player.
+/// </summary>
+/// <remarks>
+/// In single player the campaign pauses during a conversation, which is what keeps the talked-to party in place and
+/// unattackable. Co-op keeps campaign time running, so while a player's encounter with an AI party is open the
+/// server records an engagement here. The conversation approval flow and the interaction/AI-attack guards consult
+/// the registry so no other player or AI party can interact with the engaged party, and
+/// <see cref="ConversationPartyHold"/> reverts the hold when the engagement ends. Engagements are keyed per player -
+/// the requesting client's <see cref="LiteNetLib.NetPeer"/>, or <see cref="HostEngagerKey"/> for the host - so each
+/// player holds at most one engagement at a time.
+/// Aside from <see cref="Dispose"/> - which releases any leftover holds so a campaign that outlives the co-op
+/// session is not left with permanently frozen parties - this class is pure bookkeeping, so it is unit-testable
+/// without the game.
+/// </remarks>
+internal sealed class ConversationPartyTracker : IHandler
+{
+    /// <summary>
+    /// DI-wired instance, statically accessible so (static) Harmony patches can reach it. Set on construction by
+    /// the auto-activated handler registration.
+    /// </summary>
+    internal static ConversationPartyTracker Instance { get; private set; }
+
+    /// <summary>Engager key representing the host player; clients are keyed by their <see cref="LiteNetLib.NetPeer"/>.</summary>
+    internal static readonly object HostEngagerKey = new object();
+
+    private readonly object stateLock = new object();
+    private readonly Dictionary<string, Engagement> engagementsByPartyId = new Dictionary<string, Engagement>();
+    private readonly Dictionary<object, string> partyIdsByEngager = new Dictionary<object, string>();
+
+    private volatile bool isEmpty = true;
+
+    /// <summary>Lock-free fast path for per-frame guards: true when no engagements exist.</summary>
+    public bool IsEmpty => isEmpty;
+
+    /// <summary>
+    /// Object manager shared with the engagement guards, so per-frame checks reuse the DI-wired instance instead
+    /// of resolving it from the container on every call. The tracker itself never uses it.
+    /// </summary>
+    internal IObjectManager ObjectManager { get; }
+
+    public ConversationPartyTracker(IObjectManager objectManager)
+    {
+        ObjectManager = objectManager;
+        Instance = this;
+    }
+
+    public void Dispose()
+    {
+        List<KeyValuePair<string, Engagement>> leftovers;
+        lock (stateLock)
+        {
+            leftovers = new List<KeyValuePair<string, Engagement>>(engagementsByPartyId);
+            engagementsByPartyId.Clear();
+            partyIdsByEngager.Clear();
+            isEmpty = true;
+        }
+
+        // The campaign can outlive this co-op session (the container is disposed on leaving the mode while the
+        // game stays loaded), and MobilePartyAi._isDisabled is a saveable field that vanilla never re-enables on
+        // its own - so any party still held here must be released now or it stays frozen forever.
+        foreach (var leftover in leftovers)
+            ConversationPartyHold.ReleaseParty(ObjectManager, leftover.Key, leftover.Value.WasAiDisabled);
+
+        if (Instance == this) Instance = null;
+    }
+
+    /// <summary>A single player's engagement of an AI party.</summary>
+    public readonly struct Engagement
+    {
+        /// <summary>Key of the engaging player (<see cref="LiteNetLib.NetPeer"/> or <see cref="HostEngagerKey"/>).</summary>
+        public readonly object EngagerKey;
+
+        /// <summary>Id of the engaging player's party; interactions from that party stay allowed.</summary>
+        public readonly string EngagerPartyId;
+
+        /// <summary>Whether the party's AI was already disabled before the hold, so release preserves that state.</summary>
+        public readonly bool WasAiDisabled;
+
+        public Engagement(object engagerKey, string engagerPartyId, bool wasAiDisabled)
+        {
+            EngagerKey = engagerKey;
+            EngagerPartyId = engagerPartyId;
+            WasAiDisabled = wasAiDisabled;
+        }
+    }
+
+    /// <summary>
+    /// Begins (or refreshes) <paramref name="engagerKey"/>'s engagement of the given party. Fails when another
+    /// player currently engages that party, or when this player still has a live engagement with a different
+    /// party: a new conversation must not supersede one whose approval may still be in flight (first approval
+    /// wins; the old hold is released when that conversation ends). Re-engaging the same party keeps the
+    /// originally recorded <see cref="Engagement.WasAiDisabled"/>.
+    /// </summary>
+    public bool TryBeginEngagement(object engagerKey, string engagerPartyId, string partyId, bool wasAiDisabled)
+    {
+        if (engagerKey == null || partyId == null) return false;
+
+        lock (stateLock)
+        {
+            if (engagementsByPartyId.TryGetValue(partyId, out var existing) && !Equals(existing.EngagerKey, engagerKey))
+                return false;
+
+            if (partyIdsByEngager.TryGetValue(engagerKey, out var currentPartyId))
+            {
+                // Same party: refresh, keeping the original engagement (and its WasAiDisabled).
+                return currentPartyId == partyId;
+            }
+
+            engagementsByPartyId[partyId] = new Engagement(engagerKey, engagerPartyId, wasAiDisabled);
+            partyIdsByEngager[engagerKey] = partyId;
+            isEmpty = false;
+            return true;
+        }
+    }
+
+    /// <summary>Ends <paramref name="engagerKey"/>'s engagement, returning the engaged party for release.</summary>
+    public bool TryEndEngagement(object engagerKey, out string partyId, out Engagement engagement)
+    {
+        partyId = null;
+        engagement = default;
+
+        if (engagerKey == null) return false;
+
+        lock (stateLock)
+        {
+            if (!partyIdsByEngager.TryGetValue(engagerKey, out partyId))
+                return false;
+
+            partyIdsByEngager.Remove(engagerKey);
+
+            if (engagementsByPartyId.TryGetValue(partyId, out engagement))
+                engagementsByPartyId.Remove(partyId);
+
+            isEmpty = engagementsByPartyId.Count == 0;
+            return true;
+        }
+    }
+
+    /// <summary>Gets the engagement holding the given party, if any.</summary>
+    public bool TryGetEngagement(string partyId, out Engagement engagement)
+    {
+        engagement = default;
+
+        if (partyId == null) return false;
+
+        lock (stateLock)
+        {
+            return engagementsByPartyId.TryGetValue(partyId, out engagement);
+        }
+    }
+
+    /// <summary>True when the party is engaged by a player other than <paramref name="engagerKey"/>.</summary>
+    public bool IsEngagedByOther(string partyId, object engagerKey)
+    {
+        if (partyId == null) return false;
+
+        lock (stateLock)
+        {
+            return engagementsByPartyId.TryGetValue(partyId, out var engagement) && !Equals(engagement.EngagerKey, engagerKey);
+        }
+    }
+}

--- a/source/GameInterface/Services/MapEvents/ConversationPartyTracker.cs
+++ b/source/GameInterface/Services/MapEvents/ConversationPartyTracker.cs
@@ -12,9 +12,8 @@ namespace GameInterface.Services.MapEvents;
 /// unattackable. Co-op keeps campaign time running, so while a player's encounter with an AI party is open the
 /// server records an engagement here. The conversation approval flow and the interaction/AI-attack guards consult
 /// the registry so no other player or AI party can interact with the engaged party, and
-/// <see cref="ConversationPartyHold"/> reverts the hold when the engagement ends. Engagements are keyed per player -
-/// the requesting client's <see cref="LiteNetLib.NetPeer"/>, or <see cref="HostEngagerKey"/> for the host - so each
-/// player holds at most one engagement at a time.
+/// <see cref="ConversationPartyHold"/> reverts the hold when the engagement ends. Engagements are keyed per player by
+/// the requesting client's <see cref="LiteNetLib.NetPeer"/>, so each player holds at most one engagement at a time.
 /// Aside from <see cref="Dispose"/> - which releases any leftover holds so a campaign that outlives the co-op
 /// session is not left with permanently frozen parties - this class is pure bookkeeping, so it is unit-testable
 /// without the game.
@@ -26,9 +25,6 @@ internal sealed class ConversationPartyTracker : IHandler
     /// the auto-activated handler registration.
     /// </summary>
     internal static ConversationPartyTracker Instance { get; private set; }
-
-    /// <summary>Engager key representing the host player; clients are keyed by their <see cref="LiteNetLib.NetPeer"/>.</summary>
-    internal static readonly object HostEngagerKey = new object();
 
     private readonly object stateLock = new object();
     private readonly Dictionary<string, Engagement> engagementsByPartyId = new Dictionary<string, Engagement>();
@@ -74,7 +70,7 @@ internal sealed class ConversationPartyTracker : IHandler
     /// <summary>A single player's engagement of an AI party.</summary>
     public readonly struct Engagement
     {
-        /// <summary>Key of the engaging player (<see cref="LiteNetLib.NetPeer"/> or <see cref="HostEngagerKey"/>).</summary>
+        /// <summary>Key of the engaging player (the requesting client's <see cref="LiteNetLib.NetPeer"/>).</summary>
         public readonly object EngagerKey;
 
         /// <summary>Id of the engaging player's party; interactions from that party stay allowed.</summary>

--- a/source/GameInterface/Services/MapEvents/Handlers/ConversationRequestHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/ConversationRequestHandler.cs
@@ -2,6 +2,7 @@ using Common;
 using Common.Logging;
 using Common.Messaging;
 using Common.Network;
+using Common.Network.Messages;
 using Common.Util;
 using GameInterface.Services.MapEvents.Messages.Conversation;
 using GameInterface.Services.MobileParties.Extensions;
@@ -27,6 +28,9 @@ namespace GameInterface.Services.MapEvents.Handlers;
 /// both parties are players or either party is already in a <see cref="TaleWorlds.CampaignSystem.MapEvents.MapEvent"/>.
 /// Client (on approval): re-runs <c>PlayerEncounter.RestartPlayerEncounter</c> with the same parameters under an
 /// <see cref="AllowedThread"/> so the now-approved original executes.
+/// Server (additionally): while a player's conversation is open, the AI party is held in place and marked engaged
+/// in <see cref="ConversationPartyTracker"/> (requests against it from other players are rejected); the hold is
+/// released when the client reports the encounter finished, fails to start it, or disconnects.
 /// </remarks>
 internal class ConversationRequestHandler : IHandler
 {
@@ -37,21 +41,28 @@ internal class ConversationRequestHandler : IHandler
     private readonly IMessageBroker messageBroker;
     private readonly INetwork network;
     private readonly IObjectManager objectManager;
+    private readonly ConversationPartyTracker conversationPartyTracker;
 
     private DateTime lastRequestSentUtc = DateTime.MinValue;
 
     public ConversationRequestHandler(
         IMessageBroker messageBroker,
         INetwork network,
-        IObjectManager objectManager)
+        IObjectManager objectManager,
+        ConversationPartyTracker conversationPartyTracker)
     {
         this.messageBroker = messageBroker;
         this.network = network;
         this.objectManager = objectManager;
+        this.conversationPartyTracker = conversationPartyTracker;
 
         messageBroker.Subscribe<ConversationRequested>(Handle_ConversationRequested);
         messageBroker.Subscribe<NetworkRequestConversation>(Handle_NetworkRequestConversation);
         messageBroker.Subscribe<NetworkAllowConversation>(Handle_NetworkAllowConversation);
+        messageBroker.Subscribe<ConversationEnded>(Handle_ConversationEnded);
+        messageBroker.Subscribe<NetworkConversationEnded>(Handle_NetworkConversationEnded);
+        messageBroker.Subscribe<NetworkConversationDenied>(Handle_NetworkConversationDenied);
+        messageBroker.Subscribe<PlayerDisconnected>(Handle_PlayerDisconnected);
     }
 
     public void Dispose()
@@ -59,6 +70,10 @@ internal class ConversationRequestHandler : IHandler
         messageBroker.Unsubscribe<ConversationRequested>(Handle_ConversationRequested);
         messageBroker.Unsubscribe<NetworkRequestConversation>(Handle_NetworkRequestConversation);
         messageBroker.Unsubscribe<NetworkAllowConversation>(Handle_NetworkAllowConversation);
+        messageBroker.Unsubscribe<ConversationEnded>(Handle_ConversationEnded);
+        messageBroker.Unsubscribe<NetworkConversationEnded>(Handle_NetworkConversationEnded);
+        messageBroker.Unsubscribe<NetworkConversationDenied>(Handle_NetworkConversationDenied);
+        messageBroker.Unsubscribe<PlayerDisconnected>(Handle_PlayerDisconnected);
     }
 
     /// <summary>[Client] Rate-limit, resolve ids, and forward the request to the server.</summary>
@@ -115,11 +130,76 @@ internal class ConversationRequestHandler : IHandler
             return;
         }
 
+        // Identify the AI side; the requester's own party is the player side (player-player was rejected above).
+        var attackerIsPlayer = attacker.MobileParty?.IsPlayerParty() == true;
+        var aiParty = (attackerIsPlayer ? defender : attacker).MobileParty;
+        var aiPartyId = attackerIsPlayer ? request.DefenderId : request.AttackerId;
+        var playerPartyId = attackerIsPlayer ? request.AttackerId : request.DefenderId;
+
+        if (aiParty != null && conversationPartyTracker.IsEngagedByOther(aiPartyId, requestingPeer))
+        {
+            Logger.Debug(
+                "Rejecting conversation request: the party is in a conversation with another player. PartyId={PartyId}",
+                aiPartyId);
+            network.Send(requestingPeer, new NetworkConversationDenied());
+            return;
+        }
+
         Logger.Debug(
             "Allowing conversation. AttackerId={AttackerId}, DefenderId={DefenderId}",
             request.AttackerId, request.DefenderId);
 
-        network.Send(requestingPeer, new NetworkAllowConversation(request.DefenderId, request.AttackerId, request.ForcePlayerOutFromSettlement, request.Source));
+        if (aiParty == null)
+        {
+            // No AI mobile party involved (e.g. a settlement side); nothing to hold.
+            network.Send(requestingPeer, new NetworkAllowConversation(request.DefenderId, request.AttackerId, request.ForcePlayerOutFromSettlement, request.Source));
+            return;
+        }
+
+        // Mark and hold on the game thread, then reply, so the party is frozen and protected before the client
+        // (re)opens the encounter. The checks above are only an early filter: game state can change while the
+        // approval is queued, so the game thread re-validates everything it depends on.
+        GameLoopRunner.RunOnMainThread(() =>
+        {
+            // Re-resolve on the game thread: either party may have been removed since the network-thread lookup.
+            if (!objectManager.TryGetObject(aiPartyId, out PartyBase aiPartyBase) || aiPartyBase.MobileParty == null)
+            {
+                Logger.Debug(
+                    "Rejecting conversation request: the party no longer resolves. PartyId={PartyId}",
+                    aiPartyId);
+                return;
+            }
+
+            if (!objectManager.TryGetObject(playerPartyId, out PartyBase playerPartyBase))
+            {
+                Logger.Debug(
+                    "Rejecting conversation request: the player party no longer resolves. PartyId={PartyId}",
+                    playerPartyId);
+                return;
+            }
+
+            // Re-check map events: a party may have entered a battle while the approval was queued.
+            if (aiPartyBase.MapEvent != null || playerPartyBase.MapEvent != null)
+            {
+                Logger.Debug(
+                    "Rejecting conversation request: a party entered a map event while approving. AttackerId={AttackerId}, DefenderId={DefenderId}",
+                    request.AttackerId, request.DefenderId);
+                return;
+            }
+
+            // Re-check the engagement: another player may have engaged the party meanwhile, or the requester may
+            // still hold an unfinished engagement with a different party (first approval wins).
+            if (!ConversationPartyHold.TryEngage(conversationPartyTracker, requestingPeer, playerPartyId, aiPartyBase.MobileParty, aiPartyId))
+            {
+                Logger.Debug(
+                    "Rejecting conversation request: the party or the requester is already engaged. PartyId={PartyId}",
+                    aiPartyId);
+                network.Send(requestingPeer, new NetworkConversationDenied());
+                return;
+            }
+
+            network.Send(requestingPeer, new NetworkAllowConversation(request.DefenderId, request.AttackerId, request.ForcePlayerOutFromSettlement, request.Source));
+        });
     }
 
     /// <summary>[Client] Server approved: re-run RestartPlayerEncounter with the same parameters.</summary>
@@ -127,12 +207,31 @@ internal class ConversationRequestHandler : IHandler
     {
         var message = payload.What;
 
-        if (!objectManager.TryGetObjectWithLogging<PartyBase>(message.DefenderId, out var defender)) return;
-        if (!objectManager.TryGetObjectWithLogging<PartyBase>(message.AttackerId, out var attacker)) return;
+        if (!objectManager.TryGetObjectWithLogging<PartyBase>(message.DefenderId, out var defender))
+        {
+            SendConversationEndedToServer();
+            return;
+        }
+
+        if (!objectManager.TryGetObjectWithLogging<PartyBase>(message.AttackerId, out var attacker))
+        {
+            SendConversationEndedToServer();
+            return;
+        }
 
         if (PlayerEncounter.Current != null)
         {
+            // A duplicate approval for the encounter that is already open (the rate-limited request was retried
+            // while the first approval was in flight): ignore it. Sending ConversationEnded here would release
+            // the server-side hold while the conversation is still active.
+            if (PlayerEncounter.EncounteredParty == defender || PlayerEncounter.EncounteredParty == attacker)
+            {
+                Logger.Debug("Ignoring duplicate conversation approval for the already-open encounter");
+                return;
+            }
+
             Logger.Warning("Conversation allowed but PlayerEncounter.Current is not null; cannot restart encounter");
+            SendConversationEndedToServer();
             return;
         }
 
@@ -148,5 +247,58 @@ internal class ConversationRequestHandler : IHandler
                 PlayerEncounter.RestartPlayerEncounter(defender, attacker, message.ForcePlayerOutFromSettlement);
             }
         }
+    }
+
+    /// <summary>[Client] This player's encounter finished; tell the server to release the held party.</summary>
+    private void Handle_ConversationEnded(MessagePayload<ConversationEnded> payload)
+    {
+        SendConversationEndedToServer();
+    }
+
+    /// <summary>
+    /// [Client] Tell the server this player's conversation is over (the encounter finished, or an approved one
+    /// failed to start), so it releases the held party.
+    /// </summary>
+    private void SendConversationEndedToServer()
+    {
+        // On a client, SendAll targets the server (its only connected peer).
+        network.SendAll(new NetworkConversationEnded());
+    }
+
+    /// <summary>[Server] A client's encounter finished: release the AI party held for that player, if any.</summary>
+    private void Handle_NetworkConversationEnded(MessagePayload<NetworkConversationEnded> payload)
+    {
+        if (!ModInformation.IsServer) return;
+
+        if (!(payload.Who is NetPeer peer))
+        {
+            Logger.Error("Received {Message} with no originating peer", nameof(NetworkConversationEnded));
+            return;
+        }
+
+        ReleaseEngagementOnMainThread(peer);
+    }
+
+    /// <summary>[Client] The server denied the request because the party is engaged; tell the player why.</summary>
+    private void Handle_NetworkConversationDenied(MessagePayload<NetworkConversationDenied> payload)
+    {
+        if (ModInformation.IsServer) return;
+
+        GameLoopRunner.RunOnMainThread(ConversationPartyHold.ShowInteractionBlockedMessage);
+    }
+
+    /// <summary>[Server] A player disconnected: release the AI party held for them, if any.</summary>
+    private void Handle_PlayerDisconnected(MessagePayload<PlayerDisconnected> payload)
+    {
+        if (!ModInformation.IsServer) return;
+
+        ReleaseEngagementOnMainThread(payload.What.PlayerId);
+    }
+
+    /// <summary>[Server] Releases the given player's engagement on the game thread.</summary>
+    private void ReleaseEngagementOnMainThread(NetPeer peer)
+    {
+        GameLoopRunner.RunOnMainThread(() =>
+            ConversationPartyHold.EndEngagement(conversationPartyTracker, peer));
     }
 }

--- a/source/GameInterface/Services/MapEvents/Handlers/ConversationRequestHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/ConversationRequestHandler.cs
@@ -112,13 +112,51 @@ internal class ConversationRequestHandler : IHandler
         if (!objectManager.TryGetObjectWithLogging<PartyBase>(request.AttackerId, out var attacker)) return;
         if (!objectManager.TryGetObjectWithLogging<PartyBase>(request.DefenderId, out var defender)) return;
 
+        if (!TryAcceptConversationRequest(requestingPeer, request, attacker, defender, out var aiParty, out var aiPartyId, out var playerPartyId))
+            return;
+
+        if (aiParty == null)
+        {
+            // No AI mobile party involved (e.g. a settlement side); nothing to hold.
+            SendAllowConversation(requestingPeer, request);
+            return;
+        }
+
+        // Mark and hold on the game thread, then reply, so the party is frozen and protected before the client
+        // (re)opens the encounter. The filter above runs on the network thread; game state can change while the
+        // approval is queued, so the hold step re-validates everything it depends on.
+        GameLoopRunner.RunOnMainThread(() => HoldAndApprove(requestingPeer, request, aiPartyId, playerPartyId));
+    }
+
+    /// <summary>
+    /// [Server] Network-thread filter that rejects when both parties are players or either is already in a battle,
+    /// and identifies the AI side. Returns false (rejection logged, and the requester told when the party is engaged
+    /// by another player) when the request must not proceed. On success <paramref name="aiParty"/> is the AI mobile
+    /// party to hold, or null when only a settlement side is involved (allow, but nothing to hold).
+    /// </summary>
+    private bool TryAcceptConversationRequest(
+        NetPeer requestingPeer,
+        NetworkRequestConversation request,
+        PartyBase attacker,
+        PartyBase defender,
+        out MobileParty aiParty,
+        out string aiPartyId,
+        out string playerPartyId)
+    {
+        aiParty = null;
+        aiPartyId = null;
+        playerPartyId = null;
+
+        var attackerIsPlayer = attacker.MobileParty?.IsPlayerParty() == true;
+        var defenderIsPlayer = defender.MobileParty?.IsPlayerParty() == true;
+
         // Reject: a conversation between two human players is not driven through PlayerEncounter.Init.
-        if (attacker.MobileParty?.IsPlayerParty() == true && defender.MobileParty?.IsPlayerParty() == true)
+        if (attackerIsPlayer && defenderIsPlayer)
         {
             Logger.Debug(
                 "Rejecting conversation request: both parties are players. AttackerId={AttackerId}, DefenderId={DefenderId}",
                 request.AttackerId, request.DefenderId);
-            return;
+            return false;
         }
 
         // Reject: a party already in a battle must not (re)open an encounter conversation.
@@ -127,14 +165,25 @@ internal class ConversationRequestHandler : IHandler
             Logger.Debug(
                 "Rejecting conversation request: a party is already in a map event. AttackerId={AttackerId}, DefenderId={DefenderId}",
                 request.AttackerId, request.DefenderId);
-            return;
+            return false;
         }
 
         // Identify the AI side; the requester's own party is the player side (player-player was rejected above).
-        var attackerIsPlayer = attacker.MobileParty?.IsPlayerParty() == true;
-        var aiParty = (attackerIsPlayer ? defender : attacker).MobileParty;
-        var aiPartyId = attackerIsPlayer ? request.DefenderId : request.AttackerId;
-        var playerPartyId = attackerIsPlayer ? request.AttackerId : request.DefenderId;
+        PartyBase aiSide;
+        if (attackerIsPlayer)
+        {
+            aiSide = defender;
+            aiPartyId = request.DefenderId;
+            playerPartyId = request.AttackerId;
+        }
+        else
+        {
+            aiSide = attacker;
+            aiPartyId = request.AttackerId;
+            playerPartyId = request.DefenderId;
+        }
+
+        aiParty = aiSide.MobileParty;
 
         if (aiParty != null && conversationPartyTracker.IsEngagedByOther(aiPartyId, requestingPeer))
         {
@@ -142,64 +191,67 @@ internal class ConversationRequestHandler : IHandler
                 "Rejecting conversation request: the party is in a conversation with another player. PartyId={PartyId}",
                 aiPartyId);
             network.Send(requestingPeer, new NetworkConversationDenied());
-            return;
+            return false;
         }
 
         Logger.Debug(
             "Allowing conversation. AttackerId={AttackerId}, DefenderId={DefenderId}",
             request.AttackerId, request.DefenderId);
 
-        if (aiParty == null)
+        return true;
+    }
+
+    /// <summary>
+    /// [Server, game thread] Re-validate (state can change while the approval is queued), hold the AI party, and
+    /// reply to allow. Stays silent (rejecting) when a party no longer resolves or entered a battle meanwhile, and
+    /// tells the requester when the party or the requester became engaged in the interim (first approval wins).
+    /// </summary>
+    private void HoldAndApprove(NetPeer requestingPeer, NetworkRequestConversation request, string aiPartyId, string playerPartyId)
+    {
+        // Re-resolve on the game thread: either party may have been removed since the network-thread lookup.
+        if (!objectManager.TryGetObject(aiPartyId, out PartyBase aiPartyBase) || aiPartyBase.MobileParty == null)
         {
-            // No AI mobile party involved (e.g. a settlement side); nothing to hold.
-            network.Send(requestingPeer, new NetworkAllowConversation(request.DefenderId, request.AttackerId, request.ForcePlayerOutFromSettlement, request.Source));
+            Logger.Debug(
+                "Rejecting conversation request: the party no longer resolves. PartyId={PartyId}",
+                aiPartyId);
             return;
         }
 
-        // Mark and hold on the game thread, then reply, so the party is frozen and protected before the client
-        // (re)opens the encounter. The checks above are only an early filter: game state can change while the
-        // approval is queued, so the game thread re-validates everything it depends on.
-        GameLoopRunner.RunOnMainThread(() =>
+        if (!objectManager.TryGetObject(playerPartyId, out PartyBase playerPartyBase))
         {
-            // Re-resolve on the game thread: either party may have been removed since the network-thread lookup.
-            if (!objectManager.TryGetObject(aiPartyId, out PartyBase aiPartyBase) || aiPartyBase.MobileParty == null)
-            {
-                Logger.Debug(
-                    "Rejecting conversation request: the party no longer resolves. PartyId={PartyId}",
-                    aiPartyId);
-                return;
-            }
+            Logger.Debug(
+                "Rejecting conversation request: the player party no longer resolves. PartyId={PartyId}",
+                playerPartyId);
+            return;
+        }
 
-            if (!objectManager.TryGetObject(playerPartyId, out PartyBase playerPartyBase))
-            {
-                Logger.Debug(
-                    "Rejecting conversation request: the player party no longer resolves. PartyId={PartyId}",
-                    playerPartyId);
-                return;
-            }
+        // Re-check map events: a party may have entered a battle while the approval was queued.
+        if (aiPartyBase.MapEvent != null || playerPartyBase.MapEvent != null)
+        {
+            Logger.Debug(
+                "Rejecting conversation request: a party entered a map event while approving. AttackerId={AttackerId}, DefenderId={DefenderId}",
+                request.AttackerId, request.DefenderId);
+            return;
+        }
 
-            // Re-check map events: a party may have entered a battle while the approval was queued.
-            if (aiPartyBase.MapEvent != null || playerPartyBase.MapEvent != null)
-            {
-                Logger.Debug(
-                    "Rejecting conversation request: a party entered a map event while approving. AttackerId={AttackerId}, DefenderId={DefenderId}",
-                    request.AttackerId, request.DefenderId);
-                return;
-            }
+        // Re-check the engagement: another player may have engaged the party meanwhile, or the requester may
+        // still hold an unfinished engagement with a different party (first approval wins).
+        if (!ConversationPartyHold.TryEngage(conversationPartyTracker, requestingPeer, playerPartyId, aiPartyBase.MobileParty, aiPartyId))
+        {
+            Logger.Debug(
+                "Rejecting conversation request: the party or the requester is already engaged. PartyId={PartyId}",
+                aiPartyId);
+            network.Send(requestingPeer, new NetworkConversationDenied());
+            return;
+        }
 
-            // Re-check the engagement: another player may have engaged the party meanwhile, or the requester may
-            // still hold an unfinished engagement with a different party (first approval wins).
-            if (!ConversationPartyHold.TryEngage(conversationPartyTracker, requestingPeer, playerPartyId, aiPartyBase.MobileParty, aiPartyId))
-            {
-                Logger.Debug(
-                    "Rejecting conversation request: the party or the requester is already engaged. PartyId={PartyId}",
-                    aiPartyId);
-                network.Send(requestingPeer, new NetworkConversationDenied());
-                return;
-            }
+        SendAllowConversation(requestingPeer, request);
+    }
 
-            network.Send(requestingPeer, new NetworkAllowConversation(request.DefenderId, request.AttackerId, request.ForcePlayerOutFromSettlement, request.Source));
-        });
+    /// <summary>[Server] Replies to the requester that the conversation may (re)open.</summary>
+    private void SendAllowConversation(NetPeer requestingPeer, NetworkRequestConversation request)
+    {
+        network.Send(requestingPeer, new NetworkAllowConversation(request.DefenderId, request.AttackerId, request.ForcePlayerOutFromSettlement, request.Source));
     }
 
     /// <summary>[Client] Server approved: re-run RestartPlayerEncounter with the same parameters.</summary>

--- a/source/GameInterface/Services/MapEvents/Messages/Conversation/ConversationEnded.cs
+++ b/source/GameInterface/Services/MapEvents/Messages/Conversation/ConversationEnded.cs
@@ -1,0 +1,12 @@
+using Common.Messaging;
+
+namespace GameInterface.Services.MapEvents.Messages.Conversation;
+
+/// <summary>
+/// Local (client-side) notification, published when this client's <c>PlayerEncounter</c> finishes, telling the
+/// server to release the AI party held for this player's conversation. Bridged to the network as
+/// <see cref="NetworkConversationEnded"/> by <see cref="Handlers.ConversationRequestHandler"/>.
+/// </summary>
+internal readonly struct ConversationEnded : IEvent
+{
+}

--- a/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkConversationDenied.cs
+++ b/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkConversationDenied.cs
@@ -1,0 +1,14 @@
+using Common.Messaging;
+using ProtoBuf;
+
+namespace GameInterface.Services.MapEvents.Messages.Conversation;
+
+/// <summary>
+/// Server -&gt; Client notification that a conversation request was denied because the targeted party is engaged in
+/// another player's conversation. The client shows the player why their interaction did nothing; carrying no
+/// payload, it identifies the request implicitly (one outstanding request per client at a time).
+/// </summary>
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkConversationDenied : ICommand
+{
+}

--- a/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkConversationDenied.cs
+++ b/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkConversationDenied.cs
@@ -4,7 +4,7 @@ using ProtoBuf;
 namespace GameInterface.Services.MapEvents.Messages.Conversation;
 
 /// <summary>
-/// Server -&gt; Client notification that a conversation request was denied because the targeted party is engaged in
+/// Server to Client notification that a conversation request was denied because the targeted party is engaged in
 /// another player's conversation. The client shows the player why their interaction did nothing; carrying no
 /// payload, it identifies the request implicitly (one outstanding request per client at a time).
 /// </summary>

--- a/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkConversationEnded.cs
+++ b/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkConversationEnded.cs
@@ -1,0 +1,14 @@
+using Common.Messaging;
+using ProtoBuf;
+
+namespace GameInterface.Services.MapEvents.Messages.Conversation;
+
+/// <summary>
+/// Client -&gt; Server notification that this client's player encounter finished (or an approved one failed to
+/// start). The server releases the AI party held for that player's conversation, if any; the sender is identified
+/// by its peer, so no payload is needed.
+/// </summary>
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkConversationEnded : ICommand
+{
+}

--- a/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkConversationEnded.cs
+++ b/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkConversationEnded.cs
@@ -4,7 +4,7 @@ using ProtoBuf;
 namespace GameInterface.Services.MapEvents.Messages.Conversation;
 
 /// <summary>
-/// Client -&gt; Server notification that this client's player encounter finished (or an approved one failed to
+/// Client to Server notification that this client's player encounter finished (or an approved one failed to
 /// start). The server releases the AI party held for that player's conversation, if any; the sender is identified
 /// by its peer, so no payload is needed.
 /// </summary>

--- a/source/GameInterface/Services/MapEvents/Patches/EncounterManagerPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/EncounterManagerPatches.cs
@@ -63,26 +63,14 @@ internal class EncounterManagerPatches
         // Our own server-approved re-run (AllowedThread) runs the real method.
         if (CallOriginalPolicy.IsOriginalAllowed()) return true;
 
-        // The server runs it locally (authoritative), unless the targeted party is held in a conversation by
-        // another player.
-        if (ModInformation.IsServer) return ConversationPartyHold.CanHostRestartEncounter(attackerParty, defenderParty);
+        // The server runs it locally (authoritative).
+        if (ModInformation.IsServer) return true;
 
         // Client: gate the encounter restart behind server approval (rate-limited + validated in
         // ConversationRequestHandler). On approval the handler re-runs this exact method under an AllowedThread.
         MessageBroker.Instance.Publish(null, new ConversationRequested(defenderParty, attackerParty, forcePlayerOutFromSettlement: false, ConversationRestartSource.EncounterManager));
 
         return false;
-    }
-
-    // After the host's encounter (re)starts via EncounterManager, hold the encountered AI party (see
-    // PlayerEncounterPatches.RestartPlayerEncounterPostfix for why this is a postfix).
-    [HarmonyPatch("RestartPlayerEncounter")]
-    [HarmonyPostfix]
-    private static void RestartPlayerEncounterPostfix()
-    {
-        if (!ModInformation.IsServer) return;
-
-        ConversationPartyHold.EngageHostEncounteredParty();
     }
 }
 

--- a/source/GameInterface/Services/MapEvents/Patches/EncounterManagerPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/EncounterManagerPatches.cs
@@ -63,14 +63,26 @@ internal class EncounterManagerPatches
         // Our own server-approved re-run (AllowedThread) runs the real method.
         if (CallOriginalPolicy.IsOriginalAllowed()) return true;
 
-        // The server runs it locally (authoritative).
-        if (ModInformation.IsServer) return true;
+        // The server runs it locally (authoritative), unless the targeted party is held in a conversation by
+        // another player.
+        if (ModInformation.IsServer) return ConversationPartyHold.CanHostRestartEncounter(attackerParty, defenderParty);
 
         // Client: gate the encounter restart behind server approval (rate-limited + validated in
         // ConversationRequestHandler). On approval the handler re-runs this exact method under an AllowedThread.
         MessageBroker.Instance.Publish(null, new ConversationRequested(defenderParty, attackerParty, forcePlayerOutFromSettlement: false, ConversationRestartSource.EncounterManager));
 
         return false;
+    }
+
+    // After the host's encounter (re)starts via EncounterManager, hold the encountered AI party (see
+    // PlayerEncounterPatches.RestartPlayerEncounterPostfix for why this is a postfix).
+    [HarmonyPatch("RestartPlayerEncounter")]
+    [HarmonyPostfix]
+    private static void RestartPlayerEncounterPostfix()
+    {
+        if (!ModInformation.IsServer) return;
+
+        ConversationPartyHold.EngageHostEncounteredParty();
     }
 }
 

--- a/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
@@ -183,14 +183,10 @@ internal class InteractionPatches
         }
 
         // A party held in a conversation with a player can only be interacted with by that player's party. This is
-        // the hard stop that keeps AI parties (and the host) from starting an encounter or battle with it, since
+        // the hard stop that keeps other AI parties from starting an encounter or battle with it, since
         // OnPartyInteraction only runs when this check passes.
         if (ConversationPartyHold.IsInteractionBlocked(__instance, mobileParty))
         {
-            // The host's own bump is blocked here (clients are told via NetworkConversationDenied instead).
-            if (mobileParty?.IsMainParty == true)
-                ConversationPartyHold.ShowInteractionBlockedMessage();
-
             __result = false;
         }
     }

--- a/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
@@ -177,9 +177,21 @@ internal class InteractionPatches
             return;
 
         if (__instance.MobileParty?.IsPlayerParty() == true && mobileParty?.IsPlayerParty() == true)
-        {  
+        {
             __result = false;
             return;
+        }
+
+        // A party held in a conversation with a player can only be interacted with by that player's party. This is
+        // the hard stop that keeps AI parties (and the host) from starting an encounter or battle with it, since
+        // OnPartyInteraction only runs when this check passes.
+        if (ConversationPartyHold.IsInteractionBlocked(__instance, mobileParty))
+        {
+            // The host's own bump is blocked here (clients are told via NetworkConversationDenied instead).
+            if (mobileParty?.IsMainParty == true)
+                ConversationPartyHold.ShowInteractionBlockedMessage();
+
+            __result = false;
         }
     }
 

--- a/source/GameInterface/Services/MapEvents/Patches/PlayerEncounterPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/PlayerEncounterPatches.cs
@@ -26,8 +26,9 @@ internal class PlayerEncounterPatches
         // Our own server-approved re-run (AllowedThread) runs the real RestartPlayerEncounter.
         if (CallOriginalPolicy.IsOriginalAllowed()) return true;
 
-        // The server runs RestartPlayerEncounter locally (authoritative).
-        if (ModInformation.IsServer) return true;
+        // The server runs RestartPlayerEncounter locally (authoritative), unless the targeted party is held in a
+        // conversation by another player.
+        if (ModInformation.IsServer) return ConversationPartyHold.CanHostRestartEncounter(attackerParty, defenderParty);
 
         // Client: gate the encounter restart behind server approval. The send is rate-limited in
         // ConversationRequestHandler (max 1 request / 500ms) so a retried restart does not spam the server. On
@@ -35,6 +36,18 @@ internal class PlayerEncounterPatches
         MessageBroker.Instance.Publish(null, new ConversationRequested(defenderParty, attackerParty, forcePlayerOutFromSettlement, ConversationRestartSource.PlayerEncounter));
 
         return false;
+    }
+
+    // After the host's encounter (re)starts, hold the encountered AI party so it stays in place and cannot be
+    // interacted with by others while the host converses with it. Marking happens in the postfix because the
+    // restart's internal Finish releases the host's previous engagement first.
+    [HarmonyPatch(nameof(PlayerEncounter.RestartPlayerEncounter))]
+    [HarmonyPostfix]
+    public static void RestartPlayerEncounterPostfix()
+    {
+        if (!ModInformation.IsServer) return;
+
+        ConversationPartyHold.EngageHostEncounteredParty();
     }
 
     [HarmonyPatch("StartBattleInternal")]
@@ -121,11 +134,19 @@ internal class PlayerEncounterPatches
     [HarmonyPostfix]
     private static void FinishPostfix()
     {
-        if (ModInformation.IsServer) return;
+        if (ModInformation.IsServer)
+        {
+            // The host's encounter is over: release the AI party held for the host's conversation, if any.
+            ConversationPartyHold.EndHostEngagement();
+            return;
+        }
 
         // Skip our own server-approved restart: RestartPlayerEncounter calls Finish internally, and we run that
         // under an AllowedThread. Holding there would fight the restart we just asked the server to authorize.
         if (CallOriginalPolicy.IsOriginalAllowed()) return;
+
+        // The server holds the AI party this player was conversing with; tell it the encounter is over.
+        MessageBroker.Instance.Publish(null, new ConversationEnded());
 
         // Don't interfere with battle flow.
         if (MobileParty.MainParty.MapEvent != null) return;

--- a/source/GameInterface/Services/MapEvents/Patches/PlayerEncounterPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/PlayerEncounterPatches.cs
@@ -26,9 +26,8 @@ internal class PlayerEncounterPatches
         // Our own server-approved re-run (AllowedThread) runs the real RestartPlayerEncounter.
         if (CallOriginalPolicy.IsOriginalAllowed()) return true;
 
-        // The server runs RestartPlayerEncounter locally (authoritative), unless the targeted party is held in a
-        // conversation by another player.
-        if (ModInformation.IsServer) return ConversationPartyHold.CanHostRestartEncounter(attackerParty, defenderParty);
+        // The server runs RestartPlayerEncounter locally (authoritative).
+        if (ModInformation.IsServer) return true;
 
         // Client: gate the encounter restart behind server approval. The send is rate-limited in
         // ConversationRequestHandler (max 1 request / 500ms) so a retried restart does not spam the server. On
@@ -36,18 +35,6 @@ internal class PlayerEncounterPatches
         MessageBroker.Instance.Publish(null, new ConversationRequested(defenderParty, attackerParty, forcePlayerOutFromSettlement, ConversationRestartSource.PlayerEncounter));
 
         return false;
-    }
-
-    // After the host's encounter (re)starts, hold the encountered AI party so it stays in place and cannot be
-    // interacted with by others while the host converses with it. Marking happens in the postfix because the
-    // restart's internal Finish releases the host's previous engagement first.
-    [HarmonyPatch(nameof(PlayerEncounter.RestartPlayerEncounter))]
-    [HarmonyPostfix]
-    public static void RestartPlayerEncounterPostfix()
-    {
-        if (!ModInformation.IsServer) return;
-
-        ConversationPartyHold.EngageHostEncounteredParty();
     }
 
     [HarmonyPatch("StartBattleInternal")]
@@ -134,12 +121,7 @@ internal class PlayerEncounterPatches
     [HarmonyPostfix]
     private static void FinishPostfix()
     {
-        if (ModInformation.IsServer)
-        {
-            // The host's encounter is over: release the AI party held for the host's conversation, if any.
-            ConversationPartyHold.EndHostEngagement();
-            return;
-        }
+        if (ModInformation.IsServer) return;
 
         // Skip our own server-approved restart: RestartPlayerEncounter calls Finish internally, and we run that
         // under an AllowedThread. Holding there would fight the restart we just asked the server to authorize.

--- a/source/GameInterface/Services/MobilePartyAIs/Patches/DefaultMobilePartyAIModelPatches.cs
+++ b/source/GameInterface/Services/MobilePartyAIs/Patches/DefaultMobilePartyAIModelPatches.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using GameInterface.Services.MapEvents;
+using HarmonyLib;
 using Helpers;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
@@ -28,6 +29,11 @@ internal class DefaultMobilePartyAIModelPatches
             __result = false;
 
         if (!CanAttackTargetParty(party, targetParty))
+            __result = false;
+
+        // Don't consider attacking a party that is held in a conversation with a player; the interaction guard
+        // would block the attack anyway, and this keeps the AI from chasing an unattackable target.
+        if (ConversationPartyHold.IsInPlayerConversation(targetParty))
             __result = false;
     }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?

If the player starts a conversation with the AI, the AI will keep moving (if it was already pathing) and the party can be attacked mid conversation by another player or AI.

## What is the new behavior?
Resolves #1234

While a player is in a map conversation/encounter with an AI party, the server holds that party in place and marks it engaged.

- Other players cannot open a conversation or interact with the held party and a blocked player is shown "You cannot interact with the party while another player is interacting with it".
- AI parties no longer consider the held party an attack target.
- The hold is released when the conversation ends, the engaging player disconnects, or the encounter escalates into a battle (the map-event rules take over from there)

https://github.com/user-attachments/assets/9ad43fbd-d11e-4ec0-87fa-51cc7e1ea143

