### PR TITLE
Disabled join clan p2p dialog

### DIFF
--- a/source/E2E.Tests/Services/MapEvents/PlayerPartyInteractionFlowTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/PlayerPartyInteractionFlowTests.cs
@@ -121,7 +121,7 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
     }
 
     [Fact]
-    public void OfferServices_WithNoValidServiceOptions_ShowsNevermindAndCanEndInteraction()
+    public void OfferServices_WithNoEnabledServiceOptions_ShowsDisabledOptionsAndCanEndInteraction()
     {
         var (client1, _, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
         var responderClanLeaderId = TestEnvironment.CreateRegisteredObject<Hero>();
@@ -143,6 +143,10 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
             s.Phase == PlayerPartyInteractionPhase.InitialOptions);
 
         Assert.Contains(PlayerPartyInteractionOption.OfferServices, initialState.Options);
+        Assert.Contains(PlayerPartyInteractionOption.JoinClan, initialState.Options);
+        Assert.Contains(PlayerPartyInteractionOption.Vassal, initialState.Options);
+        Assert.DoesNotContain(PlayerPartyInteractionOption.JoinClan, initialState.EnabledOptions);
+        Assert.DoesNotContain(PlayerPartyInteractionOption.Vassal, initialState.EnabledOptions);
 
         Server.NetworkSentMessages.Clear();
         client1.NetworkSentMessages.Clear();
@@ -154,8 +158,11 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
         {
             Assert.Equal(PlayerPartyInteractionPhase.OfferServices, PlayerPartyInteractionDialogState.Phase);
             Assert.True(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.Leave));
-            Assert.False(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.JoinClan));
-            Assert.False(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.Vassal));
+            Assert.True(PlayerPartyInteractionDialogState.IsOptionEnabled(PlayerPartyInteractionOption.Leave));
+            Assert.True(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.JoinClan));
+            Assert.False(PlayerPartyInteractionDialogState.IsOptionEnabled(PlayerPartyInteractionOption.JoinClan));
+            Assert.True(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.Vassal));
+            Assert.False(PlayerPartyInteractionDialogState.IsOptionEnabled(PlayerPartyInteractionOption.Vassal));
         });
 
         Server.NetworkSentMessages.Clear();
@@ -166,7 +173,7 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
     }
 
     [Fact]
-    public void OfferServices_WithValidServiceOptions_StillShowsNevermind()
+    public void OfferServices_WithClanLeader_ShowsJoinClanDisabledAndNevermind()
     {
         var (client1, _, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
 
@@ -187,13 +194,16 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
         {
             Assert.Equal(PlayerPartyInteractionPhase.OfferServices, PlayerPartyInteractionDialogState.Phase);
             Assert.True(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.JoinClan));
+            Assert.False(PlayerPartyInteractionDialogState.IsOptionEnabled(PlayerPartyInteractionOption.JoinClan));
+            Assert.True(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.Vassal));
+            Assert.False(PlayerPartyInteractionDialogState.IsOptionEnabled(PlayerPartyInteractionOption.Vassal));
             Assert.True(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.Leave));
-            Assert.False(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.Vassal));
+            Assert.True(PlayerPartyInteractionDialogState.IsOptionEnabled(PlayerPartyInteractionOption.Leave));
         });
     }
 
     [Fact]
-    public void OfferServices_WithTierOneClanAndKingdomLeader_DoesNotShowMercenary()
+    public void OfferServices_WithTierOneClanAndKingdomLeader_DisablesVassal()
     {
         var (client1, _, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
         SetupResponderKingdomLeader(initiatorPartyId, responderPartyId, initiatorClanTier: 1);
@@ -210,13 +220,16 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
         client1.Call(() =>
         {
             Assert.True(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.JoinClan));
+            Assert.False(PlayerPartyInteractionDialogState.IsOptionEnabled(PlayerPartyInteractionOption.JoinClan));
             Assert.True(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.Leave));
-            Assert.False(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.Vassal));
+            Assert.True(PlayerPartyInteractionDialogState.IsOptionEnabled(PlayerPartyInteractionOption.Leave));
+            Assert.True(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.Vassal));
+            Assert.False(PlayerPartyInteractionDialogState.IsOptionEnabled(PlayerPartyInteractionOption.Vassal));
         });
     }
 
     [Fact]
