### PR TITLE
[1332] Null-guard kingdom decision sync and make governor removal idempotent

### DIFF
--- a/source/GameInterface.Tests/Services/Actions/ChangeGovernorActionPatchesTests.cs
+++ b/source/GameInterface.Tests/Services/Actions/ChangeGovernorActionPatchesTests.cs
@@ -1,0 +1,87 @@
+﻿using Common;
+using Common.Messaging;
+using GameInterface.Services.Actions.Messages;
+using GameInterface.Services.Actions.Patches;
+using System;
+using System.Collections.Generic;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Settlements;
+using Xunit;
+using FormatterServices = System.Runtime.Serialization.FormatterServices;
+
+namespace GameInterface.Tests.Services.Actions
+{
+    /// <summary>
+    /// Tests for the governor removal prefix in <see cref="ChangeGovernorActionPatches"/>.
+    /// </summary>
+    public class ChangeGovernorActionPatchesTests
+    {
+        private static Hero CreateHero(bool isGovernor)
+        {
+            Hero hero = (Hero)FormatterServices.GetUninitializedObject(typeof(Hero));
+            if (isGovernor)
+            {
+                hero.GovernorOf = (Town)FormatterServices.GetUninitializedObject(typeof(Town));
+            }
+            return hero;
+        }
+
+        private static List<GovernorRemoved> RunPrefix(Hero hero, bool isServer, out bool runOriginal)
+        {
+            var published = new List<GovernorRemoved>();
+            Action<MessagePayload<GovernorRemoved>> capture = payload => published.Add(payload.What);
+            bool originalIsServer = ModInformation.IsServer;
+            MessageBroker.Instance.Subscribe(capture);
+            try
+            {
+                ModInformation.IsServer = isServer;
+                runOriginal = ChangeGovernorActionPatches.ApplyGiveUpInternalPrefix(hero);
+            }
+            finally
+            {
+                ModInformation.IsServer = originalIsServer;
+                MessageBroker.Instance.Unsubscribe(capture);
+            }
+            return published;
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void RemovingNonGovernor_SkipsVanillaAndDoesNotAnnounce(bool isServer)
+        {
+            // A removal can arrive after another sync channel already cleared the
+            // governorship; vanilla would NullReference on GovernorOf, so the prefix
+            // must turn it into a no-op without re-announcing.
+            Hero hero = CreateHero(isGovernor: false);
+
+            var published = RunPrefix(hero, isServer, out bool runOriginal);
+
+            Assert.False(runOriginal);
+            Assert.Empty(published);
+        }
+
+        [Fact]
+        public void ServerRemovingActiveGovernor_RunsVanilla()
+        {
+            Hero hero = CreateHero(isGovernor: true);
+
+            var published = RunPrefix(hero, isServer: true, out bool runOriginal);
+
+            Assert.True(runOriginal);
+            Assert.Empty(published);
+        }
+
+        [Fact]
+        public void ClientRemovingActiveGovernor_RequestsRemovalInsteadOfApplying()
+        {
+            Hero hero = CreateHero(isGovernor: true);
+
+            var published = RunPrefix(hero, isServer: false, out bool runOriginal);
+
+            Assert.False(runOriginal);
+            GovernorRemoved request = Assert.Single(published);
+            Assert.Same(hero, request.Governor);
+        }
+    }
+}

--- a/source/GameInterface.Tests/Services/Kingdoms/KingdomDecision/KingSelectionKingdomDecisionSerializationTest.cs
+++ b/source/GameInterface.Tests/Services/Kingdoms/KingdomDecision/KingSelectionKingdomDecisionSerializationTest.cs
@@ -1,8 +1,14 @@
 ﻿using GameInterface.Services.Kingdoms.Data;
+using GameInterface.Services.Kingdoms.Extentions;
+using GameInterface.Services.ObjectManager;
 using ProtoBuf;
+using Serilog;
 using System.IO;
 using System.Reflection;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Election;
 using Xunit;
+using FormatterServices = System.Runtime.Serialization.FormatterServices;
 
 namespace GameInterface.Tests.Services.Kingdoms.KingdomDecision
 {
@@ -26,6 +32,34 @@ namespace GameInterface.Tests.Services.Kingdoms.KingdomDecision
             Assert.Equal(kingSelectionKingdomDecisionData.NotifyPlayer, deserializedObj.NotifyPlayer);
             Assert.Equal(kingSelectionKingdomDecisionData.IsEnforced, deserializedObj.IsEnforced);
             Assert.Equal(kingSelectionKingdomDecisionData.ClanToExcludeId, deserializedObj.ClanToExcludeId);
+        }
+
+        [Fact]
+        public void RoundTrip_WithNullClanToExclude_DoesNotThrowAndPreservesNull()
+        {
+            // KingSelectionKingdomDecision's clanToExclude ctor arg defaults to null, so the id is null on the wire.
+            ObjectManager objectManager = new ObjectManager(new LoggerConfiguration().CreateLogger());
+            Clan proposerClan = (Clan)FormatterServices.GetUninitializedObject(typeof(Clan));
+            proposerClan.StringId = "ProposerClan";
+            Kingdom kingdom = (Kingdom)FormatterServices.GetUninitializedObject(typeof(Kingdom));
+            kingdom.StringId = "Kingdom";
+            objectManager.AddExisting(proposerClan.StringId, proposerClan);
+            objectManager.AddExisting(kingdom.StringId, kingdom);
+
+            KingSelectionKingdomDecisionData data = new KingSelectionKingdomDecisionData(
+                proposerClan.StringId, kingdom.StringId, 10, true, true, true, null);
+
+            // Deserialization: a null clanToExclude id must reconstruct the decision, not drop it.
+            Assert.True(data.TryGetKingdomDecision(objectManager, out var kingdomDecision));
+            Assert.True(kingdomDecision is KingSelectionKingdomDecision);
+            KingSelectionKingdomDecision decision = (KingSelectionKingdomDecision)kingdomDecision;
+            Assert.Null(decision._clanToExclude);
+
+            // Serialization: converting back must not throw on the null field and must keep it null.
+            KingdomDecisionData roundTrippedData = decision.ToKingdomDecisionData();
+            Assert.True(roundTrippedData is KingSelectionKingdomDecisionData);
+            KingSelectionKingdomDecisionData roundTripped = (KingSelectionKingdomDecisionData)roundTrippedData;
+            Assert.Null(roundTripped.ClanToExcludeId);
         }
     }
 }

