### PR TITLE
[1319] Generate battle terrain seed on server

### DIFF
--- a/source/GameInterface.Tests/Serialization/NetworkStartAttackMissionSerializationTest.cs
+++ b/source/GameInterface.Tests/Serialization/NetworkStartAttackMissionSerializationTest.cs
@@ -1,0 +1,33 @@
+﻿using GameInterface.Services.MapEvents.Messages.Start;
+using ProtoBuf.Meta;
+using System.IO;
+using Xunit;
+
+namespace GameInterface.Tests.Serialization;
+
+public class NetworkStartAttackMissionSerializationTest
+{
+    [Fact]
+    public void RoundTrip_PreservesRandomTerrainSeed()
+    {
+        var original = new NetworkStartAttackMission(4242);
+
+        byte[] bytes;
+        using (var ms = new MemoryStream())
+        {
+            RuntimeTypeModel.Default.Serialize(ms, original);
+            bytes = ms.ToArray();
+        }
+
+        Assert.NotEmpty(bytes);
+
+        NetworkStartAttackMission result;
+        using (var ms = new MemoryStream(bytes))
+        {
+            result = (NetworkStartAttackMission)RuntimeTypeModel.Default.Deserialize(ms, null, typeof(NetworkStartAttackMission));
+        }
+
+        Assert.Equal(original.RandomTerrainSeed, result.RandomTerrainSeed);
+        Assert.Equal(4242, result.RandomTerrainSeed);
+    }
+}

--- a/source/GameInterface/Services/MapEvents/Handlers/BattleHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/BattleHandler.cs
@@ -17,6 +17,7 @@ using GameInterface.Services.Players;
 using LiteNetLib;
 using Serilog;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using TaleWorlds.CampaignSystem;
@@ -45,6 +46,16 @@ internal class BattleHandler : IHandler
     // Server-side: number of players in a map event at the last broadcast, used to
     // detect when fast-forward becomes (un)available and to keep clients informed.
     private int lastBroadcastPlayersInMapEvent;
+
+    // Exclusive upper bound for the terrain seed, preserving the range of the original
+    // client-side MBRandom.RandomInt(10000) roll this replaces.
+    private const int MaxTerrainSeed = 10000;
+
+    // Server-side: terrain seed chosen once per map event and reused for every client
+    // that opens the same battle, so they all use the same terrain seed. Keyed by
+    // map event id; the entry is evicted when the event finalizes.
+    private readonly ConcurrentDictionary<string, int> mapEventTerrainSeeds = new ConcurrentDictionary<string, int>();
+    private readonly Random terrainSeedRandom = new Random();
 
     public BattleHandler(
         IMessageBroker messageBroker,
@@ -123,8 +134,24 @@ internal class BattleHandler : IHandler
             side.MakeReadyForMission(null);
         }
 
-        var message = new NetworkStartAttackMission();
+        // Roll the terrain seed once for this map event and reuse it for every client
+        // that opens the battle, so they all use the same terrain seed. The seed is
+        // chosen server-side and carried in the message instead of rolled per machine.
+        var randomTerrainSeed = mapEventTerrainSeeds.GetOrAdd(payload.What.MapEventId, _ => RollTerrainSeed());
+
+        var message = new NetworkStartAttackMission(randomTerrainSeed);
         network.Send(payload.Who as NetPeer, message);
+    }
+
+    private int RollTerrainSeed()
+    {
+        // This runs on the network thread, so it avoids MBRandom, which mutates the
+        // game's shared main-thread RNG state. System.Random is not thread-safe, so
+        // the shared instance is guarded.
+        lock (terrainSeedRandom)
+        {
+            return terrainSeedRandom.Next(MaxTerrainSeed);
+        }
     }
 
     private void Handle_NetworkStartAttackMission(MessagePayload<NetworkStartAttackMission> payload)
@@ -132,10 +159,11 @@ internal class BattleHandler : IHandler
         // Opening a mission pushes a screen, and ScreenManager only tolerates screen
         // changes from the main thread; doing it from the network thread races its
         // layer lists and crashes the game.
-        GameLoopRunner.RunOnMainThread(OpenAttackMission);
+        var randomTerrainSeed = payload.What.RandomTerrainSeed;
+        GameLoopRunner.RunOnMainThread(() => OpenAttackMission(randomTerrainSeed));
     }
 
-    private static void OpenAttackMission()
+    private static void OpenAttackMission(int randomTerrainSeed)
     {
         try
         {
@@ -190,8 +218,9 @@ internal class BattleHandler : IHandler
             rec2.NeedsRandomTerrain = false;
             rec2.PlayingInCampaignMode = true;
 
-            // TODO make this server side
-            rec2.RandomTerrainSeed = MBRandom.RandomInt(10000);
+            // Seed chosen server-side and carried in NetworkStartAttackMission so every
+            // client uses the same terrain seed for this battle.
+            rec2.RandomTerrainSeed = randomTerrainSeed;
             rec2.AtmosphereOnCampaign = Campaign.Current.Models.MapWeatherModel.GetAtmosphereModel(MobileParty.MainParty.Position);
             rec2.SceneHasMapPatch = true;
             rec2.DecalAtlasGroup = 2;
@@ -335,6 +364,10 @@ internal class BattleHandler : IHandler
         // A map event ended; its parties have left it, so re-evaluate whether
         // fast-forward should become available again.
         RefreshFastForwardState(finalizedMapEvent: payload.What.MapEvent);
+
+        // The battle is over, so drop its cached terrain seed.
+        if (objectManager.TryGetId(payload.What.MapEvent, out var mapEventId))
+            mapEventTerrainSeeds.TryRemove(mapEventId, out _);
     }
 
     private void Handle_TimeSpeedChangedAttempted(MessagePayload<TimeSpeedChangedAttempted> payload)

--- a/source/GameInterface/Services/MapEvents/Messages/Start/NetworkStartAttackMission.cs
+++ b/source/GameInterface/Services/MapEvents/Messages/Start/NetworkStartAttackMission.cs
@@ -1,12 +1,16 @@
 ﻿using Common.Messaging;
 using ProtoBuf;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace GameInterface.Services.MapEvents.Messages.Start;
 
-[ProtoContract]
+[ProtoContract(SkipConstructor = true)]
 internal readonly struct NetworkStartAttackMission : ICommand
 {
+    [ProtoMember(1)]
+    public readonly int RandomTerrainSeed;
+
+    public NetworkStartAttackMission(int randomTerrainSeed)
+    {
+        RandomTerrainSeed = randomTerrainSeed;
+    }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Battle terrain seeds are generated client side

## What is the new behavior?

Resolves #1319

Battle terrain seeds are generated server side and synced to clients
