### PR TITLE
Smithing Stamina Fixes

### DIFF
--- a/source/GameInterface/Services/ItemModifiers/ItemModifierGroupRegistry.cs
+++ b/source/GameInterface/Services/ItemModifiers/ItemModifierGroupRegistry.cs
@@ -1,0 +1,52 @@
+﻿using GameInterface.Registry.Auto;
+using GameInterface.Services.ObjectManager;
+using HarmonyLib;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using TaleWorlds.Core;
+using TaleWorlds.ObjectSystem;
+
+namespace GameInterface.Services.ItemModifiers;
+
+/// <summary>
+/// Registry for <see cref="ItemModifierGroup"/> objects
+/// </summary>
+internal class ItemModifierGroupRegistry : AutoRegistryBase<ItemModifierGroup>
+{
+    public ItemModifierGroupRegistry(ILogger logger, IAutoRegistryFactory autoRegistryFactory, IObjectManager objectManager)
+        : base(logger, autoRegistryFactory, objectManager)
+    {
+    }
+
+    public override IEnumerable<MethodBase> Constructors => new MethodBase[] {
+        AccessTools.Constructor(typeof(ItemModifierGroup))
+    };
+
+    public override IEnumerable<MethodBase> DestroyMethods => Array.Empty<MethodBase>();
+    
+    public override void RegisterAllObjects()
+    {
+        foreach (var itemModifierGroup in MBObjectManager.Instance.GetObjectTypeList<ItemModifierGroup>())
+        {
+            RegisterExistingObject(itemModifierGroup.StringId, itemModifierGroup);
+        }
+    }
+
+    public override void OnClientCreated(ItemModifierGroup obj, string id)
+    {
+    }
+
+    public override void OnClientDestroyed(ItemModifierGroup obj, string id)
+    {
+    }
+
+    public override void OnServerCreated(ItemModifierGroup obj, string id)
+    {
+    }
+
+    public override void OnServerDestroyed(ItemModifierGroup obj, string id)
+    {
+    }
+}

--- a/source/GameInterface/Services/Smithing/Handlers/CraftingCampaignBehaviorCraftingHandler.cs
+++ b/source/GameInterface/Services/Smithing/Handlers/CraftingCampaignBehaviorCraftingHandler.cs
@@ -1,4 +1,5 @@
-﻿using Common.Logging;
+﻿using Common;
+using Common.Logging;
 using Common.Messaging;
 using Common.Network;
 using Common.Serialization;
@@ -268,8 +269,8 @@ namespace GameInterface.Services.Smithing.Handlers
 
             byte[] craftedItemObjectData = itemObjectInterface.PackageItemObject(obj.CraftedItemObject);
 
-            CraftingBinaryPackage package = binaryPackageFactory.GetBinaryPackage<CraftingBinaryPackage>(obj.CraftingLogic);
-            byte[] craftingLogicData = BinaryFormatterSerializer.Serialize(package);
+            string itemModifierGroupId = null;
+            if (obj.CraftingLogic.CurrentItemModifierGroup != null && !objectManager.TryGetIdWithLogging(obj.CraftingLogic.CurrentItemModifierGroup, out itemModifierGroupId)) return;
 
             var weaponDesignElementCraftingPieceIds = new List<string>();
             var weaponDesignElementScalePercentages = new List<int>();
@@ -303,7 +304,7 @@ namespace GameInterface.Services.Smithing.Handlers
                 weaponModifierId,
                 obj.NextCraftedItemId,
                 playerHeroId,
-                craftingLogicData
+                itemModifierGroupId
             );
             network.SendAll(message);
         }
@@ -316,8 +317,8 @@ namespace GameInterface.Services.Smithing.Handlers
 
             ItemObject craftedItemObject = itemObjectInterface.UnpackItemObject(obj.CraftedItemObjectData);
 
-            CraftingBinaryPackage package = BinaryFormatterSerializer.Deserialize<CraftingBinaryPackage>(obj.CraftingLogicData);
-            Crafting craftingLogic = package.Unpack<Crafting>(binaryPackageFactory);
+            ItemModifierGroup itemModifierGroup = null;
+            if (obj.ItemModifierGroupId != null && !objectManager.TryGetObjectWithLogging(obj.ItemModifierGroupId, out itemModifierGroup)) return;
 
             if (!GetUsedPieces(obj.WeaponDesignElementCraftingPieceIds, obj.WeaponDesignElementScalePercentages, out WeaponDesignElement[] usedPieces)) return;
 
@@ -352,7 +353,7 @@ namespace GameInterface.Services.Smithing.Handlers
                 weaponDesign,
                 craftedItemObject.Name,
                 craftedItemObject.Culture,
-                craftingLogic.CurrentItemModifierGroup,
+                itemModifierGroup,
                 ref craftedItemObject,
                 nextCraftedItemId);
             }
@@ -388,8 +389,8 @@ namespace GameInterface.Services.Smithing.Handlers
 
             ItemObject craftedItemObject = itemObjectInterface.UnpackItemObject(obj.CraftedItemObjectData);
 
-            CraftingBinaryPackage package = BinaryFormatterSerializer.Deserialize<CraftingBinaryPackage>(obj.CraftingLogicData);
-            Crafting craftingLogic = package.Unpack<Crafting>(binaryPackageFactory);
+            ItemModifierGroup itemModifierGroup = null;
+            if (obj.ItemModifierGroupId != null && !objectManager.TryGetObjectWithLogging(obj.ItemModifierGroupId, out itemModifierGroup)) return;
 
             if (!GetUsedPieces(obj.WeaponDesignElementCraftingPieceIds, obj.WeaponDesignElementScalePercentages, out WeaponDesignElement[] usedPieces)) return;
 
