### PR TITLE
[1372] Only announce all players connected once everyone has joined

### DIFF
--- a/source/Coop.Core/Server/Connections/ConnectionCollection.cs
+++ b/source/Coop.Core/Server/Connections/ConnectionCollection.cs
@@ -29,6 +29,14 @@ public class ConnectionCollection : IConnectionCollection
         .Select(conn => conn.Value)
         .Where(conn => conn.IsLoading);
 
+    /// <summary>
+    /// True only when there is at least one connection and every connection has finished joining
+    /// (reached the campaign or a mission). A peer can be connected but still resolving or creating
+    /// its character without counting as loading, so this is what tells whether announcing that all
+    /// players are connected is actually accurate.
+    /// </summary>
+    public bool AllPlayersJoined => !ConnectionStates.IsEmpty && ConnectionStates.Values.All(conn => conn.HasJoinedGame);
+
     private readonly IMessageBroker messageBroker;
     private readonly ConnectionContext connectionContext;
 
@@ -86,7 +94,10 @@ public class ConnectionCollection : IConnectionCollection
         if (loadingCount == lastBroadcastLoadingCount) return;
 
         lastBroadcastLoadingCount = loadingCount;
-        messageBroker.Publish(this, new LoadingPlayersChanged(loadingCount));
+        // A loading peer is never joined, so AllPlayersJoined can only be true once the count hits
+        // zero; gate on that to skip the scan while players are still loading.
+        var allPlayersJoined = loadingCount == 0 && AllPlayersJoined;
+        messageBroker.Publish(this, new LoadingPlayersChanged(loadingCount, allPlayersJoined));
     }
 
     public IEnumerator<IConnectionLogic> GetEnumerator() => ConnectionStates.Values.GetEnumerator();

--- a/source/Coop.Core/Server/Connections/ConnectionLogic.cs
+++ b/source/Coop.Core/Server/Connections/ConnectionLogic.cs
@@ -53,6 +53,8 @@ public class ConnectionLogic : IConnectionLogic
 
     public bool IsLoading => State.IsLoading;
 
+    public bool HasJoinedGame => State.HasJoinedGame;
+
     public TState SetState<TState>() where TState : IConnectionState
     {
         TState newState = (TState)stateFactories[typeof(TState)]();

--- a/source/Coop.Core/Server/Connections/IConnectionState.cs
+++ b/source/Coop.Core/Server/Connections/IConnectionState.cs
@@ -14,6 +14,11 @@ public interface IConnectionState : IState, IDisposable
     bool IsLoading { get; }
 
     /// <summary>
+    /// Whether this connection has finished joining and is now in the game (campaign or mission).
+    /// </summary>
+    bool HasJoinedGame { get; }
+
+    /// <summary>
     /// Player is in the process of creating a character
     /// </summary>
     void CreateCharacter();

--- a/source/Coop.Core/Server/Connections/Messages/LoadingPlayersChanged.cs
+++ b/source/Coop.Core/Server/Connections/Messages/LoadingPlayersChanged.cs
@@ -14,8 +14,15 @@ internal record LoadingPlayersChanged : IEvent
     /// </summary>
     public int LoadingPlayerCount { get; }
 
-    public LoadingPlayersChanged(int loadingPlayerCount)
+    /// <summary>
+    /// Whether every connection has finished joining and is now in the game. Lets consumers tell a
+    /// genuine "everyone is in" moment from a connection still resolving or creating its character.
+    /// </summary>
+    public bool AllPlayersJoined { get; }
+
+    public LoadingPlayersChanged(int loadingPlayerCount, bool allPlayersJoined)
     {
         LoadingPlayerCount = loadingPlayerCount;
+        AllPlayersJoined = allPlayersJoined;
     }
 }

--- a/source/Coop.Core/Server/Connections/States/CampaignState.cs
+++ b/source/Coop.Core/Server/Connections/States/CampaignState.cs
@@ -18,6 +18,8 @@ public class CampaignState : ConnectionStateBase
         this.messageBroker = messageBroker;
     }
 
+    public override bool HasJoinedGame => true;
+
     public override void Dispose()
     {
         messageBroker.Unsubscribe<NetworkPlayerMissionEntered>(PlayerMissionEnteredHandler);

--- a/source/Coop.Core/Server/Connections/States/ConnectionStateBase.cs
+++ b/source/Coop.Core/Server/Connections/States/ConnectionStateBase.cs
@@ -17,6 +17,11 @@ public abstract class ConnectionStateBase : IConnectionState
     /// </summary>
     public virtual bool IsLoading => false;
 
+    /// <summary>
+    /// Connections have not finished joining by default; the in-game states override this.
+    /// </summary>
+    public virtual bool HasJoinedGame => false;
+
     public abstract void CreateCharacter();
     public abstract void TransferSave();
     public abstract void Load();

--- a/source/Coop.Core/Server/Connections/States/MissionState.cs
+++ b/source/Coop.Core/Server/Connections/States/MissionState.cs
@@ -18,6 +18,8 @@ public class MissionState : ConnectionStateBase
         messageBroker.Subscribe<NetworkPlayerCampaignEntered>(PlayerTransitionsCampaignHandler);
     }
 