-    public void OfferServices_WithTierTwoClanAndKingdomLeader_ShowsVassal()
+    public void OfferServices_WithTierTwoClanAndKingdomLeader_EnablesVassal()
     {
         var (client1, _, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
         SetupResponderKingdomLeader(initiatorPartyId, responderPartyId, initiatorClanTier: 2);
@@ -228,20 +241,26 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
             s.PartyId == initiatorPartyId &&
             s.Phase == PlayerPartyInteractionPhase.InitialOptions);
 
+        Assert.Contains(PlayerPartyInteractionOption.Vassal, initialState.Options);
+        Assert.Contains(PlayerPartyInteractionOption.Vassal, initialState.EnabledOptions);
+
         OpenServiceOptions(client1, initialState);
 
         client1.Call(() =>
         {
             Assert.True(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.JoinClan));
+            Assert.False(PlayerPartyInteractionDialogState.IsOptionEnabled(PlayerPartyInteractionOption.JoinClan));
             Assert.True(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.Leave));
+            Assert.True(PlayerPartyInteractionDialogState.IsOptionEnabled(PlayerPartyInteractionOption.Leave));
             Assert.True(PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.Vassal));
+            Assert.True(PlayerPartyInteractionDialogState.IsOptionEnabled(PlayerPartyInteractionOption.Vassal));
         });
     }
 
     [Fact]
-    public void ClanServiceProposal_AcceptedByResponder_JoinsResponderClan()
+    public void ClanServiceProposal_Disabled_DoesNotSubmitOrJoinResponderClan()
     {
-        var (client1, client2, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+        var (client1, _, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
 
         RequestInteraction(client1, initiatorPartyId, responderPartyId);
         var sessionId = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>().Single().SessionId;
@@ -251,16 +270,26 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
             s.Phase == PlayerPartyInteractionPhase.InitialOptions);
 
         OpenServiceOptions(client1, initialState);
-        SubmitCurrentDialogOption(client1, PlayerPartyInteractionOption.JoinClan);
-        SubmitOption(client2, sessionId, responderPartyId, PlayerPartyInteractionOption.AcceptProposal);
 
+        Server.NetworkSentMessages.Clear();
+        client1.NetworkSentMessages.Clear();
+        SubmitCurrentDialogOption(client1, PlayerPartyInteractionOption.JoinClan);
+
+        Assert.Empty(client1.NetworkSentMessages.GetMessages<NetworkSubmitPlayerPartyInteractionOption>());
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionState>());
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionEnded>());
+
+        SubmitOption(client1, sessionId, initiatorPartyId, PlayerPartyInteractionOption.JoinClan);
+
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionState>());
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionEnded>());
         Server.Call(() =>
         {
             Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(initiatorPartyId, out var initiatorParty));
             Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(responderPartyId, out var responderParty));
 
-            Assert.Equal(responderParty.LeaderHero.Clan, initiatorParty.LeaderHero.Clan);
-            Assert.Equal(responderParty.LeaderHero.Clan, initiatorParty.MobileParty.ActualClan);
+            Assert.NotEqual(responderParty.LeaderHero.Clan, initiatorParty.LeaderHero.Clan);
+            Assert.NotEqual(responderParty.LeaderHero.Clan, initiatorParty.MobileParty.ActualClan);
         });
     }
 
@@ -308,7 +337,7 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
 
     [Theory]
     [InlineData(PlayerPartyInteractionProposal.Trade, "I have a proposal that may benefit us both.")]
