### PR TITLE
[28] Fix client crash when engaging a party on the campaign map

### DIFF
--- a/source/GameInterface/Services/MapEvents/Patches/EncounterManagerPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/EncounterManagerPatches.cs
@@ -51,6 +51,20 @@ internal class EncounterManagerPatches
         if (!mobileParty.IsControlledByThisInstance())
             return false;
 
+        // On a client, the controlled party's engage state arrives from the server across independent,
+        // non-atomic sync channels (ShortTermBehavior, AiBehaviorPartyBase, AiBehaviorInteractable). While
+        // an engage behavior has arrived but its target/interactable has not, vanilla dereferences the
+        // still-null target and throws, crashing the campaign tick. Skip this tick; the state converges
+        // shortly and the encounter then proceeds normally.
+        if (ModInformation.IsClient)
+        {
+            if (mobileParty.Ai.AiBehaviorInteractable == null)
+                return false;
+
+            if (mobileParty.ShortTermBehavior == AiBehavior.EngageParty && mobileParty.ShortTermTargetParty == null)
+                return false;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?

In a co-op session, when a client player engages a hostile party on the campaign map — for example clicking a roaming looter party to attack it, often right after recruiting troops and a companion — the client crashes to the main menu the instant the party is engaged.

## What is the new behavior?
Resolves Bannerlord-Coop-Team/Bannerlord-Coop-Issues#28

Engaging a party on a client no longer crashes. The encounter opens normally and the battle proceeds as expected.
