### PR TITLE
[1458] Fix empty enemy side when a client starts a battle through conversation

### DIFF
--- a/source/Common/GameThread.cs
+++ b/source/Common/GameThread.cs
@@ -268,38 +268,38 @@ public class GameThread : IUpdateable
 
     /// <summary>
     /// Blocks until <paramref name="condition"/> returns true or <paramref name="deadline"/> passes, and
-    /// reports which happened. When the caller already owns the game-loop thread it drains <see cref="Update"/>
-    /// each iteration, so the work the condition depends on — and the blocking <see cref="Run"/> handlers the
-    /// network thread is waiting on — keeps making progress; a bare wait on the game-loop thread would stall
-    /// the very queue it is waiting on, a self-inflicted deadlock that only breaks at the deadline. Off the
-    /// game-loop thread another thread owns the pump, so it just polls.
+    /// reports which happened, draining <see cref="Update"/> each iteration so the work the condition depends
+    /// on — and the blocking <see cref="Run"/> handlers the network thread is waiting on — keeps making
+    /// progress; a bare wait on the game-loop thread would stall the very queue it is waiting on, a
+    /// self-inflicted deadlock that only breaks at the deadline. Must be called on the game-loop thread,
+    /// which owns the pump.
     /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when called off the game-loop thread.</exception>
     public static bool WaitWhilePumping(Func<bool> condition, DateTime deadline)
     {
-        bool ownsPump = Instance.IsGameThread;
+        if (!Instance.IsGameThread)
+            throw new InvalidOperationException(
+                $"{nameof(WaitWhilePumping)} must be called on the game-loop thread; it drains the queue while it waits.");
 
         while (true)
         {
-            if (ownsPump)
+            // Drain with the mod's patches live. The queued actions are ordinary game-loop work and must not
+            // inherit an AllowedThread allowance the caller happens to hold — that would silence the
+            // replication patches the actions rely on. The normal game-loop pump runs them with no allowance,
+            // so suspend any ambient one here to match it.
+            using (AllowedThread.Suspend())
             {
-                // Drain with the mod's patches live. The queued actions are ordinary game-loop work and must
-                // not inherit an AllowedThread allowance the caller happens to hold — that would silence the
-                // replication patches the actions rely on. The normal game-loop pump runs them with no
-                // allowance, so suspend any ambient one here to match it.
-                using (AllowedThread.Suspend())
+                // A single failing queued action must not abort the wait (which would also leave that action's
+                // own blocking caller waiting out its full timeout); log and keep pumping, mirroring RunSafe.
+                // Without this guard the throw would escape into whatever the waiter is doing — e.g. mid
+                // battle-start construction.
+                try
                 {
-                    // A single failing queued action must not abort the wait (which would also leave that
-                    // action's own blocking caller waiting out its full timeout); log and keep pumping,
-                    // mirroring RunSafe. Without this guard the throw would escape into whatever the waiter is
-                    // doing — e.g. mid battle-start construction.
-                    try
-                    {
-                        Instance.Update(TimeSpan.Zero);
-                    }
-                    catch (Exception e)
-                    {
-                        Logger.Error(e, "A queued action threw while pumping the game thread during a blocking wait");
-                    }
+                    Instance.Update(TimeSpan.Zero);
+                }
+                catch (Exception e)
+                {
+                    Logger.Error(e, "A queued action threw while pumping the game thread during a blocking wait");
                 }
             }
 

--- a/source/Common/GameThread.cs
+++ b/source/Common/GameThread.cs
@@ -1,4 +1,5 @@
 using Common.Logging;
+using Common.Util;
 using Serilog;
 using System;
 using System.Collections.Generic;
@@ -35,6 +36,13 @@ public class GameThread : IUpdateable
     }
 
     public bool IsInitialized => m_GameLoopThreadId != 0;
+
+    /// <summary>
+    /// True when the caller is running on the game-loop thread that drains the queue in <see cref="Update"/>.
+    /// A blocking caller already on this thread must pump <see cref="Update"/> itself while it waits, or it
+    /// stalls the very queue its completion depends on.
+    /// </summary>
+    public bool IsGameThread => Thread.CurrentThread.ManagedThreadId == m_GameLoopThreadId;
 
     private GameThread()
     {
@@ -256,6 +264,53 @@ public class GameThread : IUpdateable
                 Logger.Error(e, "Failed to run action on the game thread: {Context}", context ?? "(none)");
             }
         }, blocking, label);