-    [InlineData(PlayerPartyInteractionProposal.JoinClan, "I wish to offer my services in your clan.")]
+    [InlineData(PlayerPartyInteractionProposal.JoinClan, "(COMING SOON) I wish to offer my services in your clan.")]
     [InlineData(PlayerPartyInteractionProposal.Vassal, "I wish to swear my allegiance to your majesty.")]
     public void ProposalPending_DialogText_ShowsInitiatorSelectedLine(
         PlayerPartyInteractionProposal proposal,

--- a/source/GameInterface.Tests/Serialization/NetworkPlayerPartyInteractionSerializationTest.cs
+++ b/source/GameInterface.Tests/Serialization/NetworkPlayerPartyInteractionSerializationTest.cs
@@ -44,7 +44,8 @@ public class NetworkPlayerPartyInteractionSerializationTest
             initiatorAcceptedTrade: true,
             responderAcceptedTrade: false,
             partyItems: new[] { new ItemRosterElementData(new ItemObjectData("party-item", null, itemModifierNull: true), 3) },
-            otherPartyItems: new[] { new ItemRosterElementData(new ItemObjectData("other-item", null, itemModifierNull: true), 4) });
+            otherPartyItems: new[] { new ItemRosterElementData(new ItemObjectData("other-item", null, itemModifierNull: true), 4) },
+            enabledOptions: new[] { PlayerPartyInteractionOption.AcceptProposal });
 
         var result = RoundTrip(original);
 
@@ -55,6 +56,7 @@ public class NetworkPlayerPartyInteractionSerializationTest
         Assert.Equal(original.Phase, result.Phase);
         Assert.Equal(original.Proposal, result.Proposal);
         Assert.Equal(original.Options, result.Options);
+        Assert.Equal(original.EnabledOptions, result.EnabledOptions);
         Assert.Equal(original.IsInitiator, result.IsInitiator);
         Assert.Equal(original.InitiatorAcceptedTrade, result.InitiatorAcceptedTrade);
         Assert.Equal(original.ResponderAcceptedTrade, result.ResponderAcceptedTrade);

--- a/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkPlayerPartyInteractionState.cs
+++ b/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkPlayerPartyInteractionState.cs
@@ -32,6 +32,8 @@ internal readonly struct NetworkPlayerPartyInteractionState : ICommand
     public readonly ItemRosterElementData[] PartyItems;
     [ProtoMember(12)]
     public readonly ItemRosterElementData[] OtherPartyItems;
+    [ProtoMember(13)]
+    public readonly PlayerPartyInteractionOption[] EnabledOptions;
 
     public NetworkPlayerPartyInteractionState(
         string sessionId,
@@ -45,7 +47,8 @@ internal readonly struct NetworkPlayerPartyInteractionState : ICommand
         bool initiatorAcceptedTrade = false,
         bool responderAcceptedTrade = false,
         ItemRosterElementData[] partyItems = null,
-        ItemRosterElementData[] otherPartyItems = null)
+        ItemRosterElementData[] otherPartyItems = null,
+        PlayerPartyInteractionOption[] enabledOptions = null)
     {
         SessionId = sessionId;
         PartyId = partyId;
@@ -59,5 +62,6 @@ internal readonly struct NetworkPlayerPartyInteractionState : ICommand
         ResponderAcceptedTrade = responderAcceptedTrade;
         PartyItems = partyItems ?? new ItemRosterElementData[0];
         OtherPartyItems = otherPartyItems ?? new ItemRosterElementData[0];
+        EnabledOptions = enabledOptions ?? Options;
     }
 }

--- a/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyInteractionCampaignBehavior.cs
+++ b/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyInteractionCampaignBehavior.cs
@@ -90,11 +90,11 @@ public class PlayerPartyInteractionCampaignBehavior : CampaignBehaviorBase
             "coop_player_party_interaction_join_clan",
             ServiceToken,
             InitiatorWaitToken,
-            "I wish to offer my services in your clan.",
+            "(COMING SOON) I wish to offer my services in your clan.",
             () => PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.JoinClan),
             () => PlayerPartyInteractionDialogState.Submit(PlayerPartyInteractionOption.JoinClan),
             PlayerPartyDialogPriority,
