### PR TITLE
Player to player interaction base implementation

### DIFF
--- a/UIMovies/CoopPlayerPartyTradeOverlay.xml
+++ b/UIMovies/CoopPlayerPartyTradeOverlay.xml
@@ -1,0 +1,14 @@
+<Prefab>
+  <Window>
+    <Widget WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" DoNotAcceptEvents="true">
+      <Children>
+        <TextWidget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="360" SuggestedHeight="42"
+                    HorizontalAlignment="Left" VerticalAlignment="Bottom" MarginLeft="520" MarginBottom="72"
+                    Brush="Clan.TabControl.Text" Brush.FontSize="24" Text="@RemoteAcceptedText"/>
+        <TextWidget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="360" SuggestedHeight="42"
+                    HorizontalAlignment="Right" VerticalAlignment="Bottom" MarginRight="520" MarginBottom="72"
+                    Brush="Clan.TabControl.Text" Brush.FontSize="24" Text="@LocalAcceptedText"/>
+      </Children>
+    </Widget>
+  </Window>
+</Prefab>

--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -4,6 +4,7 @@ using Coop.Core;
 using Coop.Lib.NoHarmony;
 using Coop.UI.LoadGameUI;
 using GameInterface;
+using GameInterface.Services.MapEvents.PlayerPartyInteractions;
 using GameInterface.Services.TroopRosters;
 using GameInterface.Services.UI;
 using Serilog;
@@ -11,6 +12,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using TaleWorlds.CampaignSystem;
 using TaleWorlds.Core;
 using TaleWorlds.Engine;
 using TaleWorlds.Library;
@@ -229,6 +231,14 @@ namespace Coop
             Module.CurrentModule.AddInitialStateOption(JoinCoopGame);
 #endif
             #endregion
+        }
+
+        protected override void OnGameStart(Game game, IGameStarter gameStarterObject)
+        {
+            base.OnGameStart(game, gameStarterObject);
+
+            if (gameStarterObject is CampaignGameStarter campaignGameStarter)
+                campaignGameStarter.AddBehavior(new PlayerPartyInteractionCampaignBehavior());
         }
 
         protected override void OnBeforeInitialModuleScreenSetAsRoot()

--- a/source/E2E.Tests/Services/MapEvents/PlayerPartyInteractionFlowTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/PlayerPartyInteractionFlowTests.cs
@@ -1,0 +1,1031 @@
+using Common.Network;
+using E2E.Tests.Environment.Instance;
+using GameInterface.Services.Entity;
+using GameInterface.Services.Inventory.Data;
+using GameInterface.Services.MapEvents.Messages.Conversation;
+using GameInterface.Services.MapEvents.PlayerPartyInteractions;
+using GameInterface.Services.TroopRosters.Data;
+using System.Reflection;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.BarterSystem;
+using TaleWorlds.CampaignSystem.BarterSystem.Barterables;
+using TaleWorlds.CampaignSystem.MapEvents;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.Core;
+using TaleWorlds.Core.ImageIdentifiers;
+using TaleWorlds.Library;
+using Xunit.Abstractions;
+
+namespace E2E.Tests.Services.MapEvents;
+
+public class PlayerPartyInteractionFlowTests : MapEventTestBase
+{
+    public PlayerPartyInteractionFlowTests(ITestOutputHelper output) : base(output)
+    {
+        ClearPlayerPartyInteractionState();
+    }
+
+    [Fact]
+    public void ClientRequest_PlayerPartyInteraction_StartsServerDrivenDialogStates()
+    {
+        var (client1, _, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+
+        RequestInteraction(client1, initiatorPartyId, responderPartyId);
+
+        var started = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>().Single();
+        Assert.Equal(initiatorPartyId, started.InitiatorPartyId);
+        Assert.Equal(responderPartyId, started.ResponderPartyId);
+
+        var states = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionState>().ToArray();
+        Assert.Contains(states, s =>
+            s.SessionId == started.SessionId &&
+            s.PartyId == initiatorPartyId &&
+            s.Phase == PlayerPartyInteractionPhase.InitialOptions &&
+            s.IsInitiator &&
+            s.Options.Contains(PlayerPartyInteractionOption.TradeProposal));
+        Assert.Contains(states, s =>
+            s.SessionId == started.SessionId &&
+            s.PartyId == responderPartyId &&
+            s.Phase == PlayerPartyInteractionPhase.WaitingForProposal &&
+            !s.IsInitiator &&
+            s.Options.SequenceEqual(new[] { PlayerPartyInteractionOption.Leave }));
+    }
+
+    [Fact]
+    public void TradeProposal_AcceptedByResponder_EntersTradeActiveForBothParties()
+    {
+        var (client1, client2, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+        RequestInteraction(client1, initiatorPartyId, responderPartyId);
+        var sessionId = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>().Single().SessionId;
+        var initiatorInitialState = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionState>().Single(s =>
+            s.SessionId == sessionId &&
+            s.PartyId == initiatorPartyId &&
+            s.Phase == PlayerPartyInteractionPhase.InitialOptions);
+
+        Server.NetworkSentMessages.Clear();
+        client1.NetworkSentMessages.Clear();
+        SubmitDialogOption(client1, initiatorInitialState, PlayerPartyInteractionOption.TradeProposal);
+
+        var submittedOption = client1.NetworkSentMessages.GetMessages<NetworkSubmitPlayerPartyInteractionOption>().Single();
+        Assert.Equal(sessionId, submittedOption.SessionId);
+        Assert.Equal(initiatorPartyId, submittedOption.PartyId);
+        Assert.Equal(PlayerPartyInteractionOption.TradeProposal, submittedOption.Option);
+
+        var proposalStates = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionState>().ToArray();
+        Assert.Contains(proposalStates, s =>
+            s.PartyId == initiatorPartyId &&
+            s.Phase == PlayerPartyInteractionPhase.WaitingForResponse &&
+            s.Proposal == PlayerPartyInteractionProposal.Trade);
+        Assert.Contains(proposalStates, s =>
+            s.PartyId == responderPartyId &&
+            s.Phase == PlayerPartyInteractionPhase.ProposalPending &&
+            s.Proposal == PlayerPartyInteractionProposal.Trade &&
+            s.Options.Contains(PlayerPartyInteractionOption.AcceptProposal));
+        client2.Call(() =>
+        {
+            Assert.Equal(sessionId, PlayerPartyInteractionDialogState.SessionId);
+            Assert.Equal(responderPartyId, PlayerPartyInteractionDialogState.PartyId);
+            Assert.Equal(PlayerPartyInteractionPhase.ProposalPending, PlayerPartyInteractionDialogState.Phase);
+            Assert.Equal(PlayerPartyInteractionProposal.Trade, PlayerPartyInteractionDialogState.Proposal);
+            Assert.Equal("I have a proposal that may benefit us both.", PlayerPartyInteractionDialogState.GetDialogText());
+            Assert.True(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.AcceptProposal));
+            Assert.True(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.DeclineProposal));
+            Assert.True(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.Leave));
+        });
+
+        Server.NetworkSentMessages.Clear();
+        SubmitOption(client2, sessionId, responderPartyId, PlayerPartyInteractionOption.AcceptProposal);
+
+        var tradeStates = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionState>().ToArray();
+        Assert.Contains(tradeStates, s => s.PartyId == initiatorPartyId && s.Phase == PlayerPartyInteractionPhase.TradeActive);
+        Assert.Contains(tradeStates, s => s.PartyId == responderPartyId && s.Phase == PlayerPartyInteractionPhase.TradeActive);
+    }
+
+    [Fact]
+    public void OptionSubmit_SpoofedResponderPartyId_DoesNotActAsResponder()
+    {
+        var (client1, _, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+        RequestInteraction(client1, initiatorPartyId, responderPartyId);
+        var sessionId = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>().Single().SessionId;
+        SubmitOption(client1, sessionId, initiatorPartyId, PlayerPartyInteractionOption.TradeProposal);
+
+        Server.NetworkSentMessages.Clear();
+        client1.Call(() => client1.Resolve<INetwork>().SendAll(new NetworkSubmitPlayerPartyInteractionOption(
+            sessionId,
+            PlayerPartyInteractionOption.AcceptProposal,
+            responderPartyId)));
+
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionState>());
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionEnded>());
+    }
+
+    [Fact]
+    public void OfferServices_WithNoValidServiceOptions_ShowsNevermindAndCanEndInteraction()
+    {
+        var (client1, _, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+        var responderClanLeaderId = TestEnvironment.CreateRegisteredObject<Hero>();
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(responderPartyId, out var responderParty));
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(responderClanLeaderId, out var responderClanLeader));
+
+            responderClanLeader.Clan = responderParty.LeaderHero.Clan;
+            responderParty.LeaderHero.Clan.SetLeader(responderClanLeader);
+        });
+
+        RequestInteraction(client1, initiatorPartyId, responderPartyId);
+        var sessionId = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>().Single().SessionId;
+        var initialState = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionState>().Single(s =>
+            s.SessionId == sessionId &&
+            s.PartyId == initiatorPartyId &&
+            s.Phase == PlayerPartyInteractionPhase.InitialOptions);
+
+        Assert.Contains(PlayerPartyInteractionOption.OfferServices, initialState.Options);
+
+        Server.NetworkSentMessages.Clear();
+        client1.NetworkSentMessages.Clear();
+        OpenServiceOptions(client1, initialState);
+
+        Assert.Empty(client1.NetworkSentMessages.GetMessages<NetworkSubmitPlayerPartyInteractionOption>());
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionState>());
+        client1.Call(() =>
+        {
+            Assert.Equal(PlayerPartyInteractionPhase.OfferServices, PlayerPartyInteractionDialogState.Phase);
+            Assert.True(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.Leave));
+            Assert.False(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.JoinClan));
+            Assert.False(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.Vassal));
+        });
+
+        Server.NetworkSentMessages.Clear();
+        SubmitCurrentDialogOption(client1, PlayerPartyInteractionOption.Leave);
+
+        var ended = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionEnded>().Single();
+        Assert.Equal(PlayerPartyInteractionOutcomeType.Left, ended.OutcomeType);
+    }
+
+    [Fact]
+    public void OfferServices_WithValidServiceOptions_StillShowsNevermind()
+    {
+        var (client1, _, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+
+        RequestInteraction(client1, initiatorPartyId, responderPartyId);
+        var sessionId = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>().Single().SessionId;
+        var initialState = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionState>().Single(s =>
+            s.SessionId == sessionId &&
+            s.PartyId == initiatorPartyId &&
+            s.Phase == PlayerPartyInteractionPhase.InitialOptions);
+
+        Server.NetworkSentMessages.Clear();
+        client1.NetworkSentMessages.Clear();
+        OpenServiceOptions(client1, initialState);
+
+        Assert.Empty(client1.NetworkSentMessages.GetMessages<NetworkSubmitPlayerPartyInteractionOption>());
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionState>());
+        client1.Call(() =>
+        {
+            Assert.Equal(PlayerPartyInteractionPhase.OfferServices, PlayerPartyInteractionDialogState.Phase);
+            Assert.True(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.JoinClan));
+            Assert.True(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.Leave));
+            Assert.False(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.Vassal));
+        });
+    }
+
+    [Fact]
+    public void OfferServices_WithTierOneClanAndKingdomLeader_DoesNotShowMercenary()
+    {
+        var (client1, _, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+        SetupResponderKingdomLeader(initiatorPartyId, responderPartyId, initiatorClanTier: 1);
+
+        RequestInteraction(client1, initiatorPartyId, responderPartyId);
+        var sessionId = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>().Single().SessionId;
+        var initialState = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionState>().Single(s =>
+            s.SessionId == sessionId &&
+            s.PartyId == initiatorPartyId &&
+            s.Phase == PlayerPartyInteractionPhase.InitialOptions);
+
+        OpenServiceOptions(client1, initialState);
+
+        client1.Call(() =>
+        {
+            Assert.True(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.JoinClan));
+            Assert.True(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.Leave));
+            Assert.False(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.Vassal));
+        });
+    }
+
+    [Fact]
+    public void OfferServices_WithTierTwoClanAndKingdomLeader_ShowsVassal()
+    {
+        var (client1, _, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+        SetupResponderKingdomLeader(initiatorPartyId, responderPartyId, initiatorClanTier: 2);
+
+        RequestInteraction(client1, initiatorPartyId, responderPartyId);
+        var sessionId = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>().Single().SessionId;
+        var initialState = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionState>().Single(s =>
+            s.SessionId == sessionId &&
+            s.PartyId == initiatorPartyId &&
+            s.Phase == PlayerPartyInteractionPhase.InitialOptions);
+
+        OpenServiceOptions(client1, initialState);
+
+        client1.Call(() =>
+        {
+            Assert.True(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.JoinClan));
+            Assert.True(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.Leave));
+            Assert.True(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.Vassal));
+        });
+    }
+
+    [Fact]
+    public void ClanServiceProposal_AcceptedByResponder_JoinsResponderClan()
+    {
+        var (client1, client2, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+
+        RequestInteraction(client1, initiatorPartyId, responderPartyId);
+        var sessionId = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>().Single().SessionId;
+        var initialState = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionState>().Single(s =>
+            s.SessionId == sessionId &&
+            s.PartyId == initiatorPartyId &&
+            s.Phase == PlayerPartyInteractionPhase.InitialOptions);
+
+        OpenServiceOptions(client1, initialState);
+        SubmitCurrentDialogOption(client1, PlayerPartyInteractionOption.JoinClan);
+        SubmitOption(client2, sessionId, responderPartyId, PlayerPartyInteractionOption.AcceptProposal);
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(initiatorPartyId, out var initiatorParty));
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(responderPartyId, out var responderParty));
+
+            Assert.Equal(responderParty.LeaderHero.Clan, initiatorParty.LeaderHero.Clan);
+            Assert.Equal(responderParty.LeaderHero.Clan, initiatorParty.MobileParty.ActualClan);
+        });
+    }
+
+    [Fact]
+    public void VassalServiceProposal_AcceptedByResponder_EndsWithoutJoiningKingdom()
+    {
+        var (client1, client2, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+        SetupResponderKingdomLeader(initiatorPartyId, responderPartyId, initiatorClanTier: 2);
+
+        RequestInteraction(client1, initiatorPartyId, responderPartyId);
+        var sessionId = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>().Single().SessionId;
+        var initialState = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionState>().Single(s =>
+            s.SessionId == sessionId &&
+            s.PartyId == initiatorPartyId &&
+            s.Phase == PlayerPartyInteractionPhase.InitialOptions);
+        string? initialKingdomId = null;
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(initiatorPartyId, out var initiatorParty));
+            var initialKingdom = initiatorParty.LeaderHero.Clan.Kingdom;
+            initialKingdomId = initialKingdom?.StringId;
+        });
+
+        OpenServiceOptions(client1, initialState);
+        SubmitCurrentDialogOption(client1, PlayerPartyInteractionOption.Vassal);
+        Server.NetworkSentMessages.Clear();
+        SubmitOption(client2, sessionId, responderPartyId, PlayerPartyInteractionOption.AcceptProposal);
+
+        var ended = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionEnded>().Single();
+        Assert.Equal(PlayerPartyInteractionOutcomeType.VassalAccepted, ended.OutcomeType);
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(initiatorPartyId, out var initiatorParty));
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(responderPartyId, out var responderParty));
+
+            var currentKingdom = initiatorParty.LeaderHero.Clan.Kingdom;
+            var currentKingdomId = currentKingdom?.StringId;
+
+            Assert.Equal(initialKingdomId, currentKingdomId);
+            Assert.NotEqual(responderParty.LeaderHero.Clan.Kingdom, currentKingdom);
+            Assert.False(initiatorParty.LeaderHero.Clan.IsUnderMercenaryService);
+        });
+    }
+
+    [Theory]
+    [InlineData(PlayerPartyInteractionProposal.Trade, "I have a proposal that may benefit us both.")]
+    [InlineData(PlayerPartyInteractionProposal.JoinClan, "I wish to offer my services in your clan.")]
+    [InlineData(PlayerPartyInteractionProposal.Vassal, "I wish to swear my allegiance to your majesty.")]
+    public void ProposalPending_DialogText_ShowsInitiatorSelectedLine(
+        PlayerPartyInteractionProposal proposal,
+        string expectedText)
+    {
+        PlayerPartyInteractionDialogState.Apply(new NetworkPlayerPartyInteractionState(
+            "session-1",
+            "responder-party",
+            "initiator-party",
+            "RandomPlayer",
+            PlayerPartyInteractionPhase.ProposalPending,
+            proposal,
+            new[]
+            {
+                PlayerPartyInteractionOption.AcceptProposal,
+                PlayerPartyInteractionOption.DeclineProposal,
+                PlayerPartyInteractionOption.Leave
+            },
+            isInitiator: false));
+
+        try
+        {
+            Assert.Equal(expectedText, PlayerPartyInteractionDialogState.GetDialogText());
+        }
+        finally
+        {
+            PlayerPartyInteractionDialogState.Clear("session-1");
+        }
+    }
+
+    [Theory]
+    [InlineData(PlayerPartyInteractionOutcomeType.TradeAccepted, "Barter offer accepted.")]
+    [InlineData(PlayerPartyInteractionOutcomeType.TradeDeclined, "Trade proposal declined.")]
+    [InlineData(PlayerPartyInteractionOutcomeType.ClanJoinAccepted, "Clan service proposal accepted.")]
+    [InlineData(PlayerPartyInteractionOutcomeType.ClanJoinDeclined, "Clan service proposal declined.")]
+    [InlineData(PlayerPartyInteractionOutcomeType.VassalAccepted, "Vassalage offer accepted.")]
+    [InlineData(PlayerPartyInteractionOutcomeType.VassalDeclined, "Vassalage offer declined.")]
+    public void OutcomeMessages_UsePlayerPartyInteractionResult(PlayerPartyInteractionOutcomeType outcomeType, string expectedMessage)
+    {
+        Assert.Equal(expectedMessage, PlayerPartyTradeContext.GetOutcomeMessage(outcomeType));
+    }
+
+    [Fact]
+    public void RemovedMercenaryInteractionValues_AreNotDefined()
+    {
+        Assert.DoesNotContain("Mercenary", Enum.GetNames(typeof(PlayerPartyInteractionOption)));
+        Assert.DoesNotContain("Mercenary", Enum.GetNames(typeof(PlayerPartyInteractionProposal)));
+        Assert.DoesNotContain("MercenaryAccepted", Enum.GetNames(typeof(PlayerPartyInteractionOutcomeType)));
+        Assert.DoesNotContain("MercenaryDeclined", Enum.GetNames(typeof(PlayerPartyInteractionOutcomeType)));
+    }
+
+    [Fact]
+    public void TradeBarterData_IncludesPartyItemRosterBarterables()
+    {
+        var (_, _, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+        var initiatorItemId = TestEnvironment.CreateRegisteredObject<ItemObject>();
+        var responderItemId = TestEnvironment.CreateRegisteredObject<ItemObject>();
+        var initiatorTroopId = TestEnvironment.CreateRegisteredObject<CharacterObject>();
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(initiatorPartyId, out var initiatorParty));
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(responderPartyId, out var responderParty));
+            Assert.True(Server.ObjectManager.TryGetObject<ItemObject>(initiatorItemId, out var initiatorItem));
+            Assert.True(Server.ObjectManager.TryGetObject<ItemObject>(responderItemId, out var responderItem));
+            Assert.True(Server.ObjectManager.TryGetObject<CharacterObject>(initiatorTroopId, out var initiatorTroop));
+
+            initiatorParty.ItemRoster.AddToCounts(initiatorItem, 3);
+            responderParty.ItemRoster.AddToCounts(responderItem, 4);
+            initiatorParty.MemberRoster.AddToCounts(initiatorTroop, 5);
+
+            var barterData = new BarterData(
+                initiatorParty.LeaderHero,
+                responderParty.LeaderHero,
+                initiatorParty,
+                responderParty,
+                null,
+                0,
+                false);
+
+            InvokeAddBarterGroups(barterData);
+            InvokeAddPartyBarterables(barterData, initiatorParty.LeaderHero, responderParty.LeaderHero, initiatorParty, responderParty);
+            InvokeAddPartyBarterables(barterData, responderParty.LeaderHero, initiatorParty.LeaderHero, responderParty, initiatorParty);
+
+            var barterables = barterData.GetBarterables();
+
+            Assert.Contains(barterables, b =>
+                b is ItemBarterable itemBarterable &&
+                itemBarterable.OriginalParty == initiatorParty &&
+                itemBarterable.Group is ItemBarterGroup &&
+                itemBarterable.ItemRosterElement.Amount == 3);
+            Assert.Contains(barterables, b =>
+                b is ItemBarterable itemBarterable &&
+                itemBarterable.OriginalParty == responderParty &&
+                itemBarterable.Group is ItemBarterGroup &&
+                itemBarterable.ItemRosterElement.Amount == 4);
+            var troopBarterable = Assert.Single(
+                barterables.OfType<PlayerPartyTroopBarterable>(),
+                b => b.OriginalParty == initiatorParty && b.TroopRosterElement.Character == initiatorTroop);
+            Assert.Equal(initiatorParty, troopBarterable.OriginalParty);
+            Assert.IsType<OtherBarterGroup>(troopBarterable.Group);
+            Assert.Equal(initiatorTroop, troopBarterable.TroopRosterElement.Character);
+            Assert.Equal(5, troopBarterable.TroopRosterElement.Number);
+            Assert.Equal("item_barterable", troopBarterable.StringID);
+            Assert.IsType<CharacterImageIdentifier>(troopBarterable.GetVisualIdentifier());
+            Assert.Equal(2, barterables.OfType<GoldBarterable>().Count());
+        });
+    }
+
+    [Fact]
+    public void TradeContext_CanOffer_AllowsLocalFiefsWithNullOriginalParty()
+    {
+        var (_, _, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+        var settlementId = TestEnvironment.CreateRegisteredObject<Settlement>();
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(initiatorPartyId, out var initiatorParty));
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(responderPartyId, out var responderParty));
+            Assert.True(Server.ObjectManager.TryGetObject<Settlement>(settlementId, out var settlement));
+
+            var localFief = new FiefBarterable(settlement, initiatorParty.LeaderHero, responderParty.LeaderHero);
+            var remoteFief = new FiefBarterable(settlement, responderParty.LeaderHero, initiatorParty.LeaderHero);
+
+            Assert.Null(localFief.OriginalParty);
+            Assert.Null(remoteFief.OriginalParty);
+
+            PlayerPartyTradeContext.Begin("session-1", initiatorParty);
+            try
+            {
+                Assert.True(PlayerPartyTradeContext.CanOffer(localFief));
+                Assert.False(PlayerPartyTradeContext.CanOffer(remoteFief));
+            }
+            finally
+            {
+                PlayerPartyTradeContext.End("session-1");
+            }
+        });
+    }
+
+    [Fact]
+    public void TradeActiveState_IncludesServerPartyItemSnapshots()
+    {
+        var (client1, client2, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+        var initiatorItemId = TestEnvironment.CreateRegisteredObject<ItemObject>();
+        var responderItemId = TestEnvironment.CreateRegisteredObject<ItemObject>();
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(initiatorPartyId, out var initiatorParty));
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(responderPartyId, out var responderParty));
+            Assert.True(Server.ObjectManager.TryGetObject<ItemObject>(initiatorItemId, out var initiatorItem));
+            Assert.True(Server.ObjectManager.TryGetObject<ItemObject>(responderItemId, out var responderItem));
+
+            initiatorParty.ItemRoster.AddToCounts(initiatorItem, 3);
+            responderParty.ItemRoster.AddToCounts(responderItem, 4);
+        });
+
+        Server.NetworkSentMessages.Clear();
+        StartTrade(client1, client2, initiatorPartyId, responderPartyId);
+
+        var tradeStates = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionState>()
+            .Where(s => s.Phase == PlayerPartyInteractionPhase.TradeActive)
+            .ToArray();
+
+        var initiatorState = tradeStates.Single(s => s.PartyId == initiatorPartyId);
+        Assert.Single(initiatorState.PartyItems);
+        Assert.Equal(initiatorItemId, initiatorState.PartyItems[0].ItemObjectData.ItemObjectId);
+        Assert.Equal(3, initiatorState.PartyItems[0].Amount);
+        Assert.Single(initiatorState.OtherPartyItems);
+        Assert.Equal(responderItemId, initiatorState.OtherPartyItems[0].ItemObjectData.ItemObjectId);
+        Assert.Equal(4, initiatorState.OtherPartyItems[0].Amount);
+
+        var responderState = tradeStates.Single(s => s.PartyId == responderPartyId);
+        Assert.Single(responderState.PartyItems);
+        Assert.Equal(responderItemId, responderState.PartyItems[0].ItemObjectData.ItemObjectId);
+        Assert.Equal(4, responderState.PartyItems[0].Amount);
+        Assert.Single(responderState.OtherPartyItems);
+        Assert.Equal(initiatorItemId, responderState.OtherPartyItems[0].ItemObjectData.ItemObjectId);
+        Assert.Equal(3, responderState.OtherPartyItems[0].Amount);
+    }
+
+    [Fact]
+    public void TradeAccept_FromBothParties_EndsWithTradeAcceptedOutcome()
+    {
+        var (client1, client2, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+        var sessionId = StartTrade(client1, client2, initiatorPartyId, responderPartyId);
+
+        Server.NetworkSentMessages.Clear();
+        client1.Call(() => client1.Resolve<INetwork>().SendAll(new NetworkPlayerPartyTradeAcceptChanged(sessionId, accepted: true)));
+        client2.Call(() => client2.Resolve<INetwork>().SendAll(new NetworkPlayerPartyTradeAcceptChanged(sessionId, accepted: true)));
+
+        var ended = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionEnded>().Single();
+        Assert.Equal(sessionId, ended.SessionId);
+        Assert.Equal(initiatorPartyId, ended.InitiatorPartyId);
+        Assert.Equal(responderPartyId, ended.ResponderPartyId);
+        Assert.Equal(PlayerPartyInteractionOutcomeType.TradeAccepted, ended.OutcomeType);
+        AssertInteractionStateCleared(client1);
+        AssertInteractionStateCleared(client2);
+
+        Server.NetworkSentMessages.Clear();
+        RequestInteraction(client1, initiatorPartyId, responderPartyId);
+
+        var restarted = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>().Single();
+        Assert.NotEqual(sessionId, restarted.SessionId);
+        Assert.Equal(initiatorPartyId, restarted.InitiatorPartyId);
+        Assert.Equal(responderPartyId, restarted.ResponderPartyId);
+    }
+
+    [Fact]
+    public void TradeAccept_FromBothParties_AppliesAcceptedTradeContents()
+    {
+        var (client1, client2, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+        var initiatorItemId = TestEnvironment.CreateRegisteredObject<ItemObject>();
+        var responderItemId = TestEnvironment.CreateRegisteredObject<ItemObject>();
+        var initiatorTroopId = TestEnvironment.CreateRegisteredObject<CharacterObject>();
+        var responderTroopId = TestEnvironment.CreateRegisteredObject<CharacterObject>();
+        var initiatorPrisonerId = TestEnvironment.CreateRegisteredObject<Hero>();
+        var responderPrisonerId = TestEnvironment.CreateRegisteredObject<Hero>();
+        var initiatorSettlementId = TestEnvironment.CreateRegisteredObject<Settlement>();
+        var responderSettlementId = TestEnvironment.CreateRegisteredObject<Settlement>();
+        var initiatorTownId = TestEnvironment.CreateRegisteredObject<Town>();
+        var responderTownId = TestEnvironment.CreateRegisteredObject<Town>();
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(initiatorPartyId, out var initiatorParty));
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(responderPartyId, out var responderParty));
+            Assert.True(Server.ObjectManager.TryGetObject<ItemObject>(initiatorItemId, out var initiatorItem));
+            Assert.True(Server.ObjectManager.TryGetObject<ItemObject>(responderItemId, out var responderItem));
+            Assert.True(Server.ObjectManager.TryGetObject<CharacterObject>(initiatorTroopId, out var initiatorTroop));
+            Assert.True(Server.ObjectManager.TryGetObject<CharacterObject>(responderTroopId, out var responderTroop));
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(initiatorPrisonerId, out var initiatorPrisoner));
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(responderPrisonerId, out var responderPrisoner));
+            Assert.True(Server.ObjectManager.TryGetObject<Settlement>(initiatorSettlementId, out var initiatorSettlement));
+            Assert.True(Server.ObjectManager.TryGetObject<Settlement>(responderSettlementId, out var responderSettlement));
+            Assert.True(Server.ObjectManager.TryGetObject<Town>(initiatorTownId, out var initiatorTown));
+            Assert.True(Server.ObjectManager.TryGetObject<Town>(responderTownId, out var responderTown));
+
+            initiatorParty.LeaderHero.Gold = 100;
+            responderParty.LeaderHero.Gold = 60;
+            initiatorParty.ItemRoster.AddToCounts(initiatorItem, 5);
+            responderParty.ItemRoster.AddToCounts(responderItem, 7);
+            initiatorParty.MemberRoster.AddToCounts(initiatorTroop, 6);
+            responderParty.MemberRoster.AddToCounts(responderTroop, 8);
+            initiatorParty.PrisonRoster.AddToCounts(initiatorPrisoner.CharacterObject, 1);
+            responderParty.PrisonRoster.AddToCounts(responderPrisoner.CharacterObject, 1);
+            SetupFief(initiatorSettlement, initiatorTown, initiatorParty);
+            SetupFief(responderSettlement, responderTown, responderParty);
+        });
+
+        var sessionId = StartTrade(client1, client2, initiatorPartyId, responderPartyId);
+
+        client1.Call(() => client1.Resolve<INetwork>().SendAll(new NetworkPlayerPartyTradeOfferUpdated(
+            sessionId,
+            initiatorPartyId,
+            new[]
+            {
+                new ItemRosterElementData(new ItemObjectData(initiatorItemId, null, itemModifierNull: true), 2)
+            },
+            new[] { new TroopRosterElementData(initiatorTroopId, 4, 0, 0, isHero: false) },
+            offeredGold: 25,
+            offeredFiefs: new[] { initiatorSettlementId },
+            offeredPrisoners: new[] { new TroopRosterElementData(initiatorPrisonerId, 1, 0, 0, isHero: true) })));
+        client2.Call(() => client2.Resolve<INetwork>().SendAll(new NetworkPlayerPartyTradeOfferUpdated(
+            sessionId,
+            responderPartyId,
+            new[]
+            {
+                new ItemRosterElementData(new ItemObjectData(responderItemId, null, itemModifierNull: true), 3)
+            },
+            new[] { new TroopRosterElementData(responderTroopId, 5, 0, 0, isHero: false) },
+            offeredGold: 10,
+            offeredFiefs: new[] { responderSettlementId },
+            offeredPrisoners: new[] { new TroopRosterElementData(responderPrisonerId, 1, 0, 0, isHero: true) })));
+
+        Server.NetworkSentMessages.Clear();
+        client1.Call(() => client1.Resolve<INetwork>().SendAll(new NetworkPlayerPartyTradeAcceptChanged(sessionId, accepted: true)));
+        client2.Call(() => client2.Resolve<INetwork>().SendAll(new NetworkPlayerPartyTradeAcceptChanged(sessionId, accepted: true)));
+
+        var ended = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionEnded>().Single();
+        Assert.Equal(PlayerPartyInteractionOutcomeType.TradeAccepted, ended.OutcomeType);
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(initiatorPartyId, out var initiatorParty));
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(responderPartyId, out var responderParty));
+            Assert.True(Server.ObjectManager.TryGetObject<ItemObject>(initiatorItemId, out var initiatorItem));
+            Assert.True(Server.ObjectManager.TryGetObject<ItemObject>(responderItemId, out var responderItem));
+            Assert.True(Server.ObjectManager.TryGetObject<CharacterObject>(initiatorTroopId, out var initiatorTroop));
+            Assert.True(Server.ObjectManager.TryGetObject<CharacterObject>(responderTroopId, out var responderTroop));
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(initiatorPrisonerId, out var initiatorPrisoner));
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(responderPrisonerId, out var responderPrisoner));
+            Assert.True(Server.ObjectManager.TryGetObject<Settlement>(initiatorSettlementId, out var initiatorSettlement));
+            Assert.True(Server.ObjectManager.TryGetObject<Settlement>(responderSettlementId, out var responderSettlement));
+
+            Assert.Equal(85, initiatorParty.LeaderHero.Gold);
+            Assert.Equal(75, responderParty.LeaderHero.Gold);
+
+            Assert.Equal(3, GetItemAmount(initiatorParty, initiatorItem));
+            Assert.Equal(2, GetItemAmount(responderParty, initiatorItem));
+            Assert.Equal(3, GetItemAmount(initiatorParty, responderItem));
+            Assert.Equal(4, GetItemAmount(responderParty, responderItem));
+
+            Assert.Equal(2, initiatorParty.MemberRoster.GetElementNumber(initiatorTroop));
+            Assert.Equal(4, responderParty.MemberRoster.GetElementNumber(initiatorTroop));
+            Assert.Equal(5, initiatorParty.MemberRoster.GetElementNumber(responderTroop));
+            Assert.Equal(3, responderParty.MemberRoster.GetElementNumber(responderTroop));
+
+            Assert.Equal(0, initiatorParty.PrisonRoster.GetElementNumber(initiatorPrisoner.CharacterObject));
+            Assert.Equal(1, responderParty.PrisonRoster.GetElementNumber(initiatorPrisoner.CharacterObject));
+            Assert.Equal(1, initiatorParty.PrisonRoster.GetElementNumber(responderPrisoner.CharacterObject));
+            Assert.Equal(0, responderParty.PrisonRoster.GetElementNumber(responderPrisoner.CharacterObject));
+
+            Assert.Equal(responderParty.LeaderHero.Clan, initiatorSettlement.OwnerClan);
+            Assert.Equal(initiatorParty.LeaderHero.Clan, responderSettlement.OwnerClan);
+        });
+    }
+
+    [Fact]
+    public void LeaveOption_EndsInteractionAndClearsTracking()
+    {
+        var (client1, _, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+        RequestInteraction(client1, initiatorPartyId, responderPartyId);
+        var sessionId = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>().Single().SessionId;
+
+        Server.NetworkSentMessages.Clear();
+        SubmitOption(client1, sessionId, initiatorPartyId, PlayerPartyInteractionOption.Leave);
+
+        var ended = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionEnded>().Single();
+        Assert.Equal(PlayerPartyInteractionOutcomeType.Left, ended.OutcomeType);
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionState>());
+    }
+
+    [Fact]
+    public void TradeProposal_DeclinedByResponder_EndsInteraction()
+    {
+        var (client1, client2, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+        RequestInteraction(client1, initiatorPartyId, responderPartyId);
+        var sessionId = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>().Single().SessionId;
+        SubmitOption(client1, sessionId, initiatorPartyId, PlayerPartyInteractionOption.TradeProposal);
+
+        Server.NetworkSentMessages.Clear();
+        SubmitOption(client2, sessionId, responderPartyId, PlayerPartyInteractionOption.DeclineProposal);
+
+        var ended = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionEnded>().Single();
+        Assert.Equal(PlayerPartyInteractionOutcomeType.TradeDeclined, ended.OutcomeType);
+        AssertInteractionStateCleared(client1);
+        AssertInteractionStateCleared(client2);
+    }
+
+    [Fact]
+    public void TradeOfferUpdate_RelaysThroughServerAndClearsAcceptState()
+    {
+        var (client1, client2, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+        var sessionId = StartTrade(client1, client2, initiatorPartyId, responderPartyId);
+
+        Server.NetworkSentMessages.Clear();
+        client1.Call(() => client1.Resolve<INetwork>().SendAll(new NetworkPlayerPartyTradeOfferUpdated(
+            sessionId,
+            initiatorPartyId,
+            new[]
+            {
+                new ItemRosterElementData(new ItemObjectData("item-1", null, itemModifierNull: true), 2)
+            },
+            new[] { new TroopRosterElementData("troop-1", 3, 0, 7, isHero: false) },
+            offeredGold: 25,
+            offeredFiefs: new[] { "fief-1" },
+            offeredPrisoners: new[] { new TroopRosterElementData("prisoner-1", 1, 0, 0, isHero: true) })));
+
+        var relayedOffer = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyTradeOfferUpdated>().Single();
+        Assert.Equal(sessionId, relayedOffer.SessionId);
+        Assert.Equal(initiatorPartyId, relayedOffer.PartyId);
+        Assert.Single(relayedOffer.OfferedItems);
+        Assert.Equal(2, relayedOffer.OfferedItems[0].Amount);
+        Assert.Single(relayedOffer.OfferedTroops);
+        Assert.Equal("troop-1", relayedOffer.OfferedTroops[0].CharacterId);
+        Assert.Equal(3, relayedOffer.OfferedTroops[0].Number);
+        Assert.Equal(25, relayedOffer.OfferedGold);
+        Assert.Single(relayedOffer.OfferedFiefs);
+        Assert.Equal("fief-1", relayedOffer.OfferedFiefs[0]);
+        Assert.Single(relayedOffer.OfferedPrisoners);
+        Assert.Equal("prisoner-1", relayedOffer.OfferedPrisoners[0].CharacterId);
+
+        var states = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionState>().ToArray();
+        Assert.Contains(states, s =>
+            s.PartyId == initiatorPartyId &&
+            !s.InitiatorAcceptedTrade &&
+            !s.ResponderAcceptedTrade);
+        Assert.Contains(states, s =>
+            s.PartyId == responderPartyId &&
+            !s.InitiatorAcceptedTrade &&
+            !s.ResponderAcceptedTrade);
+    }
+
+    [Fact]
+    public void TradeOfferUpdate_SpoofedResponderPartyId_UsesSenderParty()
+    {
+        var (client1, client2, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+        var sessionId = StartTrade(client1, client2, initiatorPartyId, responderPartyId);
+
+        Server.NetworkSentMessages.Clear();
+        client1.Call(() => client1.Resolve<INetwork>().SendAll(new NetworkPlayerPartyTradeOfferUpdated(
+            sessionId,
+            responderPartyId,
+            new[]
+            {
+                new ItemRosterElementData(new ItemObjectData("item-1", null, itemModifierNull: true), 2)
+            },
+            Array.Empty<TroopRosterElementData>())));
+
+        var relayedOffer = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyTradeOfferUpdated>().Single();
+        Assert.Equal(sessionId, relayedOffer.SessionId);
+        Assert.Equal(initiatorPartyId, relayedOffer.PartyId);
+    }
+
+    [Fact]
+    public void TradeOfferUpdate_AfterEitherPlayerAccepts_IsIgnored()
+    {
+        var (client1, client2, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+        var sessionId = StartTrade(client1, client2, initiatorPartyId, responderPartyId);
+
+        Server.NetworkSentMessages.Clear();
+        client1.Call(() => client1.Resolve<INetwork>().SendAll(new NetworkPlayerPartyTradeAcceptChanged(sessionId, accepted: true)));
+        Assert.Contains(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionState>(), s =>
+            s.PartyId == initiatorPartyId &&
+            s.InitiatorAcceptedTrade &&
+            !s.ResponderAcceptedTrade);
+
+        Server.NetworkSentMessages.Clear();
+        client1.Call(() => client1.Resolve<INetwork>().SendAll(new NetworkPlayerPartyTradeOfferUpdated(
+            sessionId,
+            initiatorPartyId,
+            new[]
+            {
+                new ItemRosterElementData(new ItemObjectData("item-1", null, itemModifierNull: true), 2)
+            },
+            Array.Empty<TroopRosterElementData>())));
+
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyTradeOfferUpdated>());
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionState>());
+    }
+
+    [Fact]
+    public void TradeCancel_EndsInteractionAndAllowsNewInteraction()
+    {
+        var (client1, client2, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+        var sessionId = StartTrade(client1, client2, initiatorPartyId, responderPartyId);
+
+        Server.NetworkSentMessages.Clear();
+        SubmitOption(client1, sessionId, initiatorPartyId, PlayerPartyInteractionOption.Leave);
+
+        var ended = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionEnded>().Single();
+        Assert.Equal(sessionId, ended.SessionId);
+        Assert.Equal(PlayerPartyInteractionOutcomeType.TradeDeclined, ended.OutcomeType);
+        AssertInteractionStateCleared(client1);
+        AssertInteractionStateCleared(client2);
+
+        Server.NetworkSentMessages.Clear();
+        RequestInteraction(client1, initiatorPartyId, responderPartyId);
+
+        var restarted = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>().Single();
+        Assert.NotEqual(sessionId, restarted.SessionId);
+        Assert.Equal(initiatorPartyId, restarted.InitiatorPartyId);
+        Assert.Equal(responderPartyId, restarted.ResponderPartyId);
+    }
+
+    [Fact]
+    public void HostilePlayerParties_RequestIsRejectedWithoutStartingInteraction()
+    {
+        var (client1, _, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+        MakePartiesHostile(initiatorPartyId, responderPartyId);
+
+        RequestInteraction(client1, initiatorPartyId, responderPartyId);
+
+        var denied = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionDenied>().Single();
+        Assert.Equal(PlayerPartyInteractionDeniedReason.Hostile, denied.Reason);
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>());
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionState>());
+    }
+
+    [Fact]
+    public void AiPartyConversation_UsesExistingAllowPath()
+    {
+        var (client1, _, initiatorPartyId, _) = CreateTwoPlayerParties();
+        var aiPartyId = CreateMobilePartyBase();
+
+        RequestInteraction(client1, initiatorPartyId, aiPartyId);
+
+        var allowed = Server.NetworkSentMessages.GetMessages<NetworkAllowConversation>().Single();
+        Assert.Equal(initiatorPartyId, allowed.AttackerId);
+        Assert.Equal(aiPartyId, allowed.DefenderId);
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>());
+        AssertInteractionStateCleared(client1);
+
+        client1.Call(() => client1.Resolve<INetwork>().SendAll(new NetworkConversationEnded()));
+    }
+
+    [Fact]
+    public void ExistingBattleJoin_UsesExistingAllowPath()
+    {
+        var (client1, _, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+        var mapEventSideId = CreateServerMapEventSide();
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<MapEventSide>(mapEventSideId, out var side));
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(responderPartyId, out var responderParty));
+
+            responderParty.MapEventSide = side;
+        }, MapEventDisabledMethods);
+
+        RequestInteraction(client1, initiatorPartyId, responderPartyId);
+
+        var allowed = Server.NetworkSentMessages.GetMessages<NetworkAllowConversation>().Single();
+        Assert.Equal(initiatorPartyId, allowed.AttackerId);
+        Assert.Equal(responderPartyId, allowed.DefenderId);
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>());
+    }
+
+    private (EnvironmentInstance client1, EnvironmentInstance client2, string initiatorPartyId, string responderPartyId) CreateTwoPlayerParties()
+    {
+        var clients = Clients.ToArray();
+        var client1 = clients[0];
+        var client2 = clients[1];
+
+        client1.Resolve<IControllerIdProvider>().SetControllerId("PlayerOne");
+        client2.Resolve<IControllerIdProvider>().SetControllerId("PlayerTwo");
+
+        var (_, initiatorMobilePartyId) = CreatePlayerHeroParty("PlayerOne");
+        var (_, responderMobilePartyId) = CreatePlayerHeroParty("PlayerTwo");
+
+        return (
+            client1,
+            client2,
+            GetPartyBaseId(Server, initiatorMobilePartyId),
+            GetPartyBaseId(Server, responderMobilePartyId));
+    }
+
+    private string StartTrade(EnvironmentInstance client1, EnvironmentInstance client2, string initiatorPartyId, string responderPartyId)
+    {
+        RequestInteraction(client1, initiatorPartyId, responderPartyId);
+        var sessionId = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>().Single().SessionId;
+        SubmitOption(client1, sessionId, initiatorPartyId, PlayerPartyInteractionOption.TradeProposal);
+        SubmitOption(client2, sessionId, responderPartyId, PlayerPartyInteractionOption.AcceptProposal);
+
+        return sessionId;
+    }
+
+    private string CreateMobilePartyBase()
+    {
+        var mobilePartyId = TestEnvironment.CreateRegisteredObject<MobileParty>();
+        return GetPartyBaseId(Server, mobilePartyId);
+    }
+
+    private void RequestInteraction(EnvironmentInstance client, string initiatorPartyId, string responderPartyId)
+    {
+        client.Call(() =>
+            client.Resolve<INetwork>().SendAll(new NetworkRequestConversation(
+                responderPartyId,
+                initiatorPartyId,
+                forcePlayerOutFromSettlement: false,
+                ConversationRestartSource.PlayerEncounter)));
+    }
+
+    private void SubmitOption(EnvironmentInstance client, string sessionId, string partyId, PlayerPartyInteractionOption option)
+    {
+        client.Call(() =>
+            client.Resolve<INetwork>().SendAll(new NetworkSubmitPlayerPartyInteractionOption(sessionId, option, partyId)));
+    }
+
+    private void SubmitDialogOption(
+        EnvironmentInstance client,
+        NetworkPlayerPartyInteractionState state,
+        PlayerPartyInteractionOption option)
+    {
+        client.Call(() =>
+        {
+            PlayerPartyInteractionDialogState.Apply(state);
+            PlayerPartyInteractionDialogState.Submit(option);
+        });
+    }
+
+    private void OpenServiceOptions(
+        EnvironmentInstance client,
+        NetworkPlayerPartyInteractionState state)
+    {
+        client.Call(() =>
+        {
+            PlayerPartyInteractionDialogState.Apply(state);
+            PlayerPartyInteractionDialogState.ShowServiceOptions();
+        });
+    }
+
+    private void SubmitCurrentDialogOption(EnvironmentInstance client, PlayerPartyInteractionOption option)
+    {
+        client.Call(() => PlayerPartyInteractionDialogState.Submit(option));
+    }
+
+    private static void AssertInteractionStateCleared(EnvironmentInstance client)
+    {
+        client.Call(() =>
+        {
+            Assert.False(PlayerPartyInteractionDialogState.HasActiveState);
+            Assert.False(PlayerPartyTradeContext.IsActive);
+        });
+    }
+
+    private void ClearPlayerPartyInteractionState()
+    {
+        Server.Call(ClearPlayerPartyInteractionStateForInstance);
+
+        foreach (var client in Clients)
+            client.Call(ClearPlayerPartyInteractionStateForInstance);
+    }
+
+    private static void ClearPlayerPartyInteractionStateForInstance()
+    {
+        PlayerPartyInteractionDialogState.Clear();
+        PlayerPartyTradeContext.End();
+    }
+
+    private static string GetPartyBaseId(EnvironmentInstance instance, string mobilePartyId)
+    {
+        string? partyBaseId = null;
+
+        instance.Call(() =>
+        {
+            Assert.True(instance.ObjectManager.TryGetObject<MobileParty>(mobilePartyId, out var party));
+            Assert.True(instance.ObjectManager.TryGetId(party.Party, out partyBaseId));
+        });
+
+        Assert.NotNull(partyBaseId);
+        return partyBaseId!;
+    }
+
+    private static int GetItemAmount(PartyBase party, ItemObject itemObject)
+    {
+        foreach (var item in party.ItemRoster)
+        {
+            if (item.EquipmentElement.Item == itemObject)
+                return item.Amount;
+        }
+
+        return 0;
+    }
+
+    private static void SetupFief(Settlement settlement, Town town, PartyBase ownerParty)
+    {
+        settlement.Town = town;
+        settlement.SetSettlementComponent(town);
+        town.OwnerClan = ownerParty.LeaderHero.Clan;
+        town.IsOwnerUnassigned = false;
+    }
+
+    private void SetupResponderKingdomLeader(string initiatorPartyId, string responderPartyId, int initiatorClanTier)
+    {
+        var kingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(initiatorPartyId, out var initiatorParty));
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(responderPartyId, out var responderParty));
+            Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(kingdomId, out var kingdom));
+
+            initiatorParty.LeaderHero.Clan.Tier = initiatorClanTier;
+            responderParty.LeaderHero.Clan.Kingdom = kingdom;
+            kingdom.RulingClan = responderParty.LeaderHero.Clan;
+            Assert.True(responderParty.LeaderHero.IsKingdomLeader);
+        });
+    }
+
+    private void MakePartiesHostile(string initiatorPartyId, string responderPartyId)
+    {
+        var initiatorClanId = TestEnvironment.CreateRegisteredObject<Clan>();
+        var responderClanId = TestEnvironment.CreateRegisteredObject<Clan>();
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(initiatorPartyId, out var initiatorParty));
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(responderPartyId, out var responderParty));
+            Assert.True(Server.ObjectManager.TryGetObject<Clan>(initiatorClanId, out var initiatorClan));
+            Assert.True(Server.ObjectManager.TryGetObject<Clan>(responderClanId, out var responderClan));
+
+            initiatorParty.MobileParty.ActualClan = initiatorClan;
+            responderParty.MobileParty.ActualClan = responderClan;
+            SetWar(initiatorClan, responderClan);
+            Assert.Equal(initiatorClan, initiatorParty.MapFaction);
+            Assert.Equal(responderClan, responderParty.MapFaction);
+            Assert.Contains(responderClan, initiatorClan.FactionsAtWarWith);
+            Assert.Contains(initiatorClan, responderClan.FactionsAtWarWith);
+        });
+    }
+
+    private static void SetWar(Clan initiatorClan, Clan responderClan)
+    {
+        var factionsAtWarWith = typeof(Clan).GetField("_factionsAtWarWith", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        var initiatorWars = new MBList<IFaction> { responderClan };
+        var responderWars = new MBList<IFaction> { initiatorClan };
+
+        factionsAtWarWith!.SetValue(initiatorClan, initiatorWars);
+        factionsAtWarWith.SetValue(responderClan, responderWars);
+    }
+
+    private static void InvokeAddBarterGroups(BarterData barterData)
+        => typeof(PlayerPartyInteractionHandler)
+            .GetMethod("AddBarterGroups", BindingFlags.Static | BindingFlags.NonPublic)!
+            .Invoke(null, new object[] { barterData });
+
+    private static void InvokeAddPartyBarterables(
+        BarterData barterData,
+        Hero ownerHero,
+        Hero otherHero,
+        PartyBase ownerParty,
+        PartyBase otherParty)
+        => typeof(PlayerPartyInteractionHandler)
+            .GetMethod("AddPartyBarterables", BindingFlags.Static | BindingFlags.NonPublic)!
+            .Invoke(null, new object[] { barterData, ownerHero, otherHero, ownerParty, otherParty });
+}