+    public override bool HasJoinedGame => true;
+
     public override void Dispose()
     {
         messageBroker.Unsubscribe<NetworkPlayerCampaignEntered>(PlayerTransitionsCampaignHandler);

--- a/source/Coop.Core/Server/Services/Connection/Handlers/PlayerConnectionServerMessageHandler.cs
+++ b/source/Coop.Core/Server/Services/Connection/Handlers/PlayerConnectionServerMessageHandler.cs
@@ -38,9 +38,19 @@ public class PlayerConnectionServerMessageHandler : IHandler
 
     internal void Handle_LoadingPlayersChanged(MessagePayload<LoadingPlayersChanged> obj)
     {
-        Volatile.Write(ref loadingPlayerCount, obj.What.LoadingPlayerCount);
+        var count = obj.What.LoadingPlayerCount;
+        Volatile.Write(ref loadingPlayerCount, count);
 
-        BroadcastNotification(loadingPlayerCount > 0 ? LoadingMessage(loadingPlayerCount) : UnpauseReadyMessage);
+        if (count > 0)
+        {
+            BroadcastNotification(LoadingMessage(count));
+        }
+        else if (obj.What.AllPlayersJoined)
+        {
+            BroadcastNotification(UnpauseReadyMessage);
+        }
+        // Otherwise no one is loading but a player is still joining (resolving or creating a
+        // character), so stay quiet rather than falsely announce that everyone is connected.
     }
 
     internal void Handle_TimeSpeedChangeAttempted(MessagePayload<TimeSpeedChangedAttempted> obj)

--- a/source/Coop.Tests/Server/Connections/States/ConnectionCollectionTests.cs
+++ b/source/Coop.Tests/Server/Connections/States/ConnectionCollectionTests.cs
@@ -128,5 +128,52 @@ namespace Coop.Tests.Server.Connections.States
             var clearedMessage = Assert.Single(serverComponent.TestMessageBroker.GetMessagesFromType<LoadingPlayersChanged>());
             Assert.Equal(0, clearedMessage.LoadingPlayerCount);
         }
+
+        [Fact]
+        public void AllPlayersJoined_OnlyTrueOnceConnectionReachesCampaign()
+        {
+            // Arrange
+            var connectPayload = new MessagePayload<PlayerConnected>(this, new PlayerConnected(playerPeer));
+
+            // No connections yet, so there is nobody to be "all connected".
+            Assert.False(connectionCollection.AllPlayersJoined);
+
+            connectionCollection.PlayerJoiningHandler(connectPayload);
+            var connectionLogic = connectionCollection.ConnectionStates[playerPeer];
+
+            // Resolving, creating a character, transferring and loading all count as still joining.
+            Assert.False(connectionCollection.AllPlayersJoined);
+            connectionLogic.SetState<CreateCharacterState>();
+            Assert.False(connectionCollection.AllPlayersJoined);
+            connectionLogic.SetState<TransferSaveState>();
+            Assert.False(connectionCollection.AllPlayersJoined);
+            connectionLogic.SetState<LoadingState>();
+            Assert.False(connectionCollection.AllPlayersJoined);
+
+            // Reaching the campaign means the player has finished joining.
+            connectionLogic.SetState<CampaignState>();
+            Assert.True(connectionCollection.AllPlayersJoined);
+        }
+
+        [Fact]
+        public void AllPlayersJoined_FalseWhileAnotherPeerIsStillJoining()
+        {
+            // Arrange: peer A finishes joining while peer B is still creating its character.
+            var network = serverComponent.Container.Resolve<TestNetwork>();
+            var otherPeer = network.CreatePeer();
+
+            connectionCollection.PlayerJoiningHandler(new MessagePayload<PlayerConnected>(this, new PlayerConnected(playerPeer)));
+            connectionCollection.PlayerJoiningHandler(new MessagePayload<PlayerConnected>(this, new PlayerConnected(otherPeer)));
+
+            connectionCollection.ConnectionStates[playerPeer].SetState<CampaignState>();
+            connectionCollection.ConnectionStates[otherPeer].SetState<CreateCharacterState>();
+
+            // Assert: one peer is in the game but the other has not finished joining.
+            Assert.False(connectionCollection.AllPlayersJoined);
+
+            // Once the other peer also reaches the campaign, everyone has joined.
+            connectionCollection.ConnectionStates[otherPeer].SetState<CampaignState>();
+            Assert.True(connectionCollection.AllPlayersJoined);
+        }
     }
 }