--- a/source/GameInterface.Tests/Services/Kingdoms/KingdomDecision/SettlementClaimantDecisionSerializationTest.cs
+++ b/source/GameInterface.Tests/Services/Kingdoms/KingdomDecision/SettlementClaimantDecisionSerializationTest.cs
@@ -1,8 +1,15 @@
 ﻿using GameInterface.Services.Kingdoms.Data;
+using GameInterface.Services.Kingdoms.Extentions;
+using GameInterface.Services.ObjectManager;
 using ProtoBuf;
+using Serilog;
 using System.IO;
 using System.Reflection;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Election;
+using TaleWorlds.CampaignSystem.Settlements;
 using Xunit;
+using FormatterServices = System.Runtime.Serialization.FormatterServices;
 
 namespace GameInterface.Tests.Services.Kingdoms.KingdomDecision
 {
@@ -45,6 +52,42 @@ namespace GameInterface.Tests.Services.Kingdoms.KingdomDecision
             Assert.NotNull(obj2);
             object? obj3 = fieldInfo3?.GetValue(null);
             Assert.NotNull(obj3);
+        }
+
+        [Fact]
+        public void RoundTrip_WithNullCapturerAndClanToExclude_DoesNotThrowAndPreservesNulls()
+        {
+            // Vanilla raises this decision with capturerHero and clanToExclude both null
+            // (e.g. a fief reassignment after a clan leaves or dies), so both ids are null on the wire.
+            ObjectManager objectManager = new ObjectManager(new LoggerConfiguration().CreateLogger());
+            Clan proposerClan = (Clan)FormatterServices.GetUninitializedObject(typeof(Clan));
+            proposerClan.StringId = "ProposerClan";
+            Kingdom kingdom = (Kingdom)FormatterServices.GetUninitializedObject(typeof(Kingdom));
+            kingdom.StringId = "Kingdom";
+            Settlement settlement = (Settlement)FormatterServices.GetUninitializedObject(typeof(Settlement));
+            settlement.StringId = "Settlement";
+            objectManager.AddExisting(proposerClan.StringId, proposerClan);
+            objectManager.AddExisting(kingdom.StringId, kingdom);
+            objectManager.AddExisting(settlement.StringId, settlement);
+
+            SettlementClaimantDecisionData data = new SettlementClaimantDecisionData(
+                proposerClan.StringId, kingdom.StringId, 10, true, true, true, settlement.StringId, null, null);
+
+            // Deserialization: null optional ids must reconstruct the decision, not drop it.
+            Assert.True(data.TryGetKingdomDecision(objectManager, out var kingdomDecision));
+            Assert.True(kingdomDecision is SettlementClaimantDecision);
+            SettlementClaimantDecision decision = (SettlementClaimantDecision)kingdomDecision;
+            Assert.Null(decision._capturerHero);
+            Assert.Null(decision.ClanToExclude);
+            Assert.Same(settlement, decision.Settlement);
+
+            // Serialization: converting back must not throw on the null fields and must keep them null.
+            KingdomDecisionData roundTrippedData = decision.ToKingdomDecisionData();
+            Assert.True(roundTrippedData is SettlementClaimantDecisionData);
+            SettlementClaimantDecisionData roundTripped = (SettlementClaimantDecisionData)roundTrippedData;
+            Assert.Null(roundTripped.CapturerHeroId);
+            Assert.Null(roundTripped.ClanToExcludeId);
+            Assert.Equal(settlement.StringId, roundTripped.SettlementId);
         }
     }
 }