+    }
+
+    /// <summary>
+    /// Blocks until <paramref name="condition"/> returns true or <paramref name="deadline"/> passes, and
+    /// reports which happened. When the caller already owns the game-loop thread it drains <see cref="Update"/>
+    /// each iteration, so the work the condition depends on — and the blocking <see cref="Run"/> handlers the
+    /// network thread is waiting on — keeps making progress; a bare wait on the game-loop thread would stall
+    /// the very queue it is waiting on, a self-inflicted deadlock that only breaks at the deadline. Off the
+    /// game-loop thread another thread owns the pump, so it just polls.
+    /// </summary>
+    public static bool WaitWhilePumping(Func<bool> condition, DateTime deadline)
+    {
+        bool ownsPump = Instance.IsGameThread;
+
+        while (true)
+        {
+            if (ownsPump)
+            {
+                // Drain with the mod's patches live. The queued actions are ordinary game-loop work and must
+                // not inherit an AllowedThread allowance the caller happens to hold — that would silence the
+                // replication patches the actions rely on. The normal game-loop pump runs them with no
+                // allowance, so suspend any ambient one here to match it.
+                using (AllowedThread.Suspend())
+                {
+                    // A single failing queued action must not abort the wait (which would also leave that
+                    // action's own blocking caller waiting out its full timeout); log and keep pumping,
+                    // mirroring RunSafe. Without this guard the throw would escape into whatever the waiter is
+                    // doing — e.g. mid battle-start construction.
+                    try
+                    {
+                        Instance.Update(TimeSpan.Zero);
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Error(e, "A queued action threw while pumping the game thread during a blocking wait");
+                    }
+                }
+            }
+
+            if (condition())
+                return true;
+
+            if (DateTime.UtcNow >= deadline)
+                return false;
+
+            Thread.Sleep(5);
+        }
     }
 
     private static string BuildLabel(string callerFile, string callerMember)

--- a/source/Common/Util/AllowedThread.cs
+++ b/source/Common/Util/AllowedThread.cs
@@ -59,4 +59,28 @@ public class AllowedThread : IDisposable
     }
 
     public static bool IsThisThreadAllowed() => _allowedCount > 0;
+
+    /// <summary>
+    /// Clears this thread's allowance for the returned scope's lifetime and restores the previous count on
+    /// dispose. Use when running code on this thread that must NOT inherit an ambient allowance the caller
+    /// happens to hold — e.g. draining the game-thread queue, whose unrelated actions must run with the mod's
+    /// patches live, not silenced by a scope the drainer is nested inside.
+    /// </summary>
+    public static IDisposable Suspend() => new SuspendScope();
+
+    private sealed class SuspendScope : IDisposable
+    {
+        private readonly int _restoreCount;
+
+        public SuspendScope()
+        {
+            _restoreCount = _allowedCount;
+            _allowedCount = 0;
+        }
+
+        public void Dispose()
+        {
+            _allowedCount = _restoreCount;
+        }
+    }
 }

--- a/source/GameInterface.Tests/Utils/GameThreadPumpTests.cs
+++ b/source/GameInterface.Tests/Utils/GameThreadPumpTests.cs
@@ -39,9 +39,23 @@ public class GameThreadPumpTests
     }
 
     [Fact]
+    public void WaitWhilePumping_ThrowsWhenCalledOffTheGameLoopThread()
+    {
+        // The xUnit worker thread is not the game-loop thread, so it can't pump; the wait refuses to run.
+        Assert.False(GameThread.Instance.IsGameThread);
+        Assert.Throws<InvalidOperationException>(
+            () => GameThread.WaitWhilePumping(() => true, DateTime.UtcNow + TimeSpan.FromSeconds(1)));
+    }
+
+    [Fact]
     public void WaitWhilePumping_ReturnsTrueImmediately_WhenTheConditionAlreadyHolds()
     {
-        bool result = GameThread.WaitWhilePumping(() => true, DateTime.UtcNow + TimeSpan.FromSeconds(1));
+        bool result = false;
+
+        // Must run on the game-loop thread (it owns the pump).
+        GameThread.Run(
+            () => result = GameThread.WaitWhilePumping(() => true, DateTime.UtcNow + TimeSpan.FromSeconds(1)),
+            blocking: true);
 
         Assert.True(result);
     }
@@ -49,13 +63,19 @@ public class GameThreadPumpTests
     [Fact]
     public void WaitWhilePumping_ReturnsFalse_WhenTheConditionNeverHoldsBeforeTheDeadline()
     {
-        DateTime start = DateTime.UtcNow;
+        bool result = true;
+        TimeSpan elapsed = TimeSpan.Zero;
 
-        bool result = GameThread.WaitWhilePumping(() => false, DateTime.UtcNow + TimeSpan.FromMilliseconds(150));
+        GameThread.Run(() =>
+        {
+            DateTime start = DateTime.UtcNow;
+            result = GameThread.WaitWhilePumping(() => false, DateTime.UtcNow + TimeSpan.FromMilliseconds(150));
+            elapsed = DateTime.UtcNow - start;
+        }, blocking: true);
 
         Assert.False(result);
         // It waited up to the deadline rather than returning early.
-        Assert.True(DateTime.UtcNow - start >= TimeSpan.FromMilliseconds(100));
+        Assert.True(elapsed >= TimeSpan.FromMilliseconds(100));
     }
 
     [Fact]

