### PR TITLE
[1318] Declare war when a client attacks a not-already-hostile party

### DIFF
--- a/source/GameInterface.Tests/Serialization/NetworkAttackMissionAttemptedSerializationTest.cs
+++ b/source/GameInterface.Tests/Serialization/NetworkAttackMissionAttemptedSerializationTest.cs
@@ -1,0 +1,35 @@
+﻿using GameInterface.Services.MapEvents.Messages.Start;
+using ProtoBuf.Meta;
+using System.IO;
+using Xunit;
+
+namespace GameInterface.Tests.Serialization;
+
+public class NetworkAttackMissionAttemptedSerializationTest
+{
+    [Fact]
+    public void RoundTrip_PreservesMapEventAndAttackerIds()
+    {
+        var original = new NetworkAttackMissionAttempted("mapEvent-7", "attacker-42");
+
+        byte[] bytes;
+        using (var ms = new MemoryStream())
+        {
+            RuntimeTypeModel.Default.Serialize(ms, original);
+            bytes = ms.ToArray();
+        }
+
+        Assert.NotEmpty(bytes);
+
+        NetworkAttackMissionAttempted result;
+        using (var ms = new MemoryStream(bytes))
+        {
+            result = (NetworkAttackMissionAttempted)RuntimeTypeModel.Default.Deserialize(ms, null, typeof(NetworkAttackMissionAttempted));
+        }
+
+        Assert.Equal(original.MapEventId, result.MapEventId);
+        Assert.Equal("mapEvent-7", result.MapEventId);
+        Assert.Equal(original.AttackerPartyId, result.AttackerPartyId);
+        Assert.Equal("attacker-42", result.AttackerPartyId);
+    }
+}

--- a/source/GameInterface/Services/MapEvents/Handlers/BattleHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/BattleHandler.cs
@@ -23,6 +23,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.Encounters;
 using TaleWorlds.CampaignSystem.GameMenus;
 using TaleWorlds.CampaignSystem.Map;
@@ -52,6 +53,10 @@ internal class BattleHandler : IHandler
     // Exclusive upper bound for the terrain seed, preserving the range of the original
     // client-side MBRandom.RandomInt(10000) roll this replaces.
     private const int MaxTerrainSeed = 10000;
+
+    // The -10 player-hostility relation penalty vanilla applies against the target faction leader
+    // when an attack first turns a faction hostile (the war block of BeHostileAction).
+    private const int PlayerHostilityRelationPenalty = -10;
 
     // Server-side: terrain seed chosen once per map event and reused for every client
     // that opens the same battle, so they all use the same terrain seed. Keyed by
@@ -120,7 +125,13 @@ internal class BattleHandler : IHandler
 
         mapEventLogger.DebugMapEvent(payload.What.MapEvent, "Handling attack mission attempted for map event");
 
-        var message = new NetworkAttackMissionAttempted(mapEventId);
+        // Carry the attacking party (this client's main party) so the server can apply the
+        // attack's hostile-action consequences against the opposing side; the server has no
+        // main party to derive the attacker from. If it can't be resolved the mission still
+        // proceeds and only the consequences are skipped server-side.
+        objectManager.TryGetIdWithLogging(MobileParty.MainParty, out string attackerPartyId);
+
+        var message = new NetworkAttackMissionAttempted(mapEventId, attackerPartyId);
         network.SendAll(message);
     }
 
@@ -149,6 +160,11 @@ internal class BattleHandler : IHandler
 
                 mapEventLogger.DebugMapEvent(mapEvent, "Handling network attack mission attempted for map event. Making sides mission-ready and replying with mission start");
 
+                // Apply the diplomatic consequences of the client's attack (war / relation)
+                // authoritatively before the mission opens, reproducing the hostile-action head of
+                // vanilla EncounterAttackConsequence that neither the client nor the server runs.
+                ApplyClientAttackHostileConsequences(mapEvent, payload.What.AttackerPartyId);
+
                 foreach (var side in mapEvent._sides)
                 {
                     side.MakeReadyForMission(null);
@@ -161,6 +177,70 @@ internal class BattleHandler : IHandler
                 Logger.Error(e, "Failed to make map event sides mission-ready for {Message}", nameof(NetworkAttackMissionAttempted));
             }
         });
