### PR TITLE
Fixed party management not finishing done logic

### DIFF
--- a/source/GameInterface/Services/Party/Handlers/PartyDoneLogicHandler.cs
+++ b/source/GameInterface/Services/Party/Handlers/PartyDoneLogicHandler.cs
@@ -59,8 +59,9 @@ internal class PartyDoneLogicHandler : IHandler
         string leftPartyId = null;
         if (obj.What.LeftParty != null && !objectManager.TryGetIdWithLogging(obj.What.LeftParty, out leftPartyId)) return;
 
-        string leftPrisonerRosterId = null;
-        if (obj.What.LeftPrisonerRoster != null && !objectManager.TryGetIdWithLogging(obj.What.LeftPrisonerRoster, out leftPrisonerRosterId)) return;
+        // Don't need to check if it resolved or not, not all left prisoner rosters are managed
+        // Examples being discarding prisoners or taking prisoners after a battle
+        objectManager.TryGetIdWithLogging(obj.What.LeftPrisonerRoster, out var leftPrisonerRosterId);
 
         var upgradedTroopHistory = new UpgradedTroopHistoryData(new());
         foreach (Tuple<CharacterObject, CharacterObject, int> tuple in obj.What.UpgradedTroopHistory)


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Previously syncing prisoner management caused regular party management to stop working. This was because the newly resolved left prison roster with the object manager would return null for unmanaged left prison rosters.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Removed check for a null result from resolving left prison roster with the object manager.

## Other information