-            null,
+            IsJoinClanEnabled,
             null);
 
         starter.AddPlayerLine(
@@ -105,7 +105,7 @@ public class PlayerPartyInteractionCampaignBehavior : CampaignBehaviorBase
             () => PlayerPartyInteractionDialogState.HasOption(PlayerPartyInteractionOption.Vassal),
             () => PlayerPartyInteractionDialogState.Submit(PlayerPartyInteractionOption.Vassal),
             PlayerPartyDialogPriority,
-            null,
+            IsVassalEnabled,
             null);
 
         starter.AddPlayerLine(
@@ -163,6 +163,12 @@ public class PlayerPartyInteractionCampaignBehavior : CampaignBehaviorBase
             null,
             null);
     }
+
+    private static bool IsJoinClanEnabled(out TextObject explanation)
+        => PlayerPartyInteractionDialogState.IsOptionEnabled(PlayerPartyInteractionOption.JoinClan, out explanation);
+
+    private static bool IsVassalEnabled(out TextObject explanation)
+        => PlayerPartyInteractionDialogState.IsOptionEnabled(PlayerPartyInteractionOption.Vassal, out explanation);
 
     private static bool IsPhase(params PlayerPartyInteractionPhase[] phases)
     {

--- a/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyInteractionDialogState.cs
+++ b/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyInteractionDialogState.cs
@@ -46,6 +46,26 @@ public static class PlayerPartyInteractionDialogState
     public static bool HasOption(PlayerPartyInteractionOption option)
         => hasState && currentState.Options != null && currentState.Options.Contains(option);
 
+    public static bool IsOptionEnabled(PlayerPartyInteractionOption option)
+    {
+        if (!HasOption(option)) return false;
+
+        var enabledOptions = currentState.EnabledOptions ?? currentState.Options;
+        return enabledOptions != null && enabledOptions.Contains(option);
+    }
+
+    public static bool IsOptionEnabled(PlayerPartyInteractionOption option, out TextObject explanation)
+    {
+        if (IsOptionEnabled(option))
+        {
+            explanation = null;
+            return true;
+        }
+
+        explanation = new TextObject("{=coop_player_party_interaction_disabled}This option is not available.");
+        return false;
+    }
+
     public static string GetDialogText()
     {
         switch (Phase)
@@ -67,7 +87,7 @@ public static class PlayerPartyInteractionDialogState
 
     public static void Submit(PlayerPartyInteractionOption option)
     {
-        if (!HasActiveState) return;
+        if (!IsOptionEnabled(option)) return;
 
         MessageBroker.Instance.Publish(null, new PlayerPartyInteractionOptionSelected(SessionId, PartyId, option));
     }
@@ -90,7 +110,8 @@ public static class PlayerPartyInteractionDialogState
             currentState.InitiatorAcceptedTrade,
             currentState.ResponderAcceptedTrade,
             currentState.PartyItems,
-            currentState.OtherPartyItems);
+            currentState.OtherPartyItems,
+            GetLocalServiceEnabledOptions());
 
         RefreshConversation();
     }
@@ -102,7 +123,7 @@ public static class PlayerPartyInteractionDialogState
             case PlayerPartyInteractionProposal.Trade:
                 return "I have a proposal that may benefit us both.";
             case PlayerPartyInteractionProposal.JoinClan:
-                return "I wish to offer my services in your clan.";
+                return "(COMING SOON) I wish to offer my services in your clan.";
             case PlayerPartyInteractionProposal.Vassal:
                 return "I wish to swear my allegiance to your majesty.";
             default:
@@ -111,11 +132,17 @@ public static class PlayerPartyInteractionDialogState
     }
 
     private static PlayerPartyInteractionOption[] GetLocalServiceOptions()
