### PR TITLE
[1426] Guard client battle-size calc against a not-yet-synced map event

### DIFF
--- a/source/GameInterface.Tests/Services/GuantletMapEventVisuals/GauntletMapEventVisualPatchesTests.cs
+++ b/source/GameInterface.Tests/Services/GuantletMapEventVisuals/GauntletMapEventVisualPatchesTests.cs
@@ -1,0 +1,110 @@
+﻿using GameInterface.Services.GuantletMapEventVisuals.Patches;
+using System.Reflection;
+using TaleWorlds.CampaignSystem.MapEvents;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.Library;
+using Xunit;
+using FormatterServices = System.Runtime.Serialization.FormatterServices;
+
+namespace GameInterface.Tests.Services.GuantletMapEventVisuals
+{
+    /// <summary>
+    /// Tests the not-yet-ready guard in <see cref="GauntletMapEventVisualPatches"/> that keeps the
+    /// field-battle battle-size calc from dereferencing a client map event whose sides - or the
+    /// parties within them - have not finished syncing.
+    /// </summary>
+    public class GauntletMapEventVisualPatchesTests
+    {
+        private static readonly FieldInfo SidesField =
+            typeof(MapEvent).GetField("_sides", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        private static readonly FieldInfo BattlePartiesField =
+            typeof(MapEventSide).GetField("_battleParties", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        private static readonly PropertyInfo PartyProperty =
+            typeof(MapEventParty).GetProperty(nameof(MapEventParty.Party))!;
+
+        // DefenderSide reads _sides[0]; AttackerSide reads _sides[1].
+        private static MapEvent CreateMapEvent(MapEventSide? defender, MapEventSide? attacker)
+        {
+            MapEvent mapEvent = (MapEvent)FormatterServices.GetUninitializedObject(typeof(MapEvent));
+            SidesField.SetValue(mapEvent, new[] { defender, attacker });
+            return mapEvent;
+        }
+
+        // Sides are created via GetUninitializedObject on the client too, so give each one a real
+        // _battleParties list (the registry reinitializes it before the side is used) to mirror runtime.
+        private static MapEventSide CreateSide(params MapEventParty[] parties)
+        {
+            MapEventSide side = (MapEventSide)FormatterServices.GetUninitializedObject(typeof(MapEventSide));
+            BattlePartiesField.SetValue(side, new MBList<MapEventParty>(parties));
+            return side;
+        }
+
+        // resolved = the party's underlying Party reference has synced (non-null); otherwise it is the
+        // transient state where the MapEventParty exists in the side but its Party has not arrived yet.
+        private static MapEventParty CreateParty(bool resolved)
+        {
+            MapEventParty party = (MapEventParty)FormatterServices.GetUninitializedObject(typeof(MapEventParty));
+            if (resolved)
+                PartyProperty.SetValue(party, (PartyBase)FormatterServices.GetUninitializedObject(typeof(PartyBase)));
+            return party;
+        }
+
+        [Fact]
+        public void BattleSizeComputable_NullMapEvent_ReturnsFalse()
+        {
+            Assert.False(GauntletMapEventVisualPatches.BattleSizeComputable(null));
+        }
+
+        [Fact]
+        public void BattleSizeComputable_BothSidesNull_ReturnsFalse()
+        {
+            MapEvent mapEvent = CreateMapEvent(defender: null, attacker: null);
+
+            Assert.False(GauntletMapEventVisualPatches.BattleSizeComputable(mapEvent));
+        }
+
+        [Fact]
+        public void BattleSizeComputable_DefenderSideNull_ReturnsFalse()
+        {
+            MapEvent mapEvent = CreateMapEvent(defender: null, attacker: CreateSide());
+
+            Assert.False(GauntletMapEventVisualPatches.BattleSizeComputable(mapEvent));
+        }
+
+        [Fact]
+        public void BattleSizeComputable_AttackerSideNull_ReturnsFalse()
+        {
+            MapEvent mapEvent = CreateMapEvent(defender: CreateSide(), attacker: null);
+
+            Assert.False(GauntletMapEventVisualPatches.BattleSizeComputable(mapEvent));
+        }
+
+        [Fact]
+        public void BattleSizeComputable_SidesPresentButPartyUnresolved_ReturnsFalse()
+        {
+            MapEvent mapEvent = CreateMapEvent(
+                defender: CreateSide(CreateParty(resolved: true)),
+                attacker: CreateSide(CreateParty(resolved: false)));
+
+            Assert.False(GauntletMapEventVisualPatches.BattleSizeComputable(mapEvent));
+        }
+
+        [Fact]
+        public void BattleSizeComputable_SidesPresentNoParties_ReturnsTrue()
+        {
+            MapEvent mapEvent = CreateMapEvent(defender: CreateSide(), attacker: CreateSide());
+
+            Assert.True(GauntletMapEventVisualPatches.BattleSizeComputable(mapEvent));
+        }
+
+        [Fact]
+        public void BattleSizeComputable_SidesPresentAllPartiesResolved_ReturnsTrue()
+        {
+            MapEvent mapEvent = CreateMapEvent(
+                defender: CreateSide(CreateParty(resolved: true)),
+                attacker: CreateSide(CreateParty(resolved: true), CreateParty(resolved: true)));
+
+            Assert.True(GauntletMapEventVisualPatches.BattleSizeComputable(mapEvent));
+        }
+    }
+}

--- a/source/GameInterface.Tests/Services/GuantletMapEventVisuals/GauntletMapEventVisualPatchesTests.cs
+++ b/source/GameInterface.Tests/Services/GuantletMapEventVisuals/GauntletMapEventVisualPatchesTests.cs
@@ -89,6 +89,10 @@ namespace GameInterface.Tests.Services.GuantletMapEventVisuals
             Assert.False(GauntletMapEventVisualPatches.BattleSizeComputable(mapEvent));
         }
 
+        // An empty-but-present side is computable, not "unready": the guard asks whether the battle-size
+        // calc can run without throwing, not whether the battle is fully populated. Vanilla walks zero
+        // parties and reports 0 men (the smallest size), so the guard lets it through to compute that real
+        // 0 rather than defaulting - the two paths yield the same 0 here either way.
         [Fact]
         public void BattleSizeComputable_SidesPresentNoParties_ReturnsTrue()
         {

--- a/source/GameInterface/Services/GuantletMapEventVisuals/Patches/GauntletMapEventVisualPatches.cs
+++ b/source/GameInterface/Services/GuantletMapEventVisuals/Patches/GauntletMapEventVisualPatches.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.MapEvents;
 
 namespace GameInterface.Services.GuantletMapEventVisuals.Patches;
 
@@ -32,5 +33,41 @@ internal class GauntletMapEventVisualPatches
 
         var message = new GauntletMapEventVisualInitialized(__instance, position, isVisible);
         MessageBroker.Instance.Publish(__instance, message);
+    }
+
+    [HarmonyPatch("GetBattleSizeValue")]
+    [HarmonyPrefix]
+    private static bool PrefixGetBattleSizeValue(GauntletMapEventVisual __instance, ref int __result)
+    {
+        // On the client a map event's sides - and the parties within them - sync in over several
+        // messages, so a replicated visual init can run before the battle-size data is ready. Until
+        // both sides exist and every involved party is resolved, report the smallest size so the
+        // ambient-sound setup still completes instead of dereferencing un-synced state and aborting
+        // the rest of Initialize (the battle icon is set up earlier). Once everything has synced this
+        // is a no-op (always so on the server) and vanilla computes the real size.
+        if (BattleSizeComputable(__instance.MapEvent)) return true;
+
+        __result = 0;
+        return false;
+    }
+
+    // The battle-size calc walks both sides and dereferences each involved party's underlying Party.
+    // On the client those are populated after the map event is created (sides via assignment, each
+    // party's Party via sync), so all must be present before it can run without hitting un-ready state.
+    internal static bool BattleSizeComputable(MapEvent mapEvent)
+    {
+        if (mapEvent?.AttackerSide == null || mapEvent.DefenderSide == null) return false;
+
+        return PartiesResolved(mapEvent.AttackerSide) && PartiesResolved(mapEvent.DefenderSide);
+    }
+
+    private static bool PartiesResolved(MapEventSide side)
+    {
+        foreach (var party in side.Parties)
+        {
+            if (party?.Party == null) return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?

When a client starts a field battle (for example, attacking a looter party on the map), the battle icon appears at the battle's location, but the field-battle ambient battle sound is sometimes missing for that battle and the client log records a `NullReferenceException` for the battle visual. It is intermittent and it depends on whether the battle's details have finished arriving on the client when the icon is set up.

## What is the new behavior?
Resolves #1426

The field-battle ambient battle sound is now set up reliably and the client log no longer records that error; the battle icon still appears exactly as before. (If the battle's details are still arriving when the sound starts, it begins at the lowest intensity instead of not playing at all.)
