### PR TITLE
Fixed Flakey Test

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,6 +2,7 @@ name: Build and Test
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 # Cancel superseded runs when a PR is updated
 concurrency:

--- a/source/Coop.Tests/ServerTestComponent.cs
+++ b/source/Coop.Tests/ServerTestComponent.cs
@@ -18,6 +18,9 @@ internal class ServerTestComponent : TestComponentBase
         var builder = new ContainerBuilder();
         builder.RegisterModule<ServerModule>();
         builder.RegisterModule<RegistryModule>();
+
+        RegisterMock<ICoopServer>(builder);
+
         Container = BuildContainer(builder);
     }
 }

--- a/source/Coop.Tests/TestComponentBase.cs
+++ b/source/Coop.Tests/TestComponentBase.cs
@@ -104,7 +104,7 @@ internal abstract class TestComponentBase
         return builder;
     }
 
-    private void RegisterMock<T>(ContainerBuilder builder) where T : class
+    protected void RegisterMock<T>(ContainerBuilder builder) where T : class
     {
         var mock = new Mock<T>();
         builder.RegisterInstance(mock).AsSelf().SingleInstance();


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
ServerTestComponent built the real ServerModule, which auto-instantiates ServerHeroHandler — and that handler depends on ICoopServer, so a real CoopServer was constructed in the test container. CoopServer's base ctor starts a background Poller thread whose Update calls OverloadedPeerManager.CheckForOverloadedPeers() on the same manager the test drives, racing the test's sequential calls (extra Pause, or a spurious resume). This only surfaced under load (e.g. CI).

Register a mock ICoopServer in ServerTestComponent so the real CoopServer and its poller thread are never created. Also stops every server unit test from leaking a live NetManager + poller thread.

## Other information