+        => GetLocalServiceOptions(currentState.Options, addLeave: true);
+
+    private static PlayerPartyInteractionOption[] GetLocalServiceEnabledOptions()
+        => GetLocalServiceOptions(currentState.EnabledOptions ?? currentState.Options, addLeave: false);
+
+    private static PlayerPartyInteractionOption[] GetLocalServiceOptions(PlayerPartyInteractionOption[] sourceOptions, bool addLeave)
     {
         var options = new List<PlayerPartyInteractionOption>();
-        if (currentState.Options != null)
+        if (sourceOptions != null)
         {
-            foreach (var option in currentState.Options)
+            foreach (var option in sourceOptions)
             {
                 if (!IsServiceOption(option)) continue;
                 if (options.Contains(option)) continue;
@@ -124,7 +151,7 @@ public static class PlayerPartyInteractionDialogState
             }
         }
 
-        if (!options.Contains(PlayerPartyInteractionOption.Leave))
+        if (addLeave && !options.Contains(PlayerPartyInteractionOption.Leave))
             options.Add(PlayerPartyInteractionOption.Leave);
 
         return options.ToArray();

--- a/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyInteractionHandler.cs
+++ b/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyInteractionHandler.cs
@@ -396,7 +396,7 @@ internal class PlayerPartyInteractionHandler : IHandler
 
         var proposal = ToProposal(option);
         if (proposal == PlayerPartyInteractionProposal.None) return;
-        if (!session.InitiatorOptions.Contains(option)) return;
+        if (!session.InitiatorEnabledOptions.Contains(option)) return;
 
         session.Proposal = proposal;
         SendInitiatorState(session, PlayerPartyInteractionPhase.WaitingForResponse, proposal, Array.Empty<PlayerPartyInteractionOption>());
@@ -445,7 +445,8 @@ internal class PlayerPartyInteractionHandler : IHandler
             session,
             PlayerPartyInteractionPhase.InitialOptions,
             PlayerPartyInteractionProposal.None,
-            session.InitiatorOptions.ToArray());
+            session.InitiatorOptions.ToArray(),
+            session.InitiatorEnabledOptions.ToArray());
 
         SendResponderState(
             session,
@@ -491,7 +492,8 @@ internal class PlayerPartyInteractionHandler : IHandler
         PlayerPartyInteractionSession session,
         PlayerPartyInteractionPhase phase,
         PlayerPartyInteractionProposal proposal,
-        PlayerPartyInteractionOption[] options)
+        PlayerPartyInteractionOption[] options,
+        PlayerPartyInteractionOption[] enabledOptions = null)
     {
         var partyItems = phase == PlayerPartyInteractionPhase.TradeActive
             ? ResolvePartyItemIds(session.InitiatorPartyId)
@@ -512,7 +514,8 @@ internal class PlayerPartyInteractionHandler : IHandler
             session.InitiatorAcceptedTrade,
             session.ResponderAcceptedTrade,
             partyItems,
-            otherPartyItems));
+            otherPartyItems,
+            enabledOptions));
     }
 
     private void SendResponderState(
@@ -540,7 +543,8 @@ internal class PlayerPartyInteractionHandler : IHandler
             session.InitiatorAcceptedTrade,
             session.ResponderAcceptedTrade,
             partyItems,
-            otherPartyItems));
+            otherPartyItems,
+            options));
     }
 
     private void EndSession(PlayerPartyInteractionSession session, PlayerPartyInteractionOutcomeType outcomeType)
