### PR TITLE
[1450] Stop client re-applying battle results; replicate clan renown

### DIFF
--- a/source/E2E.Tests/Services/Clans/ClanSyncTests.cs
+++ b/source/E2E.Tests/Services/Clans/ClanSyncTests.cs
@@ -1,4 +1,6 @@
-﻿using E2E.Tests.Util;
+﻿using Common.Messaging;
+using E2E.Tests.Util;
+using GameInterface.Services.Clans.Messages;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Core;
@@ -73,8 +75,29 @@ namespace E2E.Tests.Services.Clans
             TestEnvironment.AssertProperty<Clan, uint>(nameof(Clan.BannerBackgroundColorSecondary), 654);
             TestEnvironment.AssertProperty<Clan, uint>(nameof(Clan.BannerIconColor),765);
             //TestEnvironment.AssertProperty<Clan, bool>(nameof(Clan._midPointCalculated), true);
-            TestEnvironment.AssertProperty<Clan, float>(nameof(Clan.Renown), 20f);
+            // Clan.Renown is not AutoSynced as a property (its setter is JIT-inlined into its writers); it is
+            // replicated from the server via ClanRenownChanged. See Server_ClanRenown_SyncsToClients below.
             TestEnvironment.AssertProperty<Clan, CampaignTime>(nameof(Clan.NotAttackableByPlayerUntilTime), new CampaignTime(7644567));
+        }
+
+        [Fact]
+        public void Server_ClanRenown_SyncsToClients()
+        {
+            // Renown can't be AutoSynced through the property setter (it's inlined into Clan.AddRenown /
+            // ResetClanRenown), so the server publishes ClanRenownChanged from those writers (ClanRenownPatch)
+            // and clients apply it. Drive that publish and assert clients converge on the server's value.
+            Server.Call(() =>
+            {
+                Assert.True(Server.ObjectManager.TryGetObject(ClanId, out Clan clan));
+                clan.Renown = 20f;
+                MessageBroker.Instance.Publish(clan, new ClanRenownChanged(ClanId, clan.Renown));
+            });
+
+            foreach (var client in Clients)
+            {
+                Assert.True(client.ObjectManager.TryGetObject(ClanId, out Clan clan));
+                Assert.Equal(20f, clan.Renown);
+            }
         }
     }
 }

--- a/source/E2E.Tests/Services/MapEvents/MapEventResultCommitTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/MapEventResultCommitTests.cs
@@ -1,0 +1,44 @@
+﻿using E2E.Tests.Util;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem.MapEvents;
+using Xunit.Abstractions;
+
+namespace E2E.Tests.Services.MapEvents;
+
+public class MapEventResultCommitTests : MapEventTestBase
+{
+    public MapEventResultCommitTests(ITestOutputHelper output) : base(output) { }
+
+    /// <summary>
+    /// The server is authoritative for committing the battle economy (xp/renown/influence/morale/gold) and
+    /// replicates it. After a battle the client's PlayerEncounter result path reaches
+    /// <c>MapEvent.CommitCalculatedMapEventResults</c> locally and would re-apply that economy on top of the
+    /// server's already-replicated values. The client patch skips that commit. We assert it via a party's
+    /// <c>PlunderedGold</c>: the commit's gold step unconditionally zeroes PlunderedGold after applying it, so
+    /// if the commit were not skipped on the client the seeded value would drop to 0; with the patch it stays.
+    /// </summary>
+    [Fact]
+    public void ClientCommitCalculatedMapEventResults_DoesNotApply()
+    {
+        // Arrange — a server-authored battle, replicated to the client with its sides and parties.
+        var ctx = CreateServerMapEvent();
+        var client = Clients.First();
+
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<MapEvent>(ctx.MapEventId, out var mapEvent));
+
+            var winnerParty = mapEvent.AttackerSide.Parties.First();
+
+            // Seed a non-zero plunder. CommitGoldChanges (the last step of the commit) zeroes PlunderedGold on
+            // every party after applying it, so a running commit would reset this to 0.
+            winnerParty.PlunderedGold = 500;
+
+            // The exact method the client's encounter result path reaches via CalculateAndCommitMapEventResults.
+            AccessTools.Method(typeof(MapEvent), "CommitCalculatedMapEventResults").Invoke(mapEvent, null);
+
+            // The client patch skipped the commit, so the seeded plunder was never consumed.
+            Assert.Equal(500, winnerParty.PlunderedGold);
+        }, MapEventDisabledMethods);
+    }
+}

