### PR TITLE
[1375] Hide map event icons outside the client's view range

### DIFF
--- a/source/GameInterface/Services/GuantletMapEventVisuals/GauntletMapEventVisualSync.cs
+++ b/source/GameInterface/Services/GuantletMapEventVisuals/GauntletMapEventVisualSync.cs
@@ -12,7 +12,6 @@ internal class GauntletMapEventVisualSync : IDynamicSync
     {
         autoSyncBuilder.AddProperty(AccessTools.Property(typeof(GauntletMapEventVisual), nameof(GauntletMapEventVisual.MapEvent)));
         autoSyncBuilder.AddProperty(AccessTools.Property(typeof(GauntletMapEventVisual), nameof(GauntletMapEventVisual.WorldPosition)));
-        autoSyncBuilder.AddProperty(AccessTools.Property(typeof(GauntletMapEventVisual), nameof(GauntletMapEventVisual.IsVisible)));
     }
 }
 

--- a/source/GameInterface/Services/GuantletMapEventVisuals/Handlers/GauntletMapEventVisaulHandler.cs
+++ b/source/GameInterface/Services/GuantletMapEventVisuals/Handlers/GauntletMapEventVisaulHandler.cs
@@ -52,7 +52,12 @@ internal class GauntletMapEventVisaulHandler : IHandler
         {
             try
             {
-                visual.Initialize(payload.What.Position, payload.What.IsVisible);
+                // Initialize from this client's own map-event visibility, not the server's. The server
+                // force-spots every party (no main party) so its value is always visible; map-event icon
+                // visibility is local (see MapEventVisibilityClientPatch), and the vanilla IsVisible setter
+                // keeps the visual in lock-step, so seeding the visual from the local value keeps the icon
+                // and battle sound consistent here instead of starting in the server-visible state.
+                visual.Initialize(payload.What.Position, visual.MapEvent?.IsVisible ?? false);
             }
             catch (Exception ex)
             {

--- a/source/GameInterface/Services/MapEvents/MapEventSync.cs
+++ b/source/GameInterface/Services/MapEvents/MapEventSync.cs
@@ -14,7 +14,6 @@ internal class MapEventSync : IDynamicSync
         autoSyncBuilder.AddProperty(AccessTools.Property(typeof(MapEvent), nameof(MapEvent.Component)));
         autoSyncBuilder.AddProperty(AccessTools.Property(typeof(MapEvent), nameof(MapEvent.IsInvulnerable)));
         autoSyncBuilder.AddProperty(AccessTools.Property(typeof(MapEvent), nameof(MapEvent.IsPlayerSimulation)));
-        autoSyncBuilder.AddProperty(AccessTools.Property(typeof(MapEvent), nameof(MapEvent.IsVisible)));
         autoSyncBuilder.AddProperty(AccessTools.Property(typeof(MapEvent), nameof(MapEvent.MapEventSettlement)));
         autoSyncBuilder.AddProperty(AccessTools.Property(typeof(MapEvent), nameof(MapEvent.Position)));
         autoSyncBuilder.AddProperty(AccessTools.Property(typeof(MapEvent), nameof(MapEvent.State)));
@@ -27,7 +26,6 @@ internal class MapEventSync : IDynamicSync
         autoSyncBuilder.AddField(AccessTools.Field(typeof(MapEvent), nameof(MapEvent._mapEventResultsCalculated)));
         autoSyncBuilder.AddField(AccessTools.Field(typeof(MapEvent), nameof(MapEvent._eventTerrainType)));
         autoSyncBuilder.AddField(AccessTools.Field(typeof(MapEvent), nameof(MapEvent._isFinishCalled)));
-        autoSyncBuilder.AddField(AccessTools.Field(typeof(MapEvent), nameof(MapEvent._isVisible)));
         autoSyncBuilder.AddField(AccessTools.Field(typeof(MapEvent), nameof(MapEvent._keepSiegeEvent)));
         autoSyncBuilder.AddField(AccessTools.Field(typeof(MapEvent), nameof(MapEvent._mapEventStartTime)));
         autoSyncBuilder.AddField(AccessTools.Field(typeof(MapEvent), nameof(MapEvent._mapEventType)));

--- a/source/GameInterface/Services/MapEvents/Patches/MapEventVisibilityClientPatch.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/MapEventVisibilityClientPatch.cs
@@ -9,20 +9,6 @@ namespace GameInterface.Services.MapEvents.Patches;
 /// <summary>
 /// Keeps a map event's battle icon visibility correct on the client.
 /// </summary>
-/// <remarks>
-/// Map-event icon visibility is a per-machine concern: vanilla derives it from whether any involved
-/// party is visible to the local main party's see range, so it must be computed locally rather than
-/// synced. The dedicated server has no main party and force-marks every party visible, so it would only
-/// ever report a battle as visible; that value is therefore not synced (see <see cref="MapEventSync"/>),
-/// and each client reconciles its own icons here instead.
-///
-/// The vanilla party-visibility chain (PartyBase.OnVisibilityChanged -> MapEvent.PartyVisibilityChanged)
-/// only fires on visibility transitions, which never happen for battles that stay outside the client's
-/// view-update range or that begin with already-visible parties. Reconciling every real tick covers both
-/// cases, runs right after the vanilla visibility pass (so it reads fresh party state), and is gated to
-/// only touch the icon when it actually changes. Runs on the client only; the server's authoritative
-/// behaviour is unchanged.
-/// </remarks>
 [HarmonyPatch(typeof(Campaign))]
 internal class MapEventVisibilityClientPatch
 {

--- a/source/GameInterface/Services/MapEvents/Patches/MapEventVisibilityClientPatch.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/MapEventVisibilityClientPatch.cs
@@ -1,0 +1,69 @@
+﻿using Common;
+using HarmonyLib;
+using System;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.MapEvents;
+
+namespace GameInterface.Services.MapEvents.Patches;
+
+/// <summary>
+/// Keeps a map event's battle icon visibility correct on the client.
+/// </summary>
+/// <remarks>
+/// Map-event icon visibility is a per-machine concern: vanilla derives it from whether any involved
+/// party is visible to the local main party's see range, so it must be computed locally rather than
+/// synced. The dedicated server has no main party and force-marks every party visible, so it would only
+/// ever report a battle as visible; that value is therefore not synced (see <see cref="MapEventSync"/>),
+/// and each client reconciles its own icons here instead.
+///
+/// The vanilla party-visibility chain (PartyBase.OnVisibilityChanged -> MapEvent.PartyVisibilityChanged)
+/// only fires on visibility transitions, which never happen for battles that stay outside the client's
+/// view-update range or that begin with already-visible parties. Reconciling every real tick covers both
+/// cases, runs right after the vanilla visibility pass (so it reads fresh party state), and is gated to
+/// only touch the icon when it actually changes. Runs on the client only; the server's authoritative
+/// behaviour is unchanged.
+/// </remarks>
+[HarmonyPatch(typeof(Campaign))]
+internal class MapEventVisibilityClientPatch
+{
+    // MapEvent.IsVisible has a private setter; driving it (rather than the backing field) preserves the
+    // vanilla side effect that pushes the new visibility to the map-event visual / battle icon. Cached as
+    // a compiled delegate so the per-change call avoids reflection and argument boxing.
+    private static readonly Action<MapEvent, bool> SetIsVisible =
+        AccessTools.MethodDelegate<Action<MapEvent, bool>>(
+            AccessTools.PropertySetter(typeof(MapEvent), nameof(MapEvent.IsVisible)));
+
+    [HarmonyPatch(nameof(Campaign.RealTick))]
+    [HarmonyPostfix]
+    private static void Postfix_RealTick()
+    {
+        if (!ModInformation.IsClient) return;
+
+        var mapEventManager = Campaign.Current?.MapEventManager;
+        if (mapEventManager == null) return;
+
+        foreach (var mapEvent in mapEventManager.MapEvents)
+        {
+            // Skip events whose sides are not both assigned yet. On the client a map event is created
+            // first and its sides are wired up afterwards via separate messages, so during that window
+            // enumerating InvolvedParties would dereference an unassigned side.
+            if (mapEvent?.AttackerSide == null || mapEvent.DefenderSide == null) continue;
+
+            bool shouldBeVisible = AnyInvolvedPartyVisible(mapEvent);
+            if (mapEvent.IsVisible != shouldBeVisible)
+                SetIsVisible(mapEvent, shouldBeVisible);
+        }
+    }
+
+    // Mirrors vanilla MapEvent.PartyVisibilityChanged: the icon is visible while any involved party is.
+    private static bool AnyInvolvedPartyVisible(MapEvent mapEvent)
+    {
+        foreach (var party in mapEvent.InvolvedParties)
+        {
+            if (party != null && party.IsVisible)
+                return true;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

Client can see map events even when they're outside of the party's view range

## What is the new behavior?

Resolves #1375

Clients now only show what's within their view range


<img width="256" height="327" alt="image" src="https://github.com/user-attachments/assets/128ef6a4-391d-421e-93f0-6060bc1d789b" />
<img width="331" height="460" alt="image" src="https://github.com/user-attachments/assets/b2f942b2-f28f-4466-9ff7-bb3fdc75e0a6" />

