### PR TITLE
Register all troop CharacterObjects so client recruitment and roster sync work

### DIFF
--- a/source/GameInterface/Services/CharacterObjects/CharacterObjectRegistry.cs
+++ b/source/GameInterface/Services/CharacterObjects/CharacterObjectRegistry.cs
@@ -7,7 +7,6 @@ using HarmonyLib;
 using Serilog;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CharacterDevelopment;
@@ -29,7 +28,10 @@ internal class CharacterObjectRegistry : AutoRegistryBase<CharacterObject>
 
     public override void RegisterAllObjects()
     {
-        foreach (CharacterObject character in Hero.DeadOrDisabledHeroes.Concat(Hero.AllAliveHeroes).Select(hero => hero.CharacterObject))
+        // Register every CharacterObject (basic troop templates as well as hero characters), not just
+        // hero-owned ones: troops need a network id keyed by their stable StringId so rosters and
+        // recruitment can resolve them on every machine.
+        foreach (CharacterObject character in CharacterObject.All)
         {
             RegisterExistingObject(character.StringId, character);
         }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)
<!-- Not unit-testable: the registration runs against the live campaign's CharacterObject set, which needs the game runtime. Verified by recruiting in a running co-op session. -->

## PR Type
What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?

On a recent development build, recruiting troops no longer works for a client. At a village you can pick volunteers and click Done, but nothing happens: the party count does not increase, gold is unchanged, and reopening the recruitment menu still offers the same troops. Basic troops added or removed on the host also fail to show up reliably on clients. This worked until recently and regressed with the P2P mesh refactor (#1412), which stopped registering non-hero troop templates over the network.

## What is the new behavior?

Recruiting works again: the chosen troops join the party, gold is spent, and they are no longer offered. Basic troops also resolve when rosters sync between host and clients.
