### PR TITLE
[1466] Resolve destroyed/disbanded party on the game thread

### DIFF
--- a/source/GameInterface.Tests/Services/MobileParties/PartyLifetimeHandlerTests.cs
+++ b/source/GameInterface.Tests/Services/MobileParties/PartyLifetimeHandlerTests.cs
@@ -1,4 +1,5 @@
-﻿using Common.Messaging;
+﻿using Common;
+using Common.Messaging;
 using Common.Network;
 using Common.Util;
 using GameInterface.Registry.Auto;
@@ -6,6 +7,9 @@ using GameInterface.Services.MobileParties.Handlers;
 using GameInterface.Services.MobileParties.Messages.Lifetime;
 using GameInterface.Services.ObjectManager;
 using Moq;
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using TaleWorlds.CampaignSystem.Party;
 using Xunit;
 
@@ -13,11 +17,31 @@ namespace GameInterface.Tests.Services.MobileParties;
 
 /// <summary>
 /// Unit tests for the server send-side of party destruction replication in
-/// <see cref="PartyLifetimeHandler"/>. A party destroyed with a null destroyer (e.g. vanilla
-/// patrol culling) must still be replicated to clients instead of leaving a zombie party behind.
+/// <see cref="PartyLifetimeHandler"/>, plus the receive-side threading guarantee: the network
+/// (poller) thread must defer object resolution and the <c>IsActive</c> guard onto the game-loop
+/// thread, so a party resolved on the poller thread cannot go stale before the action applies.
 /// </summary>