--- a/source/GameInterface/Services/Clans/ClanSync.cs
+++ b/source/GameInterface/Services/Clans/ClanSync.cs
@@ -44,7 +44,9 @@ internal class ClanSync : IAutoSync
         AutoSyncRegistry.AddProperty(AccessTools.Property(typeof(Clan), nameof(Clan.BannerBackgroundColorPrimary)));
         AutoSyncRegistry.AddProperty(AccessTools.Property(typeof(Clan), nameof(Clan.BannerBackgroundColorSecondary)));
         AutoSyncRegistry.AddProperty(AccessTools.Property(typeof(Clan), nameof(Clan.BannerIconColor)));
-        AutoSyncRegistry.AddProperty(AccessTools.Property(typeof(Clan), nameof(Clan.Renown)));
+        // Clan.Renown is intentionally not AutoSynced here: its trivial auto-property setter gets JIT-inlined into
+        // its writers (Clan.AddRenown / ResetClanRenown), so a setter prefix never fires. Renown is replicated
+        // from those writer methods instead (ClanRenownPatch + ClanRenownHandler).
         AutoSyncRegistry.AddProperty(AccessTools.Property(typeof(Clan), nameof(Clan.NotAttackableByPlayerUntilTime)));
     }
 }

--- a/source/GameInterface/Services/Clans/Commands/ClanDebugCommands.cs
+++ b/source/GameInterface/Services/Clans/Commands/ClanDebugCommands.cs
@@ -194,5 +194,69 @@ namespace GameInterface.Services.GameDebug.Commands
 
             return clan.Name.ToString() + " given renown";
         }
+
+        // coop.debug.clan.economy
+        /// <summary>
+        /// Read-only: prints a clan's battle-economy values (renown, influence, leader-party morale, and
+        /// total troop xp). Run it on the host and on a client with the same clan id to compare the two.
+        /// </summary>
+        [CommandLineArgumentFunction("economy", "coop.debug.clan")]
+        public static string ClanEconomy(List<string> args)
+        {
+            if (!TryGetObjectManager(out IObjectManager objectManager))
+            {
+                return "Unable to resolve ObjectManager";
+            }
+
+            Clan clan;
+            if (args.Count >= 1)
+            {
+                // The argument can be a StringId, or a display name (which may contain spaces, so rejoin them).
+                string query = string.Join(" ", args);
+
+                if (!objectManager.TryGetObject(query, out clan))
+                {
+                    clan = Campaign.Current?.CampaignObjectManager?.Clans
+                        ?.FirstOrDefault(c => string.Equals(c.Name?.ToString(), query, System.StringComparison.OrdinalIgnoreCase));
+                }
+
+                if (clan == null)
+                {
+                    return $"Clan not found by id or name: '{query}'";
+                }
+            }
+            else
+            {
+                // No argument: use this instance's main hero clan (works on a client). The host has no main
+                // hero, so pass the clan id or name printed by a client's output.
+                clan = Hero.MainHero?.Clan;
+                if (clan == null)
+                {
+                    return "No main hero on this instance; pass a clan id or name: coop.debug.clan.economy <clanIdOrName>";
+                }
+            }
+
+            StringBuilder stringBuilder = new StringBuilder();
+            stringBuilder.AppendLine($"Clan '{clan.Name}' ({clan.StringId})");
+            stringBuilder.AppendLine($"  Renown:    {clan.Renown}");
+            stringBuilder.AppendLine($"  Influence: {clan.Influence}");
+
+            var leaderParty = clan.Leader?.PartyBelongedTo;
+            if (leaderParty != null)
+            {
+                int totalTroopXp = 0;
+                var roster = leaderParty.MemberRoster;
+                for (int i = 0; i < roster.Count; i++)
+                {
+                    totalTroopXp += roster.GetElementXp(i);
+                }
+
+                stringBuilder.AppendLine($"  Leader party '{leaderParty.Name}':");
+                stringBuilder.AppendLine($"    RecentEventsMorale: {leaderParty.RecentEventsMorale}");
+                stringBuilder.AppendLine($"    Total troop xp:     {totalTroopXp}");
+            }
+
+            return stringBuilder.ToString();
+        }
     }
 }