@@ -563,47 +567,29 @@ internal class PlayerPartyInteractionHandler : IHandler
 
     private void AddInitialOptions(PlayerPartyInteractionSession session, PartyBase initiatorParty, PartyBase responderParty)
     {
-        session.InitiatorOptions.Add(PlayerPartyInteractionOption.TradeProposal);
-        session.InitiatorOptions.Add(PlayerPartyInteractionOption.OfferServices);
-
-        var serviceOptions = GetServiceOptions(initiatorParty, responderParty);
-        foreach (var serviceOption in serviceOptions)
-            session.InitiatorOptions.Add(serviceOption);
-
-        session.InitiatorOptions.Add(PlayerPartyInteractionOption.Leave);
+        AddInitiatorOption(session, PlayerPartyInteractionOption.TradeProposal, enabled: true);
+        AddInitiatorOption(session, PlayerPartyInteractionOption.OfferServices, enabled: true);
+        AddInitiatorOption(session, PlayerPartyInteractionOption.JoinClan, enabled: false);
+        AddInitiatorOption(
+            session,
+            PlayerPartyInteractionOption.Vassal,
+            IsVassalServiceAvailable(initiatorParty, responderParty));
+        AddInitiatorOption(session, PlayerPartyInteractionOption.Leave, enabled: true);
     }
 
-    private PlayerPartyInteractionOption[] GetServiceDialogOptions(PlayerPartyInteractionSession session)
+    private static void AddInitiatorOption(PlayerPartyInteractionSession session, PlayerPartyInteractionOption option, bool enabled)
     {
-        var options = new List<PlayerPartyInteractionOption>(GetServiceOptions(session));
-        options.Add(PlayerPartyInteractionOption.Leave);
-        return options.ToArray();
+        session.InitiatorOptions.Add(option);
+        if (enabled)
+            session.InitiatorEnabledOptions.Add(option);
     }
 
-    private PlayerPartyInteractionOption[] GetServiceOptions(PlayerPartyInteractionSession session)
+    private static bool IsVassalServiceAvailable(PartyBase initiatorParty, PartyBase responderParty)
     {
-        if (!objectManager.TryGetObject<PartyBase>(session.InitiatorPartyId, out var initiatorParty)) return Array.Empty<PlayerPartyInteractionOption>();
-        if (!objectManager.TryGetObject<PartyBase>(session.ResponderPartyId, out var responderParty)) return Array.Empty<PlayerPartyInteractionOption>();
-
-        return GetServiceOptions(initiatorParty, responderParty);
-    }
-
-    private static PlayerPartyInteractionOption[] GetServiceOptions(PartyBase initiatorParty, PartyBase responderParty)
-    {
-        var options = new List<PlayerPartyInteractionOption>();
         var initiatorClan = initiatorParty.LeaderHero?.Clan ?? initiatorParty.MobileParty?.ActualClan;
         var responderHero = responderParty.LeaderHero;
 
-        if (responderHero?.IsClanLeader == true)
-            options.Add(PlayerPartyInteractionOption.JoinClan);
-
-        if (responderHero?.IsKingdomLeader == true && initiatorClan != null)
-        {
-            if (initiatorClan.Tier == 2)
-                options.Add(PlayerPartyInteractionOption.Vassal);
-        }
-
-        return options.ToArray();
+        return responderHero?.IsKingdomLeader == true && initiatorClan?.Tier == 2;
     }
 
     private static PlayerPartyInteractionProposal ToProposal(PlayerPartyInteractionOption option)

--- a/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyInteractionSession.cs
+++ b/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyInteractionSession.cs
@@ -29,6 +29,7 @@ internal sealed class PlayerPartyInteractionSession
     public TroopRosterElementData[] ResponderOfferedTroops { get; set; } = new TroopRosterElementData[0];
 
     public HashSet<PlayerPartyInteractionOption> InitiatorOptions { get; } = new HashSet<PlayerPartyInteractionOption>();
+    public HashSet<PlayerPartyInteractionOption> InitiatorEnabledOptions { get; } = new HashSet<PlayerPartyInteractionOption>();
 
     public PlayerPartyInteractionSession(
         string sessionId,


### PR DESCRIPTION
Disabled join clan p2p dialog. When join kingdom is not available, it shows as disabled instead of disappearing.

## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Dialog option for joining another players clan was enabled.
When unavailable, we removed the dialog to join the other players kingdom.

## What is the new behavior?
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Dialog option for joining another players clan now says "(COMING SOON)" and is disabled until we implement it
Instead of removing the join kingdom dialog option when not applicable, we disable it instead now.


## Other information