+/// <remarks>
+/// The threading tests reuse <see cref="Coop.Tests"/>'s <c>TestGameLoopPump</c>, started from a
+/// <c>[ModuleInitializer]</c>, to run a real game-loop thread (mirroring
+/// <see cref="GameInterface.Tests.Utils.GenericHandlerThreadingTests"/>). A marshaled apply only
+/// differs observably from inline execution when the publishing thread is NOT the game-loop thread,
+/// so each test publishes from the xUnit worker thread and asserts the resolution ran on the
+/// game-loop thread instead.
+/// </remarks>
 public class PartyLifetimeHandlerTests
 {
+    static PartyLifetimeHandlerTests()
+    {
+        // Force Coop.Tests' TestGameLoopPump module initializer to run so the dedicated game-loop
+        // thread is up even when this class runs in isolation (a filtered run won't have loaded
+        // Coop.Tests through any other test, and merely referencing a type does not run its
+        // initializer). RunModuleConstructor is idempotent.
+        RuntimeHelpers.RunModuleConstructor(typeof(Coop.Tests.Mocks.TestNetwork).Module.ModuleHandle);
+    }
+
+    private static readonly TimeSpan ApplyTimeout = TimeSpan.FromSeconds(10);
+
     private readonly Mock<IMessageBroker> messageBroker = new();
     private readonly Mock<IObjectManager> objectManager = new();
     private readonly Mock<INetwork> network = new();
@@ -25,8 +49,20 @@ public class PartyLifetimeHandlerTests
 
     private object? sentMessage;
 
+    private Action<MessagePayload<NetworkApplyDestroyParty>>? destroyPartyReceiver;
+    private Action<MessagePayload<NetworkPartyDisbanded>>? partyDisbandedReceiver;
+
     public PartyLifetimeHandlerTests()
     {
+        // Capture the receive-path subscribers so the threading tests can drive them through the
+        // real subscription wiring without widening the handlers' visibility.
+        messageBroker
+            .Setup(b => b.Subscribe(It.IsAny<Action<MessagePayload<NetworkApplyDestroyParty>>>()))
+            .Callback<Action<MessagePayload<NetworkApplyDestroyParty>>>(s => destroyPartyReceiver = s);
+        messageBroker
+            .Setup(b => b.Subscribe(It.IsAny<Action<MessagePayload<NetworkPartyDisbanded>>>()))
+            .Callback<Action<MessagePayload<NetworkPartyDisbanded>>>(s => partyDisbandedReceiver = s);
+
         handler = new PartyLifetimeHandler(messageBroker.Object, objectManager.Object, network.Object);
 
         network.Setup(n => n.SendAll(It.IsAny<IMessage>()))
@@ -96,6 +132,79 @@ public class PartyLifetimeHandlerTests
 
         Assert.Null(sentMessage);
         network.Verify(n => n.SendAll(It.IsAny<IMessage>()), Times.Never);
+    }
+
+    [Fact]
+    public void Handle_DestroyParty_ResolvesPartyOnGameLoopThread()
+    {
+        Assert.True(GameThread.Instance.IsInitialized, "game-loop pump was not initialized");
+        Assert.NotNull(destroyPartyReceiver);
+
+        var (resolvedThreadId, resolved) = CaptureResolutionThread();
+
+        int publishThreadId = Environment.CurrentManagedThreadId;
+        int gameLoopThreadId = GetGameLoopThreadId();
+        // If the publisher were itself the game-loop thread, GameThread.Run would run inline and the
+        // marshaling would be unobservable.
+        Assert.NotEqual(publishThreadId, gameLoopThreadId);
+
+        destroyPartyReceiver!(new MessagePayload<NetworkApplyDestroyParty>(
+            this, new NetworkApplyDestroyParty("victor-1", "defeated-1")));
+
+        Assert.True(resolved.Wait(ApplyTimeout), "resolution did not run within the timeout");
+        Assert.Equal(gameLoopThreadId, resolvedThreadId.Value);
+    }
+
+    [Fact]
+    public void Handle_NetworkPartyDisbanded_ResolvesPartyOnGameLoopThread()
+    {
+        Assert.True(GameThread.Instance.IsInitialized, "game-loop pump was not initialized");
+        Assert.NotNull(partyDisbandedReceiver);
+
+        var (resolvedThreadId, resolved) = CaptureResolutionThread();
+
+        int publishThreadId = Environment.CurrentManagedThreadId;
+        int gameLoopThreadId = GetGameLoopThreadId();
+        Assert.NotEqual(publishThreadId, gameLoopThreadId);
+
+        partyDisbandedReceiver!(new MessagePayload<NetworkPartyDisbanded>(
+            this, new NetworkPartyDisbanded("disbanded-1", "settlement-1")));
+
+        Assert.True(resolved.Wait(ApplyTimeout), "resolution did not run within the timeout");
+        Assert.Equal(gameLoopThreadId, resolvedThreadId.Value);
+    }
+
+    /// <summary>
+    /// Stubs the first party resolution to fail (so the real destroy/disband action is never invoked)
+    /// while recording the thread it ran on. Returns the captured thread id and a handle signaled once
+    /// resolution has run.
+    /// </summary>
+    private (StrongBox<int> ThreadId, ManualResetEventSlim Resolved) CaptureResolutionThread()
+    {
+        var resolvedThreadId = new StrongBox<int>(0);
+        var resolved = new ManualResetEventSlim(false);
+
+        MobileParty outParty = null!;
+        objectManager
+            .Setup(o => o.TryGetObjectWithLogging(It.IsAny<string>(), out outParty))
+            .Returns(false)
+            .Callback(() =>
+            {
+                resolvedThreadId.Value = Environment.CurrentManagedThreadId;
+                resolved.Set();
+            });
+
+        return (resolvedThreadId, resolved);
+    }
+
+    /// <summary>
+    /// Captures the game-loop thread id by running a blocking probe on it.
+    /// </summary>
+    private static int GetGameLoopThreadId()
+    {
+        int gameLoopThreadId = 0;
+        GameThread.Run(() => gameLoopThreadId = Environment.CurrentManagedThreadId, blocking: true);
+        return gameLoopThreadId;
     }
 
     private MessagePayload<DestroyPartyApplied> Payload(PartyBase? victoriousPartyBase, MobileParty defeated) =>

--- a/source/GameInterface.Tests/Services/MobileParties/PartyLifetimeHandlerTests.cs
+++ b/source/GameInterface.Tests/Services/MobileParties/PartyLifetimeHandlerTests.cs
@@ -1,5 +1,4 @@
-﻿using Common;
-using Common.Messaging;
+﻿using Common.Messaging;
 using Common.Network;
 using Common.Util;
 using GameInterface.Registry.Auto;
@@ -7,9 +6,6 @@ using GameInterface.Services.MobileParties.Handlers;
 using GameInterface.Services.MobileParties.Messages.Lifetime;
 using GameInterface.Services.ObjectManager;
 using Moq;
-using System;
-using System.Runtime.CompilerServices;
-using System.Threading;
 using TaleWorlds.CampaignSystem.Party;
 using Xunit;
 
@@ -17,31 +13,11 @@ namespace GameInterface.Tests.Services.MobileParties;
 
 /// <summary>
 /// Unit tests for the server send-side of party destruction replication in
-/// <see cref="PartyLifetimeHandler"/>, plus the receive-side threading guarantee: the network
-/// (poller) thread must defer object resolution and the <c>IsActive</c> guard onto the game-loop
-/// thread, so a party resolved on the poller thread cannot go stale before the action applies.
+/// <see cref="PartyLifetimeHandler"/>. A party destroyed with a null destroyer (e.g. vanilla
+/// patrol culling) must still be replicated to clients instead of leaving a zombie party behind.
 /// </summary>
-/// <remarks>
-/// The threading tests reuse <see cref="Coop.Tests"/>'s <c>TestGameLoopPump</c>, started from a
-/// <c>[ModuleInitializer]</c>, to run a real game-loop thread (mirroring
-/// <see cref="GameInterface.Tests.Utils.GenericHandlerThreadingTests"/>). A marshaled apply only
-/// differs observably from inline execution when the publishing thread is NOT the game-loop thread,
-/// so each test publishes from the xUnit worker thread and asserts the resolution ran on the
-/// game-loop thread instead.
-/// </remarks>
 public class PartyLifetimeHandlerTests
 {
-    static PartyLifetimeHandlerTests()
-    {
-        // Force Coop.Tests' TestGameLoopPump module initializer to run so the dedicated game-loop
-        // thread is up even when this class runs in isolation (a filtered run won't have loaded
-        // Coop.Tests through any other test, and merely referencing a type does not run its
-        // initializer). RunModuleConstructor is idempotent.
-        RuntimeHelpers.RunModuleConstructor(typeof(Coop.Tests.Mocks.TestNetwork).Module.ModuleHandle);
-    }
-
-    private static readonly TimeSpan ApplyTimeout = TimeSpan.FromSeconds(10);
-
     private readonly Mock<IMessageBroker> messageBroker = new();
     private readonly Mock<IObjectManager> objectManager = new();
     private readonly Mock<INetwork> network = new();
@@ -49,20 +25,8 @@ public class PartyLifetimeHandlerTests
 
     private object? sentMessage;
 
-    private Action<MessagePayload<NetworkApplyDestroyParty>>? destroyPartyReceiver;
-    private Action<MessagePayload<NetworkPartyDisbanded>>? partyDisbandedReceiver;
-
     public PartyLifetimeHandlerTests()
     {
-        // Capture the receive-path subscribers so the threading tests can drive them through the
-        // real subscription wiring without widening the handlers' visibility.
-        messageBroker
-            .Setup(b => b.Subscribe(It.IsAny<Action<MessagePayload<NetworkApplyDestroyParty>>>()))
-            .Callback<Action<MessagePayload<NetworkApplyDestroyParty>>>(s => destroyPartyReceiver = s);
-        messageBroker
-            .Setup(b => b.Subscribe(It.IsAny<Action<MessagePayload<NetworkPartyDisbanded>>>()))
-            .Callback<Action<MessagePayload<NetworkPartyDisbanded>>>(s => partyDisbandedReceiver = s);
-
         handler = new PartyLifetimeHandler(messageBroker.Object, objectManager.Object, network.Object);
 
         network.Setup(n => n.SendAll(It.IsAny<IMessage>()))
@@ -132,79 +96,6 @@ public class PartyLifetimeHandlerTests
 
         Assert.Null(sentMessage);
         network.Verify(n => n.SendAll(It.IsAny<IMessage>()), Times.Never);
-    }
-
-    [Fact]
-    public void Handle_DestroyParty_ResolvesPartyOnGameLoopThread()
-    {
-        Assert.True(GameThread.Instance.IsInitialized, "game-loop pump was not initialized");
-        Assert.NotNull(destroyPartyReceiver);
-
-        var (resolvedThreadId, resolved) = CaptureResolutionThread();
-
-        int publishThreadId = Environment.CurrentManagedThreadId;
-        int gameLoopThreadId = GetGameLoopThreadId();
-        // If the publisher were itself the game-loop thread, GameThread.Run would run inline and the
-        // marshaling would be unobservable.
-        Assert.NotEqual(publishThreadId, gameLoopThreadId);
-
-        destroyPartyReceiver!(new MessagePayload<NetworkApplyDestroyParty>(
-            this, new NetworkApplyDestroyParty("victor-1", "defeated-1")));
-
-        Assert.True(resolved.Wait(ApplyTimeout), "resolution did not run within the timeout");
-        Assert.Equal(gameLoopThreadId, resolvedThreadId.Value);
-    }
-
-    [Fact]
-    public void Handle_NetworkPartyDisbanded_ResolvesPartyOnGameLoopThread()
-    {
-        Assert.True(GameThread.Instance.IsInitialized, "game-loop pump was not initialized");
-        Assert.NotNull(partyDisbandedReceiver);
-
-        var (resolvedThreadId, resolved) = CaptureResolutionThread();
-
-        int publishThreadId = Environment.CurrentManagedThreadId;
-        int gameLoopThreadId = GetGameLoopThreadId();
-        Assert.NotEqual(publishThreadId, gameLoopThreadId);
-
-        partyDisbandedReceiver!(new MessagePayload<NetworkPartyDisbanded>(
-            this, new NetworkPartyDisbanded("disbanded-1", "settlement-1")));
-
-        Assert.True(resolved.Wait(ApplyTimeout), "resolution did not run within the timeout");
-        Assert.Equal(gameLoopThreadId, resolvedThreadId.Value);
-    }
-
-    /// <summary>
-    /// Stubs the first party resolution to fail (so the real destroy/disband action is never invoked)
-    /// while recording the thread it ran on. Returns the captured thread id and a handle signaled once
-    /// resolution has run.
-    /// </summary>
-    private (StrongBox<int> ThreadId, ManualResetEventSlim Resolved) CaptureResolutionThread()
-    {
-        var resolvedThreadId = new StrongBox<int>(0);
-        var resolved = new ManualResetEventSlim(false);
-
-        MobileParty outParty = null!;
-        objectManager
-            .Setup(o => o.TryGetObjectWithLogging(It.IsAny<string>(), out outParty))
-            .Returns(false)
-            .Callback(() =>
-            {
-                resolvedThreadId.Value = Environment.CurrentManagedThreadId;
-                resolved.Set();
-            });
-
-        return (resolvedThreadId, resolved);
-    }
-
-    /// <summary>
-    /// Captures the game-loop thread id by running a blocking probe on it.
-    /// </summary>
-    private static int GetGameLoopThreadId()
-    {
-        int gameLoopThreadId = 0;
-        GameThread.Run(() => gameLoopThreadId = Environment.CurrentManagedThreadId, blocking: true);
-        return gameLoopThreadId;
     }
 
     private MessagePayload<DestroyPartyApplied> Payload(PartyBase? victoriousPartyBase, MobileParty defeated) =>

--- a/source/GameInterface/Services/MobileParties/Handlers/PartyLifetimeHandler.cs
+++ b/source/GameInterface/Services/MobileParties/Handlers/PartyLifetimeHandler.cs
@@ -85,34 +85,35 @@ internal class PartyLifetimeHandler : IHandler
             victoriousPartyBaseId,
             defeatedPartyId);
 
-        if (!objectManager.TryGetObjectWithLogging<MobileParty>(defeatedPartyId, out var defeatedParty))
-            return;
-
-        // An inactive party was already destroyed locally — e.g. this destruction happened inside
-        // a parent action that was also replayed here (a settlement ownership change destroying
-        // its garrison). Applying it again would double-run the vanilla destruction.
-        if (!defeatedParty.IsActive)
-        {
-            Logger.Debug(
-                "[{Role}] Skipping destroy for already-inactive party {DefeatedPartyId}",
-                role,
-                defeatedPartyId);
-            return;
-        }
-
-        // A null victor id means the server destroyed the party with a null destroyer (e.g. patrol
-        // culling). Pass null through to match the server; vanilla supports a null destroyer. A
-        // non-null id that cannot be resolved is still a real error and bails as before.
-        PartyBase victoriousPartyBase = null;
-        if (victoriousPartyBaseId != null &&
-            !objectManager.TryGetObjectWithLogging<PartyBase>(victoriousPartyBaseId, out victoriousPartyBase))
-            return;
-
-
+        // Resolve and guard inside the callback so they run at apply time on the game thread, not on
+        // the poller thread — see RunOnGameThreadSkippingPatches.
         RunOnGameThreadSkippingPatches(
             "DestroyPartyAction.Apply",
             () =>
             {
+                if (!objectManager.TryGetObjectWithLogging<MobileParty>(defeatedPartyId, out var defeatedParty))
+                    return;
+
+                // An inactive party was already destroyed locally — e.g. this destruction happened inside
+                // a parent action that was also replayed here (a settlement ownership change destroying
+                // its garrison). Applying it again would double-run the vanilla destruction.
+                if (!defeatedParty.IsActive)
+                {
+                    Logger.Debug(
+                        "[{Role}] Skipping destroy for already-inactive party {DefeatedPartyId}",
+                        role,
+                        defeatedPartyId);
+                    return;
+                }
+
+                // A null victor id means the server destroyed the party with a null destroyer (e.g. patrol
+                // culling). Pass null through to match the server; vanilla supports a null destroyer. A
+                // non-null id that cannot be resolved is still a real error and bails as before.
+                PartyBase victoriousPartyBase = null;
+                if (victoriousPartyBaseId != null &&
+                    !objectManager.TryGetObjectWithLogging<PartyBase>(victoriousPartyBaseId, out victoriousPartyBase))
+                    return;
+
                 DestroyPartyAction.Apply(victoriousPartyBase, defeatedParty);
             }
         );
@@ -156,28 +157,30 @@ internal class PartyLifetimeHandler : IHandler
             disbandedPartyId,
             settlementId);
 