--- a/source/GameInterface/Services/Clans/Handlers/ClanRenownHandler.cs
+++ b/source/GameInterface/Services/Clans/Handlers/ClanRenownHandler.cs
@@ -6,7 +6,6 @@ using Common.Util;
 using GameInterface.Services.Clans.Messages;
 using GameInterface.Services.ObjectManager;
 using Serilog;
-using System;
 using TaleWorlds.CampaignSystem;
 
 namespace GameInterface.Services.Clans.Handlers
@@ -48,28 +47,25 @@ namespace GameInterface.Services.Clans.Handlers
         {
             var payload = obj.What;
 
-            if (!objectManager.TryGetObject<Clan>(payload.ClanId, out var clan))
+            // Resolve and apply on the game thread. The object registry is mutated on the game thread, so a
+            // lookup on the poll thread can race a registration and miss the clan; doing it inside the queued
+            // action serializes it with that work. RunSafe logs a thrown apply instead of letting it kill the
+            // game-thread pump.
+            GameThread.RunSafe(() =>
             {
-                Logger.Error("Unable to find clan ({clanId}) for renown change", payload.ClanId);
-                return;
-            }
+                if (!objectManager.TryGetObject<Clan>(payload.ClanId, out var clan))
+                {
+                    Logger.Error("Unable to find clan ({clanId}) for renown change", payload.ClanId);
+                    return;
+                }
 
-            GameThread.Run(() =>
-            {
-                try
+                // Apply the server's absolute value (not a delta) so clients converge. AllowedThread keeps any
+                // patches on the write path standing down on the receive side.
+                using (new AllowedThread())
                 {
-                    // Apply the server's absolute value (not a delta) so clients converge. AllowedThread keeps any
-                    // patches on the write path standing down on the receive side.
-                    using (new AllowedThread())
-                    {
-                        clan.Renown = payload.Renown;
-                    }
+                    clan.Renown = payload.Renown;
                 }
-                catch (Exception e)
-                {
-                    Logger.Error(e, "Failed to apply clan renown change for clan ({clanId})", payload.ClanId);
-                }
-            });
+            }, context: $"apply clan renown for {payload.ClanId}");
         }
     }
 }

--- a/source/GameInterface/Services/Clans/Handlers/ClanRenownHandler.cs
+++ b/source/GameInterface/Services/Clans/Handlers/ClanRenownHandler.cs
@@ -1,0 +1,75 @@
+﻿using Common;
+using Common.Logging;
+using Common.Messaging;
+using Common.Network;
+using Common.Util;
+using GameInterface.Services.Clans.Messages;
+using GameInterface.Services.ObjectManager;
+using Serilog;
+using System;
+using TaleWorlds.CampaignSystem;
+
+namespace GameInterface.Services.Clans.Handlers
+{
+    /// <summary>
+    /// Replicates server-authoritative clan renown changes to clients. Clan.Renown's setter is JIT-inlined into
+    /// its writers, so it can't be AutoSynced through a setter prefix; the new absolute renown is published from
+    /// Clan.AddRenown / ResetClanRenown on the server (ClanRenownPatch) and applied here on clients.
+    /// </summary>
+    public class ClanRenownHandler : IHandler
+    {
+        private readonly IMessageBroker messageBroker;
+        private readonly IObjectManager objectManager;
+        private readonly INetwork network;
+        private readonly ILogger Logger = LogManager.GetLogger<ClanRenownHandler>();
+
+        public ClanRenownHandler(IMessageBroker messageBroker, IObjectManager objectManager, INetwork network)
+        {
+            this.messageBroker = messageBroker;
+            this.objectManager = objectManager;
+            this.network = network;
+            messageBroker.Subscribe<ClanRenownChanged>(Handle);
+            messageBroker.Subscribe<NetworkClanRenownChanged>(Handle);
+        }
+
+        public void Dispose()
+        {
+            messageBroker.Unsubscribe<ClanRenownChanged>(Handle);
+            messageBroker.Unsubscribe<NetworkClanRenownChanged>(Handle);
+        }
+
+        private void Handle(MessagePayload<ClanRenownChanged> obj)
+        {
+            var payload = obj.What;
+            network.SendAll(new NetworkClanRenownChanged(payload.ClanId, payload.Renown));
+        }
+
+        private void Handle(MessagePayload<NetworkClanRenownChanged> obj)
+        {
+            var payload = obj.What;
+
+            if (!objectManager.TryGetObject<Clan>(payload.ClanId, out var clan))
+            {
+                Logger.Error("Unable to find clan ({clanId}) for renown change", payload.ClanId);
+                return;
+            }
+
+            GameThread.Run(() =>
+            {
+                try
+                {
+                    // Apply the server's absolute value (not a delta) so clients converge. AllowedThread keeps any
+                    // patches on the write path standing down on the receive side.
+                    using (new AllowedThread())
+                    {
+                        clan.Renown = payload.Renown;
+                    }
+                }
+                catch (Exception e)
+                {
+                    Logger.Error(e, "Failed to apply clan renown change for clan ({clanId})", payload.ClanId);
+                }
+            });
+        }
+    }
+}

