### PR TITLE
[1320] Rate-limit client settlement-encounter requests

### DIFF
--- a/source/Coop.Core/Client/Services/MobileParties/Handlers/ClientSettlementExitEnterHandler.cs
+++ b/source/Coop.Core/Client/Services/MobileParties/Handlers/ClientSettlementExitEnterHandler.cs
@@ -1,4 +1,5 @@
-﻿using Common.Messaging;
+﻿using System;
+using Common.Messaging;
 using Common.Network;
 using Coop.Core.Client.Services.MobileParties.Messages;
 using Coop.Core.Server.Services.MobileParties.Messages;
@@ -13,9 +14,13 @@ namespace Coop.Core.Client.Services.MobileParties.Handlers;
 /// </summary>
 public class ClientSettlementExitEnterHandler : IHandler
 {
+    private static readonly TimeSpan RequestCooldown = TimeSpan.FromMilliseconds(500);
+
     private readonly IMessageBroker messageBroker;
     private readonly INetwork network;
     private readonly IObjectManager objectManager;
+
+    private DateTime lastRequestSentUtc = DateTime.MinValue;
 
     public ClientSettlementExitEnterHandler(IMessageBroker messageBroker, INetwork network, IObjectManager objectManager)
     {
@@ -47,10 +52,20 @@ public class ClientSettlementExitEnterHandler : IHandler
 
     private void Handle(MessagePayload<StartSettlementEncounterAttempted> obj)
     {
+        // This only ever runs for the single party this client controls (the publisher gates on
+        // IsControlledByThisInstance). That party re-attempts the settlement encounter every campaign tick
+        // until its PlayerEncounter is set up, which on a client only happens once the server round-trip
+        // completes. Rate-limit the request so those per-tick re-attempts do not flood the server.
+        var now = DateTime.UtcNow;
+        if (now - lastRequestSentUtc < RequestCooldown)
+            return;
+
         var payload = obj.What;
 
         if (!objectManager.TryGetIdWithLogging(payload.Party, out var partyId)) return;
         if (!objectManager.TryGetIdWithLogging(payload.Settlement, out var settlementId)) return;
+
+        lastRequestSentUtc = now;
 
         var message = new NetworkRequestStartSettlementEncounter(partyId, settlementId);
 

--- a/source/Coop.IntegrationTests/MobileParties/EnterExitSettlementTest.cs
+++ b/source/Coop.IntegrationTests/MobileParties/EnterExitSettlementTest.cs
@@ -1,3 +1,4 @@
+using Coop.Core.Server.Services.MobileParties.Messages;
 using Coop.IntegrationTests.Environment;
 using GameInterface.Services.MobileParties.Messages.Behavior;
 
@@ -40,6 +41,36 @@ namespace Coop.IntegrationTests.MobileParties
             client1.SimulateMessage(this, message);
 
             // Assert
+            foreach (var client in TestEnvironment.Clients.Where(c => c != client1))
+            {
+                Assert.Equal(1, client.InternalMessages.GetMessageCount<PartyEnterSettlement>());
+            }
+        }
+
+        /// <summary>
+        /// While the first settlement-encounter request is still in flight, the controlled party re-attempts the
+        /// encounter every campaign tick. Verify those rapid retries are rate-limited to a single network request
+        /// instead of flooding the server.
+        /// </summary>
+        [Fact]
+        public void RapidEnterAttempts_RateLimited_ToOneRequest()
+        {
+            // Arrange
+            var client1 = TestEnvironment.Clients.First();
+
+            var party = client1.CreateRegisteredObject<MobileParty>("party1");
+            var settlement = client1.CreateRegisteredObject<Settlement>("settlement1");
+
+            var message = new StartSettlementEncounterAttempted(party, settlement);
+
+            // Act - two attempts in immediate succession, well within the request cooldown
+            client1.SimulateMessage(this, message);
+            client1.SimulateMessage(this, message);
+
+            // Assert - only the first attempt reaches the server; the second is dropped by the rate limiter
+            Assert.Equal(1, client1.NetworkSentMessages.GetMessageCount<NetworkRequestStartSettlementEncounter>());
+
+            // And the enter is applied on the other clients exactly once
             foreach (var client in TestEnvironment.Clients.Where(c => c != client1))
             {
                 Assert.Equal(1, client.InternalMessages.GetMessageCount<PartyEnterSettlement>());


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

When a client moves their party onto a town to enter it, the client floods the server with settlement-entry requests (over 100 per second) the whole time it waits for the server to respond.

## What is the new behavior?

Resolves #1320

Entering a town now sends a single settlement-entry request that opens the town menu normally. If the server is slow to respond, the client retries at most about twice a second instead of hundreds of times.
