### PR TITLE
[26] Fix freed prisoner unable to move after a save/reload, and parties stuck chasing a removed target

### DIFF
--- a/source/GameInterface/Services/MobileParties/Extensions/MobilePartyExtensions.cs
+++ b/source/GameInterface/Services/MobileParties/Extensions/MobilePartyExtensions.cs
@@ -58,17 +58,12 @@ public static class MobilePartyExtensions
     }
 
     /// <summary>
-    /// Clears a party's navigation orders so it stops at its current position (and is no longer classified
-    /// as moving), then asks the AI to re-decide at the next hourly tick. This is the navigation half of
-    /// how the engine fully stops a party - native pairs the public <c>SetMoveModeHold</c> (which resets
-    /// the AI behavior and <c>MoveTargetPoint</c>) with the internal <c>SetNavigationModeHold</c> (which
-    /// clears <c>PartyMoveMode</c>/<c>MoveTargetParty</c>). It deliberately leaves <c>DefaultBehavior</c>
-    /// alone so the caller, or the AI re-think, picks the next behavior. Needed because <c>SetMoveModeHold</c>
-    /// on its own leaves <c>PartyMoveMode</c>/<c>MoveTargetParty</c> intact: a party reactivated after
-    /// captivity, or one whose <c>MoveTargetParty</c> deserialized to null after a save/reload (the two
-    /// fields are saved independently), otherwise keeps stale Party-mode targeting that
-    /// <c>GetTargetCampaignPosition</c> dereferences unguarded. (The engine also clears the private
-    /// <c>_pathMode</c>; it self-corrects once the party is holding, so it is not reset here.)
+    /// Stops a party at its current position and asks its AI to re-pick a behavior, by clearing the
+    /// navigation fields directly. The engine's own <c>MobileParty.SetNavigationModeHold</c> does exactly
+    /// this, but it's <c>internal</c> so the mod can't call it; and the public <c>SetMoveModeHold</c> is not
+    /// a substitute - it resets the AI behavior but leaves <c>PartyMoveMode</c>/<c>MoveTargetParty</c> set,
+    /// which is the stale Party-mode targeting that <c>GetTargetCampaignPosition</c> dereferences (a null
+    /// <c>MoveTargetParty</c>) after a save/reload.
     /// </summary>
     public static void ResetNavigationToHold(this MobileParty party)
     {

--- a/source/GameInterface/Services/MobileParties/Extensions/MobilePartyExtensions.cs
+++ b/source/GameInterface/Services/MobileParties/Extensions/MobilePartyExtensions.cs
@@ -56,4 +56,34 @@ public static class MobilePartyExtensions
     {
         party._currentSettlement = settlement;
     }
+
+    /// <summary>
+    /// Clears a party's navigation orders so it stops at its current position (and is no longer classified
+    /// as moving), then asks the AI to re-decide at the next hourly tick. This is the navigation half of
+    /// how the engine fully stops a party - native pairs the public <c>SetMoveModeHold</c> (which resets
+    /// the AI behavior and <c>MoveTargetPoint</c>) with the internal <c>SetNavigationModeHold</c> (which
+    /// clears <c>PartyMoveMode</c>/<c>MoveTargetParty</c>). It deliberately leaves <c>DefaultBehavior</c>
+    /// alone so the caller, or the AI re-think, picks the next behavior. Needed because <c>SetMoveModeHold</c>
+    /// on its own leaves <c>PartyMoveMode</c>/<c>MoveTargetParty</c> intact: a party reactivated after
+    /// captivity, or one whose <c>MoveTargetParty</c> deserialized to null after a save/reload (the two
+    /// fields are saved independently), otherwise keeps stale Party-mode targeting that
+    /// <c>GetTargetCampaignPosition</c> dereferences unguarded. (The engine also clears the private
+    /// <c>_pathMode</c>; it self-corrects once the party is holding, so it is not reset here.)
+    /// </summary>
+    public static void ResetNavigationToHold(this MobileParty party)
+    {
+        party.PartyMoveMode = MoveModeType.Hold;
+        party.MoveTargetParty = null;
+        // Match MoveTargetPoint to Position so IsMoving (Position != MoveTargetPoint) goes false and the
+        // party leaves the moving tick list instead of being ticked every frame as a held "moving" party.
+        party.MoveTargetPoint = party.Position;
+        party.NextTargetPosition = party.Position;
+        // Ai can be null for a not-yet-fully-synced party (the tick patches guard for it), and this runs
+        // outside their try/catch, so only request the re-think when Ai exists. The navigation resets
+        // above are what actually clear the stale targeting and they don't need Ai.
+        if (party.Ai != null)
+        {
+            party.Ai.RethinkAtNextHourlyTick = true;
+        }
+    }
 }