--- a/source/GameInterface/Services/Actions/Patches/ChangeGovernorActionPatches.cs
+++ b/source/GameInterface/Services/Actions/Patches/ChangeGovernorActionPatches.cs
@@ -32,6 +32,11 @@ internal class ChangeGovernorActionPatches
     [HarmonyPrefix]
     public static bool ApplyGiveUpInternalPrefix(Hero governor)
     {
+        // Governor state syncs over several channels, so a removal can arrive after the
+        // governorship is already cleared. Vanilla dereferences GovernorOf unguarded;
+        // treat removing a non-governor as a no-op instead of re-announcing or crashing.
+        if (governor?.GovernorOf == null) return false;
+
         if (ModInformation.IsServer) return true;
 
         // Send message to server to manage removed governor

--- a/source/GameInterface/Services/Kingdoms/Data/KingSelectionKingdomDecisionData.cs
+++ b/source/GameInterface/Services/Kingdoms/Data/KingSelectionKingdomDecisionData.cs
@@ -26,7 +26,7 @@ namespace GameInterface.Services.Kingdoms.Data
         public override bool TryGetKingdomDecision(IObjectManager objectManager, out KingdomDecision kingdomDecision)
         {
             if (!TryGetProposerClanAndKingdom(objectManager, out Clan proposerClan, out Kingdom kingdom) ||
-                !objectManager.TryGetObject(ClanToExcludeId, out Clan clanToExclude))
+                !TryGetOptionalObject(objectManager, ClanToExcludeId, out Clan clanToExclude))
             {
                 kingdomDecision = null;
                 return false;

--- a/source/GameInterface/Services/Kingdoms/Data/KingdomDecisionData.cs
+++ b/source/GameInterface/Services/Kingdoms/Data/KingdomDecisionData.cs
@@ -75,6 +75,26 @@ namespace GameInterface.Services.Kingdoms.Data
         }
 
         /// <summary>
+        /// Resolves an optional object id. A null or empty id represents an intentionally
+        /// absent reference and yields a null object with a successful result; a non-empty
+        /// id must resolve through the object manager.
+        /// </summary>
+        /// <typeparam name="T">type of object to resolve.</typeparam>
+        /// <param name="objectManager">object manager.</param>
+        /// <param name="id">optional StringId, may be null or empty.</param>
+        /// <param name="obj">resolved object, or null when the id is null/empty.</param>
+        /// <returns>True if the id was null/empty or resolved successfully, else false.</returns>
+        protected static bool TryGetOptionalObject<T>(IObjectManager objectManager, string id, out T obj)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                obj = default;
+                return true;
+            }
+            return objectManager.TryGetObject(id, out obj);
+        }
+
+        /// <summary>
         /// Tries to get/create the kingdom decision object from the current KingdomDecisionData object.
         /// Implemented in derived class.
         /// </summary>