--- a/source/GameInterface.Tests/Serialization/NetworkPlayerPartyInteractionSerializationTest.cs
+++ b/source/GameInterface.Tests/Serialization/NetworkPlayerPartyInteractionSerializationTest.cs
@@ -1,0 +1,165 @@
+using GameInterface.Services.Inventory.Data;
+using GameInterface.Services.MapEvents.Messages.Conversation;
+using GameInterface.Services.MapEvents.PlayerPartyInteractions;
+using GameInterface.Services.TroopRosters.Data;
+using ProtoBuf.Meta;
+using System.IO;
+using Xunit;
+
+namespace GameInterface.Tests.Serialization;
+
+public class NetworkPlayerPartyInteractionSerializationTest
+{
+    [Fact]
+    public void Started_RoundTrip_PreservesFields()
+    {
+        var original = new NetworkPlayerPartyInteractionStarted(
+            "session-1",
+            "initiator-party",
+            "responder-party",
+            "Initiator",
+            "Responder");
+
+        var result = RoundTrip(original);
+
+        Assert.Equal(original.SessionId, result.SessionId);
+        Assert.Equal(original.InitiatorPartyId, result.InitiatorPartyId);
+        Assert.Equal(original.ResponderPartyId, result.ResponderPartyId);
+        Assert.Equal(original.InitiatorName, result.InitiatorName);
+        Assert.Equal(original.ResponderName, result.ResponderName);
+    }
+
+    [Fact]
+    public void State_RoundTrip_PreservesFields()
+    {
+        var original = new NetworkPlayerPartyInteractionState(
+            "session-1",
+            "party-1",
+            "party-2",
+            "Other",
+            PlayerPartyInteractionPhase.ProposalPending,
+            PlayerPartyInteractionProposal.Trade,
+            new[] { PlayerPartyInteractionOption.AcceptProposal, PlayerPartyInteractionOption.DeclineProposal },
+            isInitiator: false,
+            initiatorAcceptedTrade: true,
+            responderAcceptedTrade: false,
+            partyItems: new[] { new ItemRosterElementData(new ItemObjectData("party-item", null, itemModifierNull: true), 3) },
+            otherPartyItems: new[] { new ItemRosterElementData(new ItemObjectData("other-item", null, itemModifierNull: true), 4) });
+
+        var result = RoundTrip(original);
+
+        Assert.Equal(original.SessionId, result.SessionId);
+        Assert.Equal(original.PartyId, result.PartyId);
+        Assert.Equal(original.OtherPartyId, result.OtherPartyId);
+        Assert.Equal(original.OtherPlayerName, result.OtherPlayerName);
+        Assert.Equal(original.Phase, result.Phase);
+        Assert.Equal(original.Proposal, result.Proposal);
+        Assert.Equal(original.Options, result.Options);
+        Assert.Equal(original.IsInitiator, result.IsInitiator);
+        Assert.Equal(original.InitiatorAcceptedTrade, result.InitiatorAcceptedTrade);
+        Assert.Equal(original.ResponderAcceptedTrade, result.ResponderAcceptedTrade);
+        Assert.Single(result.PartyItems);
+        Assert.Equal("party-item", result.PartyItems[0].ItemObjectData.ItemObjectId);
+        Assert.Equal(3, result.PartyItems[0].Amount);
+        Assert.Single(result.OtherPartyItems);
+        Assert.Equal("other-item", result.OtherPartyItems[0].ItemObjectData.ItemObjectId);
+        Assert.Equal(4, result.OtherPartyItems[0].Amount);
+    }
+
+    [Fact]
+    public void SubmitOption_RoundTrip_PreservesFields()
+    {
+        var original = new NetworkSubmitPlayerPartyInteractionOption(
+            "session-1",
+            PlayerPartyInteractionOption.TradeProposal,
+            "party-1");
+
+        var result = RoundTrip(original);
+
+        Assert.Equal(original.SessionId, result.SessionId);
+        Assert.Equal(original.Option, result.Option);
+        Assert.Equal(original.PartyId, result.PartyId);
+    }
+
+    [Fact]
+    public void Ended_RoundTrip_PreservesFields()
+    {
+        var original = new NetworkPlayerPartyInteractionEnded(
+            "session-1",
+            "initiator-party",
+            "responder-party",
+            PlayerPartyInteractionOutcomeType.TradeAccepted);
+
+        var result = RoundTrip(original);
+
+        Assert.Equal(original.SessionId, result.SessionId);
+        Assert.Equal(original.InitiatorPartyId, result.InitiatorPartyId);
+        Assert.Equal(original.ResponderPartyId, result.ResponderPartyId);
+        Assert.Equal(original.OutcomeType, result.OutcomeType);
+    }
+
+    [Fact]
+    public void Denied_RoundTrip_PreservesReason()
+    {
+        var original = new NetworkPlayerPartyInteractionDenied(PlayerPartyInteractionDeniedReason.Hostile);
+
+        var result = RoundTrip(original);
+
+        Assert.Equal(original.Reason, result.Reason);
+    }
+
+    [Fact]
+    public void TradeOffer_RoundTrip_PreservesFields()
+    {
+        var original = new NetworkPlayerPartyTradeOfferUpdated(
+            "session-1",
+            "party-1",
+            new[] { new ItemRosterElementData(new ItemObjectData("item-1", null, itemModifierNull: true), 2) },
+            new[] { new TroopRosterElementData("troop-1", 3, 1, 4, isHero: false) },
+            offeredGold: 25,
+            offeredFiefs: new[] { "fief-1" },
+            offeredPrisoners: new[] { new TroopRosterElementData("prisoner-1", 1, 0, 0, isHero: true) });
+
+        var result = RoundTrip(original);
+
+        Assert.Equal(original.SessionId, result.SessionId);
+        Assert.Equal(original.PartyId, result.PartyId);
+        Assert.Single(result.OfferedItems);
+        Assert.Equal("item-1", result.OfferedItems[0].ItemObjectData.ItemObjectId);
+        Assert.Single(result.OfferedTroops);
+        Assert.Equal("troop-1", result.OfferedTroops[0].CharacterId);
+        Assert.Equal(25, result.OfferedGold);
+        Assert.Single(result.OfferedFiefs);
+        Assert.Equal("fief-1", result.OfferedFiefs[0]);
+        Assert.Single(result.OfferedPrisoners);
+        Assert.Equal("prisoner-1", result.OfferedPrisoners[0].CharacterId);
+    }
+
+    [Fact]
+    public void TradeAccept_RoundTrip_PreservesFields()
+    {
+        var original = new NetworkPlayerPartyTradeAcceptChanged("session-1", accepted: true);
+
+        var result = RoundTrip(original);
+
+        Assert.Equal(original.SessionId, result.SessionId);
+        Assert.Equal(original.Accepted, result.Accepted);
+    }
+
+    private static T RoundTrip<T>(T original)
+    {
+        byte[] bytes;
+        using (var ms = new MemoryStream())
+        {
+            RuntimeTypeModel.Default.Serialize(ms, original);
+            bytes = ms.ToArray();
+        }
+
+        Assert.NotEmpty(bytes);
+
+        using (var ms = new MemoryStream(bytes))
+        {
+            return (T)RuntimeTypeModel.Default.Deserialize(ms, null, typeof(T));
+        }
+    }
+}