--- a/source/GameInterface/Services/Clans/Handlers/ClanRenownHandler.cs
+++ b/source/GameInterface/Services/Clans/Handlers/ClanRenownHandler.cs
@@ -47,10 +47,6 @@ namespace GameInterface.Services.Clans.Handlers
         {
             var payload = obj.What;
 
-            // Resolve and apply on the game thread. The object registry is mutated on the game thread, so a
-            // lookup on the poll thread can race a registration and miss the clan; doing it inside the queued
-            // action serializes it with that work. RunSafe logs a thrown apply instead of letting it kill the
-            // game-thread pump.
             GameThread.RunSafe(() =>
             {
                 if (!objectManager.TryGetObject<Clan>(payload.ClanId, out var clan))

--- a/source/GameInterface/Services/Clans/Handlers/ClanRenownHandler.cs
+++ b/source/GameInterface/Services/Clans/Handlers/ClanRenownHandler.cs
@@ -1,11 +1,9 @@
 ﻿using Common;
-using Common.Logging;
 using Common.Messaging;
 using Common.Network;
 using Common.Util;
 using GameInterface.Services.Clans.Messages;
 using GameInterface.Services.ObjectManager;
-using Serilog;
 using TaleWorlds.CampaignSystem;
 
 namespace GameInterface.Services.Clans.Handlers
@@ -20,7 +18,6 @@ namespace GameInterface.Services.Clans.Handlers
         private readonly IMessageBroker messageBroker;
         private readonly IObjectManager objectManager;
         private readonly INetwork network;
-        private readonly ILogger Logger = LogManager.GetLogger<ClanRenownHandler>();
 
         public ClanRenownHandler(IMessageBroker messageBroker, IObjectManager objectManager, INetwork network)
         {
@@ -49,11 +46,8 @@ namespace GameInterface.Services.Clans.Handlers
 
             GameThread.RunSafe(() =>
             {
-                if (!objectManager.TryGetObject<Clan>(payload.ClanId, out var clan))
-                {
-                    Logger.Error("Unable to find clan ({clanId}) for renown change", payload.ClanId);
+                if (!objectManager.TryGetObjectWithLogging<Clan>(payload.ClanId, out var clan))
                     return;
-                }
 
                 // Apply the server's absolute value (not a delta) so clients converge. AllowedThread keeps any
                 // patches on the write path standing down on the receive side.

--- a/source/GameInterface/Services/Clans/Messages/ClanRenownChanged.cs
+++ b/source/GameInterface/Services/Clans/Messages/ClanRenownChanged.cs
@@ -1,0 +1,18 @@
+﻿using Common.Messaging;
+
+namespace GameInterface.Services.Clans.Messages;
+
+/// <summary>
+/// Local event raised on the server when a clan's renown changes, so it can be replicated to clients.
+/// </summary>
+public record ClanRenownChanged : IEvent
+{
+    public string ClanId { get; }
+    public float Renown { get; }
+
+    public ClanRenownChanged(string clanId, float renown)
+    {
+        ClanId = clanId;
+        Renown = renown;
+    }
+}

--- a/source/GameInterface/Services/Clans/Messages/NetworkClanRenownChanged.cs
+++ b/source/GameInterface/Services/Clans/Messages/NetworkClanRenownChanged.cs
@@ -1,0 +1,19 @@
+﻿using Common.Messaging;
+using ProtoBuf;
+
+namespace GameInterface.Services.Clans.Messages;
+
+[ProtoContract(SkipConstructor = true)]
+internal class NetworkClanRenownChanged : ICommand
+{
+    [ProtoMember(1)]
+    public string ClanId { get; }
+    [ProtoMember(2)]
+    public float Renown { get; }
+
+    public NetworkClanRenownChanged(string clanId, float renown)
+    {
+        ClanId = clanId;
+        Renown = renown;
+    }
+}

--- a/source/GameInterface/Services/Clans/Patches/ClanRenownPatch.cs
+++ b/source/GameInterface/Services/Clans/Patches/ClanRenownPatch.cs
@@ -1,0 +1,37 @@
+﻿using Common;
+using Common.Messaging;
+using GameInterface.Policies;
+using GameInterface.Services.Clans.Messages;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+
+namespace GameInterface.Services.Clans.Patches;
+
+// Clan.Renown is a trivial auto-property; the JIT inlines its setter into the methods that write it
+// (Clan.AddRenown, ResetClanRenown), so the AutoSync setter prefix never runs and renown never replicates.
+// Publish the new absolute renown from the (non-inlined) writer methods on the server instead; clients apply it
+// in ClanRenownHandler. The Renown AutoSync property registration is removed in ClanSync.
+[HarmonyPatch(typeof(Clan))]
+internal class ClanRenownPatch
+{
+    [HarmonyPatch(nameof(Clan.AddRenown))]
+    [HarmonyPostfix]
+    private static void Postfix_AddRenown(Clan __instance) => PublishRenown(__instance);
+
+    [HarmonyPatch(nameof(Clan.ResetClanRenown))]
+    [HarmonyPostfix]
+    private static void Postfix_ResetClanRenown(Clan __instance) => PublishRenown(__instance);
+
+    private static void PublishRenown(Clan clan)
+    {
+        // Applying a replicated change re-runs the writer under an AllowedThread; don't re-announce it.
+        if (CallOriginalPolicy.IsOriginalAllowed()) return;
+
+        // The server owns renown; clients receive it.
+        if (!ModInformation.IsServer) return;
+
+        if (string.IsNullOrEmpty(clan?.StringId)) return;
+
+        MessageBroker.Instance.Publish(clan, new ClanRenownChanged(clan.StringId, clan.Renown));
+    }
+}

--- a/source/GameInterface/Services/Clans/Patches/ClanRenownPatch.cs
+++ b/source/GameInterface/Services/Clans/Patches/ClanRenownPatch.cs
@@ -24,11 +24,9 @@ internal class ClanRenownPatch
 
     private static void PublishRenown(Clan clan)
     {
-        // Applying a replicated change re-runs the writer under an AllowedThread; don't re-announce it.
-        if (CallOriginalPolicy.IsOriginalAllowed()) return;
-
-        // The server owns renown; clients receive it.
         if (!ModInformation.IsServer) return;
+
+        if (CallOriginalPolicy.IsOriginalAllowed()) return;
 
         if (string.IsNullOrEmpty(clan?.StringId)) return;
 

--- a/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
@@ -64,6 +64,30 @@ public class MapEventDebugCommands
         return $"MapEvent Started";
     }
 
+    // coop.debug.mapevent.win_player_battle
+    /// <summary>
+    /// Forces the local player's current encounter to a victory so the encounter result path runs and the
+    /// client commits the battle result, without having to fight a mission. Run on the client after
+    /// starting a battle (e.g. coop.debug.mapevent.start_looter); click through any results screens.
+    /// </summary>
+    [CommandLineArgumentFunction("win_player_battle", "coop.debug.mapevent")]
+    public static string WinPlayerBattle(List<string> args)
+    {
+        if (PlayerEncounter.Current == null)
+        {
+            return "No active player encounter";
+        }
+
+        if (MobileParty.MainParty?.MapEvent == null)
+        {
+            return "Not in a battle yet; attack the enemy first so a map event exists";
+        }
+
+        PlayerEncounter.SetPlayerVictorious();
+
+        return "Forced player victory; the encounter result commits on the next tick";
+    }
+
     /// <summary>
     /// Kills a random troop from the enemy side of the current map event.
     /// </summary>

--- a/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
@@ -64,30 +64,6 @@ public class MapEventDebugCommands
         return $"MapEvent Started";
     }
 
-    // coop.debug.mapevent.win_player_battle
-    /// <summary>
-    /// Forces the local player's current encounter to a victory so the encounter result path runs and the
-    /// client commits the battle result, without having to fight a mission. Run on the client after
-    /// starting a battle (e.g. coop.debug.mapevent.start_looter); click through any results screens.
-    /// </summary>
-    [CommandLineArgumentFunction("win_player_battle", "coop.debug.mapevent")]
-    public static string WinPlayerBattle(List<string> args)
-    {
-        if (PlayerEncounter.Current == null)
-        {
-            return "No active player encounter";
-        }
-
-        if (MobileParty.MainParty?.MapEvent == null)
-        {
-            return "Not in a battle yet; attack the enemy first so a map event exists";
-        }
-
-        PlayerEncounter.SetPlayerVictorious();
-
-        return "Forced player victory; the encounter result commits on the next tick";
-    }
-
     /// <summary>
     /// Kills a random troop from the enemy side of the current map event.
     /// </summary>

--- a/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
@@ -121,13 +121,6 @@ internal class MapEventPatches
         if (CallOriginalPolicy.IsOriginalAllowed())
             return true;
 
-        // The server commits the battle economy (troop xp, renown, influence, morale, gold) during OnBattleWon
-        // and replicates it. The client's encounter result path reaches this commit locally too (both when a
-        // battle ends and when a multi-round battle continues) and re-applies it on top of the server's
-        // already-received values with no later resync, drifting the player's clan renown/influence, the party's
-        // morale, and surviving troops' xp above the server. (Hero gold and prisoner capture are already blocked
-        // on the client by the GiveGoldAction/TakePrisonerAction patches.) Skip the commit on the client so the
-        // economy stays the server's; the loot-staging steps that run before it are left intact.
         return ModInformation.IsServer;
     }
 

--- a/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
@@ -114,6 +114,23 @@ internal class MapEventPatches
         return true;
     }
 
+    [HarmonyPatch("CommitCalculatedMapEventResults")]
+    [HarmonyPrefix]
+    private static bool Prefix_CommitCalculatedMapEventResults()
+    {
+        if (CallOriginalPolicy.IsOriginalAllowed())
+            return true;
+
+        // The server commits the battle economy (troop xp, renown, influence, morale, gold) during OnBattleWon
+        // and replicates it. The client's encounter result path reaches this commit locally too (both when a
+        // battle ends and when a multi-round battle continues) and re-applies it on top of the server's
+        // already-received values with no later resync, drifting the player's clan renown/influence, the party's
+        // morale, and surviving troops' xp above the server. (Hero gold and prisoner capture are already blocked
+        // on the client by the GiveGoldAction/TakePrisonerAction patches.) Skip the commit on the client so the
+        // economy stays the server's; the loot-staging steps that run before it are left intact.
+        return !ModInformation.IsClient;
+    }
+
     [HarmonyPatch(nameof(MapEvent.Update))]
     [HarmonyPrefix]
     private static bool PrefixUpdate(MapEvent __instance)

--- a/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
@@ -128,7 +128,7 @@ internal class MapEventPatches
         // morale, and surviving troops' xp above the server. (Hero gold and prisoner capture are already blocked
         // on the client by the GiveGoldAction/TakePrisonerAction patches.) Skip the commit on the client so the
         // economy stays the server's; the loot-staging steps that run before it are left intact.
-        return !ModInformation.IsClient;
+        return ModInformation.IsServer;
     }
 
     [HarmonyPatch(nameof(MapEvent.Update))]


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

After a player wins a battle, that player's clan renown and party recent-events morale don't match between the host and that player's client. The client's renown ends up wrong and recent events morale differs. Troop xp and influence are unaffected.
<img width="1311" height="291" alt="image" src="https://github.com/user-attachments/assets/8dde4389-3ac1-4617-98d1-b266e29eca57" />



## What is the new behavior?

Resolves #1450

The host stays authoritative for battle rewards. The client no longer re-applies them locally and the clan renown the host awards now replicates to clients. After a battle the player's renown and recent-events morale match the host.

<img width="1266" height="143" alt="desync fixed" src="https://github.com/user-attachments/assets/3dbce6b0-2152-4c51-b991-aba4b19c6b76" />

Also adds a debug console command used to test this: `coop.debug.clan.economy [clanId]` (prints a clan's renown, influence, recent-events morale, and troop xp).