--- a/source/GameInterface/Services/MobileParties/Patches/ParallelRobustnessPatches.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/ParallelRobustnessPatches.cs
@@ -1,4 +1,5 @@
 ﻿using Common.Logging;
+using GameInterface.Services.MobileParties.Extensions;
 using HarmonyLib;
 using Serilog;
 using System;
@@ -13,6 +14,21 @@ internal class ParallelRobustnessPatches
 {
     static ILogger Logger = LogManager.GetLogger<ParallelRobustnessPatches>();
 
+    // PartyMoveMode and MoveTargetParty are saved independently, so a save/reload can leave
+    // PartyMoveMode == Party with a MoveTargetParty that deserialized to null - the targeted party was
+    // removed and the pointer was never cleared (RemoveParty only clears it for parties whose
+    // TargetParty/AiBehaviorPartyBase matched the removed party, not ones that merely held it as a
+    // MoveTargetParty). GetTargetCampaignPosition then dereferences MoveTargetParty unguarded and throws
+    // every tick, so demote the stale mode to Hold and let the AI re-pick a behavior.
+    static void DemoteStaleMoveTargetParty(MobileParty mobileParty)
+    {
+        if (mobileParty.PartyMoveMode == MoveModeType.Party && mobileParty.MoveTargetParty == null)
+        {
+            Logger.Warning("Resetting stale Party move mode for party {stringId}: MoveTargetParty is null",
+                mobileParty.StringId);
+            mobileParty.ResetNavigationToHold();
+        }
+    }
 
     [HarmonyPatch(nameof(CampaignTickCacheDataStore.ParallelCheckExitingSettlements))]
     [HarmonyPrefix]
@@ -117,6 +133,8 @@ internal class ParallelRobustnessPatches
                 continue;
             }
 
+            DemoteStaleMoveTargetParty(mobileParty);
+
             try
             {
                 MobileParty.CachedPartyVariables localVariables = tickCachePerParty.LocalVariables;
@@ -155,6 +173,8 @@ internal class ParallelRobustnessPatches
                     mobileParty.StringId);
                 continue;
             }