@@ -412,7 +413,7 @@ namespace GameInterface.Services.Smithing.Handlers
                 weaponDesign,
                 craftedItemObject.Name,
                 craftedItemObject.Culture,
-                craftingLogic.CurrentItemModifierGroup,
+                itemModifierGroup,
                 ref craftedItemObject,
                 nextCraftedItemId);
             }

--- a/source/GameInterface/Services/Smithing/Handlers/SmithingRefreshHandler.cs
+++ b/source/GameInterface/Services/Smithing/Handlers/SmithingRefreshHandler.cs
@@ -117,7 +117,10 @@ namespace GameInterface.Services.Smithing.Handlers
 
         private void Handle(MessagePayload<RefreshCraftingVM> obj)
         {
-            RefreshCraftingVM();
+            GameLoopRunner.RunOnMainThread(() =>
+            {
+                RefreshCraftingVM();
+            });
         }
 
         private void RefreshCraftingVM()

--- a/source/GameInterface/Services/Smithing/Messages/NetworkCreateCraftedWeaponInternal.cs
+++ b/source/GameInterface/Services/Smithing/Messages/NetworkCreateCraftedWeaponInternal.cs
@@ -41,7 +41,7 @@ public class NetworkCreateCraftedWeaponInternalServer : ICommand
     public string PlayerHeroId;
 
     [ProtoMember(12)]
-    public byte[] CraftingLogicData;
+    public string ItemModifierGroupId;
 
     public NetworkCreateCraftedWeaponInternalServer(
         string craftingCampaignBehaviorId,
@@ -55,7 +55,7 @@ public class NetworkCreateCraftedWeaponInternalServer : ICommand
         string weaponModifierId,
         string nextCraftedItemId,
         string playerHeroId,
-        byte[] craftingLogicData)
+        string itemModifierGroupId)
     {
         CraftingCampaignBehaviorId = craftingCampaignBehaviorId;
         IsFreeMode = isFreeMode;
@@ -68,7 +68,7 @@ public class NetworkCreateCraftedWeaponInternalServer : ICommand
         WeaponModifierId = weaponModifierId;
         NextCraftedItemId = nextCraftedItemId;
         PlayerHeroId = playerHeroId;
-        CraftingLogicData = craftingLogicData;
+        ItemModifierGroupId = itemModifierGroupId;
     }
 }
 
@@ -103,7 +103,7 @@ public class NetworkCreateCraftedWeaponInternalClients : ICommand
     public List<int> WeaponDesignElementScalePercentages;
 
     [ProtoMember(10)]
-    public byte[] CraftingLogicData;
+    public string ItemModifierGroupId;
 
     public NetworkCreateCraftedWeaponInternalClients(NetworkCreateCraftedWeaponInternalServer cloneObject)
     {
@@ -116,6 +116,6 @@ public class NetworkCreateCraftedWeaponInternalClients : ICommand
         WeaponName = cloneObject.WeaponName;
         WeaponDesignElementCraftingPieceIds = cloneObject.WeaponDesignElementCraftingPieceIds;
         WeaponDesignElementScalePercentages = cloneObject.WeaponDesignElementScalePercentages;
-        CraftingLogicData = cloneObject.CraftingLogicData;
+        ItemModifierGroupId = cloneObject.ItemModifierGroupId;
     }
 }

--- a/source/GameInterface/Services/Smithing/Patches/TickPatches.cs
+++ b/source/GameInterface/Services/Smithing/Patches/TickPatches.cs
@@ -10,7 +10,9 @@ using System;
 using System.Collections.Generic;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
+using TaleWorlds.CampaignSystem.CharacterDevelopment;
 using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.Core;
 using TaleWorlds.Library;
 
 namespace GameInterface.Services.Smithing.Patches
@@ -44,6 +46,23 @@ namespace GameInterface.Services.Smithing.Patches
             var message = new HourTicked(__instance);
             MessageBroker.Instance.Publish(__instance, message);
 
+            return false;
+        }
+
+        [HarmonyPatch(nameof(CraftingCampaignBehavior.GetStaminaHourlyRecoveryRate))]
+        [HarmonyPrefix]
+        public static bool GetStaminaHourlyRecoveryRatePrefix(ref int __result, Hero hero)
+        {
+            int num = 5 + MathF.Round((float)hero.GetSkillValue(DefaultSkills.Crafting) * 0.025f);
+            if (hero.GetPerkValue(DefaultPerks.Athletics.Stamina))
+            {
+                num += MathF.Round((float)num * DefaultPerks.Athletics.Stamina.PrimaryBonus);
+            }
+
+            // Multiply the vanilla result to be 10 times slower as stamina now regenerates outside of settlements
+            // Later expand this to be part of a config for players if its too slow or fast
+            // Round up the result so that crafting stamina always regenerates partially
+            __result = MathF.Ceiling(num * 0.1f);
             return false;
         }
 


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- Smithing stamina was regenerating too quickly.
- Smithing stamina wasn't updating correctly after a weapon was crafted in the smithy.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #1363 #1374
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
- Lowered smithing stamina regeneration by 10x.
- Reworked crafted weapon internal logic to not send `CraftingLogic` over the network and instead only use the `ItemModifierGroup` string id. This is significantly more efficient and seems to fix the delayed refresh when crafting weapons.

## Other information
