### PR TITLE
Fix for TroopRosterInterface.UpdateWithData

### DIFF
--- a/source/GameInterface/Services/TroopRosters/Interfaces/TroopRosterInterface.cs
+++ b/source/GameInterface/Services/TroopRosters/Interfaces/TroopRosterInterface.cs
@@ -1,5 +1,6 @@
 ﻿using Common.Logging;
 using Common.Messaging;
+using GameInterface.Services.Heroes.Extensions;
 using GameInterface.Services.Heroes.Messages.Collections;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.TroopRosters.Data;
@@ -108,11 +109,16 @@ internal class TroopRosterInterface : ITroopRosterInterface
 
     public void UpdateWithData(TroopRoster targetTroopRoster, TroopRosterData packedTroopRosterElements, Hero mainHero)
     {
-        // Clear without removing MainHero (causes issues if MainHero is removed)
+        // Only preserve heroes in a player's troopRoster
+        bool preserveHeroes = mainHero != null && mainHero.IsPlayerHero() && targetTroopRoster.OwnerParty?.MemberRoster == targetTroopRoster;
+
+        // If preserving heroes, clear without removing mainHero and player companions
+        // Causes issues if mainHero or player companions are removed from a player's party
         for (int i = targetTroopRoster._count - 1; i >= 0; i--)
         {
-            if (targetTroopRoster.data[i].Character?.HeroObject == mainHero || targetTroopRoster.data[i].Character?.HeroObject?.IsPlayerCompanion == true) continue;
-            targetTroopRoster.AddToCounts(targetTroopRoster.data[i].Character, -targetTroopRoster.data[i].Number, false, -targetTroopRoster.data[i].WoundedNumber, 0, true);
+            var character = targetTroopRoster.data[i].Character;
+            if (preserveHeroes && (character?.HeroObject == mainHero || character?.HeroObject?.IsPlayerCompanion == true)) continue;
+            targetTroopRoster.AddToCounts(character, -targetTroopRoster.data[i].Number, false, -targetTroopRoster.data[i].WoundedNumber, 0, true);
         }
 
         if (packedTroopRosterElements.Data == null) return;
@@ -120,8 +126,9 @@ internal class TroopRosterInterface : ITroopRosterInterface
         // Rebuild roster with new data
         foreach (var element in UnpackTroopRosterData(packedTroopRosterElements))
         {
-            // Clear doesn't remove mainHero and companions, avoid adding duplicates of any existing heroes to the roster when rebuilding
-            if (element.Character.IsHero && targetTroopRoster.Contains(element.Character))
+            // If preserving heroes, clear doesn't remove mainHero and companions
+            // Avoid adding duplicates of any existing heroes to the roster when rebuilding
+            if (preserveHeroes && targetTroopRoster.Contains(element.Character))
                 continue;
 
             targetTroopRoster.Add(element);

--- a/source/GameInterface/Services/TroopRosters/Interfaces/TroopRosterInterface.cs
+++ b/source/GameInterface/Services/TroopRosters/Interfaces/TroopRosterInterface.cs
@@ -120,6 +120,10 @@ internal class TroopRosterInterface : ITroopRosterInterface
         // Rebuild roster with new data
         foreach (var element in UnpackTroopRosterData(packedTroopRosterElements))
         {
+            // Clear doesn't remove mainHero and companions, avoid adding duplicates of any existing heroes to the roster when rebuilding
+            if (element.Character.IsHero && targetTroopRoster.Contains(element.Character))
+                continue;
+
             targetTroopRoster.Add(element);
         }
     }


### PR DESCRIPTION
`TroopRosterInterface.UpdateWithData` is currently duplicating any heroes in a roster that were skipped during the clearing stage of rebuilding the roster. This PR adds a check to avoid duplicating any heroes already in the roster.

An example of where this is currently causing an issue is during `TradeDoneLogic` where the number of each hero in the player's party duplicates each time the trade screen is closed.

## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Other information