+
+            DemoteStaleMoveTargetParty(mobileParty);
 
             try
             {

--- a/source/GameInterface/Services/MobileParties/Patches/ParallelRobustnessPatches.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/ParallelRobustnessPatches.cs
@@ -24,7 +24,9 @@ internal class ParallelRobustnessPatches
     {
         if (mobileParty.PartyMoveMode == MoveModeType.Party && mobileParty.MoveTargetParty == null)
         {
-            Logger.Warning("Resetting stale Party move mode for party {stringId}: MoveTargetParty is null",
+            // Expected after a save/reload (the two fields serialize independently) and self-healing, so
+            // a Debug breadcrumb is enough - not a Warning.
+            Logger.Debug("Resetting stale Party move mode for party {stringId}: MoveTargetParty is null",
                 mobileParty.StringId);
             mobileParty.ResetNavigationToHold();
         }

--- a/source/GameInterface/Services/PlayerCaptivityService/Commands/PlayerCaptivityCommands.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Commands/PlayerCaptivityCommands.cs
@@ -93,41 +93,6 @@ Captures the given hero and assigns the given mobile party as the captor.";
         return CaptureHero(hero, newCaptor);
     }
 
-    private const string ReleasePlayerUsage =
-@"Usage:
-  coop.debug.player_captivity.release_player <heroId>
-
-Example:
-  coop.debug.player_captivity.release_player Player
-
-Releases the given captive hero from captivity (server-authoritative).";
-
-    [CommandLineArgumentFunction("release_player", "coop.debug.player_captivity")]
-    public static string ReleasePlayer(List<string> args)
-    {
-        var ctx = new CommandContext(
-            "release_player",
-            ReleasePlayerUsage,
-            args);
-
-        if (!ctx.RequireServer(out var error))
-            return error;
-
-        if (!ctx.RequireArgCount(1, out error))
-            return error;
-
-        if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
-            return error;
-
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to release hero: " + error;
-
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
-            return "Failed to release hero: " + error;
-
-        return ReleaseHero(hero);
-    }
-
     private static bool TryGetRandomCaptor(out MobileParty newCaptor, out string error)
     {
         newCaptor = null;
@@ -208,48 +173,6 @@ Releases the given captive hero from captivity (server-authoritative).";
         {
             return CommandHelpers.FormatException(
                 $"Failed to capture hero '{GetHeroDisplayName(hero)}' by '{newCaptor.StringId}'",
-                ex);
-        }
-    }
-
-    private static string ReleaseHero(Hero hero)
-    {
-        if (hero == null)
-        {
-            return "Failed to release hero: hero is null.";
-        }
-
-        if (!hero.IsPrisoner)
-        {
-            return $"Hero '{GetHeroDisplayName(hero)}' is not a prisoner.";
-        }
-
-        var captorName = hero.PartyBelongedToAsPrisoner?.MobileParty?.StringId
-            ?? hero.PartyBelongedToAsPrisoner?.Settlement?.StringId
-            ?? "unknown";
-
-        try
-        {
-            // On the server the EndCaptivityAction patch routes a player hero through the coop release
-            // (PlayerCaptivityEndedByServer -> ReleasePlayerFromCaptivity), which reactivates its parked party.
-            EndCaptivityAction.ApplyByEscape(hero);
-
-            // The coop release skips and returns if it can't resolve the player's party, leaving the hero
-            // captive without throwing, so confirm the state actually changed before reporting success.
-            if (hero.IsPrisoner)
-            {
-                return $"Release did not complete: hero '{GetHeroDisplayName(hero)}' is still a prisoner (the server could not resolve its party).";
-            }
-
-            return
-                "Hero released successfully.\n" +
-                $"Hero: {GetHeroDisplayName(hero)}\n" +
-                $"Former captor: {captorName}";
-        }
-        catch (Exception ex)
-        {
-            return CommandHelpers.FormatException(
-                $"Failed to release hero '{GetHeroDisplayName(hero)}'",
                 ex);
         }
     }

--- a/source/GameInterface/Services/PlayerCaptivityService/Commands/PlayerCaptivityCommands.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Commands/PlayerCaptivityCommands.cs
@@ -93,6 +93,41 @@ Captures the given hero and assigns the given mobile party as the captor.";
         return CaptureHero(hero, newCaptor);
     }
 
+    private const string ReleasePlayerUsage =
+@"Usage:
+  coop.debug.player_captivity.release_player <heroId>
+
+Example:
+  coop.debug.player_captivity.release_player Player
+
+Releases the given captive hero from captivity (server-authoritative).";
+
+    [CommandLineArgumentFunction("release_player", "coop.debug.player_captivity")]
+    public static string ReleasePlayer(List<string> args)
+    {
+        var ctx = new CommandContext(
+            "release_player",
+            ReleasePlayerUsage,
+            args);
+
+        if (!ctx.RequireServer(out var error))
+            return error;
+
+        if (!ctx.RequireArgCount(1, out error))
+            return error;
+
+        if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
+            return error;
+
+        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+            return "Failed to release hero: " + error;
+
+        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
+            return "Failed to release hero: " + error;
+
+        return ReleaseHero(hero);
+    }
+
     private static bool TryGetRandomCaptor(out MobileParty newCaptor, out string error)
     {
         newCaptor = null;
@@ -173,6 +208,48 @@ Captures the given hero and assigns the given mobile party as the captor.";
         {
             return CommandHelpers.FormatException(
                 $"Failed to capture hero '{GetHeroDisplayName(hero)}' by '{newCaptor.StringId}'",
+                ex);
+        }
+    }
+
+    private static string ReleaseHero(Hero hero)
+    {
+        if (hero == null)
+        {
+            return "Failed to release hero: hero is null.";
+        }
+
+        if (!hero.IsPrisoner)
+        {
+            return $"Hero '{GetHeroDisplayName(hero)}' is not a prisoner.";
+        }
+
+        var captorName = hero.PartyBelongedToAsPrisoner?.MobileParty?.StringId
+            ?? hero.PartyBelongedToAsPrisoner?.Settlement?.StringId
+            ?? "unknown";
+
+        try
+        {
+            // On the server the EndCaptivityAction patch routes a player hero through the coop release
+            // (PlayerCaptivityEndedByServer -> ReleasePlayerFromCaptivity), which reactivates its parked party.
+            EndCaptivityAction.ApplyByEscape(hero);
+
+            // The coop release skips and returns if it can't resolve the player's party, leaving the hero
+            // captive without throwing, so confirm the state actually changed before reporting success.
+            if (hero.IsPrisoner)
+            {
+                return $"Release did not complete: hero '{GetHeroDisplayName(hero)}' is still a prisoner (the server could not resolve its party).";
+            }
+
+            return
+                "Hero released successfully.\n" +
+                $"Hero: {GetHeroDisplayName(hero)}\n" +
+                $"Former captor: {captorName}";
+        }
+        catch (Exception ex)
+        {
+            return CommandHelpers.FormatException(
+                $"Failed to release hero '{GetHeroDisplayName(hero)}'",
                 ex);
         }
     }

--- a/source/GameInterface/Services/PlayerCaptivityService/Handlers/PlayerCaptivityServerHandler.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Handlers/PlayerCaptivityServerHandler.cs
@@ -320,6 +320,11 @@ internal class PlayerCaptivityServerHandler : IHandler
             playerParty.IgnoreForHours(4);
             playerParty.Party.SetAsCameraFollowParty();
             playerParty.SetMoveModeHold();
+            // SetMoveModeHold only resets the AI behavior, not the navigation mode, so the freed party
+            // would keep whatever Party-mode target it had at capture (its old captor, or a party that
+            // was destroyed and deserialized to null after a save/reload). Clear it so the released party
+            // actually holds and obeys the player's next move order instead of being stuck or throwing.
+            playerParty.ResetNavigationToHold();
 
             // Native grants the released hero captivity XP through Campaign.Current.PlayerCaptivity,
             // which on the server tracks the host hero — using it here would XP the wrong hero.


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

If the game saves when a client is prisoner and the server reloads, then when the client reconnects and frees itself from the imprisoning party, it is unable to move

https://github.com/user-attachments/assets/a1ca9f8e-21bc-490f-b13d-4aeca6815d13


This is one symptom of a wider problem: after a save/reload (and on a fresh client join) a party can come back still set to chase a party that no longer exists. So as well as the freed prisoner being stuck, any party that was mid-engagement when the save happened (the looters/bandits that caught you, nearby AI lords) stops moving and spams GetTargetCampaignPosition errors in the log.

## What is the new behavior?

Resolves Bannerlord-Coop-Team/Bannerlord-Coop-Issues#26

The prisoner client is able to move after freeing itself. Parties left chasing a party that no longer exists now just stop and re-decide instead of getting stuck or spamming errors, so the log stays clean after a reload or a client join.

https://github.com/user-attachments/assets/e1f43d18-067b-4997-8a55-e1fa3cce3b0e