--- a/source/GameInterface/Services/Kingdoms/Data/SettlementClaimantDecisionData.cs
+++ b/source/GameInterface/Services/Kingdoms/Data/SettlementClaimantDecisionData.cs
@@ -39,9 +39,9 @@ namespace GameInterface.Services.Kingdoms.Data
         public override bool TryGetKingdomDecision(IObjectManager objectManager, out KingdomDecision kingdomDecision)
         {
             if (!TryGetProposerClanAndKingdom(objectManager, out Clan proposerClan, out Kingdom kingdom) || 
-                !objectManager.TryGetObject(ClanToExcludeId, out Clan clanToExclude) ||
+                !TryGetOptionalObject(objectManager, ClanToExcludeId, out Clan clanToExclude) ||
                 !objectManager.TryGetObject(SettlementId, out Settlement settlement) ||
-                !objectManager.TryGetObject(CapturerHeroId, out Hero capturerHero))
+                !TryGetOptionalObject(objectManager, CapturerHeroId, out Hero capturerHero))
             {
                 kingdomDecision = null;
                 return false;

--- a/source/GameInterface/Services/Kingdoms/Data/SettlementClaimantDecisionData.cs
+++ b/source/GameInterface/Services/Kingdoms/Data/SettlementClaimantDecisionData.cs
@@ -20,7 +20,6 @@ namespace GameInterface.Services.Kingdoms.Data
         private static readonly FieldInfo ClanToExcludeField = typeof(SettlementClaimantDecision).GetField(nameof(SettlementClaimantDecision.ClanToExclude), BindingFlags.Instance | BindingFlags.Public);
         private static readonly FieldInfo CapturerHeroField = typeof(SettlementClaimantDecision).GetField("_capturerHero", BindingFlags.Instance | BindingFlags.NonPublic);
 
-
         [ProtoMember(1)]
         public string SettlementId { get; }
         [ProtoMember(2)]

--- a/source/GameInterface/Services/Kingdoms/Extentions/KingdomDecisionExtensions.cs
+++ b/source/GameInterface/Services/Kingdoms/Extentions/KingdomDecisionExtensions.cs
@@ -85,7 +85,7 @@ namespace GameInterface.Services.Kingdoms.Extentions
             if (kingSelectionKingdomDecision != null)
             {
                 return new KingSelectionKingdomDecisionData(kingSelectionKingdomDecision.ProposerClan.StringId, kingSelectionKingdomDecision.Kingdom.StringId,
-                    kingSelectionKingdomDecision.TriggerTime._numTicks, kingSelectionKingdomDecision.IsEnforced, kingSelectionKingdomDecision.NotifyPlayer, kingSelectionKingdomDecision.PlayerExamined, kingSelectionKingdomDecision._clanToExclude.StringId);
+                    kingSelectionKingdomDecision.TriggerTime._numTicks, kingSelectionKingdomDecision.IsEnforced, kingSelectionKingdomDecision.NotifyPlayer, kingSelectionKingdomDecision.PlayerExamined, kingSelectionKingdomDecision._clanToExclude?.StringId);
             }
             else
             {
@@ -113,7 +113,7 @@ namespace GameInterface.Services.Kingdoms.Extentions
             if (settlementClaimantDecision != null)
             {
                 return new SettlementClaimantDecisionData(settlementClaimantDecision.ProposerClan.StringId, settlementClaimantDecision.Kingdom.StringId,
-                    settlementClaimantDecision.TriggerTime._numTicks, settlementClaimantDecision.IsEnforced, settlementClaimantDecision.NotifyPlayer, settlementClaimantDecision.PlayerExamined, settlementClaimantDecision.Settlement.StringId, settlementClaimantDecision._capturerHero.StringId, settlementClaimantDecision.ClanToExclude.StringId);
+                    settlementClaimantDecision.TriggerTime._numTicks, settlementClaimantDecision.IsEnforced, settlementClaimantDecision.NotifyPlayer, settlementClaimantDecision.PlayerExamined, settlementClaimantDecision.Settlement.StringId, settlementClaimantDecision._capturerHero?.StringId, settlementClaimantDecision.ClanToExclude?.StringId);
             }
             else
             {


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?

Play co-op and let any castle or town fall in a siege, the winning kingdom then holds a vote over which clan gets to keep the fief, and the moment the next ingame day starts, the game crashes on server+client. A kingdom voting on its next king can do the same.

There's a second crash solved here as well, whichi s that when a town or castle that has a governor changes hands, the governor gets dismissed, and the game sometimes processes that dismissal twice, and the second one also crashes both the server and the players.

## What is the new behavior?
Resolves #1332

None of this causes crashes and they work as expected