--- a/source/Coop.Tests/Server/Services/Connection/PlayerConnectionServerMessageHandlerTests.cs
+++ b/source/Coop.Tests/Server/Services/Connection/PlayerConnectionServerMessageHandlerTests.cs
@@ -24,7 +24,7 @@ public class PlayerConnectionServerMessageHandlerTests
         var network = new TestNetwork();
         var connectedPeer = network.CreatePeer();
         var handler = new PlayerConnectionServerMessageHandler(broker, network);
-        var payload = new MessagePayload<LoadingPlayersChanged>(this, new LoadingPlayersChanged(2));
+        var payload = new MessagePayload<LoadingPlayersChanged>(this, new LoadingPlayersChanged(2, allPlayersJoined: false));
 
         // Act
         handler.Handle_LoadingPlayersChanged(payload);
@@ -45,7 +45,7 @@ public class PlayerConnectionServerMessageHandlerTests
         var network = new TestNetwork();
         var connectedPeer = network.CreatePeer();
         var handler = new PlayerConnectionServerMessageHandler(broker, network);
-        var payload = new MessagePayload<LoadingPlayersChanged>(this, new LoadingPlayersChanged(0));
+        var payload = new MessagePayload<LoadingPlayersChanged>(this, new LoadingPlayersChanged(0, allPlayersJoined: true));
 
         // Act
         handler.Handle_LoadingPlayersChanged(payload);
@@ -59,6 +59,24 @@ public class PlayerConnectionServerMessageHandlerTests
     }
 
     [Fact]
+    public void LoadingPlayersChanged_WhenNoPlayersLoadingButSomeoneStillJoining_SendsNothing()
+    {
+        // Arrange
+        var broker = new TestMessageBroker();
+        var network = new TestNetwork();
+        var connectedPeer = network.CreatePeer();
+        var handler = new PlayerConnectionServerMessageHandler(broker, network);
+        var payload = new MessagePayload<LoadingPlayersChanged>(this, new LoadingPlayersChanged(0, allPlayersJoined: false));
+
+        // Act
+        handler.Handle_LoadingPlayersChanged(payload);
+
+        // Assert
+        Assert.Empty(broker.GetMessagesFromType<SendInformationMessage>());
+        Assert.False(network.SentNetworkMessages.ContainsKey(connectedPeer.Id));
+    }
+
+    [Fact]
     public void TimeSpeedChangeAttempted_WhilePlayersLoading_RemindsControlsAreDisabled()
     {
         // Arrange
@@ -66,7 +84,7 @@ public class PlayerConnectionServerMessageHandlerTests
         var network = new TestNetwork();
         var handler = new PlayerConnectionServerMessageHandler(broker, network);
         handler.Handle_LoadingPlayersChanged(
-            new MessagePayload<LoadingPlayersChanged>(this, new LoadingPlayersChanged(2)));
+            new MessagePayload<LoadingPlayersChanged>(this, new LoadingPlayersChanged(2, allPlayersJoined: false)));
 
         // Act
         handler.Handle_TimeSpeedChangeAttempted(

--- a/source/Coop.Tests/Server/Services/Time/TimeHandlerTests.cs
+++ b/source/Coop.Tests/Server/Services/Time/TimeHandlerTests.cs
@@ -46,7 +46,7 @@ public class TimeHandlerTests
         var connections = new Mock<IConnectionCollection>();
         var handler = new TimeHandler(broker, network, timeControlInterface.Object, connections.Object);
         var peer = network.CreatePeer();
-        var payload = new MessagePayload<LoadingPlayersChanged>(this, new LoadingPlayersChanged(2));
+        var payload = new MessagePayload<LoadingPlayersChanged>(this, new LoadingPlayersChanged(2, allPlayersJoined: false));
 
         // Act
         handler.Handle_LoadingPlayersChanged(payload);
@@ -68,7 +68,7 @@ public class TimeHandlerTests
         var connections = new Mock<IConnectionCollection>();
         var handler = new TimeHandler(broker, network, timeControlInterface.Object, connections.Object);
         var peer = network.CreatePeer();
-        var payload = new MessagePayload<LoadingPlayersChanged>(this, new LoadingPlayersChanged(0));
+        var payload = new MessagePayload<LoadingPlayersChanged>(this, new LoadingPlayersChanged(0, allPlayersJoined: true));
 
         // Act
         handler.Handle_LoadingPlayersChanged(payload);


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

The server's "All players connected, game can now be un-paused" message pops up too early

## What is the new behavior?

Resolves #1372

The "All players connected, game can now be un-paused" message now only appears once every connected player has actually finished joining and is on the campaign map (or in a mission). If anyone is still joining, the server stays quiet until they are in.
