### PR TITLE
fixed bandit hanging on fleeing and fleeing from garrison party

### DIFF
--- a/source/GameInterface/Services/Bandits/Patches/DisableAiBanditPatrollingBehavior.cs
+++ b/source/GameInterface/Services/Bandits/Patches/DisableAiBanditPatrollingBehavior.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using Common;
+using HarmonyLib;
 using TaleWorlds.CampaignSystem.CampaignBehaviors.AiBehaviors;
 
 namespace GameInterface.Services.Bandits.Patches;
@@ -7,5 +8,5 @@ namespace GameInterface.Services.Bandits.Patches;
 internal class DisableAiBanditPatrollingBehavior
 {
     [HarmonyPatch(nameof(AiLandBanditPatrollingBehavior.RegisterEvents))]
-    static bool Prefix() => false;
+    static bool Prefix() => ModInformation.IsServer;
 }

--- a/source/GameInterface/Services/MobilePartyAIs/Patches/DefaultMobilePartyAIModelPatches.cs
+++ b/source/GameInterface/Services/MobilePartyAIs/Patches/DefaultMobilePartyAIModelPatches.cs
@@ -1,4 +1,5 @@
-﻿using GameInterface.Services.MapEvents;
+﻿using Common;
+using GameInterface.Services.MapEvents;
 using HarmonyLib;
 using Helpers;
 using System.Collections.Generic;
@@ -36,7 +37,21 @@ internal class DefaultMobilePartyAIModelPatches
         if (ConversationPartyHold.IsInPlayerConversation(targetParty))
             __result = false;
     }
+    [HarmonyPatch(typeof(DefaultMobilePartyAIModel))]
+    internal class FixGarrisonFleePatch
+    {
+        [HarmonyPatch("CalculateInitiativeScoresForEnemy")]
+        static bool Prefix(MobileParty mobileParty, MobileParty enemyParty, ref float avoidScore, ref float attackScore)
+        {
+            if (!ModInformation.IsServer) return true;
+            if (!enemyParty.IsGarrison) return true;
+            if (enemyParty.CurrentSettlement == null) return true;
 
+            avoidScore = 0f;
+            attackScore = 0f;
+            return false;
+        }
+    }
     private static bool CanAttackTargetParty(MobileParty party, MobileParty targetParty)
     {
         if (party?.Ai == null || targetParty == null)


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ x ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ x ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #1400 and #1434
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Other information
bug1:
BanditPatrollingBehavior was disabled, making bandits unable to update their patrol target and keep on fleeing from the same party.
bug2:
Garrison parties exist as MobileParty objects in the MobilePartyLocator, unlike vanilla where they are never present as mobile map entities. This caused nearby bandits to  flee from garrisoned settlements.
Fix: Skip garrison parties with a valid CurrentSettlement in CalculateInitiativeScoresForEnemy, matching vanilla behavior where these parties would never appear in the locator search.