### PR TITLE
Disable executing player heroes

### DIFF
--- a/source/GameInterface/Services/Party/Patches/PartyScreenLogicPatches.cs
+++ b/source/GameInterface/Services/Party/Patches/PartyScreenLogicPatches.cs
@@ -1,6 +1,7 @@
 ﻿using Common.Logging;
 using Common.Messaging;
 using Common.Util;
+using GameInterface.Services.Heroes.Extensions;
 using GameInterface.Services.Party.Messages;
 using HarmonyLib;
 using Serilog;
@@ -115,5 +116,12 @@ internal class PartyScreenLogicPatches
         // Send message to server to run KillCharacterAction.ApplyByExecution
         var message = new HeroExecuted(command.Character.HeroObject, Hero.MainHero);
         MessageBroker.Instance.Publish(__instance, message);
+    }
+
+    [HarmonyPatch(nameof(PartyScreenLogic.IsExecutable))]
+    [HarmonyPrefix]
+    public static bool IsExecutablePrefix(PartyScreenLogic.TroopType troopType, CharacterObject character, PartyScreenLogic.PartyRosterSide side)
+    {
+        return !(character.IsHero && character.HeroObject.IsPlayerHero());
     }
 }

--- a/source/GameInterface/Services/Party/Patches/PartyScreenLogicPatches.cs
+++ b/source/GameInterface/Services/Party/Patches/PartyScreenLogicPatches.cs
@@ -122,6 +122,7 @@ internal class PartyScreenLogicPatches
     [HarmonyPrefix]
     public static bool IsExecutablePrefix(PartyScreenLogic.TroopType troopType, CharacterObject character, PartyScreenLogic.PartyRosterSide side)
     {
-        return !(character.IsHero && character.HeroObject.IsPlayerHero());
+        // Executable if NOT player hero
+        return character.HeroObject?.IsPlayerHero() != true;
     }
 }


### PR DESCRIPTION
Adds an additional flag to `PartyScreenLogic.IsExecutable()` to prevent players being able to execute each other.

## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #1503 
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Other information