--- a/source/GameInterface.Tests/Services/MapEvents/PlayerPartyInteractionDialogStateTests.cs
+++ b/source/GameInterface.Tests/Services/MapEvents/PlayerPartyInteractionDialogStateTests.cs
@@ -1,0 +1,54 @@
+using GameInterface.Services.MapEvents.Messages.Conversation;
+using GameInterface.Services.MapEvents.PlayerPartyInteractions;
+using Xunit;
+
+namespace GameInterface.Tests.Services.MapEvents;
+
+public class PlayerPartyInteractionDialogStateTests
+{
+    [Fact]
+    public void WaitingForProposal_UsesStableText()
+    {
+        try
+        {
+            PlayerPartyInteractionDialogState.Apply(new NetworkPlayerPartyInteractionState(
+                "session-1",
+                "party-1",
+                "party-2",
+                "RandomPlayer",
+                PlayerPartyInteractionPhase.WaitingForProposal,
+                PlayerPartyInteractionProposal.None,
+                new[] { PlayerPartyInteractionOption.Leave },
+                isInitiator: false));
+
+            Assert.Equal("Awaiting proposal from RandomPlayer...", PlayerPartyInteractionDialogState.GetDialogText());
+        }
+        finally
+        {
+            PlayerPartyInteractionDialogState.Clear("session-1");
+        }
+    }
+
+    [Fact]
+    public void WaitingForResponse_UsesStableText()
+    {
+        try
+        {
+            PlayerPartyInteractionDialogState.Apply(new NetworkPlayerPartyInteractionState(
+                "session-1",
+                "party-1",
+                "party-2",
+                "RandomPlayer",
+                PlayerPartyInteractionPhase.WaitingForResponse,
+                PlayerPartyInteractionProposal.Trade,
+                new PlayerPartyInteractionOption[0],
+                isInitiator: true));
+
+            Assert.Equal("Awaiting response from RandomPlayer...", PlayerPartyInteractionDialogState.GetDialogText());
+        }
+        finally
+        {
+            PlayerPartyInteractionDialogState.Clear("session-1");
+        }
+    }
+}

--- a/source/GameInterface.Tests/Services/MapEvents/PlayerPartyTradeContextTests.cs
+++ b/source/GameInterface.Tests/Services/MapEvents/PlayerPartyTradeContextTests.cs
@@ -1,0 +1,94 @@
+using GameInterface.Services.MapEvents.PlayerPartyInteractions;
+using System;
+using TaleWorlds.CampaignSystem.Inventory;
+using Xunit;
+
+namespace GameInterface.Tests.Services.MapEvents;
+
+public class PlayerPartyTradeContextTests : IDisposable
+{
+    public void Dispose()
+    {
+        PlayerPartyTradeContext.End();
+    }
+
+    [Fact]
+    public void CanTransfer_AllowsBothSidesWhenInactive()
+    {
+        Assert.True(PlayerPartyTradeContext.CanTransfer(new TransferCommand
+        {
+            FromSide = InventoryLogic.InventorySide.PlayerInventory
+        }));
+        Assert.True(PlayerPartyTradeContext.CanTransfer(new TransferCommand
+        {
+            FromSide = InventoryLogic.InventorySide.OtherInventory
+        }));
+    }
+
+    [Fact]
+    public void CanTransfer_BlocksOpposingSideWhenActive()
+    {
+        PlayerPartyTradeContext.Begin("session-1");
+
+        Assert.True(PlayerPartyTradeContext.CanTransfer(new TransferCommand
+        {
+            FromSide = InventoryLogic.InventorySide.PlayerInventory
+        }));
+        Assert.False(PlayerPartyTradeContext.CanTransfer(new TransferCommand
+        {
+            FromSide = InventoryLogic.InventorySide.OtherInventory
+        }));
+    }
+
+    [Fact]
+    public void CanTransfer_BlocksAllTransfersAfterEitherPlayerAccepted()
+    {
+        PlayerPartyTradeContext.Begin("session-1");
+        PlayerPartyTradeContext.UpdateAcceptance(localAccepted: false, remoteAccepted: true);
+
+        Assert.False(PlayerPartyTradeContext.CanTransfer(new TransferCommand
+        {
+            FromSide = InventoryLogic.InventorySide.PlayerInventory
+        }));
+
+        PlayerPartyTradeContext.UpdateAcceptance(localAccepted: true, remoteAccepted: false);
+
+        Assert.False(PlayerPartyTradeContext.CanTransfer(new TransferCommand
+        {
+            FromSide = InventoryLogic.InventorySide.PlayerInventory
+        }));
+    }
+
+    [Fact]
+    public void CanAccept_BlocksRepeatAcceptAfterLocalAccept()
+    {
+        PlayerPartyTradeContext.Begin("session-1");
+
+        Assert.True(PlayerPartyTradeContext.CanAccept());
+
+        PlayerPartyTradeContext.UpdateAcceptance(localAccepted: true, remoteAccepted: false);
+
+        Assert.False(PlayerPartyTradeContext.CanAccept());
+        Assert.False(PlayerPartyTradeContext.CanCancel());
+    }
+
+    [Fact]
+    public void CanReset_BlocksResetWhileActive()
+    {
+        Assert.True(PlayerPartyTradeContext.CanReset());
+
+        PlayerPartyTradeContext.Begin("session-1");
+
+        Assert.False(PlayerPartyTradeContext.CanReset());
+    }
+
+    [Fact]
+    public void CanOffer_BlocksUnknownBarterableWhenActive()
+    {
+        Assert.True(PlayerPartyTradeContext.CanOffer(null));
+
+        PlayerPartyTradeContext.Begin("session-1");
+
+        Assert.False(PlayerPartyTradeContext.CanOffer(null));
+    }
+}

--- a/source/GameInterface/Services/Barters/Patches/PlayerPartyBarterVMPatches.cs
+++ b/source/GameInterface/Services/Barters/Patches/PlayerPartyBarterVMPatches.cs
@@ -1,0 +1,193 @@
+using GameInterface.Services.MapEvents.PlayerPartyInteractions;
+using HarmonyLib;
+using System.Collections.Generic;
+using System.Reflection;
+using TaleWorlds.CampaignSystem.BarterSystem;
+using TaleWorlds.CampaignSystem.ViewModelCollection.Barter;
+using TaleWorlds.Core;
+using TaleWorlds.GauntletUI.BaseTypes;
+using TaleWorlds.GauntletUI.ExtraWidgets;
+using TaleWorlds.Library;
+using TaleWorlds.Localization;
+using TaleWorlds.MountAndBlade.GauntletUI.Widgets.Party;
+
+namespace GameInterface.Services.Barters.Patches;
+
+[HarmonyPatch(typeof(BarterVM))]
+internal class PlayerPartyBarterVMPatches
+{
+    [HarmonyPatch(MethodType.Constructor, typeof(BarterData))]
+    [HarmonyPostfix]
+    static void ConstructorPostfix(BarterVM __instance)
+        => PlayerPartyTradeContext.SetBarterVM(__instance);
+
+    [HarmonyPatch(nameof(BarterVM.OfferItemAdd))]
+    [HarmonyPrefix]
+    static bool OfferItemAddPrefix(BarterItemVM barterItemVM)
+        => PlayerPartyTradeContext.CanOffer(barterItemVM?.Barterable);
+
+    [HarmonyPatch(nameof(BarterVM.OfferItemRemove))]
+    [HarmonyPrefix]
+    static bool OfferItemRemovePrefix(BarterItemVM barterItemVM)
+        => PlayerPartyTradeContext.CanOffer(barterItemVM?.Barterable);
+
+    [HarmonyPatch("SendOffer")]
+    [HarmonyPostfix]
+    static void SendOfferPostfix(BarterVM __instance)
+        => PlayerPartyTradeContext.PublishOfferChanged(__instance);
+
+    [HarmonyPatch("RefreshOfferLabel")]
+    [HarmonyPostfix]
+    static void RefreshOfferLabelPostfix()
+        => PlayerPartyTradeContext.RefreshBarterControls();
+
+    [HarmonyPatch(nameof(BarterVM.ExecuteOffer))]
+    [HarmonyPrefix]
+    static bool ExecuteOfferPrefix()
+    {
+        if (!PlayerPartyTradeContext.IsActive) return true;
+        if (!PlayerPartyTradeContext.CanAccept()) return false;
+
+        PlayerPartyTradeContext.PublishAccept(true);
+        return false;
+    }
+
+    [HarmonyPatch(nameof(BarterVM.ExecuteCancel))]
+    [HarmonyPrefix]
+    static bool ExecuteCancelPrefix()
+    {
+        if (!PlayerPartyTradeContext.IsActive) return true;
+        if (!PlayerPartyTradeContext.CanCancel()) return false;
+
+        PlayerPartyTradeContext.PublishLeave();
+        return false;
+    }
+
+    [HarmonyPatch(nameof(BarterVM.ExecuteReset))]
+    [HarmonyPrefix]
+    static bool ExecuteResetPrefix()
+        => PlayerPartyTradeContext.CanReset();
+
+    [HarmonyPatch(nameof(BarterVM.ExecuteAutoBalance))]
+    [HarmonyPrefix]
+    static bool ExecuteAutoBalancePrefix()
+        => PlayerPartyTradeContext.CanModifyOffer();
+
+    [HarmonyPatch("TransferItem")]
+    [HarmonyPrefix]
+    static bool TransferItemPrefix(BarterItemVM item)
+        => PlayerPartyTradeContext.CanOffer(item?.Barterable);
+}
+
+[HarmonyPatch(typeof(DialogButtonsParentWidget))]
+internal class PlayerPartyBarterDialogButtonsPatches
+{
+    [HarmonyPatch("set_ResetButton")]
+    [HarmonyPostfix]
+    static void SetResetButtonPostfix(ButtonWidget value)
+        => PlayerPartyTradeContext.SetResetButton(value);
+}
+
+[HarmonyPatch(typeof(PartyHeaderToggleWidget))]
+internal class PlayerPartyBarterHeaderTogglePatches
+{
+    [HarmonyPatch("UpdateSize")]
+    [HarmonyPostfix]
+    static void UpdateSizePostfix(PartyHeaderToggleWidget __instance)
+    {
+        if (!PlayerPartyTradeContext.IsActive) return;
+        if (__instance?.ListPanel == null) return;
+        if (__instance.ListPanel.ChildCount != 0) return;
+        if (__instance.ListPanel.Id?.Contains("Diplomatic") != true) return;
+
+        __instance.IsVisible = false;
+        __instance.ListPanel.IsVisible = false;
+    }
+}
+
+[HarmonyPatch]
+internal class PlayerPartyBarterTransferAllPatches
+{
+    static IEnumerable<MethodBase> TargetMethods()
+    {
+        yield return AccessTools.Method(typeof(BarterVM), nameof(BarterVM.ExecuteTransferAllLeftFief));
+        yield return AccessTools.Method(typeof(BarterVM), nameof(BarterVM.ExecuteTransferAllLeftItem));
+        yield return AccessTools.Method(typeof(BarterVM), nameof(BarterVM.ExecuteTransferAllLeftPrisoner));
+        yield return AccessTools.Method(typeof(BarterVM), nameof(BarterVM.ExecuteTransferAllLeftOther));
+        yield return AccessTools.Method(typeof(BarterVM), nameof(BarterVM.ExecuteTransferAllRightFief));
+        yield return AccessTools.Method(typeof(BarterVM), nameof(BarterVM.ExecuteTransferAllRightItem));
+        yield return AccessTools.Method(typeof(BarterVM), nameof(BarterVM.ExecuteTransferAllRightPrisoner));
+        yield return AccessTools.Method(typeof(BarterVM), nameof(BarterVM.ExecuteTransferAllRightOther));
+        yield return AccessTools.Method(typeof(BarterVM), nameof(BarterVM.ExecuteTransferAllGoldLeft));
+        yield return AccessTools.Method(typeof(BarterVM), nameof(BarterVM.ExecuteTransferAllGoldRight));
+    }
+
+    [HarmonyPrefix]
+    static bool ExecuteTransferAllPrefix(BarterVM __instance, MethodBase __originalMethod)
+        => PlayerPartyTradeContext.CanOfferTransferAll(__instance, __originalMethod?.Name);
+}
+
+[HarmonyPatch]
+internal class PlayerPartyBarterItemVMPatches
+{
+    static IEnumerable<MethodBase> TargetMethods()
+    {
+        yield return AccessTools.Method(typeof(BarterItemVM), nameof(BarterItemVM.ExecuteAction));
+        yield return AccessTools.Method(typeof(BarterItemVM), nameof(BarterItemVM.ExecuteAddOffered));
+        yield return AccessTools.Method(typeof(BarterItemVM), nameof(BarterItemVM.ExecuteRemoveOffered));
+    }
+
+    [HarmonyPrefix]
+    static bool ExecuteItemActionPrefix(BarterItemVM __instance)
+        => PlayerPartyTradeContext.CanOffer(__instance?.Barterable);
+}
+
+[HarmonyPatch(typeof(BarterManager))]
+internal class PlayerPartyBarterManagerPatches
+{
+    [HarmonyPatch(nameof(BarterManager.ApplyAndFinalizePlayerBarter))]
+    [HarmonyPrefix]
+    static bool ApplyAndFinalizePlayerBarterPrefix()
+    {
+        if (!PlayerPartyTradeContext.IsActive) return true;
+        if (!PlayerPartyTradeContext.CanAccept()) return false;
+
+        PlayerPartyTradeContext.PublishAccept(true);
+        return false;
+    }
+
+    [HarmonyPatch(nameof(BarterManager.CancelAndFinalizePlayerBarter))]
+    [HarmonyPrefix]
+    static bool CancelAndFinalizePlayerBarterPrefix()
+    {
+        if (!PlayerPartyTradeContext.IsActive) return true;
+        if (!PlayerPartyTradeContext.CanCancel()) return false;
+
+        PlayerPartyTradeContext.PublishLeave();
+        return false;
+    }
+}
+
+[HarmonyPatch(typeof(InformationManager))]
+internal class PlayerPartyBarterInformationManagerPatches
+{
+    [HarmonyPatch(nameof(InformationManager.DisplayMessage))]
+    [HarmonyPrefix]
+    static bool DisplayMessagePrefix(InformationMessage message)
+        => !PlayerPartyTradeContext.SuppressNativeCloseMessages;
+}
+
+[HarmonyPatch(typeof(MBInformationManager))]
+internal class PlayerPartyBarterMBInformationManagerPatches
+{
+    [HarmonyPatch(
+        nameof(MBInformationManager.AddQuickInformation),
+        typeof(TextObject),
+        typeof(int),
+        typeof(BasicCharacterObject),
+        typeof(Equipment),
+        typeof(string))]
+    [HarmonyPrefix]
+    static bool AddQuickInformationPrefix(TextObject message)
+        => !PlayerPartyTradeContext.SuppressNativeCloseMessages;
+}

--- a/source/GameInterface/Services/Inventory/Patches/InventoryLogicPatches.cs
+++ b/source/GameInterface/Services/Inventory/Patches/InventoryLogicPatches.cs
@@ -3,8 +3,10 @@ using Common.Logging;
 using Common.Messaging;
 using Common.Util;
 using GameInterface.Services.Inventory.Messages;
+using GameInterface.Services.MapEvents.PlayerPartyInteractions;
 using HarmonyLib;
 using Serilog;
+using System.Collections.Generic;
 using TaleWorlds.CampaignSystem.Inventory;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.Core;
@@ -20,6 +22,13 @@ internal class InventoryLogicPatches
     [HarmonyPrefix]
     static bool DoneLogicPrefix(InventoryLogic __instance, ref bool __result)
     {
+        if (PlayerPartyTradeContext.IsActive)
+        {
+            PlayerPartyTradeContext.PublishAccept(true);
+            __result = true;
+            return false;
+        }
+
         if (__instance.IsPreviewingItem)
         {
             __result = false;
@@ -70,5 +79,22 @@ internal class InventoryLogicPatches
 
         __result = true;
         return false;
+    }
+
+    [HarmonyPatch(nameof(InventoryLogic.TransferItem))]
+    [HarmonyPrefix]
+    static bool TransferItemPrefix(ref TransferCommand transferCommand, ref List<TransferCommandResult> __result)
+    {
+        if (PlayerPartyTradeContext.CanTransfer(transferCommand)) return true;
+
+        __result = new List<TransferCommandResult>();
+        return false;
+    }
+
+    [HarmonyPatch(nameof(InventoryLogic.TransferItem))]
+    [HarmonyPostfix]
+    static void TransferItemPostfix(InventoryLogic __instance)
+    {
+        PlayerPartyTradeContext.PublishOfferChanged(__instance);
     }
 }

--- a/source/GameInterface/Services/MapEvents/ConversationPartyTracker.cs
+++ b/source/GameInterface/Services/MapEvents/ConversationPartyTracker.cs
@@ -1,6 +1,7 @@
 using Common.Messaging;
 using GameInterface.Services.ObjectManager;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace GameInterface.Services.MapEvents;
 
@@ -28,7 +29,7 @@ internal sealed class ConversationPartyTracker : IHandler
 
     private readonly object stateLock = new object();
     private readonly Dictionary<string, Engagement> engagementsByPartyId = new Dictionary<string, Engagement>();
-    private readonly Dictionary<object, string> partyIdsByEngager = new Dictionary<object, string>();
+    private readonly Dictionary<object, string> partyIdsByEngager = new Dictionary<object, string>(ReferenceObjectComparer.Instance);
 
     // Player-vs-player conversations: both player parties' ids -> the partner's id. Unlike an AI engagement no party
     // is held/AI-disabled; this just marks the two players unattackable by anyone but each other until the battle
@@ -38,7 +39,7 @@ internal sealed class ConversationPartyTracker : IHandler
     // Defender party id <-> the defender client's peer, learned from NetworkPvpDefenderShown. The attacker peer is
     // tracked elsewhere (it sent the request); this lets a disconnecting defender be mapped back to its conversation.
     private readonly Dictionary<string, object> pvpPeerByPartyId = new Dictionary<string, object>();
-    private readonly Dictionary<object, string> pvpPartyIdByPeer = new Dictionary<object, string>();
+    private readonly Dictionary<object, string> pvpPartyIdByPeer = new Dictionary<object, string>(ReferenceObjectComparer.Instance);
 
     private volatile bool isEmpty = true;
     private volatile bool pvpIsEmpty = true;
@@ -115,7 +116,7 @@ internal sealed class ConversationPartyTracker : IHandler
 
         lock (stateLock)
         {
-            if (engagementsByPartyId.TryGetValue(partyId, out var existing) && !Equals(existing.EngagerKey, engagerKey))
+            if (engagementsByPartyId.TryGetValue(partyId, out var existing) && !ReferenceEquals(existing.EngagerKey, engagerKey))
                 return false;
 
             if (partyIdsByEngager.TryGetValue(engagerKey, out var currentPartyId))
@@ -174,7 +175,7 @@ internal sealed class ConversationPartyTracker : IHandler
 
         lock (stateLock)
         {
-            return engagementsByPartyId.TryGetValue(partyId, out var engagement) && !Equals(engagement.EngagerKey, engagerKey);
+            return engagementsByPartyId.TryGetValue(partyId, out var engagement) && !ReferenceEquals(engagement.EngagerKey, engagerKey);
         }
     }
 
@@ -254,5 +255,14 @@ internal sealed class ConversationPartyTracker : IHandler
             pvpPeerByPartyId.Remove(partyId);
             pvpPartyIdByPeer.Remove(peer);
         }
+    }
+
+    private sealed class ReferenceObjectComparer : IEqualityComparer<object>
+    {
+        public static readonly ReferenceObjectComparer Instance = new ReferenceObjectComparer();
+
+        public new bool Equals(object x, object y) => ReferenceEquals(x, y);
+
+        public int GetHashCode(object obj) => RuntimeHelpers.GetHashCode(obj);
     }
 }

--- a/source/GameInterface/Services/MapEvents/Handlers/ConversationRequestHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/ConversationRequestHandler.cs
@@ -6,6 +6,7 @@ using Common.Network.Messages;
 using Common.Util;
 using GameInterface.Services.MapEvents.Messages;
 using GameInterface.Services.MapEvents.Messages.Conversation;
+using GameInterface.Services.MapEvents.PlayerPartyInteractions;
 using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Services.ObjectManager;
 using HarmonyLib;
@@ -44,6 +45,7 @@ internal class ConversationRequestHandler : IHandler
     private readonly INetwork network;
     private readonly IObjectManager objectManager;
     private readonly ConversationPartyTracker conversationPartyTracker;
+    private readonly PlayerPartyInteractionHandler playerPartyInteractionHandler;
 
     private DateTime lastRequestSentUtc = DateTime.MinValue;
 
@@ -56,12 +58,14 @@ internal class ConversationRequestHandler : IHandler
         IMessageBroker messageBroker,
         INetwork network,
         IObjectManager objectManager,
-        ConversationPartyTracker conversationPartyTracker)
+        ConversationPartyTracker conversationPartyTracker,
+        PlayerPartyInteractionHandler playerPartyInteractionHandler)
     {
         this.messageBroker = messageBroker;
         this.network = network;
         this.objectManager = objectManager;
         this.conversationPartyTracker = conversationPartyTracker;
+        this.playerPartyInteractionHandler = playerPartyInteractionHandler;
 
         messageBroker.Subscribe<ConversationRequested>(Handle_ConversationRequested);
         messageBroker.Subscribe<NetworkRequestConversation>(Handle_NetworkRequestConversation);
@@ -196,11 +200,11 @@ internal class ConversationRequestHandler : IHandler
                 return false;
             }
 
-            isPlayerVsPlayer = true;
             Logger.Debug(
-                "Allowing conversation: both parties are players (PvP). AttackerId={AttackerId}, DefenderId={DefenderId}",
+                "Starting custom player-party interaction. AttackerId={AttackerId}, DefenderId={DefenderId}",
                 request.AttackerId, request.DefenderId);
-            return true;
+            playerPartyInteractionHandler.TryStartSession(requestingPeer, request, attacker, defender);
+            return false;
         }
 
         // Reject: both parties are already in (separate) battles; do not (re)open an encounter conversation.