--- a/source/GameInterface.Tests/Utils/GameThreadPumpTests.cs
+++ b/source/GameInterface.Tests/Utils/GameThreadPumpTests.cs
@@ -1,0 +1,128 @@
+﻿using Common;
+using Common.Util;
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Xunit;
+
+namespace GameInterface.Tests.Utils;
+
+/// <summary>
+/// Covers <see cref="GameThread.IsGameThread"/> and <see cref="GameThread.WaitWhilePumping"/> — the pump that
+/// keeps a blocking caller already on the game-loop thread (e.g. the client's map-event-creation wait) from
+/// deadlocking. A bare wait on that thread would stall the queue its completion depends on; WaitWhilePumping
+/// drains <see cref="GameThread.Update"/> itself while it waits so the network thread keeps making progress.
+/// </summary>
+public class GameThreadPumpTests
+{
+    static GameThreadPumpTests()
+    {
+        // Coop.Tests starts and continuously pumps a dedicated game-loop thread from a [ModuleInitializer]
+        // (TestGameLoopPump); force that initializer to run so the pump is up even when this class runs in
+        // isolation (see GenericHandlerThreadingTests for the full rationale). RunModuleConstructor is idempotent.
+        RuntimeHelpers.RunModuleConstructor(typeof(Coop.Tests.Mocks.TestNetwork).Module.ModuleHandle);
+    }
+
+    [Fact]
+    public void IsGameThread_IsTrueOnTheGameLoopThread_AndFalseElsewhere()
+    {
+        Assert.True(GameThread.Instance.IsInitialized, "game-loop pump was not initialized");
+
+        // The xUnit worker thread is not the game-loop thread.
+        Assert.False(GameThread.Instance.IsGameThread);
+
+        // A probe marshaled onto the game-loop thread sees itself as the game thread. The probe is blocking,
+        // so it has recorded the answer by the time Run returns.
+        bool onGameThread = false;
+        GameThread.Run(() => onGameThread = GameThread.Instance.IsGameThread, blocking: true);
+        Assert.True(onGameThread);
+    }
+
+    [Fact]
+    public void WaitWhilePumping_ReturnsTrueImmediately_WhenTheConditionAlreadyHolds()
+    {
+        bool result = GameThread.WaitWhilePumping(() => true, DateTime.UtcNow + TimeSpan.FromSeconds(1));
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void WaitWhilePumping_ReturnsFalse_WhenTheConditionNeverHoldsBeforeTheDeadline()
+    {
+        DateTime start = DateTime.UtcNow;
+
+        bool result = GameThread.WaitWhilePumping(() => false, DateTime.UtcNow + TimeSpan.FromMilliseconds(150));
+
+        Assert.False(result);
+        // It waited up to the deadline rather than returning early.
+        Assert.True(DateTime.UtcNow - start >= TimeSpan.FromMilliseconds(100));
+    }
+
+    [Fact]
+    public void WaitWhilePumping_OnTheGameLoopThread_DrainsWorkQueuedWhileItWaits()
+    {
+        Assert.True(GameThread.Instance.IsInitialized, "game-loop pump was not initialized");
+
+        bool ran = false;
+        bool waitResult = false;
+
+        // Run the wait ON the game-loop thread, mirroring RequestBlocking running inside the StartBattleInternal
+        // prefix. While the wait occupies that thread the dedicated pump loop is paused, so the only thing that
+        // can run the queued action is WaitWhilePumping's own pump — i.e. this fails if the pump branch is broken.
+        GameThread.Run(() =>
+        {
+            var enqueued = new ManualResetEventSlim(false);
+            var worker = new Thread(() =>
+            {
+                // Non-blocking: the worker is not the game-loop thread, so this queues rather than runs inline.
+                GameThread.Run(() => ran = true);
+                enqueued.Set();
+            });
+            worker.Start();
+            enqueued.Wait();
+
+            waitResult = GameThread.WaitWhilePumping(() => ran, DateTime.UtcNow + TimeSpan.FromSeconds(5));
+
+            worker.Join();
+        }, blocking: true);
+
+        Assert.True(waitResult, "the wait gave up before its own pump drained the queued action");
+        Assert.True(ran, "the action queued while the game thread waited was never drained");
+    }
+
+    [Fact]
+    public void WaitWhilePumping_DrainsWithPatchesLive_EvenWhenCalledUnderAnAllowedThread()
+    {
+        Assert.True(GameThread.Instance.IsInitialized, "game-loop pump was not initialized");
+
+        bool? allowedWhileDraining = null;
+        bool waitResult = false;
+        bool callerAllowanceIntactAfter = false;
+
+        GameThread.Run(() =>
+        {
+            // The caller holds an allowance on the game-loop thread; the pump must not let drained,
+            // unrelated queued work inherit it (which would silence those actions' replication patches).
+            using (new AllowedThread())
+            {
+                var enqueued = new ManualResetEventSlim(false);
+                var worker = new Thread(() =>
+                {
+                    GameThread.Run(() => allowedWhileDraining = AllowedThread.IsThisThreadAllowed());
+                    enqueued.Set();
+                });
+                worker.Start();
+                enqueued.Wait();
+
+                waitResult = GameThread.WaitWhilePumping(() => allowedWhileDraining.HasValue, DateTime.UtcNow + TimeSpan.FromSeconds(5));
+
+                worker.Join();
+                callerAllowanceIntactAfter = AllowedThread.IsThisThreadAllowed();
+            }
+        }, blocking: true);
+
+        Assert.True(waitResult, "the queued action was never drained");
+        Assert.False(allowedWhileDraining, "the drained action inherited the caller's AllowedThread allowance");
+        Assert.True(callerAllowanceIntactAfter, "the caller's allowance was not restored after the pump");
+    }
+}

--- a/source/GameInterface/Services/MapEvents/Handlers/MapEventCreationCoordinator.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/MapEventCreationCoordinator.cs
@@ -110,7 +110,15 @@ internal class MapEventCreationCoordinator : IHandler
             // On a client, SendAll targets the server (its only connected peer).
             network.SendAll(new NetworkRequestCreateMapEvent(requestId, attackerId, defenderId, flags));
 
-            if (!pending.Completed.Wait(timeout))
+            // This runs on the game-loop thread (the StartBattleInternal prefix, during a campaign tick). A
+            // bare blocking wait here stops the thread from pumping GameThread.Update, which the network
+            // thread relies on: it processes messages in order, and a message ahead of the reply (e.g. a
+            // NetworkMapEventFinalizeAttempted, applied through a blocking GameThread.Run) waits for that
+            // pump. The reply — and the AutoRegistry create broadcast that materializes the MapEvent — then
+            // sits behind a handler that can never complete, so the wait always times out under battle load.
+            // GameThread.WaitWhilePumping keeps draining the queue while we wait so the network thread makes
+            // progress (it falls back to a plain poll when not on the game-loop thread).
+            if (!GameThread.WaitWhilePumping(() => pending.Completed.IsSet, deadline))
             {
                 Logger.Error("Timed out after {Timeout} waiting for the server to create the map event. RequestId={RequestId}", timeout, requestId);
                 return null;
@@ -122,26 +130,21 @@ internal class MapEventCreationCoordinator : IHandler
                 return null;
             }
 
-            // The MapEvent object is materialized on this client by the AutoRegistry create broadcast, which is sent
-            // just before this response. Poll briefly in case the response is processed first.
-            while (true)
+            // The MapEvent object is materialized on this client by the AutoRegistry create broadcast, which is
+            // sent just before the reply; keep pumping in case the reply is processed first.
+            MapEvent mapEvent = null;
+            if (!GameThread.WaitWhilePumping(
+                    () => objectManager.TryGetObject(pending.MapEventId, out mapEvent) && mapEvent != null,
+                    deadline))
             {
-                if (objectManager.TryGetObject(pending.MapEventId, out MapEvent mapEvent) && mapEvent != null)
-                {
-                    Logger.Debug("Resolved server-created map event {MapEventId}. RequestId={RequestId}", pending.MapEventId, requestId);
-                    return mapEvent;
-                }
-
-                if (DateTime.UtcNow >= deadline)
-                {
-                    Logger.Error(
-                        "Server created map event {MapEventId} but it was not resolvable on this client before timeout. RequestId={RequestId}",
-                        pending.MapEventId, requestId);
-                    return null;
-                }
-
-                Thread.Sleep(5);
+                Logger.Error(
+                    "Server created map event {MapEventId} but it was not resolvable on this client before timeout. RequestId={RequestId}",
+                    pending.MapEventId, requestId);
+                return null;
             }
+
+            Logger.Debug("Resolved server-created map event {MapEventId}. RequestId={RequestId}", pending.MapEventId, requestId);
+            return mapEvent;
         }
         finally
         {


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

There is an issue where when you start a conversation with a noble and go through the attack dialogues, when the game transitions from conversation to the map (which takes several seconds on `development`) sometimes the subsequent MapEvent (where you get to choose Attack!) isn't properly loaded. The top pane showing the parties involved will say that your party has zero enemies

## What is the new behavior?

Resolves #1458

The transition from conversation to the map is much quicker and should now reliably show the opposing parties. This is done by allowing the main thread to drain the queue while it's waiting