+    }
+
+    /// <summary>
+    /// When a client attacks a not-already-hostile party, declares war on the target faction and
+    /// applies the player-hostility relation penalty against its leader — the war block of vanilla
+    /// MenuHelper.EncounterAttackConsequence (BeHostileAction.ApplyEncounterHostileAction), which
+    /// neither the client (it defers to the server) nor the dedicated server (it never opens the
+    /// encounter menu) runs. Vanilla gates the war declaration on the attacker being the
+    /// single-player main party; the server is never that party, so it is reproduced explicitly for
+    /// the client attacker. Runs with patches live: the war declaration replicates through the
+    /// server-authoritative stance sync, and the relation change is applied server-authoritatively
+    /// like every other co-op relation change. The whole block sits behind the not-already-at-war
+    /// check, so repeated attack requests for the same battle apply it at most once.
+    /// </summary>
+    private void ApplyClientAttackHostileConsequences(MapEvent mapEvent, string attackerPartyId)
+    {
+        try
+        {
+            // GameThread runs queued actions unguarded, so the campaign can have been torn down
+            // between the request arriving and this draining; the sibling OpenAttackMission guards
+            // the same way before dereferencing campaign state.
+            if (Campaign.Current == null)
+                return;
+
+            if (!objectManager.TryGetObject(attackerPartyId, out MobileParty attackerMobileParty))
+            {
+                Logger.Warning("Could not resolve attacker party {AttackerPartyId} for attack hostile-action consequences", attackerPartyId);
+                return;
+            }
+
+            var attackerParty = attackerMobileParty.Party;
+
+            // OpponentSide is only meaningful while the attacker is a side in this event.
+            if (attackerParty.MapEvent != mapEvent)
+                return;
+
+            var defenderParty = mapEvent.GetLeaderParty(attackerParty.OpponentSide);
+            if (defenderParty == null)
+                return;
+
+            var attackerFaction = attackerParty.MapFaction;
+            var defenderFaction = defenderParty.MapFaction;
+            if (attackerFaction == null || defenderFaction == null || attackerFaction == defenderFaction)
+                return;
+
+            if (Campaign.Current.Models.EncounterModel.IsEncounterExemptFromHostileActions(attackerParty, defenderParty))
+                return;
+
+            // Already hostile: nothing to declare, and this is what makes the consequence idempotent
+            // across the duplicate attack requests a client can send during the server round-trip.
+            if (FactionManager.IsAtWarAgainstFaction(attackerFaction, defenderFaction))
+                return;
+
+            if (attackerParty.LeaderHero != null && defenderFaction.Leader != null)
+            {
+                ChangeRelationAction.ApplyRelationChangeBetweenHeroes(attackerParty.LeaderHero, defenderFaction.Leader, PlayerHostilityRelationPenalty);
+            }
+
+            DeclareWarAction.ApplyByPlayerHostility(attackerFaction, defenderFaction);
+        }
+        catch (Exception e)
+        {
+            Logger.Error(e, "Failed to apply attack hostile-action consequences");
+        }
     }
 
     private int RollTerrainSeed()

--- a/source/GameInterface/Services/MapEvents/Messages/Start/NetworkAttackMissionAttempted.cs
+++ b/source/GameInterface/Services/MapEvents/Messages/Start/NetworkAttackMissionAttempted.cs
@@ -9,8 +9,15 @@ internal readonly struct NetworkAttackMissionAttempted : ICommand
     [ProtoMember(1)]
     public readonly string MapEventId;
 
-    public NetworkAttackMissionAttempted(string mapEventId)
+    // The attacking client's main party. The dedicated server has no main party of its own,
+    // so it needs the attacker's identity to apply the attack's hostile-action consequences
+    // (war / relation) against the opposing side.
+    [ProtoMember(2)]
+    public readonly string AttackerPartyId;
+
+    public NetworkAttackMissionAttempted(string mapEventId, string attackerPartyId)
     {
         MapEventId = mapEventId;
+        AttackerPartyId = attackerPartyId;
     }
 }


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

When a client attacked a party that was not already an enemy, i.e. neutral caravan, or attacking a neutral kingdom's party, no war was ever declared, on the host or on any client. The target faction simply stayed neutral after the battle.

## What is the new behavior?

Resolves #1318

Attacking a not-already-hostile party now declares war on that party's faction. The war is applied authoritatively by the host and replicates to every client — the two factions show as at war, and that faction's parties turn hostile on the host and all clients, instead of the target staying neutral. 
<img width="697" height="478" alt="image" src="https://github.com/user-attachments/assets/7251504d-f90b-4c80-b41d-def5d06e8283" />
<img width="333" height="56" alt="image" src="https://github.com/user-attachments/assets/b600dfef-4a8d-4722-b2cd-d50d23fdfb9b" />