--- a/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkPlayerPartyInteractionDenied.cs
+++ b/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkPlayerPartyInteractionDenied.cs
@@ -1,0 +1,17 @@
+using Common.Messaging;
+using GameInterface.Services.MapEvents.PlayerPartyInteractions;
+using ProtoBuf;
+
+namespace GameInterface.Services.MapEvents.Messages.Conversation;
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkPlayerPartyInteractionDenied : ICommand
+{
+    [ProtoMember(1)]
+    public readonly PlayerPartyInteractionDeniedReason Reason;
+
+    public NetworkPlayerPartyInteractionDenied(PlayerPartyInteractionDeniedReason reason)
+    {
+        Reason = reason;
+    }
+}

--- a/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkPlayerPartyInteractionEnded.cs
+++ b/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkPlayerPartyInteractionEnded.cs
@@ -1,0 +1,30 @@
+using Common.Messaging;
+using GameInterface.Services.MapEvents.PlayerPartyInteractions;
+using ProtoBuf;
+
+namespace GameInterface.Services.MapEvents.Messages.Conversation;
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkPlayerPartyInteractionEnded : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string SessionId;
+    [ProtoMember(2)]
+    public readonly string InitiatorPartyId;
+    [ProtoMember(3)]
+    public readonly string ResponderPartyId;
+    [ProtoMember(4)]
+    public readonly PlayerPartyInteractionOutcomeType OutcomeType;
+
+    public NetworkPlayerPartyInteractionEnded(
+        string sessionId,
+        string initiatorPartyId,
+        string responderPartyId,
+        PlayerPartyInteractionOutcomeType outcomeType)
+    {
+        SessionId = sessionId;
+        InitiatorPartyId = initiatorPartyId;
+        ResponderPartyId = responderPartyId;
+        OutcomeType = outcomeType;
+    }
+}

--- a/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkPlayerPartyInteractionShown.cs
+++ b/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkPlayerPartyInteractionShown.cs
@@ -1,0 +1,19 @@
+using Common.Messaging;
+using ProtoBuf;
+
+namespace GameInterface.Services.MapEvents.Messages.Conversation;
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkPlayerPartyInteractionShown : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string SessionId;
+    [ProtoMember(2)]
+    public readonly string PartyId;
+
+    public NetworkPlayerPartyInteractionShown(string sessionId, string partyId)
+    {
+        SessionId = sessionId;
+        PartyId = partyId;
+    }
+}

--- a/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkPlayerPartyInteractionStarted.cs
+++ b/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkPlayerPartyInteractionStarted.cs
@@ -1,0 +1,33 @@
+using Common.Messaging;
+using ProtoBuf;
+
+namespace GameInterface.Services.MapEvents.Messages.Conversation;
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkPlayerPartyInteractionStarted : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string SessionId;
+    [ProtoMember(2)]
+    public readonly string InitiatorPartyId;
+    [ProtoMember(3)]
+    public readonly string ResponderPartyId;
+    [ProtoMember(4)]
+    public readonly string InitiatorName;
+    [ProtoMember(5)]
+    public readonly string ResponderName;
+
+    public NetworkPlayerPartyInteractionStarted(
+        string sessionId,
+        string initiatorPartyId,
+        string responderPartyId,
+        string initiatorName,
+        string responderName)
+    {
+        SessionId = sessionId;
+        InitiatorPartyId = initiatorPartyId;
+        ResponderPartyId = responderPartyId;
+        InitiatorName = initiatorName;
+        ResponderName = responderName;
+    }
+}

--- a/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkPlayerPartyInteractionState.cs
+++ b/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkPlayerPartyInteractionState.cs
@@ -1,0 +1,63 @@
+using Common.Messaging;
+using GameInterface.Services.Inventory.Data;
+using GameInterface.Services.MapEvents.PlayerPartyInteractions;
+using ProtoBuf;
+
+namespace GameInterface.Services.MapEvents.Messages.Conversation;
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkPlayerPartyInteractionState : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string SessionId;
+    [ProtoMember(2)]
+    public readonly string PartyId;
+    [ProtoMember(3)]
+    public readonly string OtherPartyId;
+    [ProtoMember(4)]
+    public readonly string OtherPlayerName;
+    [ProtoMember(5)]
+    public readonly PlayerPartyInteractionPhase Phase;
+    [ProtoMember(6)]
+    public readonly PlayerPartyInteractionProposal Proposal;
+    [ProtoMember(7)]
+    public readonly PlayerPartyInteractionOption[] Options;
+    [ProtoMember(8)]
+    public readonly bool InitiatorAcceptedTrade;
+    [ProtoMember(9)]
+    public readonly bool ResponderAcceptedTrade;
+    [ProtoMember(10)]
+    public readonly bool IsInitiator;
+    [ProtoMember(11)]
+    public readonly ItemRosterElementData[] PartyItems;
+    [ProtoMember(12)]
+    public readonly ItemRosterElementData[] OtherPartyItems;
+
+    public NetworkPlayerPartyInteractionState(
+        string sessionId,
+        string partyId,
+        string otherPartyId,
+        string otherPlayerName,
+        PlayerPartyInteractionPhase phase,
+        PlayerPartyInteractionProposal proposal,
+        PlayerPartyInteractionOption[] options,
+        bool isInitiator,
+        bool initiatorAcceptedTrade = false,
+        bool responderAcceptedTrade = false,
+        ItemRosterElementData[] partyItems = null,
+        ItemRosterElementData[] otherPartyItems = null)
+    {
+        SessionId = sessionId;
+        PartyId = partyId;
+        OtherPartyId = otherPartyId;
+        OtherPlayerName = otherPlayerName;
+        Phase = phase;
+        Proposal = proposal;
+        Options = options ?? new PlayerPartyInteractionOption[0];
+        IsInitiator = isInitiator;
+        InitiatorAcceptedTrade = initiatorAcceptedTrade;
+        ResponderAcceptedTrade = responderAcceptedTrade;
+        PartyItems = partyItems ?? new ItemRosterElementData[0];
+        OtherPartyItems = otherPartyItems ?? new ItemRosterElementData[0];
+    }
+}

--- a/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkPlayerPartyTradeAcceptChanged.cs
+++ b/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkPlayerPartyTradeAcceptChanged.cs
@@ -1,0 +1,19 @@
+using Common.Messaging;
+using ProtoBuf;
+
+namespace GameInterface.Services.MapEvents.Messages.Conversation;
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkPlayerPartyTradeAcceptChanged : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string SessionId;
+    [ProtoMember(2)]
+    public readonly bool Accepted;
+
+    public NetworkPlayerPartyTradeAcceptChanged(string sessionId, bool accepted)
+    {
+        SessionId = sessionId;
+        Accepted = accepted;
+    }
+}

--- a/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkPlayerPartyTradeOfferUpdated.cs
+++ b/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkPlayerPartyTradeOfferUpdated.cs
@@ -1,0 +1,43 @@
+using Common.Messaging;
+using GameInterface.Services.Inventory.Data;
+using GameInterface.Services.TroopRosters.Data;
+using ProtoBuf;
+
+namespace GameInterface.Services.MapEvents.Messages.Conversation;
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkPlayerPartyTradeOfferUpdated : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string SessionId;
+    [ProtoMember(2)]
+    public readonly string PartyId;
+    [ProtoMember(3)]
+    public readonly ItemRosterElementData[] OfferedItems;
+    [ProtoMember(4)]
+    public readonly TroopRosterElementData[] OfferedTroops;
+    [ProtoMember(5)]
+    public readonly int OfferedGold;
+    [ProtoMember(6)]
+    public readonly string[] OfferedFiefs;
+    [ProtoMember(7)]
+    public readonly TroopRosterElementData[] OfferedPrisoners;
+
+    public NetworkPlayerPartyTradeOfferUpdated(
+        string sessionId,
+        string partyId,
+        ItemRosterElementData[] offeredItems,
+        TroopRosterElementData[] offeredTroops,
+        int offeredGold = 0,
+        string[] offeredFiefs = null,
+        TroopRosterElementData[] offeredPrisoners = null)
+    {
+        SessionId = sessionId;
+        PartyId = partyId;
+        OfferedItems = offeredItems ?? new ItemRosterElementData[0];
+        OfferedTroops = offeredTroops ?? new TroopRosterElementData[0];
+        OfferedGold = offeredGold;
+        OfferedFiefs = offeredFiefs ?? new string[0];
+        OfferedPrisoners = offeredPrisoners ?? new TroopRosterElementData[0];
+    }
+}

--- a/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkSubmitPlayerPartyInteractionOption.cs
+++ b/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkSubmitPlayerPartyInteractionOption.cs
@@ -1,0 +1,28 @@
+using Common.Messaging;
+using GameInterface.Services.MapEvents.PlayerPartyInteractions;
+using ProtoBuf;
+
+namespace GameInterface.Services.MapEvents.Messages.Conversation;
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkSubmitPlayerPartyInteractionOption : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string SessionId;
+    [ProtoMember(2)]
+    public readonly PlayerPartyInteractionOption Option;
+    [ProtoMember(3)]
+    public readonly string PartyId;
+
+    public NetworkSubmitPlayerPartyInteractionOption(string sessionId, PlayerPartyInteractionOption option)
+        : this(sessionId, option, null)
+    {
+    }
+
+    public NetworkSubmitPlayerPartyInteractionOption(string sessionId, PlayerPartyInteractionOption option, string partyId)
+    {
+        SessionId = sessionId;
+        Option = option;
+        PartyId = partyId;
+    }
+}

--- a/source/GameInterface/Services/MapEvents/Messages/Conversation/PlayerPartyInteractionOptionSelected.cs
+++ b/source/GameInterface/Services/MapEvents/Messages/Conversation/PlayerPartyInteractionOptionSelected.cs
@@ -1,0 +1,23 @@
+using Common.Messaging;
+using GameInterface.Services.MapEvents.PlayerPartyInteractions;
+
+namespace GameInterface.Services.MapEvents.Messages.Conversation;
+
+internal readonly struct PlayerPartyInteractionOptionSelected : IEvent
+{
+    public readonly string SessionId;
+    public readonly string PartyId;
+    public readonly PlayerPartyInteractionOption Option;
+
+    public PlayerPartyInteractionOptionSelected(string sessionId, PlayerPartyInteractionOption option)
+        : this(sessionId, null, option)
+    {
+    }
+
+    public PlayerPartyInteractionOptionSelected(string sessionId, string partyId, PlayerPartyInteractionOption option)
+    {
+        SessionId = sessionId;
+        PartyId = partyId;
+        Option = option;
+    }
+}

--- a/source/GameInterface/Services/MapEvents/Messages/Conversation/PlayerPartyTradeAcceptSelected.cs
+++ b/source/GameInterface/Services/MapEvents/Messages/Conversation/PlayerPartyTradeAcceptSelected.cs
@@ -1,0 +1,15 @@
+using Common.Messaging;
+
+namespace GameInterface.Services.MapEvents.Messages.Conversation;
+
+internal readonly struct PlayerPartyTradeAcceptSelected : IEvent
+{
+    public readonly string SessionId;
+    public readonly bool Accepted;
+
+    public PlayerPartyTradeAcceptSelected(string sessionId, bool accepted)
+    {
+        SessionId = sessionId;
+        Accepted = accepted;
+    }
+}

--- a/source/GameInterface/Services/MapEvents/Messages/Conversation/PlayerPartyTradeOfferChanged.cs
+++ b/source/GameInterface/Services/MapEvents/Messages/Conversation/PlayerPartyTradeOfferChanged.cs
@@ -1,0 +1,26 @@
+using Common.Messaging;
+using TaleWorlds.CampaignSystem.Inventory;
+using TaleWorlds.CampaignSystem.ViewModelCollection.Barter;
+
+namespace GameInterface.Services.MapEvents.Messages.Conversation;
+
+internal readonly struct PlayerPartyTradeOfferChanged : IEvent
+{
+    public readonly string SessionId;
+    public readonly InventoryLogic InventoryLogic;
+    public readonly BarterVM BarterVM;
+
+    public PlayerPartyTradeOfferChanged(string sessionId, InventoryLogic inventoryLogic)
+    {
+        SessionId = sessionId;
+        InventoryLogic = inventoryLogic;
+        BarterVM = null;
+    }
+
+    public PlayerPartyTradeOfferChanged(string sessionId, BarterVM barterVM)
+    {
+        SessionId = sessionId;
+        InventoryLogic = null;
+        BarterVM = barterVM;
+    }
+}

