### PR TITLE
Fixed server NullReferenceException when looting after battle

### DIFF
--- a/source/GameInterface/Services/Inventory/Handlers/TradeHandler.cs
+++ b/source/GameInterface/Services/Inventory/Handlers/TradeHandler.cs
@@ -130,21 +130,25 @@ internal class TradeHandler : IHandler
         var totalAmount = message.TotalAmount;
 
         // Undo any purchases that are no longer present in the roster
-        foreach (var boughtItem in boughtItems)
+        // When looting, taken items are treated as bought items. Don't need to manage changed rosters in these cases
+        if (fromRoster != null)
         {
-            int difference = fromRoster.GetItemNumber(boughtItem.Item1.EquipmentElement.Item) - boughtItem.Item1.Amount;
-
-            if (difference < 0)
+            foreach (var boughtItem in boughtItems)
             {
-                int fromRosterDataIndex = fromItemRosterData.FindIndex(rosterElement => rosterElement.EquipmentElement.Equals(boughtItem.Item1));
-                if (fromRosterDataIndex >= 0) fromItemRosterData[fromRosterDataIndex].Amount -= difference;
-                else fromItemRosterData.AddItem(new ItemRosterElement(boughtItem.Item1.EquipmentElement, -difference));
+                int difference = fromRoster.GetItemNumber(boughtItem.Item1.EquipmentElement.Item) - boughtItem.Item1.Amount;
 
-                int toRosterDataIndex = toItemRosterData.FindIndex(rosterElement => rosterElement.EquipmentElement.Equals(boughtItem.Item1));
-                if (toRosterDataIndex >= 0) toItemRosterData[toRosterDataIndex].Amount += difference;
-                else toItemRosterData.AddItem(new ItemRosterElement(boughtItem.Item1.EquipmentElement, difference));
+                if (difference < 0)
+                {
+                    int fromRosterDataIndex = fromItemRosterData.FindIndex(rosterElement => rosterElement.EquipmentElement.Equals(boughtItem.Item1));
+                    if (fromRosterDataIndex >= 0) fromItemRosterData[fromRosterDataIndex].Amount -= difference;
+                    else fromItemRosterData.AddItem(new ItemRosterElement(boughtItem.Item1.EquipmentElement, -difference));
 
-                totalAmount -= boughtItem.Item2;
+                    int toRosterDataIndex = toItemRosterData.FindIndex(rosterElement => rosterElement.EquipmentElement.Equals(boughtItem.Item1));
+                    if (toRosterDataIndex >= 0) toItemRosterData[toRosterDataIndex].Amount += difference;
+                    else toItemRosterData.AddItem(new ItemRosterElement(boughtItem.Item1.EquipmentElement, difference));
+
+                    totalAmount -= boughtItem.Item2;
+                }
             }
         }
 


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`TradeHandler.Handle_CompleteTrade()` checks for bought items no longer being available in the `fromRoster` to handle multiple clients trading in a settlement at a time. When looting, taken items are treated as bought items but the roster looted isn't and shouldn't be managed on the server. This results in a `NullReferenceException` when comparing number of bought items to actual items as the `ItemRoster` containing the "actual items" is null.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Added a null check to skip this check if the `fromRoster` isn't managed by the server.

Resolves #1321 
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Other information