-        if (!objectManager.TryGetObjectWithLogging<MobileParty>(disbandedPartyId, out var party))
-            return;
-
-        // An inactive party was already disbanded locally — e.g. the disband happened inside a
-        // parent action that was also replayed here. Applying it again would double-run the
-        // vanilla disband.
-        if (!party.IsActive)
-        {
-            Logger.Debug(
-                "[{Role}] Skipping disband for already-inactive party {DisbandedPartyId}",
-                role,
-                disbandedPartyId);
-            return;
-        }
-
-        if (!objectManager.TryGetObjectWithLogging<Settlement>(settlementId, out var settlement))
-            return;
-
+        // Resolve and guard inside the callback so they run at apply time on the game thread, not on
+        // the poller thread — see RunOnGameThreadSkippingPatches.
         RunOnGameThreadSkippingPatches(
             "DestroyPartyAction.ApplyForDisbanding",
             () =>
             {
+                if (!objectManager.TryGetObjectWithLogging<MobileParty>(disbandedPartyId, out var party))
+                    return;
+
+                // An inactive party was already disbanded locally — e.g. the disband happened inside a
+                // parent action that was also replayed here. Applying it again would double-run the
+                // vanilla disband.
+                if (!party.IsActive)
+                {
+                    Logger.Debug(
+                        "[{Role}] Skipping disband for already-inactive party {DisbandedPartyId}",
+                        role,
+                        disbandedPartyId);
+                    return;
+                }
+
+                if (!objectManager.TryGetObjectWithLogging<Settlement>(settlementId, out var settlement))
+                    return;
+
                 DestroyPartyAction.ApplyForDisbanding(party, settlement);
 
                 Logger.Debug(
@@ -191,6 +194,13 @@ internal class PartyLifetimeHandler : IHandler
 
     private static string Role => ModInformation.IsServer ? "Server" : "Client";
 
+    /// <summary>
+    /// Runs <paramref name="action"/> on the game-loop thread with the mod's Harmony patches
+    /// suspended (the receive path re-runs vanilla and must not re-announce). Resolve registry
+    /// objects and read game state <b>inside</b> <paramref name="action"/>, not before the call:
+    /// the action drains a frame or more later, so anything resolved on the network (poller) thread
+    /// can be stale by apply time and races the game loop's own registry mutations.
+    /// </summary>
     private void RunOnGameThreadSkippingPatches(
         string operation,
         Action action,

--- a/source/GameInterface/Services/MobileParties/Handlers/PartyLifetimeHandler.cs
+++ b/source/GameInterface/Services/MobileParties/Handlers/PartyLifetimeHandler.cs
@@ -85,8 +85,6 @@ internal class PartyLifetimeHandler : IHandler
             victoriousPartyBaseId,
             defeatedPartyId);
 
-        // Resolve and guard inside the callback so they run at apply time on the game thread, not on
-        // the poller thread — see RunOnGameThreadSkippingPatches.
         RunOnGameThreadSkippingPatches(
             "DestroyPartyAction.Apply",
             () =>
@@ -157,8 +155,6 @@ internal class PartyLifetimeHandler : IHandler
             disbandedPartyId,
             settlementId);
 
-        // Resolve and guard inside the callback so they run at apply time on the game thread, not on
-        // the poller thread — see RunOnGameThreadSkippingPatches.
         RunOnGameThreadSkippingPatches(
             "DestroyPartyAction.ApplyForDisbanding",
             () =>

--- a/source/GameInterface/Services/MobileParties/Handlers/PartyLifetimeHandler.cs
+++ b/source/GameInterface/Services/MobileParties/Handlers/PartyLifetimeHandler.cs
@@ -190,13 +190,6 @@ internal class PartyLifetimeHandler : IHandler
 
     private static string Role => ModInformation.IsServer ? "Server" : "Client";
 
-    /// <summary>
-    /// Runs <paramref name="action"/> on the game-loop thread with the mod's Harmony patches
-    /// suspended (the receive path re-runs vanilla and must not re-announce). Resolve registry
-    /// objects and read game state <b>inside</b> <paramref name="action"/>, not before the call:
-    /// the action drains a frame or more later, so anything resolved on the network (poller) thread
-    /// can be stale by apply time and races the game loop's own registry mutations.
-    /// </summary>
     private void RunOnGameThreadSkippingPatches(
         string operation,
         Action action,


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

The two receive-path handlers in `PartyLifetimeHandler` (`Handle_DestroyParty` and
`Handle_NetworkPartyDisbanded`) resolve the party/settlement and check `IsActive` on the poller
thread, then defer the `DestroyPartyAction` apply to the game thread. The apply drains a frame or
more later, so the party can go stale between the poller-thread resolve and the apply, and the
lookup races the game loop's own registry mutations.

## What is the new behavior?

Resolves #1466

Move the object resolution and the `IsActive` guard inside the game-thread callback so they run at
apply time on the game-loop thread, not the poller thread. Mirrors the existing
`MapEventHandler.Handle_NetworkChangeBattleState` / `HireCompanionHandler.Handle_HireCompanion`
pattern.