--- a/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyInteractionCampaignBehavior.cs
+++ b/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyInteractionCampaignBehavior.cs
@@ -1,0 +1,179 @@
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Localization;
+
+namespace GameInterface.Services.MapEvents.PlayerPartyInteractions;
+
+public class PlayerPartyInteractionCampaignBehavior : CampaignBehaviorBase
+{
+    private const string RootToken = "start";
+    private const string InitialToken = "coop_player_party_interaction_initial";
+    private const string ServiceToken = "coop_player_party_interaction_services";
+    private const string ResponderToken = "coop_player_party_interaction_responder";
+    private const string InitiatorWaitToken = "coop_player_party_interaction_initiator_wait";
+    private const string CloseToken = "close_window";
+    private const int PlayerPartyDialogPriority = 10000;
+
+    public override void RegisterEvents()
+    {
+        CampaignEvents.OnSessionLaunchedEvent.AddNonSerializedListener(this, AddDialogs);
+    }
+
+    public override void SyncData(IDataStore dataStore)
+    {
+    }
+
+    private void AddDialogs(CampaignGameStarter starter)
+    {
+        starter.AddDialogLine(
+            "coop_player_party_interaction_initial_line",
+            RootToken,
+            InitialToken,
+            "{=coop_player_party_interaction_initial}{COOP_PLAYER_PARTY_INTERACTION_TEXT}",
+            () => IsPhase(PlayerPartyInteractionPhase.InitialOptions),
+            null,
+            PlayerPartyDialogPriority,
+            null);
+
+        starter.AddDialogLine(
+            "coop_player_party_interaction_services_line",
+            ServiceToken,
+            ServiceToken,
+            "{=coop_player_party_interaction_services}{COOP_PLAYER_PARTY_INTERACTION_TEXT}",
+            () => IsPhase(PlayerPartyInteractionPhase.OfferServices),
+            null,
+            PlayerPartyDialogPriority,
+            null);
+
+        starter.AddDialogLine(
+            "coop_player_party_interaction_responder_line",
+            RootToken,
+            ResponderToken,
+            "{=coop_player_party_interaction_responder}{COOP_PLAYER_PARTY_INTERACTION_TEXT}",
+            () => IsPhase(PlayerPartyInteractionPhase.WaitingForProposal, PlayerPartyInteractionPhase.ProposalPending),
+            null,
+            PlayerPartyDialogPriority,
+            null);
+
+        starter.AddDialogLine(
+            "coop_player_party_interaction_initiator_wait_line",
+            InitiatorWaitToken,
+            InitiatorWaitToken,
+            "{=coop_player_party_interaction_wait}{COOP_PLAYER_PARTY_INTERACTION_TEXT}",
+            () => IsPhase(PlayerPartyInteractionPhase.WaitingForResponse, PlayerPartyInteractionPhase.TradeActive),
+            null,
+            PlayerPartyDialogPriority,
+            null);
+
+        starter.AddPlayerLine(
+            "coop_player_party_interaction_trade",
+            InitialToken,
+            InitiatorWaitToken,
+            "I have a proposal that may benefit us both.",
+            () => PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.TradeProposal),
+            () => PlayerPartyInteractionDialogState.Submit(PlayerPartyInteractionOption.TradeProposal),
+            PlayerPartyDialogPriority,
+            null,
+            null);
+
+        starter.AddPlayerLine(
+            "coop_player_party_interaction_services",
+            InitialToken,
+            ServiceToken,
+            "I wish to offer my services.",
+            () => PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.OfferServices),
+            PlayerPartyInteractionDialogState.ShowServiceOptions,
+            PlayerPartyDialogPriority,
+            null,
+            null);
+
+        starter.AddPlayerLine(
+            "coop_player_party_interaction_join_clan",
+            ServiceToken,
+            InitiatorWaitToken,
+            "I wish to offer my services in your clan.",
+            () => PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.JoinClan),
+            () => PlayerPartyInteractionDialogState.Submit(PlayerPartyInteractionOption.JoinClan),
+            PlayerPartyDialogPriority,
+            null,
+            null);
+
+        starter.AddPlayerLine(
+            "coop_player_party_interaction_vassal",
+            ServiceToken,
+            InitiatorWaitToken,
+            "I wish to swear my allegiance to your majesty.",
+            () => PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.Vassal),
+            () => PlayerPartyInteractionDialogState.Submit(PlayerPartyInteractionOption.Vassal),
+            PlayerPartyDialogPriority,
+            null,
+            null);
+
+        starter.AddPlayerLine(
+            "coop_player_party_interaction_accept",
+            ResponderToken,
+            InitiatorWaitToken,
+            "I accept.",
+            () => PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.AcceptProposal),
+            () => PlayerPartyInteractionDialogState.Submit(PlayerPartyInteractionOption.AcceptProposal),
+            PlayerPartyDialogPriority,
+            null,
+            null);
+
+        starter.AddPlayerLine(
+            "coop_player_party_interaction_decline",
+            ResponderToken,
+            CloseToken,
+            "I decline.",
+            () => PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.DeclineProposal),
+            () => PlayerPartyInteractionDialogState.Submit(PlayerPartyInteractionOption.DeclineProposal),
+            PlayerPartyDialogPriority,
+            null,
+            null);
+
+        starter.AddPlayerLine(
+            "coop_player_party_interaction_leave_initial",
+            InitialToken,
+            CloseToken,
+            "I must leave now.",
+            () => PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.Leave),
+            () => PlayerPartyInteractionDialogState.Submit(PlayerPartyInteractionOption.Leave),
+            PlayerPartyDialogPriority,
+            null,
+            null);
+
+        starter.AddPlayerLine(
+            "coop_player_party_interaction_leave_services",
+            ServiceToken,
+            CloseToken,
+            "Nevermind.",
+            () => PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.Leave),
+            () => PlayerPartyInteractionDialogState.Submit(PlayerPartyInteractionOption.Leave),
+            PlayerPartyDialogPriority,
+            null,
+            null);
+
+        starter.AddPlayerLine(
+            "coop_player_party_interaction_leave_responder",
+            ResponderToken,
+            CloseToken,
+            "I must leave now.",
+            () => PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.Leave),
+            () => PlayerPartyInteractionDialogState.Submit(PlayerPartyInteractionOption.Leave),
+            PlayerPartyDialogPriority,
+            null,
+            null);
+    }
+
+    private static bool IsPhase(params PlayerPartyInteractionPhase[] phases)
+    {
+        MBTextManager.SetTextVariable("COOP_PLAYER_PARTY_INTERACTION_TEXT", PlayerPartyInteractionDialogState.GetDialogText());
+
+        foreach (var phase in phases)
+        {
+            if (PlayerPartyInteractionDialogState.Phase == phase)
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyInteractionConversationVMPatches.cs
+++ b/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyInteractionConversationVMPatches.cs
@@ -1,0 +1,34 @@
+using HarmonyLib;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using TaleWorlds.CampaignSystem.ViewModelCollection.Conversation;
+
+namespace GameInterface.Services.MapEvents.PlayerPartyInteractions;
+
+[HarmonyPatch(typeof(MissionConversationVM))]
+internal class PlayerPartyInteractionConversationVMPatches
+{
+    [HarmonyPatch(nameof(MissionConversationVM.Refresh))]
+    [HarmonyTranspiler]
+    private static IEnumerable<CodeInstruction> RefreshTranspiler(IEnumerable<CodeInstruction> instructions)
+    {
+        var isCurrentlyPlayerSpeaking = AccessTools.Field(typeof(MissionConversationVM), "_isCurrentlyPlayerSpeaking");
+        var shouldSkipAnswerOptions = AccessTools.Method(typeof(PlayerPartyInteractionConversationVMPatches), nameof(ShouldSkipAnswerOptions));
+
+        foreach (var instruction in instructions)
+        {
+            yield return instruction;
+
+            if (instruction.opcode == OpCodes.Ldsfld && Equals(instruction.operand, isCurrentlyPlayerSpeaking))
+                yield return new CodeInstruction(OpCodes.Call, shouldSkipAnswerOptions);
+        }
+    }
+
+    private static bool ShouldSkipAnswerOptions(bool isCurrentlyPlayerSpeaking)
+    {
+        if (PlayerPartyInteractionDialogState.HasActiveState)
+            return false;
+
+        return isCurrentlyPlayerSpeaking;
+    }
+}

--- a/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyInteractionDialogState.cs
+++ b/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyInteractionDialogState.cs
@@ -1,0 +1,216 @@
+using Common.Messaging;
+using GameInterface.Services.MapEvents.Messages.Conversation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Conversation;
+using TaleWorlds.Localization;
+
+namespace GameInterface.Services.MapEvents.PlayerPartyInteractions;
+
+public static class PlayerPartyInteractionDialogState
+{
+    private const BindingFlags InstanceBindingFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+    private const string MapConversationVmTypeName = "TaleWorlds.CampaignSystem.ViewModelCollection.Map.MapConversation.MapConversationVM";
+
+    private static NetworkPlayerPartyInteractionState currentState;
+    private static bool hasState;
+
+    public static string SessionId => hasState ? currentState.SessionId : null;
+    public static string PartyId => hasState ? currentState.PartyId : null;
+    public static string OtherPartyId => hasState ? currentState.OtherPartyId : null;
+    public static string OtherPlayerName => hasState ? currentState.OtherPlayerName : "the other player";
+    public static PlayerPartyInteractionPhase Phase => hasState ? currentState.Phase : PlayerPartyInteractionPhase.None;
+    public static PlayerPartyInteractionProposal Proposal => hasState ? currentState.Proposal : PlayerPartyInteractionProposal.None;
+    public static bool InitiatorAcceptedTrade => hasState && currentState.InitiatorAcceptedTrade;
+    public static bool ResponderAcceptedTrade => hasState && currentState.ResponderAcceptedTrade;
+    public static bool HasActiveState => hasState;
+
+    internal static void Apply(NetworkPlayerPartyInteractionState state)
+    {
+        currentState = state;
+        hasState = true;
+        RefreshConversation();
+    }
+
+    public static void Clear(string sessionId = null)
+    {
+        if (sessionId != null && hasState && currentState.SessionId != sessionId) return;
+
+        hasState = false;
+        currentState = default;
+    }
+
+    public static bool HasOption(PlayerPartyInteractionOption option)
+        => hasState && currentState.Options != null && currentState.Options.Contains(option);
+
+    public static string GetDialogText()
+    {
+        switch (Phase)
+        {
+            case PlayerPartyInteractionPhase.WaitingForProposal:
+                return $"Awaiting proposal from {OtherPlayerName}...";
+            case PlayerPartyInteractionPhase.WaitingForResponse:
+                return $"Awaiting response from {OtherPlayerName}...";
+            case PlayerPartyInteractionPhase.ProposalPending:
+                return GetProposalText();
+            case PlayerPartyInteractionPhase.TradeActive:
+                return "Let us review the trade.";
+            case PlayerPartyInteractionPhase.OfferServices:
+                return "What service do you wish to offer?";
+            default:
+                return "What would you like to discuss?";
+        }
+    }
+
+    public static void Submit(PlayerPartyInteractionOption option)
+    {
+        if (!HasActiveState) return;
+
+        MessageBroker.Instance.Publish(null, new PlayerPartyInteractionOptionSelected(SessionId, PartyId, option));
+    }
+
+    public static void ShowServiceOptions()
+    {
+        if (!HasActiveState) return;
+        if (Phase != PlayerPartyInteractionPhase.InitialOptions) return;
+        if (!HasOption(PlayerPartyInteractionOption.OfferServices)) return;
+
+        currentState = new NetworkPlayerPartyInteractionState(
+            currentState.SessionId,
+            currentState.PartyId,
+            currentState.OtherPartyId,
+            currentState.OtherPlayerName,
+            PlayerPartyInteractionPhase.OfferServices,
+            PlayerPartyInteractionProposal.None,
+            GetLocalServiceOptions(),
+            currentState.IsInitiator,
+            currentState.InitiatorAcceptedTrade,
+            currentState.ResponderAcceptedTrade,
+            currentState.PartyItems,
+            currentState.OtherPartyItems);
+
+        RefreshConversation();
+    }
+
+    private static string GetProposalText()
+    {
+        switch (Proposal)
+        {
+            case PlayerPartyInteractionProposal.Trade:
+                return "I have a proposal that may benefit us both.";
+            case PlayerPartyInteractionProposal.JoinClan:
+                return "I wish to offer my services in your clan.";
+            case PlayerPartyInteractionProposal.Vassal:
+                return "I wish to swear my allegiance to your majesty.";
+            default:
+                return $"{OtherPlayerName} has made a proposal.";
+        }
+    }
+
+    private static PlayerPartyInteractionOption[] GetLocalServiceOptions()
+    {
+        var options = new List<PlayerPartyInteractionOption>();
+        if (currentState.Options != null)
+        {
+            foreach (var option in currentState.Options)
+            {
+                if (!IsServiceOption(option)) continue;
+                if (options.Contains(option)) continue;
+
+                options.Add(option);
+            }
+        }
+
+        if (!options.Contains(PlayerPartyInteractionOption.Leave))
+            options.Add(PlayerPartyInteractionOption.Leave);
+
+        return options.ToArray();
+    }
+
+    private static bool IsServiceOption(PlayerPartyInteractionOption option)
+        => option == PlayerPartyInteractionOption.JoinClan ||
+           option == PlayerPartyInteractionOption.Vassal ||
+           option == PlayerPartyInteractionOption.Leave;
+
+    internal static void RefreshConversation()
+    {
+        var conversationManager = Campaign.Current?.ConversationManager;
+        if (conversationManager == null || !conversationManager.IsConversationInProgress) return;
+
+        MBTextManager.SetTextVariable("COOP_PLAYER_PARTY_INTERACTION_TEXT", GetDialogText());
+        conversationManager.UpdateCurrentSentenceText();
+        conversationManager.ClearCurrentOptions();
+        if (ShouldRefreshOptions())
+            conversationManager.GetPlayerSentenceOptions();
+
+        RefreshConversationVm(conversationManager);
+    }
+
+    private static bool ShouldRefreshOptions()
+        => currentState.Options != null &&
+           currentState.Options.Length > 0;
+
+    private static void RefreshConversationVm(ConversationManager conversationManager)
+    {
+        try
+        {
+            var handler = conversationManager.Handler;
+            var mapConversationVm = GetMapConversationVm(handler);
+            var dialogController = mapConversationVm?.GetType()
+                .GetProperty("DialogController", InstanceBindingFlags)?
+                .GetValue(mapConversationVm);
+            var refresh = dialogController?.GetType().GetMethod("Refresh", InstanceBindingFlags);
+
+            refresh?.Invoke(dialogController, Array.Empty<object>());
+        }
+        catch (Exception)
+        {
+        }
+    }
+
+    private static object GetMapConversationVm(object handler)
+    {
+        if (handler == null) return null;
+
+        var handlerType = handler.GetType();
+        var dataSource = handlerType.GetField("_dataSource", InstanceBindingFlags)?.GetValue(handler);
+        if (IsMapConversationVm(dataSource)) return dataSource;
+
+        foreach (var field in handlerType.GetFields(InstanceBindingFlags))
+        {
+            var fieldValue = field.GetValue(handler);
+            if (IsMapConversationVm(fieldValue)) return fieldValue;
+        }
+
+        foreach (var property in handlerType.GetProperties(InstanceBindingFlags))
+        {
+            if (property.GetIndexParameters().Length > 0) continue;
+
+            object propertyValue;
+            try
+            {
+                propertyValue = property.GetValue(handler);
+            }
+            catch (Exception)
+            {
+                continue;
+            }
+
+            if (IsMapConversationVm(propertyValue)) return propertyValue;
+        }
+
+        return null;
+    }
+
+    private static bool IsMapConversationVm(object value)
+    {
+        if (value == null) return false;
+
+        var type = value.GetType();
+        return type.FullName == MapConversationVmTypeName ||
+               type.GetProperty("DialogController", InstanceBindingFlags) != null;
+    }
+}

--- a/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyInteractionHandler.cs
+++ b/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyInteractionHandler.cs
@@ -1,0 +1,1275 @@
+using Common;
+using Common.Logging;
+using Common.Messaging;
+using Common.Network;
+using Common.Network.Messages;
+using Common.Util;
+using GameInterface.Services.Inventory.Data;
+using GameInterface.Services.MapEvents.Messages.Conversation;
+using GameInterface.Services.MobileParties.Extensions;
+using GameInterface.Services.MobileParties.Messages.Behavior;
+using GameInterface.Services.ObjectManager;
+using LiteNetLib;
+using Serilog;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using TroopRosterElementData = GameInterface.Services.TroopRosters.Data.TroopRosterElementData;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.BarterSystem;
+using TaleWorlds.CampaignSystem.BarterSystem.Barterables;
+using TaleWorlds.CampaignSystem.Conversation;
+using TaleWorlds.CampaignSystem.Encounters;
+using TaleWorlds.CampaignSystem.GameMenus;
+using TaleWorlds.CampaignSystem.Inventory;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Roster;
+using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.CampaignSystem.ViewModelCollection.Barter;
+using TaleWorlds.Core;
+using Helpers;
+using TaleWorlds.Library;
+
+namespace GameInterface.Services.MapEvents.PlayerPartyInteractions;
+
+internal class PlayerPartyInteractionHandler : IHandler
+{
+    private static readonly ILogger Logger = LogManager.GetLogger<PlayerPartyInteractionHandler>();
+    private static readonly FieldInfo PrisonerCharacterField =
+        typeof(TransferPrisonerBarterable).GetField("_prisonerCharacter", BindingFlags.Instance | BindingFlags.NonPublic);
+
+    private readonly IMessageBroker messageBroker;
+    private readonly INetwork network;
+    private readonly IObjectManager objectManager;
+    private readonly ConversationPartyTracker conversationPartyTracker;
+    private readonly PlayerPartyInteractionOutcomeHandler outcomeHandler;
+
+    private readonly ConcurrentDictionary<string, PlayerPartyInteractionSession> sessionsById = new ConcurrentDictionary<string, PlayerPartyInteractionSession>();
+    private readonly ConcurrentDictionary<string, string> sessionsByPartyId = new ConcurrentDictionary<string, string>();
+    private readonly HashSet<string> openedConversationSessionIds = new HashSet<string>();
+
+    public PlayerPartyInteractionHandler(
+        IMessageBroker messageBroker,
+        INetwork network,
+        IObjectManager objectManager,
+        ConversationPartyTracker conversationPartyTracker)
+    {
+        this.messageBroker = messageBroker;
+        this.network = network;
+        this.objectManager = objectManager;
+        this.conversationPartyTracker = conversationPartyTracker;
+        outcomeHandler = new PlayerPartyInteractionOutcomeHandler(objectManager);
+
+        messageBroker.Subscribe<NetworkPlayerPartyInteractionStarted>(Handle_NetworkPlayerPartyInteractionStarted);
+        messageBroker.Subscribe<NetworkPlayerPartyInteractionState>(Handle_NetworkPlayerPartyInteractionState);
+        messageBroker.Subscribe<NetworkSubmitPlayerPartyInteractionOption>(Handle_NetworkSubmitPlayerPartyInteractionOption);
+        messageBroker.Subscribe<NetworkPlayerPartyInteractionShown>(Handle_NetworkPlayerPartyInteractionShown);
+        messageBroker.Subscribe<NetworkPlayerPartyInteractionEnded>(Handle_NetworkPlayerPartyInteractionEnded);
+        messageBroker.Subscribe<NetworkPlayerPartyInteractionDenied>(Handle_NetworkPlayerPartyInteractionDenied);
+        messageBroker.Subscribe<PlayerPartyInteractionOptionSelected>(Handle_PlayerPartyInteractionOptionSelected);
+        messageBroker.Subscribe<PlayerPartyTradeOfferChanged>(Handle_PlayerPartyTradeOfferChanged);
+        messageBroker.Subscribe<PlayerPartyTradeAcceptSelected>(Handle_PlayerPartyTradeAcceptSelected);
+        messageBroker.Subscribe<NetworkPlayerPartyTradeOfferUpdated>(Handle_NetworkPlayerPartyTradeOfferUpdated);
+        messageBroker.Subscribe<NetworkPlayerPartyTradeAcceptChanged>(Handle_NetworkPlayerPartyTradeAcceptChanged);
+        messageBroker.Subscribe<PlayerDisconnected>(Handle_PlayerDisconnected);
+    }
+
+    public void Dispose()
+    {
+        messageBroker.Unsubscribe<NetworkPlayerPartyInteractionStarted>(Handle_NetworkPlayerPartyInteractionStarted);
+        messageBroker.Unsubscribe<NetworkPlayerPartyInteractionState>(Handle_NetworkPlayerPartyInteractionState);
+        messageBroker.Unsubscribe<NetworkSubmitPlayerPartyInteractionOption>(Handle_NetworkSubmitPlayerPartyInteractionOption);
+        messageBroker.Unsubscribe<NetworkPlayerPartyInteractionShown>(Handle_NetworkPlayerPartyInteractionShown);
+        messageBroker.Unsubscribe<NetworkPlayerPartyInteractionEnded>(Handle_NetworkPlayerPartyInteractionEnded);
+        messageBroker.Unsubscribe<NetworkPlayerPartyInteractionDenied>(Handle_NetworkPlayerPartyInteractionDenied);
+        messageBroker.Unsubscribe<PlayerPartyInteractionOptionSelected>(Handle_PlayerPartyInteractionOptionSelected);
+        messageBroker.Unsubscribe<PlayerPartyTradeOfferChanged>(Handle_PlayerPartyTradeOfferChanged);
+        messageBroker.Unsubscribe<PlayerPartyTradeAcceptSelected>(Handle_PlayerPartyTradeAcceptSelected);
+        messageBroker.Unsubscribe<NetworkPlayerPartyTradeOfferUpdated>(Handle_NetworkPlayerPartyTradeOfferUpdated);
+        messageBroker.Unsubscribe<NetworkPlayerPartyTradeAcceptChanged>(Handle_NetworkPlayerPartyTradeAcceptChanged);
+        messageBroker.Unsubscribe<PlayerDisconnected>(Handle_PlayerDisconnected);
+    }
+
+    public bool TryStartSession(
+        NetPeer initiatorPeer,
+        NetworkRequestConversation request,
+        PartyBase initiatorParty,
+        PartyBase responderParty)
+    {
+        if (!ModInformation.IsServer) return false;
+
+        if (IsPartyBusy(request.AttackerId, request.DefenderId) || IsPartyBusy(request.DefenderId, request.AttackerId))
+        {
+            network.Send(initiatorPeer, new NetworkPlayerPartyInteractionDenied(PlayerPartyInteractionDeniedReason.Busy));
+            return false;
+        }
+
+        if (AreHostile(initiatorParty, responderParty))
+        {
+            Logger.Debug(
+                "Rejecting player-party interaction: parties are hostile. InitiatorId={InitiatorId}, ResponderId={ResponderId}",
+                request.AttackerId, request.DefenderId);
+            network.Send(initiatorPeer, new NetworkPlayerPartyInteractionDenied(PlayerPartyInteractionDeniedReason.Hostile));
+            return false;
+        }
+
+        var session = new PlayerPartyInteractionSession(
+            Guid.NewGuid().ToString("N"),
+            request.AttackerId,
+            request.DefenderId,
+            GetPartyName(initiatorParty, "Player"),
+            GetPartyName(responderParty, "Player"),
+            initiatorPeer);
+
+        AddInitialOptions(session, initiatorParty, responderParty);
+
+        if (!sessionsById.TryAdd(session.SessionId, session))
+            return false;
+
+        sessionsByPartyId[session.InitiatorPartyId] = session.SessionId;
+        sessionsByPartyId[session.ResponderPartyId] = session.SessionId;
+        conversationPartyTracker.BeginPvpConversation(session.InitiatorPartyId, session.ResponderPartyId);
+
+        GameThread.RunSafe(() =>
+        {
+            HoldParty(initiatorParty.MobileParty);
+            HoldParty(responderParty.MobileParty);
+        }, context: "Hold player-party interaction parties");
+
+        network.SendAll(new NetworkPlayerPartyInteractionStarted(
+            session.SessionId,
+            session.InitiatorPartyId,
+            session.ResponderPartyId,
+            session.InitiatorName,
+            session.ResponderName));
+
+        SendInitialStates(session);
+
+        return true;
+    }
+
+    private void Handle_NetworkPlayerPartyInteractionStarted(MessagePayload<NetworkPlayerPartyInteractionStarted> payload)
+    {
+        if (ModInformation.IsServer) return;
+
+        var message = payload.What;
+
+        GameThread.RunSafe(() =>
+        {
+            if (!TryGetControlledSessionParty(message, out var myPartyId, out _)) return;
+
+            network.SendAll(new NetworkPlayerPartyInteractionShown(message.SessionId, myPartyId));
+        }, context: "Confirm player-party interaction party");
+    }
+
+    private void Handle_NetworkPlayerPartyInteractionState(MessagePayload<NetworkPlayerPartyInteractionState> payload)
+    {
+        if (ModInformation.IsServer) return;
+
+        var message = payload.What;
+
+        GameThread.RunSafe(() =>
+        {
+            if (!objectManager.TryGetObject<PartyBase>(message.PartyId, out var party)) return;
+            if (party.MobileParty?.IsControlledByThisInstance() != true) return;
+
+            PlayerPartyInteractionDialogState.Apply(message);
+            TryOpenMapConversation(message.SessionId, message.PartyId, message.OtherPartyId);
+
+            if (message.Phase == PlayerPartyInteractionPhase.TradeActive)
+            {
+                var localAccepted = message.IsInitiator ? message.InitiatorAcceptedTrade : message.ResponderAcceptedTrade;
+                var remoteAccepted = message.IsInitiator ? message.ResponderAcceptedTrade : message.InitiatorAcceptedTrade;
+                OpenTrade(message);
+                PlayerPartyTradeContext.UpdateAcceptance(localAccepted, remoteAccepted);
+                PlayerPartyTradeOverlay.Instance.UpdateState(localAccepted, remoteAccepted);
+            }
+        }, context: "Apply player-party interaction state");
+    }
+
+    private void Handle_PlayerPartyInteractionOptionSelected(MessagePayload<PlayerPartyInteractionOptionSelected> payload)
+    {
+        if (ModInformation.IsServer) return;
+
+        var message = payload.What;
+        network.SendAll(new NetworkSubmitPlayerPartyInteractionOption(message.SessionId, message.Option, message.PartyId));
+    }
+
+    private void Handle_NetworkSubmitPlayerPartyInteractionOption(MessagePayload<NetworkSubmitPlayerPartyInteractionOption> payload)
+    {
+        if (!ModInformation.IsServer) return;
+        if (!(payload.Who is NetPeer peer)) return;
+
+        var message = payload.What;
+        if (!sessionsById.TryGetValue(message.SessionId, out var session)) return;
+        if (!TryGetSessionPartyId(session, peer, out var partyId)) return;
+
+        if (partyId == session.InitiatorPartyId)
+        {
+            HandleInitiatorOption(session, message.Option);
+            return;
+        }
+
+        if (partyId == session.ResponderPartyId)
+        {
+            HandleResponderOption(session, message.Option);
+            return;
+        }
+    }
+
+    private void Handle_NetworkPlayerPartyInteractionShown(MessagePayload<NetworkPlayerPartyInteractionShown> payload)
+    {
+        if (!ModInformation.IsServer) return;
+        if (!(payload.Who is NetPeer peer)) return;
+
+        var message = payload.What;
+        if (!sessionsById.TryGetValue(message.SessionId, out var session)) return;
+
+        if (message.PartyId == session.ResponderPartyId &&
+            !ReferenceEquals(peer, session.InitiatorPeer) &&
+            session.ResponderPeer == null)
+            session.ResponderPeer = peer;
+    }
+
+    private void Handle_NetworkPlayerPartyInteractionEnded(MessagePayload<NetworkPlayerPartyInteractionEnded> payload)
+    {
+        if (ModInformation.IsServer) return;
+
+        var message = payload.What;
+
+        GameThread.RunSafe(() =>
+        {
+            var isLocalInteraction = TryGetLocalInteractionParty(message, out var localParty);
+            if (!isLocalInteraction && !IsCurrentLocalInteractionSession(message.SessionId)) return;
+
+            PlayerPartyInteractionDialogState.Clear(message.SessionId);
+            PlayerPartyTradeContext.End(message.SessionId, message.OutcomeType);
+            PlayerPartyTradeOverlay.Instance.Hide(message.SessionId);
+            openedConversationSessionIds.Remove(message.SessionId);
+
+            var conversationManager = Campaign.Current?.ConversationManager;
+            if (conversationManager?.IsConversationInProgress == true)
+                conversationManager.EndConversation();
+
+            CloseLocalPlayerPartyEncounter(localParty?.MobileParty);
+        }, context: "End player-party interaction");
+    }
+
+    private void Handle_NetworkPlayerPartyInteractionDenied(MessagePayload<NetworkPlayerPartyInteractionDenied> payload)
+    {
+        if (ModInformation.IsServer) return;
+
+        if (payload.What.Reason == PlayerPartyInteractionDeniedReason.Hostile)
+            return;
+
+        GameThread.RunSafe(
+            ConversationPartyHold.ShowInteractionBlockedMessage,
+            context: "Show player-party interaction denied");
+    }
+
+    private void Handle_PlayerPartyTradeOfferChanged(MessagePayload<PlayerPartyTradeOfferChanged> payload)
+    {
+        if (ModInformation.IsServer) return;
+
+        var message = payload.What;
+        if (!TryGetLocalPartyId(out var partyId)) return;
+
+        var offeredItems = message.InventoryLogic != null
+            ? ResolveItemIds(message.InventoryLogic.GetSoldItems())
+            : ResolveItemIds(GetOfferedBarterItems(message.BarterVM));
+        var offeredGold = message.BarterVM != null
+            ? GetOfferedGold(message.BarterVM)
+            : 0;
+        var offeredFiefs = message.BarterVM != null
+            ? ResolveSettlementIds(GetOfferedBarterFiefs(message.BarterVM))
+            : Array.Empty<string>();
+        var offeredPrisoners = message.BarterVM != null
+            ? ResolveCharacterIds(GetOfferedBarterPrisoners(message.BarterVM))
+            : Array.Empty<TroopRosterElementData>();
+        var offeredTroops = message.BarterVM != null
+            ? ResolveTroopIds(GetOfferedBarterTroops(message.BarterVM))
+            : Array.Empty<TroopRosterElementData>();
+        network.SendAll(new NetworkPlayerPartyTradeOfferUpdated(
+            message.SessionId,
+            partyId,
+            offeredItems,
+            offeredTroops,
+            offeredGold,
+            offeredFiefs,
+            offeredPrisoners));
+    }
+
+    private void Handle_PlayerPartyTradeAcceptSelected(MessagePayload<PlayerPartyTradeAcceptSelected> payload)
+    {
+        if (ModInformation.IsServer) return;
+
+        var message = payload.What;
+        network.SendAll(new NetworkPlayerPartyTradeAcceptChanged(message.SessionId, message.Accepted));
+    }
+
+    private void Handle_NetworkPlayerPartyTradeOfferUpdated(MessagePayload<NetworkPlayerPartyTradeOfferUpdated> payload)
+    {
+        if (!ModInformation.IsServer)
+        {
+            var clientMessage = payload.What;
+            GameThread.RunSafe(
+                () => PlayerPartyTradeContext.ApplyOfferUpdate(clientMessage, objectManager),
+                context: "Apply player-party trade offer update");
+            return;
+        }
+
+        if (!(payload.Who is NetPeer peer)) return;
+
+        var message = payload.What;
+        if (!sessionsById.TryGetValue(message.SessionId, out var session)) return;
+        if (!TryGetSessionPartyId(session, peer, out var partyId)) return;
+        if (session.InitiatorAcceptedTrade || session.ResponderAcceptedTrade) return;
+
+        session.SetTradeOffer(
+            partyId,
+            message.OfferedItems,
+            message.OfferedTroops,
+            message.OfferedGold,
+            message.OfferedFiefs,
+            message.OfferedPrisoners);
+        session.InitiatorAcceptedTrade = false;
+        session.ResponderAcceptedTrade = false;
+        network.SendAll(new NetworkPlayerPartyTradeOfferUpdated(
+            message.SessionId,
+            partyId,
+            message.OfferedItems,
+            message.OfferedTroops,
+            message.OfferedGold,
+            message.OfferedFiefs,
+            message.OfferedPrisoners));
+        SendTradeStates(session, false);
+    }
+
+    private void Handle_NetworkPlayerPartyTradeAcceptChanged(MessagePayload<NetworkPlayerPartyTradeAcceptChanged> payload)
+    {
+        if (!ModInformation.IsServer) return;
+        if (!(payload.Who is NetPeer peer)) return;
+
+        var message = payload.What;
+        if (!sessionsById.TryGetValue(message.SessionId, out var session)) return;
+        if (!TryGetSessionPartyId(session, peer, out var partyId)) return;
+
+        if (partyId == session.InitiatorPartyId)
+            session.InitiatorAcceptedTrade = message.Accepted;
+        else if (partyId == session.ResponderPartyId)
+            session.ResponderAcceptedTrade = message.Accepted;
+        else
+            return;
+
+        SendTradeStates(session);
+
+        if (session.InitiatorAcceptedTrade && session.ResponderAcceptedTrade)
+            EndSession(session, PlayerPartyInteractionOutcomeType.TradeAccepted);
+    }
+
+    private void Handle_PlayerDisconnected(MessagePayload<PlayerDisconnected> payload)
+    {
+        if (!ModInformation.IsServer) return;
+
+        var peer = payload.What.PlayerId;
+        foreach (var session in sessionsById.Values.ToArray())
+        {
+            if (session.InitiatorPeer == peer || session.ResponderPeer == peer)
+                EndSession(session, PlayerPartyInteractionOutcomeType.Disconnected);
+        }
+    }
+
+    private void HandleInitiatorOption(PlayerPartyInteractionSession session, PlayerPartyInteractionOption option)
+    {
+        if (option == PlayerPartyInteractionOption.Leave)
+        {
+            EndSession(session, GetLeaveOutcome(session));
+            return;
+        }
+
+        if (option == PlayerPartyInteractionOption.OfferServices)
+        {
+            return;
+        }
+
+        var proposal = ToProposal(option);
+        if (proposal == PlayerPartyInteractionProposal.None) return;
+        if (!session.InitiatorOptions.Contains(option)) return;
+
+        session.Proposal = proposal;
+        SendInitiatorState(session, PlayerPartyInteractionPhase.WaitingForResponse, proposal, Array.Empty<PlayerPartyInteractionOption>());
+        SendResponderState(
+            session,
+            PlayerPartyInteractionPhase.ProposalPending,
+            proposal,
+            new[]
+            {
+                PlayerPartyInteractionOption.AcceptProposal,
+                PlayerPartyInteractionOption.DeclineProposal,
+                PlayerPartyInteractionOption.Leave
+            });
+    }
+
+    private void HandleResponderOption(PlayerPartyInteractionSession session, PlayerPartyInteractionOption option)
+    {
+        if (option == PlayerPartyInteractionOption.Leave)
+        {
+            EndSession(session, GetLeaveOutcome(session));
+            return;
+        }
+
+        if (option == PlayerPartyInteractionOption.DeclineProposal)
+        {
+            EndSession(session, GetDeclinedOutcome(session.Proposal));
+            return;
+        }
+
+        if (option != PlayerPartyInteractionOption.AcceptProposal) return;
+
+        if (session.Proposal == PlayerPartyInteractionProposal.Trade)
+        {
+            session.InitiatorAcceptedTrade = false;
+            session.ResponderAcceptedTrade = false;
+            SendTradeStates(session);
+            return;
+        }
+
+        EndSession(session, GetAcceptedOutcome(session.Proposal));
+    }
+
+    private void SendInitialStates(PlayerPartyInteractionSession session)
+    {
+        SendInitiatorState(
+            session,
+            PlayerPartyInteractionPhase.InitialOptions,
+            PlayerPartyInteractionProposal.None,
+            session.InitiatorOptions.ToArray());
+
+        SendResponderState(
+            session,
+            PlayerPartyInteractionPhase.WaitingForProposal,
+            PlayerPartyInteractionProposal.None,
+            new[] { PlayerPartyInteractionOption.Leave });
+    }
+
+    private void SendTradeStates(PlayerPartyInteractionSession session)
+        => SendTradeStates(session, true);
+
+    private void SendTradeStates(PlayerPartyInteractionSession session, bool sendOffers)
+    {
+        SendInitiatorState(session, PlayerPartyInteractionPhase.TradeActive, session.Proposal, Array.Empty<PlayerPartyInteractionOption>());
+        SendResponderState(session, PlayerPartyInteractionPhase.TradeActive, session.Proposal, Array.Empty<PlayerPartyInteractionOption>());
+
+        if (sendOffers)
+            SendTradeOffers(session);
+    }
+
+    private void SendTradeOffers(PlayerPartyInteractionSession session)
+    {
+        network.SendAll(new NetworkPlayerPartyTradeOfferUpdated(
+            session.SessionId,
+            session.InitiatorPartyId,
+            session.InitiatorOfferedItems,
+            session.InitiatorOfferedTroops,
+            session.InitiatorOfferedGold,
+            session.InitiatorOfferedFiefs,
+            session.InitiatorOfferedPrisoners));
+
+        network.SendAll(new NetworkPlayerPartyTradeOfferUpdated(
+            session.SessionId,
+            session.ResponderPartyId,
+            session.ResponderOfferedItems,
+            session.ResponderOfferedTroops,
+            session.ResponderOfferedGold,
+            session.ResponderOfferedFiefs,
+            session.ResponderOfferedPrisoners));
+    }
+
+    private void SendInitiatorState(
+        PlayerPartyInteractionSession session,
+        PlayerPartyInteractionPhase phase,
+        PlayerPartyInteractionProposal proposal,
+        PlayerPartyInteractionOption[] options)
+    {
+        var partyItems = phase == PlayerPartyInteractionPhase.TradeActive
+            ? ResolvePartyItemIds(session.InitiatorPartyId)
+            : Array.Empty<ItemRosterElementData>();
+        var otherPartyItems = phase == PlayerPartyInteractionPhase.TradeActive
+            ? ResolvePartyItemIds(session.ResponderPartyId)
+            : Array.Empty<ItemRosterElementData>();
+
+        network.SendAll(new NetworkPlayerPartyInteractionState(
+            session.SessionId,
+            session.InitiatorPartyId,
+            session.ResponderPartyId,
+            session.ResponderName,
+            phase,
+            proposal,
+            options,
+            true,
+            session.InitiatorAcceptedTrade,
+            session.ResponderAcceptedTrade,
+            partyItems,
+            otherPartyItems));
+    }
+
+    private void SendResponderState(
+        PlayerPartyInteractionSession session,
+        PlayerPartyInteractionPhase phase,
+        PlayerPartyInteractionProposal proposal,
+        PlayerPartyInteractionOption[] options)
+    {
+        var partyItems = phase == PlayerPartyInteractionPhase.TradeActive
+            ? ResolvePartyItemIds(session.ResponderPartyId)
+            : Array.Empty<ItemRosterElementData>();
+        var otherPartyItems = phase == PlayerPartyInteractionPhase.TradeActive
+            ? ResolvePartyItemIds(session.InitiatorPartyId)
+            : Array.Empty<ItemRosterElementData>();
+
+        network.SendAll(new NetworkPlayerPartyInteractionState(
+            session.SessionId,
+            session.ResponderPartyId,
+            session.InitiatorPartyId,
+            session.InitiatorName,
+            phase,
+            proposal,
+            options,
+            false,
+            session.InitiatorAcceptedTrade,
+            session.ResponderAcceptedTrade,
+            partyItems,
+            otherPartyItems));
+    }
+
+    private void EndSession(PlayerPartyInteractionSession session, PlayerPartyInteractionOutcomeType outcomeType)
+    {
+        if (!sessionsById.TryRemove(session.SessionId, out _)) return;
+
+        sessionsByPartyId.TryRemove(session.InitiatorPartyId, out _);
+        sessionsByPartyId.TryRemove(session.ResponderPartyId, out _);
+        conversationPartyTracker.EndPvpConversation(session.InitiatorPartyId);
+
+        var outcome = new PlayerPartyInteractionOutcome(session, outcomeType);
+        outcomeHandler.Handle(outcome);
+
+        network.SendAll(new NetworkPlayerPartyInteractionEnded(
+            session.SessionId,
+            session.InitiatorPartyId,
+            session.ResponderPartyId,
+            outcomeType));
+    }
+
+    private void AddInitialOptions(PlayerPartyInteractionSession session, PartyBase initiatorParty, PartyBase responderParty)
+    {
+        session.InitiatorOptions.Add(PlayerPartyInteractionOption.TradeProposal);
+        session.InitiatorOptions.Add(PlayerPartyInteractionOption.OfferServices);
+
+        var serviceOptions = GetServiceOptions(initiatorParty, responderParty);
+        foreach (var serviceOption in serviceOptions)
+            session.InitiatorOptions.Add(serviceOption);
+
+        session.InitiatorOptions.Add(PlayerPartyInteractionOption.Leave);
+    }
+
+    private PlayerPartyInteractionOption[] GetServiceDialogOptions(PlayerPartyInteractionSession session)
+    {
+        var options = new List<PlayerPartyInteractionOption>(GetServiceOptions(session));
+        options.Add(PlayerPartyInteractionOption.Leave);
+        return options.ToArray();
+    }
+
+    private PlayerPartyInteractionOption[] GetServiceOptions(PlayerPartyInteractionSession session)
+    {
+        if (!objectManager.TryGetObject<PartyBase>(session.InitiatorPartyId, out var initiatorParty)) return Array.Empty<PlayerPartyInteractionOption>();
+        if (!objectManager.TryGetObject<PartyBase>(session.ResponderPartyId, out var responderParty)) return Array.Empty<PlayerPartyInteractionOption>();
+
+        return GetServiceOptions(initiatorParty, responderParty);
+    }
+
+    private static PlayerPartyInteractionOption[] GetServiceOptions(PartyBase initiatorParty, PartyBase responderParty)
+    {
+        var options = new List<PlayerPartyInteractionOption>();
+        var initiatorClan = initiatorParty.LeaderHero?.Clan ?? initiatorParty.MobileParty?.ActualClan;
+        var responderHero = responderParty.LeaderHero;
+
+        if (responderHero?.IsClanLeader == true)
+            options.Add(PlayerPartyInteractionOption.JoinClan);
+
+        if (responderHero?.IsKingdomLeader == true && initiatorClan != null)
+        {
+            if (initiatorClan.Tier == 2)
+                options.Add(PlayerPartyInteractionOption.Vassal);
+        }
+
+        return options.ToArray();
+    }
+
+    private static PlayerPartyInteractionProposal ToProposal(PlayerPartyInteractionOption option)
+    {
+        switch (option)
+        {
+            case PlayerPartyInteractionOption.TradeProposal:
+                return PlayerPartyInteractionProposal.Trade;
+            case PlayerPartyInteractionOption.JoinClan:
+                return PlayerPartyInteractionProposal.JoinClan;
+            case PlayerPartyInteractionOption.Vassal:
+                return PlayerPartyInteractionProposal.Vassal;
+            default:
+                return PlayerPartyInteractionProposal.None;
+        }
+    }
+
+    private static PlayerPartyInteractionOutcomeType GetAcceptedOutcome(PlayerPartyInteractionProposal proposal)
+    {
+        switch (proposal)
+        {
+            case PlayerPartyInteractionProposal.JoinClan:
+                return PlayerPartyInteractionOutcomeType.ClanJoinAccepted;
+            case PlayerPartyInteractionProposal.Vassal:
+                return PlayerPartyInteractionOutcomeType.VassalAccepted;
+            default:
+                return PlayerPartyInteractionOutcomeType.None;
+        }
+    }
+
+    private static PlayerPartyInteractionOutcomeType GetDeclinedOutcome(PlayerPartyInteractionProposal proposal)
+    {
+        switch (proposal)
+        {
+            case PlayerPartyInteractionProposal.Trade:
+                return PlayerPartyInteractionOutcomeType.TradeDeclined;
+            case PlayerPartyInteractionProposal.JoinClan:
+                return PlayerPartyInteractionOutcomeType.ClanJoinDeclined;
+            case PlayerPartyInteractionProposal.Vassal:
+                return PlayerPartyInteractionOutcomeType.VassalDeclined;
+            default:
+                return PlayerPartyInteractionOutcomeType.None;
+        }
+    }
+
+    private static PlayerPartyInteractionOutcomeType GetLeaveOutcome(PlayerPartyInteractionSession session)
+    {
+        if (session?.Proposal == PlayerPartyInteractionProposal.Trade)
+            return PlayerPartyInteractionOutcomeType.TradeDeclined;
+
+        return PlayerPartyInteractionOutcomeType.Left;
+    }
+
+    private bool IsPartyBusy(string partyId, string allowedPartnerId)
+    {
+        if (!sessionsByPartyId.TryGetValue(partyId, out var existingSessionId))
+            return conversationPartyTracker.TryGetPvpPartner(partyId, out var partner) && partner != allowedPartnerId;
+
+        if (!sessionsById.TryGetValue(existingSessionId, out var existingSession))
+            return false;
+
+        return existingSession.GetOtherPartyId(partyId) != allowedPartnerId;
+    }
+
+    private static bool AreHostile(PartyBase initiatorParty, PartyBase responderParty)
+    {
+        var initiatorFaction = initiatorParty?.MapFaction;
+        var responderFaction = responderParty?.MapFaction;
+
+        if (initiatorFaction == null || responderFaction == null) return false;
+        if (initiatorFaction == responderFaction) return false;
+
+        return FactionManager.IsAtWarAgainstFaction(initiatorFaction, responderFaction) ||
+               HasFactionWar(initiatorFaction, responderFaction) ||
+               HasFactionWar(responderFaction, initiatorFaction);
+    }
+
+    private static bool HasFactionWar(IFaction faction, IFaction otherFaction)
+    {
+        try
+        {
+            return faction.FactionsAtWarWith?.Contains(otherFaction) == true;
+        }
+        catch (NullReferenceException)
+        {
+            return false;
+        }
+    }
+
+    private static void HoldParty(MobileParty party)
+    {
+        if (party == null) return;
+
+        party.SetMoveModeHold();
+        MessageBroker.Instance.Publish(party.Ai, new PartyBehaviorChangeAttempted(party.Ai, AiBehavior.Hold, null, party.Position));
+    }
+
+    private static string GetPartyName(PartyBase party, string fallback)
+        => party?.LeaderHero?.Name?.ToString() ?? party?.Name?.ToString() ?? fallback;
+
+    private static bool TryGetSessionPartyId(PlayerPartyInteractionSession session, NetPeer peer, out string partyId)
+    {
+        partyId = null;
+
+        if (ReferenceEquals(peer, session.InitiatorPeer))
+        {
+            partyId = session.InitiatorPartyId;
+            return true;
+        }
+
+        if (session.ResponderPeer != null && ReferenceEquals(peer, session.ResponderPeer))
+        {
+            partyId = session.ResponderPartyId;
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool TryGetControlledSessionParty(
+        NetworkPlayerPartyInteractionStarted message,
+        out string myPartyId,
+        out string otherPartyId)
+    {
+        myPartyId = null;
+        otherPartyId = null;
+
+        if (objectManager.TryGetObject<PartyBase>(message.InitiatorPartyId, out var initiatorParty) &&
+            initiatorParty.MobileParty?.IsControlledByThisInstance() == true)
+        {
+            myPartyId = message.InitiatorPartyId;
+            otherPartyId = message.ResponderPartyId;
+            return true;
+        }
+
+        if (objectManager.TryGetObject<PartyBase>(message.ResponderPartyId, out var responderParty) &&
+            responderParty.MobileParty?.IsControlledByThisInstance() == true)
+        {
+            myPartyId = message.ResponderPartyId;
+            otherPartyId = message.InitiatorPartyId;
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool TryGetLocalInteractionParty(NetworkPlayerPartyInteractionEnded message, out PartyBase localParty)
+    {
+        localParty = null;
+
+        if (objectManager.TryGetObject<PartyBase>(message.InitiatorPartyId, out var initiatorParty) &&
+            initiatorParty.MobileParty?.IsControlledByThisInstance() == true)
+        {
+            localParty = initiatorParty;
+            return true;
+        }
+
+        if (objectManager.TryGetObject<PartyBase>(message.ResponderPartyId, out var responderParty) &&
+            responderParty.MobileParty?.IsControlledByThisInstance() == true)
+        {
+            localParty = responderParty;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsCurrentLocalInteractionSession(string sessionId)
+        => PlayerPartyInteractionDialogState.SessionId == sessionId ||
+           PlayerPartyTradeContext.SessionId == sessionId;
+
+    private static void CloseLocalPlayerPartyEncounter(MobileParty localParty)
+    {
+        if (PlayerEncounter.Current != null)
+            PlayerEncounter.Finish(true);
+
+        if (Campaign.Current?.CurrentMenuContext != null)
+            GameMenu.ExitToLast();
+
+        ClearLocalPartyEngageOrder(localParty);
+    }
+
+    private static void ClearLocalPartyEngageOrder(MobileParty party)
+    {
+        if (party?.Ai == null) return;
+        if (party.MapEvent != null) return;
+
+        party.SetMoveModeHold();
+        MessageBroker.Instance.Publish(party.Ai, new PartyBehaviorChangeAttempted(party.Ai, AiBehavior.Hold, null, party.Position));
+    }
+
+    private bool TryGetLocalPartyId(out string partyId)
+    {
+        partyId = PlayerPartyInteractionDialogState.PartyId;
+        return !string.IsNullOrEmpty(partyId);
+    }
+
+    private void TryOpenMapConversation(string sessionId, string myPartyId, string otherPartyId)
+    {
+        if (openedConversationSessionIds.Contains(sessionId)) return;
+
+        if (!objectManager.TryGetObject<PartyBase>(myPartyId, out var myParty)) return;
+        if (!objectManager.TryGetObject<PartyBase>(otherPartyId, out var otherParty)) return;
+
+        var myCharacter = myParty.LeaderHero?.CharacterObject;
+        var otherCharacter = otherParty.LeaderHero?.CharacterObject;
+        if (myCharacter == null || otherCharacter == null) return;
+
+        var conversationManager = Campaign.Current?.ConversationManager;
+        if (conversationManager == null) return;
+        if (conversationManager.IsConversationInProgress) return;
+
+        var playerData = new ConversationCharacterData(myCharacter, myParty, false, false, false, false, false, false);
+        var otherData = new ConversationCharacterData(otherCharacter, otherParty, false, false, false, false, false, false);
+
+        try
+        {
+            conversationManager.OpenMapConversation(playerData, otherData);
+            PlayerPartyInteractionDialogState.RefreshConversation();
+            openedConversationSessionIds.Add(sessionId);
+        }
+        catch (NullReferenceException ex)
+        {
+            Logger.Warning(ex, "Unable to open player party map conversation view");
+        }
+    }
+
+    private void OpenTrade(NetworkPlayerPartyInteractionState state)
+    {
+        if (PlayerPartyTradeContext.IsActive) return;
+        if (!objectManager.TryGetObject<PartyBase>(state.PartyId, out var myParty)) return;
+        if (!objectManager.TryGetObject<PartyBase>(state.OtherPartyId, out var otherParty)) return;
+
+        PlayerPartyTradeContext.Begin(state.SessionId, myParty);
+
+        try
+        {
+            PlayerPartyTradeOverlay.Instance.Show(state.SessionId, state.OtherPlayerName);
+        }
+        catch (NullReferenceException ex)
+        {
+            Logger.Warning(ex, "Unable to open player party trade overlay");
+        }
+
+        try
+        {
+            ApplyTradeItemSnapshots(myParty, otherParty, state);
+            OpenBarter(myParty, otherParty);
+        }
+        catch (NullReferenceException ex)
+        {
+            Logger.Warning(ex, "Unable to open player party barter screen");
+        }
+    }
+
+    private void ApplyTradeItemSnapshots(PartyBase myParty, PartyBase otherParty, NetworkPlayerPartyInteractionState state)
+    {
+        ApplyTradeItemSnapshot(myParty?.ItemRoster, state.PartyItems);
+        ApplyTradeItemSnapshot(otherParty?.ItemRoster, state.OtherPartyItems);
+    }
+
+    private void ApplyTradeItemSnapshot(ItemRoster itemRoster, ItemRosterElementData[] items)
+    {
+        if (itemRoster == null || items == null) return;
+
+        using (new AllowedThread())
+        {
+            itemRoster.Clear();
+
+            foreach (var item in items)
+            {
+                if (item.Amount <= 0) continue;
+                if (!TryResolveEquipmentElement(item.ItemObjectData, out var equipmentElement)) continue;
+
+                itemRoster.AddToCounts(equipmentElement, item.Amount);
+            }
+        }
+    }
+
+    private bool TryResolveEquipmentElement(ItemObjectData itemObjectData, out EquipmentElement equipmentElement)
+    {
+        equipmentElement = default;
+
+        if (!objectManager.TryGetObject(itemObjectData.ItemObjectId, out ItemObject itemObject))
+            return false;
+
+        ItemModifier itemModifier = null;
+        if (!itemObjectData.ItemModifierNull &&
+            !objectManager.TryGetObject(itemObjectData.ItemModifierId, out itemModifier))
+            return false;
+
+        equipmentElement = new EquipmentElement(itemObject, itemModifier);
+        return true;
+    }
+
+    private static void OpenBarter(PartyBase myParty, PartyBase otherParty)
+    {
+        var myHero = myParty?.LeaderHero;
+        var otherHero = otherParty?.LeaderHero;
+        if (myHero == null || otherHero == null) return;
+
+        var barterData = new BarterData(myHero, otherHero, myParty, otherParty, null, 0, false);
+        AddBarterGroups(barterData);
+        AddPartyBarterables(barterData, myHero, otherHero, myParty, otherParty);
+        AddPartyBarterables(barterData, otherHero, myHero, otherParty, myParty);
+
+        BarterManager.Instance.BeginPlayerBarter(barterData);
+    }
+
+    private static void AddBarterGroups(BarterData barterData)
+    {
+        barterData.AddBarterGroup(new FiefBarterGroup());
+        barterData.AddBarterGroup(new PrisonerBarterGroup());
+        barterData.AddBarterGroup(new ItemBarterGroup());
+        barterData.AddBarterGroup(new OtherBarterGroup());
+        barterData.AddBarterGroup(new GoldBarterGroup());
+    }
+
+    private static void AddPartyBarterables(
+        BarterData barterData,
+        Hero ownerHero,
+        Hero otherHero,
+        PartyBase ownerParty,
+        PartyBase otherParty)
+    {
+        barterData.AddBarterable<GoldBarterGroup>(new GoldBarterable(
+            ownerHero,
+            otherHero,
+            ownerParty,
+            otherParty,
+            Math.Max(0, ownerHero.Gold)), false);
+
+        AddPartyFiefBarterables(barterData, ownerHero, otherHero);
+        AddPartyPrisonerBarterables(barterData, ownerHero, otherHero, ownerParty, otherParty);
+        AddPartyItemBarterables(barterData, ownerHero, otherHero, ownerParty, otherParty);
+        AddPartyTroopBarterables(barterData, ownerHero, otherHero, ownerParty, otherParty);
+    }
+
+    private static void AddPartyFiefBarterables(BarterData barterData, Hero ownerHero, Hero otherHero)
+    {
+        if (ownerHero?.Clan == null || otherHero == null) return;
+
+        foreach (var fief in GetAllFiefs())
+        {
+            if (fief?.OwnerClan?.Leader != ownerHero) continue;
+            if (fief.Settlement == null) continue;
+
+            barterData.AddBarterable<FiefBarterGroup>(
+                new FiefBarterable(fief.Settlement, ownerHero, otherHero),
+                false);
+        }
+    }
+
+    private static IEnumerable<Town> GetAllFiefs()
+    {
+        try
+        {
+            return Town.AllFiefs ?? Enumerable.Empty<Town>();
+        }
+        catch (NullReferenceException)
+        {
+            return Enumerable.Empty<Town>();
+        }
+    }
+
+    private static void AddPartyPrisonerBarterables(
+        BarterData barterData,
+        Hero ownerHero,
+        Hero otherHero,
+        PartyBase ownerParty,
+        PartyBase otherParty)
+    {
+        if (ownerParty == null) return;
+
+        foreach (var prisoner in GetPrisonerHeroes(ownerParty))
+        {
+            if (prisoner?.HeroObject == null) continue;
+
+            barterData.AddBarterable<PrisonerBarterGroup>(
+                new TransferPrisonerBarterable(prisoner.HeroObject, ownerHero, ownerParty, otherHero, otherParty),
+                false);
+        }
+    }
+
+    private static IEnumerable<CharacterObject> GetPrisonerHeroes(PartyBase party)
+    {
+        try
+        {
+            return party.PrisonerHeroes ?? Enumerable.Empty<CharacterObject>();
+        }
+        catch (NullReferenceException)
+        {
+            return Enumerable.Empty<CharacterObject>();
+        }
+    }
+
+    private static void AddPartyItemBarterables(
+        BarterData barterData,
+        Hero ownerHero,
+        Hero otherHero,
+        PartyBase ownerParty,
+        PartyBase otherParty)
+    {
+        if (ownerParty?.ItemRoster == null) return;
+
+        foreach (var item in ownerParty.ItemRoster)
+        {
+            if (item.Amount <= 0 || item.EquipmentElement.Item == null) continue;
+
+            barterData.AddBarterable<ItemBarterGroup>(new ItemBarterable(
+                ownerHero,
+                otherHero,
+                ownerParty,
+                otherParty,
+                item,
+                Math.Max(0, item.EquipmentElement.Item.Value)), false);
+        }
+    }
+
+    private static void AddPartyTroopBarterables(
+        BarterData barterData,
+        Hero ownerHero,
+        Hero otherHero,
+        PartyBase ownerParty,
+        PartyBase otherParty)
+    {
+        if (ownerParty?.MemberRoster == null) return;
+
+        foreach (var troop in ownerParty.MemberRoster.GetTroopRoster())
+        {
+            if (troop.Number <= 0 || troop.Character == null) continue;
+            if (troop.Character == ownerHero?.CharacterObject) continue;
+
+            barterData.AddBarterable<OtherBarterGroup>(
+                new PlayerPartyTroopBarterable(ownerHero, otherHero, ownerParty, otherParty, troop),
+                false);
+        }
+    }
+
+    private ItemRosterElementData[] ResolveItemIds(IEnumerable<(ItemRosterElement, int)> items)
+    {
+        var result = new List<ItemRosterElementData>();
+
+        foreach (var (item, count) in items)
+        {
+            if (!objectManager.TryGetId(item.EquipmentElement.Item, out var itemObjectId))
+                continue;
+
+            string itemModifierId = null;
+            if (item.EquipmentElement.ItemModifier != null &&
+                !objectManager.TryGetId(item.EquipmentElement.ItemModifier, out itemModifierId))
+                continue;
+
+            result.Add(new ItemRosterElementData(
+                new ItemObjectData(itemObjectId, itemModifierId, item.EquipmentElement.ItemModifier == null),
+                count));
+        }
+
+        return result.ToArray();
+    }
+
+    private ItemRosterElementData[] ResolvePartyItemIds(string partyId)
+    {
+        if (!objectManager.TryGetObject<PartyBase>(partyId, out var party))
+            return Array.Empty<ItemRosterElementData>();
+
+        return ResolveItemIds(GetItemRosterElements(party.ItemRoster));
+    }
+
+    private string[] ResolveSettlementIds(IEnumerable<Settlement> settlements)
+    {
+        var result = new List<string>();
+
+        foreach (var settlement in settlements)
+        {
+            if (settlement == null || string.IsNullOrEmpty(settlement.StringId))
+                continue;
+
+            result.Add(settlement.StringId);
+        }
+
+        return result.ToArray();
+    }
+
+    private TroopRosterElementData[] ResolveCharacterIds(IEnumerable<(CharacterObject, int)> characters)
+    {
+        var result = new List<TroopRosterElementData>();
+
+        foreach (var (character, count) in characters)
+        {
+            if (character == null || count <= 0) continue;
+
+            var hero = character.HeroObject;
+            var isHero = hero != null;
+            string characterId;
+            if (isHero)
+            {
+                if (!objectManager.TryGetId(hero, out characterId)) continue;
+            }
+            else if (!objectManager.TryGetId(character, out characterId)) continue;
+
+            result.Add(new TroopRosterElementData(characterId, count, 0, 0, isHero));
+        }
+
+        return result.ToArray();
+    }
+
+    private TroopRosterElementData[] ResolveTroopIds(IEnumerable<(TroopRosterElement, int)> troops)
+    {
+        var result = new List<TroopRosterElementData>();
+
+        foreach (var (troop, count) in troops)
+        {
+            var character = troop.Character;
+            if (character == null || count <= 0) continue;
+
+            var hero = character.HeroObject;
+            var isHero = hero != null;
+            string characterId;
+            if (isHero)
+            {
+                if (!objectManager.TryGetId(hero, out characterId)) continue;
+            }
+            else if (!objectManager.TryGetId(character, out characterId)) continue;
+
+            result.Add(new TroopRosterElementData(characterId, count, troop.WoundedNumber, troop.Xp, isHero));
+        }
+
+        return result.ToArray();
+    }
+
+    private static IEnumerable<(ItemRosterElement, int)> GetItemRosterElements(ItemRoster itemRoster)
+    {
+        if (itemRoster == null) yield break;
+
+        foreach (var item in itemRoster)
+        {
+            if (item.Amount <= 0) continue;
+
+            yield return (item, item.Amount);
+        }
+    }
+
+    private static IEnumerable<(ItemRosterElement, int)> GetOfferedBarterItems(BarterVM barterVM)
+    {
+        var result = new List<(ItemRosterElement, int)>();
+        if (barterVM == null) return result;
+
+        AddOfferedBarterItems(result, barterVM.LeftOfferList);
+        AddOfferedBarterItems(result, barterVM.RightOfferList);
+
+        return result;
+    }
+
+    private static int GetOfferedGold(BarterVM barterVM)
+    {
+        if (barterVM == null) return 0;
+
+        return GetOfferedGold(barterVM.LeftOfferList) + GetOfferedGold(barterVM.RightOfferList);
+    }
+
+    private static int GetOfferedGold(IEnumerable<BarterItemVM> offeredItems)
+    {
+        if (offeredItems == null) return 0;
+
+        var result = 0;
+        foreach (var offeredItem in offeredItems)
+        {
+            if (!PlayerPartyTradeContext.CanOffer(offeredItem.Barterable)) continue;
+            if (!(offeredItem.Barterable is GoldBarterable)) continue;
+
+            result += Math.Max(0, offeredItem.Barterable.CurrentAmount);
+        }
+
+        return result;
+    }
+
+    private static IEnumerable<Settlement> GetOfferedBarterFiefs(BarterVM barterVM)
+    {
+        var result = new List<Settlement>();
+        if (barterVM == null) return result;
+
+        AddOfferedBarterFiefs(result, barterVM.LeftOfferList);
+        AddOfferedBarterFiefs(result, barterVM.RightOfferList);
+
+        return result;
+    }
+
+    private static IEnumerable<(CharacterObject, int)> GetOfferedBarterPrisoners(BarterVM barterVM)
+    {
+        var result = new List<(CharacterObject, int)>();
+        if (barterVM == null) return result;
+
+        AddOfferedBarterPrisoners(result, barterVM.LeftOfferList);
+        AddOfferedBarterPrisoners(result, barterVM.RightOfferList);
+
+        return result;
+    }
+
+    private static IEnumerable<(TroopRosterElement, int)> GetOfferedBarterTroops(BarterVM barterVM)
+    {
+        var result = new List<(TroopRosterElement, int)>();
+        if (barterVM == null) return result;
+
+        AddOfferedBarterTroops(result, barterVM.LeftOfferList);
+        AddOfferedBarterTroops(result, barterVM.RightOfferList);
+
+        return result;
+    }
+
+    private static void AddOfferedBarterItems(List<(ItemRosterElement, int)> result, IEnumerable<BarterItemVM> offeredItems)
+    {
+        if (offeredItems == null) return;
+
+        foreach (var offeredItem in offeredItems)
+        {
+            if (!PlayerPartyTradeContext.CanOffer(offeredItem.Barterable)) continue;
+            if (!(offeredItem.Barterable is ItemBarterable itemBarterable)) continue;
+
+            var count = Math.Min(offeredItem.Barterable.CurrentAmount, itemBarterable.ItemRosterElement.Amount);
+            if (count <= 0) continue;
+
+            result.Add((itemBarterable.ItemRosterElement, count));
+        }
+    }
+
+    private static void AddOfferedBarterFiefs(List<Settlement> result, IEnumerable<BarterItemVM> offeredItems)
+    {
+        if (offeredItems == null) return;
+
+        foreach (var offeredItem in offeredItems)
+        {
+            if (!PlayerPartyTradeContext.CanOffer(offeredItem.Barterable)) continue;
+            if (!(offeredItem.Barterable is FiefBarterable fiefBarterable)) continue;
+
+            result.Add(fiefBarterable.TargetSettlement);
+        }
+    }
+
+    private static void AddOfferedBarterPrisoners(List<(CharacterObject, int)> result, IEnumerable<BarterItemVM> offeredItems)
+    {
+        if (offeredItems == null) return;
+
+        foreach (var offeredItem in offeredItems)
+        {
+            if (!PlayerPartyTradeContext.CanOffer(offeredItem.Barterable)) continue;
+            if (!(offeredItem.Barterable is TransferPrisonerBarterable transferPrisonerBarterable)) continue;
+            if (!(PrisonerCharacterField?.GetValue(transferPrisonerBarterable) is Hero prisonerHero)) continue;
+
+            result.Add((prisonerHero.CharacterObject, 1));
+        }
+    }
+
+    private static void AddOfferedBarterTroops(List<(TroopRosterElement, int)> result, IEnumerable<BarterItemVM> offeredItems)
+    {
+        if (offeredItems == null) return;
+
+        foreach (var offeredItem in offeredItems)
+        {
+            if (!PlayerPartyTradeContext.CanOffer(offeredItem.Barterable)) continue;
+            if (!(offeredItem.Barterable is PlayerPartyTroopBarterable troopBarterable)) continue;
+
+            var count = Math.Min(offeredItem.Barterable.CurrentAmount, troopBarterable.TroopRosterElement.Number);
+            if (count <= 0) continue;
+
+            result.Add((troopBarterable.TroopRosterElement, count));
+        }
+    }
+}

--- a/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyInteractionOutcomeHandler.cs
+++ b/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyInteractionOutcomeHandler.cs
@@ -1,0 +1,530 @@
+using Common;
+using Common.Logging;
+using GameInterface.Services.Inventory.Data;
+using GameInterface.Services.ObjectManager;
+using GameInterface.Services.TroopRosters.Data;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Actions;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Roster;
+using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.Core;
+
+namespace GameInterface.Services.MapEvents.PlayerPartyInteractions;
+
+internal readonly struct PlayerPartyInteractionOutcome
+{
+    public readonly string SessionId;
+    public readonly string InitiatorPartyId;
+    public readonly string ResponderPartyId;
+    public readonly PlayerPartyInteractionOutcomeType OutcomeType;
+    public readonly ItemRosterElementData[] InitiatorOfferedItems;
+    public readonly ItemRosterElementData[] ResponderOfferedItems;
+    public readonly int InitiatorOfferedGold;
+    public readonly int ResponderOfferedGold;
+    public readonly string[] InitiatorOfferedFiefs;
+    public readonly string[] ResponderOfferedFiefs;
+    public readonly TroopRosterElementData[] InitiatorOfferedPrisoners;
+    public readonly TroopRosterElementData[] ResponderOfferedPrisoners;
+    public readonly TroopRosterElementData[] InitiatorOfferedTroops;
+    public readonly TroopRosterElementData[] ResponderOfferedTroops;
+
+    public PlayerPartyInteractionOutcome(PlayerPartyInteractionSession session, PlayerPartyInteractionOutcomeType outcomeType)
+    {
+        SessionId = session.SessionId;
+        InitiatorPartyId = session.InitiatorPartyId;
+        ResponderPartyId = session.ResponderPartyId;
+        OutcomeType = outcomeType;
+        InitiatorOfferedItems = session.InitiatorOfferedItems ?? new ItemRosterElementData[0];
+        ResponderOfferedItems = session.ResponderOfferedItems ?? new ItemRosterElementData[0];
+        InitiatorOfferedGold = session.InitiatorOfferedGold;
+        ResponderOfferedGold = session.ResponderOfferedGold;
+        InitiatorOfferedFiefs = session.InitiatorOfferedFiefs ?? new string[0];
+        ResponderOfferedFiefs = session.ResponderOfferedFiefs ?? new string[0];
+        InitiatorOfferedPrisoners = session.InitiatorOfferedPrisoners ?? new TroopRosterElementData[0];
+        ResponderOfferedPrisoners = session.ResponderOfferedPrisoners ?? new TroopRosterElementData[0];
+        InitiatorOfferedTroops = session.InitiatorOfferedTroops ?? new TroopRosterElementData[0];
+        ResponderOfferedTroops = session.ResponderOfferedTroops ?? new TroopRosterElementData[0];
+    }
+}
+
+internal class PlayerPartyInteractionOutcomeHandler
+{
+    private static readonly ILogger Logger = LogManager.GetLogger<PlayerPartyInteractionOutcomeHandler>();
+
+    private readonly IObjectManager objectManager;
+
+    public PlayerPartyInteractionOutcomeHandler(IObjectManager objectManager)
+    {
+        this.objectManager = objectManager;
+    }
+
+    public void Handle(PlayerPartyInteractionOutcome outcome)
+    {
+        switch (outcome.OutcomeType)
+        {
+            case PlayerPartyInteractionOutcomeType.TradeAccepted:
+                HandleTradeAccepted(outcome);
+                break;
+            case PlayerPartyInteractionOutcomeType.ClanJoinAccepted:
+                HandleClanJoinAccepted(outcome);
+                break;
+            case PlayerPartyInteractionOutcomeType.VassalAccepted:
+                //TODO : Hook up joining kingdom logic after [Bannerlord-Coop-Team/BannerlordCoop#1481](https://github.com/Bannerlord-Coop-Team/BannerlordCoop/pull/1481) is merged
+                break;
+            case PlayerPartyInteractionOutcomeType.ClanJoinDeclined:
+            case PlayerPartyInteractionOutcomeType.TradeDeclined:
+            case PlayerPartyInteractionOutcomeType.VassalDeclined:
+            case PlayerPartyInteractionOutcomeType.Left:
+            case PlayerPartyInteractionOutcomeType.Rejected:
+            case PlayerPartyInteractionOutcomeType.Disconnected:
+                // All the above lead to ending the interaction, however we may intend to have them lead to different
+                // logic in the future.
+                break;
+        }
+    }
+
+    private void HandleClanJoinAccepted(PlayerPartyInteractionOutcome outcome)
+    {
+        try
+        {
+            RunOnGameThread(() => ApplyClanJoin(outcome), "Apply player-party clan join");
+        }
+        catch (Exception e)
+        {
+            Logger.Error(e,
+                "Failed to apply player-party clan join. SessionId={SessionId}, InitiatorPartyId={InitiatorPartyId}, ResponderPartyId={ResponderPartyId}",
+                outcome.SessionId,
+                outcome.InitiatorPartyId,
+                outcome.ResponderPartyId);
+        }
+    }
+
+    private void HandleTradeAccepted(PlayerPartyInteractionOutcome outcome)
+    {
+        try
+        {
+            RunOnGameThread(() => ApplyAcceptedTrade(outcome), "Apply player-party trade");
+        }
+        catch (Exception e)
+        {
+            Logger.Error(e,
+                "Failed to apply player-party trade. SessionId={SessionId}, InitiatorPartyId={InitiatorPartyId}, ResponderPartyId={ResponderPartyId}",
+                outcome.SessionId,
+                outcome.InitiatorPartyId,
+                outcome.ResponderPartyId);
+        }
+    }
+
+    private void ApplyClanJoin(PlayerPartyInteractionOutcome outcome)
+    {
+        if (!objectManager.TryGetObject(outcome.InitiatorPartyId, out PartyBase initiatorParty))
+        {
+            Logger.Warning("Unable to apply player-party clan join: initiator party not found. PartyId={PartyId}", outcome.InitiatorPartyId);
+            return;
+        }
+
+        if (!objectManager.TryGetObject(outcome.ResponderPartyId, out PartyBase responderParty))
+        {
+            Logger.Warning("Unable to apply player-party clan join: responder party not found. PartyId={PartyId}", outcome.ResponderPartyId);
+            return;
+        }
+
+        var initiatorHero = initiatorParty.LeaderHero;
+        var responderClan = responderParty.LeaderHero?.Clan;
+        if (initiatorHero == null || responderClan == null)
+        {
+            Logger.Warning(
+                "Unable to apply player-party clan join: missing initiator hero or responder clan. InitiatorPartyId={InitiatorPartyId}, ResponderPartyId={ResponderPartyId}",
+                outcome.InitiatorPartyId,
+                outcome.ResponderPartyId);
+            return;
+        }
+
+        initiatorHero.Clan = responderClan;
+        if (initiatorParty.MobileParty != null)
+            initiatorParty.MobileParty.ActualClan = responderClan;
+    }
+
+    private void ApplyAcceptedTrade(PlayerPartyInteractionOutcome outcome)
+    {
+        if (!objectManager.TryGetObject(outcome.InitiatorPartyId, out PartyBase initiatorParty))
+        {
+            Logger.Warning("Unable to apply player-party trade: initiator party not found. PartyId={PartyId}", outcome.InitiatorPartyId);
+            return;
+        }
+
+        if (!objectManager.TryGetObject(outcome.ResponderPartyId, out PartyBase responderParty))
+        {
+            Logger.Warning("Unable to apply player-party trade: responder party not found. PartyId={PartyId}", outcome.ResponderPartyId);
+            return;
+        }
+
+        var initiatorOffer = BuildAcceptedOffer(
+            initiatorParty,
+            outcome.InitiatorOfferedItems,
+            outcome.InitiatorOfferedTroops,
+            outcome.InitiatorOfferedGold,
+            outcome.InitiatorOfferedFiefs,
+            outcome.InitiatorOfferedPrisoners);
+        var responderOffer = BuildAcceptedOffer(
+            responderParty,
+            outcome.ResponderOfferedItems,
+            outcome.ResponderOfferedTroops,
+            outcome.ResponderOfferedGold,
+            outcome.ResponderOfferedFiefs,
+            outcome.ResponderOfferedPrisoners);
+
+        ApplyOffer(initiatorParty, responderParty, initiatorOffer);
+        ApplyOffer(responderParty, initiatorParty, responderOffer);
+    }
+
+    private AcceptedTradeOffer BuildAcceptedOffer(
+        PartyBase sourceParty,
+        ItemRosterElementData[] offeredItems,
+        TroopRosterElementData[] offeredTroops,
+        int offeredGold,
+        string[] offeredFiefs,
+        TroopRosterElementData[] offeredPrisoners)
+    {
+        var offer = new AcceptedTradeOffer
+        {
+            Gold = Math.Max(0, Math.Min(offeredGold, sourceParty.LeaderHero?.Gold ?? 0))
+        };
+
+        AddItemTransfers(offer, sourceParty, offeredItems);
+        AddTroopTransfers(offer, sourceParty, offeredTroops);
+        AddFiefTransfers(offer, sourceParty, offeredFiefs);
+        AddPrisonerTransfers(offer, sourceParty, offeredPrisoners);
+
+        return offer;
+    }
+
+    private void AddItemTransfers(AcceptedTradeOffer offer, PartyBase sourceParty, ItemRosterElementData[] offeredItems)
+    {
+        var requestedItems = BuildItemRequests(offeredItems);
+        foreach (var request in requestedItems.Values)
+        {
+            if (!TryResolveEquipmentElement(request.ItemObjectData, out var equipmentElement)) continue;
+
+            var amount = Math.Min(request.Amount, GetItemAmount(sourceParty.ItemRoster, equipmentElement));
+            if (amount <= 0) continue;
+
+            offer.Items.Add(new ItemTransfer(equipmentElement, amount));
+        }
+    }
+
+    private void AddTroopTransfers(AcceptedTradeOffer offer, PartyBase sourceParty, TroopRosterElementData[] offeredTroops)
+    {
+        var requestedTroops = BuildTroopRequests(offeredTroops);
+        foreach (var request in requestedTroops.Values)
+        {
+            if (!TryResolveCharacter(request.Data, out var character)) continue;
+            if (character == sourceParty.LeaderHero?.CharacterObject) continue;
+
+            var index = sourceParty.MemberRoster.FindIndexOfTroop(character);
+            if (index < 0) continue;
+
+            var rosterElement = sourceParty.MemberRoster.GetElementCopyAtIndex(index);
+            var amount = Math.Min(request.Number, rosterElement.Number);
+            if (amount <= 0) continue;
+
+            var wounded = Math.Min(amount, Math.Min(request.WoundedNumber, rosterElement.WoundedNumber));
+            var xp = Math.Min(request.Xp, rosterElement.Xp);
+
+            offer.Troops.Add(new TroopTransfer(character, amount, wounded, xp));
+        }
+    }
+
+    private void AddFiefTransfers(AcceptedTradeOffer offer, PartyBase sourceParty, string[] offeredFiefs)
+    {
+        if (sourceParty.LeaderHero == null) return;
+        if (offeredFiefs == null) return;
+
+        var seenFiefs = new HashSet<string>();
+        foreach (var fiefId in offeredFiefs)
+        {
+            if (string.IsNullOrEmpty(fiefId)) continue;
+            if (!seenFiefs.Add(fiefId)) continue;
+            if (!objectManager.TryGetObject(fiefId, out Settlement settlement)) continue;
+            if (settlement.OwnerClan?.Leader != sourceParty.LeaderHero) continue;
+
+            offer.Fiefs.Add(settlement);
+        }
+    }
+
+    private void AddPrisonerTransfers(AcceptedTradeOffer offer, PartyBase sourceParty, TroopRosterElementData[] offeredPrisoners)
+    {
+        var requestedPrisoners = BuildTroopRequests(offeredPrisoners);
+        foreach (var request in requestedPrisoners.Values)
+        {
+            if (!TryResolveCharacter(request.Data, out var character)) continue;
+
+            var amount = Math.Min(request.Number, sourceParty.PrisonRoster.GetElementNumber(character));
+            if (amount <= 0) continue;
+
+            offer.Prisoners.Add(new PrisonerTransfer(character, amount));
+        }
+    }
+
+    private void ApplyOffer(PartyBase sourceParty, PartyBase destinationParty, AcceptedTradeOffer offer)
+    {
+        ApplyGold(sourceParty, destinationParty, offer.Gold);
+        ApplyItems(sourceParty, destinationParty, offer.Items);
+        ApplyTroops(sourceParty, destinationParty, offer.Troops);
+        ApplyPrisoners(sourceParty, destinationParty, offer.Prisoners);
+        ApplyFiefs(destinationParty, offer.Fiefs);
+    }
+
+    private static void ApplyGold(PartyBase sourceParty, PartyBase destinationParty, int amount)
+    {
+        if (amount <= 0) return;
+        if (sourceParty.LeaderHero == null || destinationParty.LeaderHero == null) return;
+
+        GiveGoldAction.ApplyBetweenCharacters(sourceParty.LeaderHero, destinationParty.LeaderHero, amount, false);
+    }
+
+    private static void ApplyItems(PartyBase sourceParty, PartyBase destinationParty, List<ItemTransfer> transfers)
+    {
+        foreach (var transfer in transfers)
+        {
+            sourceParty.ItemRoster.AddToCounts(transfer.EquipmentElement, -transfer.Amount);
+            destinationParty.ItemRoster.AddToCounts(transfer.EquipmentElement, transfer.Amount);
+        }
+    }
+
+    private static void ApplyTroops(PartyBase sourceParty, PartyBase destinationParty, List<TroopTransfer> transfers)
+    {
+        foreach (var transfer in transfers)
+        {
+            sourceParty.MemberRoster.AddToCounts(
+                transfer.Character,
+                -transfer.Amount,
+                false,
+                -transfer.WoundedNumber,
+                -transfer.Xp,
+                true,
+                -1);
+            destinationParty.MemberRoster.AddToCounts(
+                transfer.Character,
+                transfer.Amount,
+                false,
+                transfer.WoundedNumber,
+                transfer.Xp,
+                true,
+                -1);
+        }
+    }
+
+    private static void ApplyPrisoners(PartyBase sourceParty, PartyBase destinationParty, List<PrisonerTransfer> transfers)
+    {
+        foreach (var transfer in transfers)
+        {
+            for (var i = 0; i < transfer.Amount; i++)
+                TransferPrisonerAction.Apply(transfer.Character, sourceParty, destinationParty);
+        }
+    }
+
+    private static void ApplyFiefs(PartyBase destinationParty, List<Settlement> fiefs)
+    {
+        if (destinationParty.LeaderHero == null) return;
+
+        foreach (var fief in fiefs)
+            ChangeOwnerOfSettlementAction.ApplyByBarter(destinationParty.LeaderHero, fief);
+    }
+
+    private Dictionary<string, ItemRequest> BuildItemRequests(ItemRosterElementData[] offeredItems)
+    {
+        var result = new Dictionary<string, ItemRequest>();
+        if (offeredItems == null) return result;
+
+        foreach (var offeredItem in offeredItems)
+        {
+            if (offeredItem.Amount <= 0) continue;
+
+            var key = GetItemKey(offeredItem.ItemObjectData);
+            if (result.TryGetValue(key, out var request))
+            {
+                result[key] = new ItemRequest(offeredItem.ItemObjectData, request.Amount + offeredItem.Amount);
+            }
+            else
+            {
+                result[key] = new ItemRequest(offeredItem.ItemObjectData, offeredItem.Amount);
+            }
+        }
+
+        return result;
+    }
+
+    private Dictionary<string, TroopRequest> BuildTroopRequests(TroopRosterElementData[] offeredTroops)
+    {
+        var result = new Dictionary<string, TroopRequest>();
+        if (offeredTroops == null) return result;
+
+        foreach (var offeredTroop in offeredTroops)
+        {
+            if (offeredTroop.Number <= 0) continue;
+
+            var key = GetCharacterKey(offeredTroop.CharacterId, offeredTroop.IsHero);
+            if (result.TryGetValue(key, out var request))
+            {
+                result[key] = new TroopRequest(
+                    offeredTroop,
+                    request.Number + offeredTroop.Number,
+                    request.WoundedNumber + offeredTroop.WoundedNumber,
+                    request.Xp + offeredTroop.Xp);
+            }
+            else
+            {
+                result[key] = new TroopRequest(
+                    offeredTroop,
+                    offeredTroop.Number,
+                    offeredTroop.WoundedNumber,
+                    offeredTroop.Xp);
+            }
+        }
+
+        return result;
+    }
+
+    private bool TryResolveEquipmentElement(ItemObjectData itemObjectData, out EquipmentElement equipmentElement)
+    {
+        equipmentElement = default;
+
+        if (!objectManager.TryGetObject(itemObjectData.ItemObjectId, out ItemObject itemObject))
+            return false;
+
+        ItemModifier itemModifier = null;
+        if (!itemObjectData.ItemModifierNull &&
+            !objectManager.TryGetObject(itemObjectData.ItemModifierId, out itemModifier))
+            return false;
+
+        equipmentElement = new EquipmentElement(itemObject, itemModifier);
+        return true;
+    }
+
+    private bool TryResolveCharacter(TroopRosterElementData troopData, out CharacterObject character)
+    {
+        character = null;
+
+        if (troopData.IsHero)
+        {
+            if (!objectManager.TryGetObject(troopData.CharacterId, out Hero hero)) return false;
+
+            character = hero.CharacterObject;
+            return character != null;
+        }
+
+        return objectManager.TryGetObject(troopData.CharacterId, out character);
+    }
+
+    private static int GetItemAmount(ItemRoster itemRoster, EquipmentElement equipmentElement)
+    {
+        if (itemRoster == null) return 0;
+
+        foreach (var item in itemRoster)
+        {
+            if (item.EquipmentElement.Equals(equipmentElement))
+                return item.Amount;
+        }
+
+        return 0;
+    }
+
+    private static string GetItemKey(ItemObjectData itemObjectData)
+        => $"{itemObjectData.ItemObjectId}|{itemObjectData.ItemModifierId}|{itemObjectData.ItemModifierNull}";
+
+    private static string GetCharacterKey(string characterId, bool isHero)
+        => $"{characterId}|{isHero}";
+
+    private static void RunOnGameThread(Action action, string context)
+    {
+        if (!GameThread.Instance.IsInitialized || GameThread.Instance.IsGameThread)
+        {
+            action();
+            return;
+        }
+
+        GameThread.RunSafe(action, blocking: true, context: context);
+    }
+
+    private sealed class AcceptedTradeOffer
+    {
+        public int Gold { get; set; }
+        public List<ItemTransfer> Items { get; } = new List<ItemTransfer>();
+        public List<TroopTransfer> Troops { get; } = new List<TroopTransfer>();
+        public List<Settlement> Fiefs { get; } = new List<Settlement>();
+        public List<PrisonerTransfer> Prisoners { get; } = new List<PrisonerTransfer>();
+    }
+
+    private readonly struct ItemRequest
+    {
+        public readonly ItemObjectData ItemObjectData;
+        public readonly int Amount;
+
+        public ItemRequest(ItemObjectData itemObjectData, int amount)
+        {
+            ItemObjectData = itemObjectData;
+            Amount = amount;
+        }
+    }
+
+    private readonly struct TroopRequest
+    {
+        public readonly TroopRosterElementData Data;
+        public readonly int Number;
+        public readonly int WoundedNumber;
+        public readonly int Xp;
+
+        public TroopRequest(TroopRosterElementData data, int number, int woundedNumber, int xp)
+        {
+            Data = data;
+            Number = number;
+            WoundedNumber = woundedNumber;
+            Xp = xp;
+        }
+    }
+
+    private readonly struct ItemTransfer
+    {
+        public readonly EquipmentElement EquipmentElement;
+        public readonly int Amount;
+
+        public ItemTransfer(EquipmentElement equipmentElement, int amount)
+        {
+            EquipmentElement = equipmentElement;
+            Amount = amount;
+        }
+    }
+
+    private readonly struct TroopTransfer
+    {
+        public readonly CharacterObject Character;
+        public readonly int Amount;
+        public readonly int WoundedNumber;
+        public readonly int Xp;
+
+        public TroopTransfer(CharacterObject character, int amount, int woundedNumber, int xp)
+        {
+            Character = character;
+            Amount = amount;
+            WoundedNumber = woundedNumber;
+            Xp = xp;
+        }
+    }
+
+    private readonly struct PrisonerTransfer
+    {
+        public readonly CharacterObject Character;
+        public readonly int Amount;
+
+        public PrisonerTransfer(CharacterObject character, int amount)
+        {
+            Character = character;
+            Amount = amount;
+        }
+    }
+}

--- a/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyInteractionSession.cs
+++ b/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyInteractionSession.cs
@@ -1,0 +1,88 @@
+using GameInterface.Services.Inventory.Data;
+using GameInterface.Services.TroopRosters.Data;
+using LiteNetLib;
+using System.Collections.Generic;
+
+namespace GameInterface.Services.MapEvents.PlayerPartyInteractions;
+
+internal sealed class PlayerPartyInteractionSession
+{
+    public string SessionId { get; }
+    public string InitiatorPartyId { get; }
+    public string ResponderPartyId { get; }
+    public string InitiatorName { get; }
+    public string ResponderName { get; }
+    public NetPeer InitiatorPeer { get; }
+    public NetPeer ResponderPeer { get; set; }
+    public PlayerPartyInteractionProposal Proposal { get; set; }
+    public bool InitiatorAcceptedTrade { get; set; }
+    public bool ResponderAcceptedTrade { get; set; }
+    public ItemRosterElementData[] InitiatorOfferedItems { get; set; } = new ItemRosterElementData[0];
+    public ItemRosterElementData[] ResponderOfferedItems { get; set; } = new ItemRosterElementData[0];
+    public int InitiatorOfferedGold { get; set; }
+    public int ResponderOfferedGold { get; set; }
+    public string[] InitiatorOfferedFiefs { get; set; } = new string[0];
+    public string[] ResponderOfferedFiefs { get; set; } = new string[0];
+    public TroopRosterElementData[] InitiatorOfferedPrisoners { get; set; } = new TroopRosterElementData[0];
+    public TroopRosterElementData[] ResponderOfferedPrisoners { get; set; } = new TroopRosterElementData[0];
+    public TroopRosterElementData[] InitiatorOfferedTroops { get; set; } = new TroopRosterElementData[0];
+    public TroopRosterElementData[] ResponderOfferedTroops { get; set; } = new TroopRosterElementData[0];
+
+    public HashSet<PlayerPartyInteractionOption> InitiatorOptions { get; } = new HashSet<PlayerPartyInteractionOption>();
+
+    public PlayerPartyInteractionSession(
+        string sessionId,
+        string initiatorPartyId,
+        string responderPartyId,
+        string initiatorName,
+        string responderName,
+        NetPeer initiatorPeer)
+    {
+        SessionId = sessionId;
+        InitiatorPartyId = initiatorPartyId;
+        ResponderPartyId = responderPartyId;
+        InitiatorName = initiatorName;
+        ResponderName = responderName;
+        InitiatorPeer = initiatorPeer;
+    }
+
+    public bool ContainsParty(string partyId)
+        => partyId == InitiatorPartyId || partyId == ResponderPartyId;
+
+    public string GetOtherPartyId(string partyId)
+        => partyId == InitiatorPartyId ? ResponderPartyId : InitiatorPartyId;
+
+    public string GetOtherName(string partyId)
+        => partyId == InitiatorPartyId ? ResponderName : InitiatorName;
+
+    public bool IsInitiator(string partyId)
+        => partyId == InitiatorPartyId;
+
+    public void SetTradeOffer(
+        string partyId,
+        ItemRosterElementData[] offeredItems,
+        TroopRosterElementData[] offeredTroops,
+        int offeredGold,
+        string[] offeredFiefs,
+        TroopRosterElementData[] offeredPrisoners)
+    {
+        if (partyId == InitiatorPartyId)
+        {
+            InitiatorOfferedItems = offeredItems ?? new ItemRosterElementData[0];
+            InitiatorOfferedTroops = offeredTroops ?? new TroopRosterElementData[0];
+            InitiatorOfferedGold = offeredGold;
+            InitiatorOfferedFiefs = offeredFiefs ?? new string[0];
+            InitiatorOfferedPrisoners = offeredPrisoners ?? new TroopRosterElementData[0];
+            return;
+        }
+
+        if (partyId == ResponderPartyId)
+        {
+            ResponderOfferedItems = offeredItems ?? new ItemRosterElementData[0];
+            ResponderOfferedTroops = offeredTroops ?? new TroopRosterElementData[0];
+            ResponderOfferedGold = offeredGold;
+            ResponderOfferedFiefs = offeredFiefs ?? new string[0];
+            ResponderOfferedPrisoners = offeredPrisoners ?? new TroopRosterElementData[0];
+        }
+    }
+}

--- a/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyInteractionTypes.cs
+++ b/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyInteractionTypes.cs
@@ -1,0 +1,53 @@
+namespace GameInterface.Services.MapEvents.PlayerPartyInteractions;
+
+public enum PlayerPartyInteractionPhase
+{
+    None,
+    InitialOptions,
+    OfferServices,
+    WaitingForProposal,
+    WaitingForResponse,
+    ProposalPending,
+    TradeActive
+}
+
+public enum PlayerPartyInteractionOption
+{
+    None,
+    TradeProposal,
+    OfferServices,
+    JoinClan,
+    Vassal,
+    AcceptProposal,
+    DeclineProposal,
+    Leave
+}
+
+public enum PlayerPartyInteractionProposal
+{
+    None,
+    Trade,
+    JoinClan,
+    Vassal
+}
+
+public enum PlayerPartyInteractionOutcomeType
+{
+    None,
+    Left,
+    TradeAccepted,
+    TradeDeclined,
+    ClanJoinAccepted,
+    ClanJoinDeclined,
+    VassalAccepted,
+    VassalDeclined,
+    Rejected,
+    Disconnected
+}
+
+public enum PlayerPartyInteractionDeniedReason
+{
+    None,
+    Busy,
+    Hostile
+}

--- a/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyTradeContext.cs
+++ b/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyTradeContext.cs
@@ -1,0 +1,572 @@
+using Common.Messaging;
+using GameInterface.Services.Inventory.Data;
+using GameInterface.Services.MapEvents.Messages.Conversation;
+using GameInterface.Services.ObjectManager;
+using GameInterface.Services.TroopRosters.Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.BarterSystem.Barterables;
+using TaleWorlds.CampaignSystem.Inventory;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.CampaignSystem.ViewModelCollection.Barter;
+using TaleWorlds.Core;
+using TaleWorlds.GauntletUI.BaseTypes;
+using TaleWorlds.Library;
+
+namespace GameInterface.Services.MapEvents.PlayerPartyInteractions;
+
+internal static class PlayerPartyTradeContext
+{
+    public static string SessionId { get; private set; }
+    public static bool IsActive => SessionId != null;
+    public static PartyBase LocalParty { get; private set; }
+    public static bool LocalAccepted { get; private set; }
+    public static bool RemoteAccepted { get; private set; }
+    public static bool SuppressNativeCloseMessages { get; private set; }
+
+    private static BarterVM activeBarterVM;
+    private static ButtonWidget resetButton;
+    private static bool isApplyingServerOffer;
+    private static readonly FieldInfo PrisonerCharacterField =
+        typeof(TransferPrisonerBarterable).GetField("_prisonerCharacter", BindingFlags.Instance | BindingFlags.NonPublic);
+
+    private static readonly HashSet<BarterItemVM> scratchItems = new HashSet<BarterItemVM>();
+
+    public static void Begin(string sessionId, PartyBase localParty = null)
+    {
+        SessionId = sessionId;
+        LocalParty = localParty;
+        LocalAccepted = false;
+        RemoteAccepted = false;
+        activeBarterVM = null;
+        resetButton = null;
+    }
+
+    public static void End(string sessionId = null, PlayerPartyInteractionOutcomeType outcomeType = PlayerPartyInteractionOutcomeType.None)
+    {
+        if (sessionId != null && SessionId != null && SessionId != sessionId) return;
+
+        var barterVM = activeBarterVM;
+
+        SessionId = null;
+        LocalParty = null;
+        LocalAccepted = false;
+        RemoteAccepted = false;
+        activeBarterVM = null;
+        resetButton = null;
+
+        try
+        {
+            SuppressNativeCloseMessages = barterVM != null;
+            barterVM?.ExecuteCancel();
+        }
+        catch (NullReferenceException)
+        {
+        }
+        finally
+        {
+            SuppressNativeCloseMessages = false;
+        }
+
+        ShowOutcomeMessage(outcomeType);
+    }
+
+    public static void SetBarterVM(BarterVM barterVM)
+    {
+        if (!IsActive) return;
+
+        activeBarterVM = barterVM;
+        RefreshBarterControls();
+    }
+
+    public static void UpdateAcceptance(bool localAccepted, bool remoteAccepted)
+    {
+        if (!IsActive) return;
+
+        LocalAccepted = localAccepted;
+        RemoteAccepted = remoteAccepted;
+        RefreshBarterControls();
+    }
+
+    public static bool CanTransfer(TransferCommand transferCommand)
+    {
+        if (!IsActive) return true;
+        if (!CanModifyOffer()) return false;
+
+        return transferCommand.FromSide == InventoryLogic.InventorySide.PlayerInventory;
+    }
+
+    public static bool CanOffer(Barterable barterable)
+    {
+        if (!IsActive) return true;
+        if (!CanModifyOffer()) return false;
+        if (barterable == null || LocalParty == null) return false;
+        if (barterable is FiefBarterable fiefBarterable)
+            return IsOwnedByLocalParty(fiefBarterable);
+
+        return barterable.OriginalParty == LocalParty;
+    }
+
+    public static bool CanAccept()
+        => !IsActive || !LocalAccepted;
+
+    public static bool CanCancel()
+        => !IsActive || !LocalAccepted;
+
+    public static bool CanReset()
+        => !IsActive;
+
+    public static bool CanModifyOffer()
+        => !IsActive || (!LocalAccepted && !RemoteAccepted);
+
+    public static void SetResetButton(ButtonWidget buttonWidget)
+    {
+        if (!IsActive) return;
+
+        resetButton = buttonWidget;
+        RefreshResetButton();
+    }
+
+    public static bool CanOfferTransferAll(BarterVM barterVM, string methodName)
+    {
+        if (!IsActive) return true;
+        if (barterVM == null || !CanModifyOffer()) return false;
+
+        switch (methodName)
+        {
+            case nameof(BarterVM.ExecuteTransferAllLeftFief):
+                return CanOfferAny(barterVM.LeftFiefList);
+            case nameof(BarterVM.ExecuteTransferAllLeftItem):
+                return CanOfferAny(barterVM.LeftItemList);
+            case nameof(BarterVM.ExecuteTransferAllLeftPrisoner):
+                return CanOfferAny(barterVM.LeftPrisonerList);
+            case nameof(BarterVM.ExecuteTransferAllLeftOther):
+                return CanOfferAny(barterVM.LeftOtherList);
+            case nameof(BarterVM.ExecuteTransferAllRightFief):
+                return CanOfferAny(barterVM.RightFiefList);
+            case nameof(BarterVM.ExecuteTransferAllRightItem):
+                return CanOfferAny(barterVM.RightItemList);
+            case nameof(BarterVM.ExecuteTransferAllRightPrisoner):
+                return CanOfferAny(barterVM.RightPrisonerList);
+            case nameof(BarterVM.ExecuteTransferAllRightOther):
+                return CanOfferAny(barterVM.RightOtherList);
+            case nameof(BarterVM.ExecuteTransferAllGoldLeft):
+                return CanOfferAny(barterVM.LeftGoldList);
+            case nameof(BarterVM.ExecuteTransferAllGoldRight):
+                return CanOfferAny(barterVM.RightGoldList);
+            default:
+                return false;
+        }
+    }
+
+    public static void PublishOfferChanged(InventoryLogic inventoryLogic)
+    {
+        if (!IsActive) return;
+        if (isApplyingServerOffer || !CanModifyOffer()) return;
+
+        MessageBroker.Instance.Publish(inventoryLogic, new PlayerPartyTradeOfferChanged(SessionId, inventoryLogic));
+    }
+
+    public static void PublishOfferChanged(BarterVM barterVM)
+    {
+        if (!IsActive) return;
+        if (isApplyingServerOffer || !CanModifyOffer()) return;
+
+        MessageBroker.Instance.Publish(barterVM, new PlayerPartyTradeOfferChanged(SessionId, barterVM));
+    }
+
+    public static void PublishAccept(bool accepted)
+    {
+        if (!IsActive) return;
+        if (!CanAccept()) return;
+
+        if (accepted)
+        {
+            LocalAccepted = true;
+            RefreshBarterControls();
+        }
+
+        MessageBroker.Instance.Publish(null, new PlayerPartyTradeAcceptSelected(SessionId, accepted));
+    }
+
+    public static void PublishLeave()
+    {
+        if (!IsActive) return;
+        if (!CanCancel()) return;
+
+        MessageBroker.Instance.Publish(
+            null,
+            new PlayerPartyInteractionOptionSelected(
+                SessionId,
+                PlayerPartyInteractionDialogState.PartyId,
+                PlayerPartyInteractionOption.Leave));
+    }
+
+    public static void ApplyOfferUpdate(NetworkPlayerPartyTradeOfferUpdated message, IObjectManager objectManager)
+    {
+        if (!IsActive || SessionId != message.SessionId) return;
+        if (activeBarterVM == null || objectManager == null) return;
+
+        if (IsLocalOfferMessage(message, objectManager))
+        {
+            RefreshBarterControls();
+            return;
+        }
+
+        isApplyingServerOffer = true;
+
+        try
+        {
+            ApplyItemOffers(message, objectManager);
+            ApplyGoldOffer(message, objectManager);
+            ApplyFiefOffers(message, objectManager);
+            ApplyPrisonerOffers(message, objectManager);
+            ApplyTroopOffers(message, objectManager);
+            RefreshBarterControls();
+        }
+        finally
+        {
+            isApplyingServerOffer = false;
+        }
+    }
+
+    public static void RefreshBarterControls()
+    {
+        if (activeBarterVM == null) return;
+
+        activeBarterVM.DiplomaticLbl = string.Empty;
+        activeBarterVM.OtherLbl = "Troops";
+        activeBarterVM.LeftDiplomaticList?.Clear();
+        activeBarterVM.RightDiplomaticList?.Clear();
+        activeBarterVM.OfferLbl = "Accept";
+        activeBarterVM.IsOfferDisabled = LocalAccepted;
+        RefreshResetButton();
+
+        foreach (var item in GetAllBarterItems(activeBarterVM))
+            item.IsItemTransferrable = CanOffer(item.Barterable);
+    }
+
+    private static void RefreshResetButton()
+    {
+        if (resetButton == null) return;
+
+        resetButton.IsDisabled = IsActive;
+    }
+
+    private static bool IsLocalOfferMessage(NetworkPlayerPartyTradeOfferUpdated message, IObjectManager objectManager)
+    {
+        if (LocalParty == null) return false;
+        if (!objectManager.TryGetId(LocalParty, out var localPartyId)) return false;
+
+        return localPartyId == message.PartyId;
+    }
+
+    private static void ApplyItemOffers(NetworkPlayerPartyTradeOfferUpdated message, IObjectManager objectManager)
+    {
+        var offeredItems = BuildOfferedItems(message.OfferedItems);
+
+        foreach (var item in GetAllBarterItems(activeBarterVM))
+        {
+            if (!IsOwnedByParty(item, message.PartyId, objectManager)) continue;
+            if (!(item.Barterable is ItemBarterable itemBarterable)) continue;
+            if (!TryGetItemKey(itemBarterable.ItemRosterElement, objectManager, out var itemKey)) continue;
+
+            offeredItems.TryGetValue(itemKey, out var offeredAmount);
+            ApplyOfferedAmount(item, offeredAmount);
+        }
+    }
+
+    private static void ApplyGoldOffer(NetworkPlayerPartyTradeOfferUpdated message, IObjectManager objectManager)
+    {
+        foreach (var item in GetAllBarterItems(activeBarterVM))
+        {
+            if (!IsOwnedByParty(item, message.PartyId, objectManager)) continue;
+            if (!(item.Barterable is GoldBarterable)) continue;
+
+            ApplyOfferedAmount(item, message.OfferedGold);
+        }
+    }
+
+    private static void ApplyFiefOffers(NetworkPlayerPartyTradeOfferUpdated message, IObjectManager objectManager)
+    {
+        var offeredFiefs = new HashSet<string>(message.OfferedFiefs ?? new string[0]);
+
+        foreach (var item in GetAllBarterItems(activeBarterVM))
+        {
+            if (!IsOwnedByParty(item, message.PartyId, objectManager)) continue;
+            if (!(item.Barterable is FiefBarterable fiefBarterable)) continue;
+            if (!TryGetSettlementKey(fiefBarterable.TargetSettlement, objectManager, out var fiefKey)) continue;
+
+            ApplyOfferedAmount(item, offeredFiefs.Contains(fiefKey) ? 1 : 0);
+        }
+    }
+
+    private static void ApplyPrisonerOffers(NetworkPlayerPartyTradeOfferUpdated message, IObjectManager objectManager)
+    {
+        var offeredPrisoners = BuildOfferedTroops(message.OfferedPrisoners);
+
+        foreach (var item in GetAllBarterItems(activeBarterVM))
+        {
+            if (!IsOwnedByParty(item, message.PartyId, objectManager)) continue;
+            if (!(item.Barterable is TransferPrisonerBarterable transferPrisonerBarterable)) continue;
+            if (!(PrisonerCharacterField?.GetValue(transferPrisonerBarterable) is Hero prisonerHero)) continue;
+            if (!TryGetCharacterKey(prisonerHero.CharacterObject, objectManager, out var prisonerKey)) continue;
+
+            ApplyOfferedAmount(item, offeredPrisoners.ContainsKey(prisonerKey) ? 1 : 0);
+        }
+    }
+
+    private static void ApplyTroopOffers(NetworkPlayerPartyTradeOfferUpdated message, IObjectManager objectManager)
+    {
+        var offeredTroops = BuildOfferedTroops(message.OfferedTroops);
+
+        foreach (var item in GetAllBarterItems(activeBarterVM))
+        {
+            if (!IsOwnedByParty(item, message.PartyId, objectManager)) continue;
+            if (!(item.Barterable is PlayerPartyTroopBarterable troopBarterable)) continue;
+            if (!TryGetCharacterKey(troopBarterable.TroopRosterElement.Character, objectManager, out var troopKey)) continue;
+
+            offeredTroops.TryGetValue(troopKey, out var offeredAmount);
+            ApplyOfferedAmount(item, offeredAmount);
+        }
+    }
+
+    private static Dictionary<string, int> BuildOfferedItems(ItemRosterElementData[] offeredItems)
+    {
+        var result = new Dictionary<string, int>();
+        if (offeredItems == null) return result;
+
+        foreach (var offeredItem in offeredItems)
+        {
+            var key = GetItemKey(offeredItem.ItemObjectData);
+            if (result.TryGetValue(key, out var currentAmount))
+                result[key] = currentAmount + offeredItem.Amount;
+            else
+                result[key] = offeredItem.Amount;
+        }
+
+        return result;
+    }
+
+    private static Dictionary<string, int> BuildOfferedTroops(TroopRosterElementData[] offeredTroops)
+    {
+        var result = new Dictionary<string, int>();
+        if (offeredTroops == null) return result;
+
+        foreach (var offeredTroop in offeredTroops)
+        {
+            var key = GetCharacterKey(offeredTroop.CharacterId, offeredTroop.IsHero);
+            if (result.TryGetValue(key, out var currentAmount))
+                result[key] = currentAmount + offeredTroop.Number;
+            else
+                result[key] = offeredTroop.Number;
+        }
+
+        return result;
+    }
+
+    private static void ApplyOfferedAmount(BarterItemVM item, int offeredAmount)
+    {
+        var amount = Math.Max(0, Math.Min(offeredAmount, item.TotalItemCount));
+        var offerList = GetOfferListForItem(activeBarterVM, item);
+
+        if (amount > 0)
+        {
+            item.Barterable.SetIsOffered(true);
+            item.IsOffered = true;
+            item.CurrentOfferedAmount = amount;
+            item.IsItemTransferrable = CanOffer(item.Barterable);
+
+            if (!offerList.Contains(item))
+                offerList.Add(item);
+
+            return;
+        }
+
+        item.Barterable.SetIsOffered(false);
+        item.IsOffered = false;
+        if (item.IsMultiple)
+            item.CurrentOfferedAmount = 1;
+        item.IsItemTransferrable = CanOffer(item.Barterable);
+
+        activeBarterVM.LeftOfferList.Remove(item);
+        activeBarterVM.RightOfferList.Remove(item);
+    }
+
+    private static IEnumerable<BarterItemVM> GetAllBarterItems(BarterVM barterVM)
+    {
+        scratchItems.Clear();
+
+        AddItems(barterVM.LeftFiefList);
+        AddItems(barterVM.RightFiefList);
+        AddItems(barterVM.LeftPrisonerList);
+        AddItems(barterVM.RightPrisonerList);
+        AddItems(barterVM.LeftItemList);
+        AddItems(barterVM.RightItemList);
+        AddItems(barterVM.LeftOtherList);
+        AddItems(barterVM.RightOtherList);
+        AddItems(barterVM.LeftDiplomaticList);
+        AddItems(barterVM.RightDiplomaticList);
+        AddItems(barterVM.LeftGoldList);
+        AddItems(barterVM.RightGoldList);
+        AddItems(barterVM.LeftOfferList);
+        AddItems(barterVM.RightOfferList);
+
+        return scratchItems.ToArray();
+    }
+
+    private static void AddItems(IEnumerable<BarterItemVM> items)
+    {
+        if (items == null) return;
+
+        foreach (var item in items)
+        {
+            if (item != null)
+                scratchItems.Add(item);
+        }
+    }
+
+    private static bool IsOwnedByParty(BarterItemVM item, string partyId, IObjectManager objectManager)
+    {
+        if (!TryGetBarterablePartyId(item?.Barterable, objectManager, out var originalPartyId)) return false;
+
+        return originalPartyId == partyId;
+    }
+
+    private static bool IsOwnedByLocalParty(FiefBarterable fiefBarterable)
+    {
+        if (fiefBarterable == null || LocalParty == null) return false;
+        if (fiefBarterable.OriginalOwner == LocalParty.LeaderHero) return true;
+
+        return fiefBarterable.TargetSettlement?.OwnerClan?.Leader == LocalParty.LeaderHero;
+    }
+
+    private static bool TryGetBarterablePartyId(Barterable barterable, IObjectManager objectManager, out string partyId)
+    {
+        partyId = null;
+
+        if (barterable == null || objectManager == null) return false;
+
+        var party = barterable.OriginalParty;
+        if (party == null && barterable is FiefBarterable fiefBarterable)
+            party = GetPartyForFiefBarterable(fiefBarterable);
+
+        return party != null && objectManager.TryGetId(party, out partyId);
+    }
+
+    private static PartyBase GetPartyForFiefBarterable(FiefBarterable fiefBarterable)
+    {
+        try
+        {
+            return fiefBarterable.OriginalOwner?.PartyBelongedTo?.Party ??
+                   fiefBarterable.TargetSettlement?.OwnerClan?.Leader?.PartyBelongedTo?.Party;
+        }
+        catch (NullReferenceException)
+        {
+            return null;
+        }
+    }
+
+    private static bool TryGetItemKey(ItemRosterElement item, IObjectManager objectManager, out string key)
+    {
+        key = null;
+
+        if (item.EquipmentElement.Item == null) return false;
+        if (!objectManager.TryGetId(item.EquipmentElement.Item, out var itemObjectId)) return false;
+
+        string itemModifierId = null;
+        var itemModifierNull = item.EquipmentElement.ItemModifier == null;
+        if (!itemModifierNull && !objectManager.TryGetId(item.EquipmentElement.ItemModifier, out itemModifierId))
+            return false;
+
+        key = GetItemKey(new ItemObjectData(itemObjectId, itemModifierId, itemModifierNull));
+        return true;
+    }
+
+    private static bool TryGetSettlementKey(Settlement settlement, IObjectManager objectManager, out string key)
+    {
+        key = null;
+
+        if (settlement == null) return false;
+
+        key = settlement.StringId;
+        return !string.IsNullOrEmpty(key);
+    }
+
+    private static bool TryGetCharacterKey(CharacterObject character, IObjectManager objectManager, out string key)
+    {
+        key = null;
+
+        if (character == null) return false;
+
+        var hero = character.HeroObject;
+        var isHero = hero != null;
+        string characterId;
+        if (isHero)
+        {
+            if (!objectManager.TryGetId(hero, out characterId)) return false;
+        }
+        else if (!objectManager.TryGetId(character, out characterId)) return false;
+
+        key = GetCharacterKey(characterId, isHero);
+        return true;
+    }
+
+    private static string GetItemKey(ItemObjectData itemObjectData)
+        => $"{itemObjectData.ItemObjectId}|{itemObjectData.ItemModifierId}|{itemObjectData.ItemModifierNull}";
+
+    private static string GetCharacterKey(string characterId, bool isHero)
+        => $"{characterId}|{isHero}";
+
+    private static TaleWorlds.Library.MBBindingList<BarterItemVM> GetOfferListForItem(BarterVM barterVM, BarterItemVM item)
+    {
+        if (Contains(barterVM.LeftFiefList, item) ||
+            Contains(barterVM.LeftPrisonerList, item) ||
+            Contains(barterVM.LeftItemList, item) ||
+            Contains(barterVM.LeftOtherList, item) ||
+            Contains(barterVM.LeftDiplomaticList, item) ||
+            Contains(barterVM.LeftGoldList, item))
+            return barterVM.LeftOfferList;
+
+        return barterVM.RightOfferList;
+    }
+
+    private static bool Contains(IEnumerable<BarterItemVM> items, BarterItemVM item)
+        => items != null && items.Contains(item);
+
+    private static bool CanOfferAny(IEnumerable<BarterItemVM> items)
+        => items != null && items.Any(item => CanOffer(item?.Barterable));
+
+    private static void ShowOutcomeMessage(PlayerPartyInteractionOutcomeType outcomeType)
+    {
+        var message = GetOutcomeMessage(outcomeType);
+        if (message == null) return;
+
+        InformationManager.DisplayMessage(new InformationMessage(message));
+    }
+
+    internal static string GetOutcomeMessage(PlayerPartyInteractionOutcomeType outcomeType)
+    {
+        switch (outcomeType)
+        {
+            case PlayerPartyInteractionOutcomeType.TradeAccepted:
+                return "Barter offer accepted.";
+            case PlayerPartyInteractionOutcomeType.TradeDeclined:
+                return "Trade proposal declined.";
+            case PlayerPartyInteractionOutcomeType.ClanJoinAccepted:
+                return "Clan service proposal accepted.";
+            case PlayerPartyInteractionOutcomeType.ClanJoinDeclined:
+                return "Clan service proposal declined.";
+            case PlayerPartyInteractionOutcomeType.VassalAccepted:
+                return "Vassalage offer accepted.";
+            case PlayerPartyInteractionOutcomeType.VassalDeclined:
+                return "Vassalage offer declined.";
+            default:
+                return null;
+        }
+    }
+}

--- a/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyTradeOverlay.cs
+++ b/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyTradeOverlay.cs
@@ -1,0 +1,100 @@
+using TaleWorlds.Engine.GauntletUI;
+using TaleWorlds.GauntletUI.Data;
+using TaleWorlds.Library;
+using TaleWorlds.ScreenSystem;
+
+namespace GameInterface.Services.MapEvents.PlayerPartyInteractions;
+
+internal class PlayerPartyTradeOverlay : GlobalLayer
+{
+    private static PlayerPartyTradeOverlay instance;
+
+    private PlayerPartyTradeOverlayVM dataSource;
+    private GauntletLayer gauntletLayer;
+    private string sessionId;
+    private bool isShown;
+
+    public static PlayerPartyTradeOverlay Instance => instance ??= new PlayerPartyTradeOverlay();
+
+    public void Show(string activeSessionId, string otherPlayerName)
+    {
+        if (isShown && sessionId == activeSessionId)
+            return;
+
+        Hide();
+
+        sessionId = activeSessionId;
+        dataSource = new PlayerPartyTradeOverlayVM(otherPlayerName);
+        gauntletLayer = new GauntletLayer("CoopPlayerPartyTradeOverlay", 1000);
+        gauntletLayer.LoadMovie("CoopPlayerPartyTradeOverlay", dataSource);
+        Layer = gauntletLayer;
+
+        ScreenManager.AddGlobalLayer(this, false);
+        isShown = true;
+    }
+
+    public void Hide(string activeSessionId = null)
+    {
+        if (!isShown) return;
+        if (activeSessionId != null && sessionId != activeSessionId) return;
+
+        ScreenManager.RemoveGlobalLayer(this);
+        gauntletLayer = null;
+        dataSource = null;
+        sessionId = null;
+        isShown = false;
+    }
+
+    public void UpdateState(bool localAccepted, bool remoteAccepted)
+    {
+        if (!isShown || dataSource == null) return;
+
+        dataSource.LocalAccepted = localAccepted;
+        dataSource.RemoteAccepted = remoteAccepted;
+    }
+}
+
+internal class PlayerPartyTradeOverlayVM : ViewModel
+{
+    private bool localAccepted;
+    private bool remoteAccepted;
+
+    public PlayerPartyTradeOverlayVM(string otherPlayerName)
+    {
+        OtherPlayerName = otherPlayerName;
+    }
+
+    public string OtherPlayerName { get; }
+
+    [DataSourceProperty]
+    public bool LocalAccepted
+    {
+        get => localAccepted;
+        set
+        {
+            if (localAccepted == value) return;
+            localAccepted = value;
+            OnPropertyChangedWithValue(value, nameof(LocalAccepted));
+            OnPropertyChanged(nameof(LocalAcceptedText));
+        }
+    }
+
+    [DataSourceProperty]
+    public bool RemoteAccepted
+    {
+        get => remoteAccepted;
+        set
+        {
+            if (remoteAccepted == value) return;
+            remoteAccepted = value;
+            OnPropertyChangedWithValue(value, nameof(RemoteAccepted));
+            OnPropertyChanged(nameof(RemoteAcceptedText));
+        }
+    }
+
+    [DataSourceProperty]
+    public string LocalAcceptedText => LocalAccepted ? "You have accepted" : "You have not accepted";
+
+    [DataSourceProperty]
+    public string RemoteAcceptedText => RemoteAccepted ? $"{OtherPlayerName} has accepted" : $"{OtherPlayerName} has not accepted";
+}

--- a/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyTroopBarterable.cs
+++ b/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyTroopBarterable.cs
@@ -1,0 +1,55 @@
+using System;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.BarterSystem.Barterables;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Roster;
+using TaleWorlds.Core;
+using TaleWorlds.Core.ImageIdentifiers;
+using TaleWorlds.Localization;
+
+namespace GameInterface.Services.MapEvents.PlayerPartyInteractions;
+
+internal class PlayerPartyTroopBarterable : Barterable
+{
+    private readonly Hero otherHero;
+    private readonly PartyBase otherParty;
+    private readonly TroopRosterElement troopRosterElement;
+
+    public TroopRosterElement TroopRosterElement => troopRosterElement;
+
+    public override int MaxAmount => troopRosterElement.Number;
+    public override TextObject Name => troopRosterElement.Character?.Name ?? new TextObject("{=MpPSKj5s}Troop");
+    // BarterItemVisualBrushWidget only enables ImageIdentifierWidget for known native barterable type ids.
+    public override string StringID => "item_barterable";
+
+    public PlayerPartyTroopBarterable(
+        Hero ownerHero,
+        Hero otherHero,
+        PartyBase ownerParty,
+        PartyBase otherParty,
+        TroopRosterElement troopRosterElement) : base(ownerHero, ownerParty)
+    {
+        this.otherHero = otherHero;
+        this.otherParty = otherParty;
+        this.troopRosterElement = troopRosterElement;
+    }
+
+    public override void Apply()
+    {
+    }
+
+    public override int GetUnitValueForFaction(IFaction faction)
+    {
+        if (faction == otherHero?.MapFaction || faction == otherParty?.MapFaction)
+            return Math.Max(1, troopRosterElement.Character?.Level ?? 1);
+
+        return -Math.Max(1, troopRosterElement.Character?.Level ?? 1);
+    }
+
+    public override ImageIdentifier GetVisualIdentifier()
+    {
+        if (troopRosterElement.Character == null) return null;
+
+        return new CharacterImageIdentifier(CharacterCode.CreateFrom(troopRosterElement.Character));
+    }
+}


### PR DESCRIPTION
Player to player interaction. Players may barter with each other, join eachothers kingdom (no-op in this pr commit), and join each others clan (needs more testing).

Implemented essentially a full custom dialog for player-to-player interactions on the campaign map. This dialog currently supports bartering, joining the other players clan, and joining the other players kingdom (no-op, waiting for other PR first).

Bartering uses the native bannerlord party barter interface, but added full syncing so both sides can see what the other is offering. Players may offer edit items from their side. Players may trade fiefs, gold, items, and troops in this menu now.

The goal was to make the interaction feel as native as possible to real bannerlord.

## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
P2P campaign interaction was native bannerlord behavior


## What is the new behavior?
<!-- Insert issue id after hashtag. -->

<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Players may now interact with eachother on the campaign map in a native feeling way.

## Other information
