### PR TITLE
Disable AmbientSpawnReenablePatch

### DIFF
--- a/source/GameInterface/Services/Locations/Patches/AmbientSpawnReenablePatch.cs
+++ b/source/GameInterface/Services/Locations/Patches/AmbientSpawnReenablePatch.cs
@@ -1,39 +1,39 @@
-using Common;
-using HarmonyLib;
-using SandBox.CampaignBehaviors;
-using System.Collections.Generic;
-using System.Reflection;
-using TaleWorlds.CampaignSystem;
-using TaleWorlds.CampaignSystem.CampaignBehaviors;
+//using Common;
+//using HarmonyLib;
+//using SandBox.CampaignBehaviors;
+//using System.Collections.Generic;
+//using System.Reflection;
+//using TaleWorlds.CampaignSystem;
+//using TaleWorlds.CampaignSystem.CampaignBehaviors;
 
-namespace GameInterface.Services.Locations.Patches;
+//namespace GameInterface.Services.Locations.Patches;
 
-/// <summary>
-/// Re-enables the ambient crowds on clients. The host is a dedicated server that never runs a mission
-/// scene, so these behaviors stay disabled on it. Each behavior's <c>RegisterEvents</c> is skipped and
-/// re-routed through <see cref="AmbientSpawnReenable.SubscribeSpawnListenerOnly"/> so only the scene-spawn
-/// listener is wired: some of these behaviors also wire session-launched, settlement-owner-change and
-/// conversation-ended handlers that are not co-op safe. The re-subscribed crowd is scoped as ambient
-/// (made static and non-interactable) and kept identical across clients by <see cref="AmbientSpawnSeedPatch"/>.
-/// </summary>
-[HarmonyPatch]
-internal class AmbientSpawnReenablePatch
-{
-    private static IEnumerable<MethodBase> TargetMethods() => new MethodBase[]
-    {
-        AccessTools.Method(typeof(CommonTownsfolkCampaignBehavior), nameof(CommonTownsfolkCampaignBehavior.RegisterEvents)),
-        AccessTools.Method(typeof(CommonVillagersCampaignBehavior), nameof(CommonVillagersCampaignBehavior.RegisterEvents)),
-        AccessTools.Method(typeof(TownMerchantsCampaignBehavior), nameof(TownMerchantsCampaignBehavior.RegisterEvents)),
-        AccessTools.Method(typeof(WorkshopsCharactersCampaignBehavior), nameof(WorkshopsCharactersCampaignBehavior.RegisterEvents)),
-    };
+///// <summary>
+///// Re-enables the ambient crowds on clients. The host is a dedicated server that never runs a mission
+///// scene, so these behaviors stay disabled on it. Each behavior's <c>RegisterEvents</c> is skipped and
+///// re-routed through <see cref="AmbientSpawnReenable.SubscribeSpawnListenerOnly"/> so only the scene-spawn
+///// listener is wired: some of these behaviors also wire session-launched, settlement-owner-change and
+///// conversation-ended handlers that are not co-op safe. The re-subscribed crowd is scoped as ambient
+///// (made static and non-interactable) and kept identical across clients by <see cref="AmbientSpawnSeedPatch"/>.
+///// </summary>
+//[HarmonyPatch]
+//internal class AmbientSpawnReenablePatch
+//{
+//    private static IEnumerable<MethodBase> TargetMethods() => new MethodBase[]
+//    {
+//        AccessTools.Method(typeof(CommonTownsfolkCampaignBehavior), nameof(CommonTownsfolkCampaignBehavior.RegisterEvents)),
+//        AccessTools.Method(typeof(CommonVillagersCampaignBehavior), nameof(CommonVillagersCampaignBehavior.RegisterEvents)),
+//        AccessTools.Method(typeof(TownMerchantsCampaignBehavior), nameof(TownMerchantsCampaignBehavior.RegisterEvents)),
+//        AccessTools.Method(typeof(WorkshopsCharactersCampaignBehavior), nameof(WorkshopsCharactersCampaignBehavior.RegisterEvents)),
+//    };
 
-    static bool Prefix(CampaignBehaviorBase __instance)
-    {
-        if (ModInformation.IsClient)
-        {
-            AmbientSpawnReenable.SubscribeSpawnListenerOnly(__instance);
-        }
+//    static bool Prefix(CampaignBehaviorBase __instance)
+//    {
+//        if (ModInformation.IsClient)
+//        {
+//            AmbientSpawnReenable.SubscribeSpawnListenerOnly(__instance);
+//        }
 
-        return false;
-    }
-}
+//        return false;
+//    }
+//}


### PR DESCRIPTION
AmbientSpawnReenablePatch prevents dialogue options being loaded (e.g. buying workshops from notables) and doesn't seem to be needed for ambient NPCs to spawn on clients.

## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Other information
