### PR TITLE
[1538] Fix crash declaring war while a battle is still syncing

### DIFF
--- a/source/GameInterface.Tests/Services/MapEvents/CanPartyJoinBattleGuardTests.cs
+++ b/source/GameInterface.Tests/Services/MapEvents/CanPartyJoinBattleGuardTests.cs
@@ -1,0 +1,157 @@
+﻿using GameInterface.Services.MapEvents.Patches;
+using System.Reflection;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.MapEvents;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.Library;
+using Xunit;
+using FormatterServices = System.Runtime.Serialization.FormatterServices;
+
+namespace GameInterface.Tests.Services.MapEvents
+{
+    /// <summary>
+    /// Tests the unresolved-party guard in <see cref="InteractionPatches.CanEvaluateJoinBattle"/>. Vanilla
+    /// MapEvent.CanPartyJoinBattle - run by the diplomacy-continuity sweep when a war/peace stance change
+    /// fires - walks both sides and dereferences the passed party's MapFaction and every MapEventParty's
+    /// Party and Party.MapFaction. On a receiving co-op machine a MapEventParty can be in a side before its
+    /// Party/MapFaction has synced, so the check throws a NullReferenceException (issue #1538). The guard
+    /// returns false while any of that is unresolved so the prefix can skip vanilla instead of crashing.
+    ///
+    /// TaleWorlds.CampaignSystem is publicized for this test assembly, so the otherwise-private backing
+    /// members Party, MobileParty and _actualClan are assigned directly; _sides and _battleParties are
+    /// readonly fields, so they are set by reflection.
+    /// </summary>
+    public class CanPartyJoinBattleGuardTests
+    {
+        private static readonly FieldInfo SidesField =
+            typeof(MapEvent).GetField("_sides", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        private static readonly FieldInfo BattlePartiesField =
+            typeof(MapEventSide).GetField("_battleParties", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        // DefenderSide reads _sides[0]; AttackerSide reads _sides[1].
+        private static MapEvent CreateMapEvent(MapEventSide? defender, MapEventSide? attacker)
+        {
+            MapEvent mapEvent = (MapEvent)FormatterServices.GetUninitializedObject(typeof(MapEvent));
+            SidesField.SetValue(mapEvent, new[] { defender, attacker });
+            return mapEvent;
+        }
+
+        // Sides are created via GetUninitializedObject on the client too, so give each one a real
+        // _battleParties list (the registry reinitializes it before the side is used) to mirror runtime.
+        private static MapEventSide CreateSide(params MapEventParty[] parties)
+        {
+            MapEventSide side = (MapEventSide)FormatterServices.GetUninitializedObject(typeof(MapEventSide));
+            BattlePartiesField.SetValue(side, new MBList<MapEventParty>(parties));
+            return side;
+        }
+
+        // partySet = the MapEventParty's underlying Party has synced (non-null). factionResolved = that
+        // Party also resolves a non-null MapFaction. The two false cases are the transient states the guard
+        // must catch: the Party has not arrived yet, or it has but its faction has not.
+        private static MapEventParty CreateParty(bool partySet, bool factionResolved)
+        {
+            MapEventParty mapEventParty = (MapEventParty)FormatterServices.GetUninitializedObject(typeof(MapEventParty));
+            if (partySet)
+                mapEventParty.Party = CreatePartyBase(factionResolved);
+            return mapEventParty;
+        }
+
+        private static MapEventParty ResolvedParty() => CreateParty(partySet: true, factionResolved: true);
+
+        // PartyBase.MapFaction returns MobileParty.MapFaction (then Settlement.MapFaction) or null. A
+        // MobileParty whose ActualClan is set resolves MapFaction to that clan (Clan.MapFaction returns the
+        // clan itself when it is in no kingdom), with no Campaign needed; leaving MobileParty null makes
+        // PartyBase.MapFaction return null, the unresolved-faction case. (PartyBase's MobileParty-taking
+        // constructor calls Campaign.Current, so build it uninitialized and set the backing directly.)
+        private static PartyBase CreatePartyBase(bool factionResolved)
+        {
+            PartyBase partyBase = (PartyBase)FormatterServices.GetUninitializedObject(typeof(PartyBase));
+            if (factionResolved)
+            {
+                MobileParty mobileParty = (MobileParty)FormatterServices.GetUninitializedObject(typeof(MobileParty));
+                mobileParty._actualClan = (Clan)FormatterServices.GetUninitializedObject(typeof(Clan));
+                partyBase.MobileParty = mobileParty;
+            }
+            return partyBase;
+        }
+
+        [Fact]
+        public void NullMapEvent_CannotEvaluate()
+        {
+            Assert.False(InteractionPatches.CanEvaluateJoinBattle(null, CreatePartyBase(factionResolved: true)));
+        }
+
+        [Fact]
+        public void DefenderSideNull_CannotEvaluate()
+        {
+            MapEvent mapEvent = CreateMapEvent(defender: null, attacker: CreateSide());
+
+            Assert.False(InteractionPatches.CanEvaluateJoinBattle(mapEvent, CreatePartyBase(factionResolved: true)));
+        }
+
+        [Fact]
+        public void AttackerSideNull_CannotEvaluate()
+        {
+            MapEvent mapEvent = CreateMapEvent(defender: CreateSide(), attacker: null);
+
+            Assert.False(InteractionPatches.CanEvaluateJoinBattle(mapEvent, CreatePartyBase(factionResolved: true)));
+        }
+
+        [Fact]
+        public void PassedPartyNull_CannotEvaluate()
+        {
+            MapEvent mapEvent = CreateMapEvent(defender: CreateSide(), attacker: CreateSide());
+
+            Assert.False(InteractionPatches.CanEvaluateJoinBattle(mapEvent, null));
+        }
+
+        [Fact]
+        public void PassedPartyUnresolvedFaction_CannotEvaluate()
+        {
+            MapEvent mapEvent = CreateMapEvent(defender: CreateSide(), attacker: CreateSide());
+
+            Assert.False(InteractionPatches.CanEvaluateJoinBattle(mapEvent, CreatePartyBase(factionResolved: false)));
+        }
+
+        [Fact]
+        public void SidePartyUnresolved_CannotEvaluate()
+        {
+            MapEvent mapEvent = CreateMapEvent(
+                defender: CreateSide(ResolvedParty()),
+                attacker: CreateSide(CreateParty(partySet: false, factionResolved: false)));
+
+            Assert.False(InteractionPatches.CanEvaluateJoinBattle(mapEvent, CreatePartyBase(factionResolved: true)));
+        }
+
+        [Fact]
+        public void SidePartyUnresolvedFaction_CannotEvaluate()
+        {
+            MapEvent mapEvent = CreateMapEvent(
+                defender: CreateSide(ResolvedParty()),
+                attacker: CreateSide(CreateParty(partySet: true, factionResolved: false)));
+
+            Assert.False(InteractionPatches.CanEvaluateJoinBattle(mapEvent, CreatePartyBase(factionResolved: true)));
+        }
+
+        // An empty-but-present side has no parties to dereference, so the check can run (vanilla walks zero
+        // parties). The guard asks only whether the check can run without throwing, not whether the battle
+        // is fully populated.
+        [Fact]
+        public void SidesPresentNoParties_CanEvaluate()
+        {
+            MapEvent mapEvent = CreateMapEvent(defender: CreateSide(), attacker: CreateSide());
+
+            Assert.True(InteractionPatches.CanEvaluateJoinBattle(mapEvent, CreatePartyBase(factionResolved: true)));
+        }
+
+        [Fact]
+        public void SidesPresentAllPartiesResolved_CanEvaluate()
+        {
+            MapEvent mapEvent = CreateMapEvent(
+                defender: CreateSide(ResolvedParty()),
+                attacker: CreateSide(ResolvedParty(), ResolvedParty()));
+
+            Assert.True(InteractionPatches.CanEvaluateJoinBattle(mapEvent, CreatePartyBase(factionResolved: true)));
+        }
+    }
+}

--- a/source/GameInterface/Services/MapEvents/MapEventExtensions.cs
+++ b/source/GameInterface/Services/MapEvents/MapEventExtensions.cs
@@ -10,7 +10,8 @@ public static class MapEventExtensions
     {
         if (mapEvent is null) return false;
 
-        // Prevent any parties from joining a player battle
-        return mapEvent.InvolvedParties.Any(party => party.MobileParty?.IsPlayerParty() == true);
+        // Prevent any parties from joining a player battle. InvolvedParties yields MapEventParty.Party,
+        // which can be null on a receiving co-op machine before it has synced, so guard it.
+        return mapEvent.InvolvedParties.Any(party => party?.MobileParty?.IsPlayerParty() == true);
     }
 }

--- a/source/GameInterface/Services/MapEvents/MapEventExtensions.cs
+++ b/source/GameInterface/Services/MapEvents/MapEventExtensions.cs
@@ -10,8 +10,7 @@ public static class MapEventExtensions
     {
         if (mapEvent is null) return false;
 
-        // Prevent any parties from joining a player battle. InvolvedParties yields MapEventParty.Party,
-        // which can be null on a receiving co-op machine before it has synced, so guard it.
+        // Prevent any parties from joining a player battle
         return mapEvent.InvolvedParties.Any(party => party?.MobileParty?.IsPlayerParty() == true);
     }
 }

--- a/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
@@ -205,6 +205,50 @@ internal class InteractionPatches
     private static readonly ConditionalWeakTable<MapEvent, PlayerBattleAiJoinWindow> playerBattleAiJoinWindows = new();
 
     [HarmonyPatch(typeof(MapEvent), nameof(MapEvent.CanPartyJoinBattle))]
+    [HarmonyPrefix]
+    private static bool Prefix_CanPartyJoinBattle(MapEvent __instance, PartyBase party, ref bool __result)
+    {
+        // Vanilla CanPartyJoinBattle runs All(...) over both sides, dereferencing party.MapFaction and,
+        // for every MapEventParty, x.Party and x.Party.MapFaction. On a receiving co-op machine a
+        // MapEventParty can sit in a side before its Party/MapFaction has synced, so the lambda hits a
+        // null and throws when a war is declared mid-battle (issue #1538). While anything the check needs
+        // is still unresolved, skip vanilla and answer true ("can stay") so the diplomacy-continuity sweep
+        // in CheckMapEvents leaves the half-synced event intact instead of tearing it down; the server
+        // replicates the real side membership separately. Once everything is resolved (always on the
+        // server) this is a no-op and vanilla computes the real answer.
+        if (CanEvaluateJoinBattle(__instance, party))
+            return true;
+
+        __result = true;
+        return false;
+    }
+
+    // The vanilla check dereferences the passed party's MapFaction and, for every MapEventParty on both
+    // sides, its Party and that Party's MapFaction. On the client those sync in over several messages, so
+    // all must be present before the check can run without hitting un-ready state.
+    internal static bool CanEvaluateJoinBattle(MapEvent mapEvent, PartyBase party)
+    {
+        if (mapEvent?.AttackerSide == null || mapEvent.DefenderSide == null)
+            return false;
+
+        if (party?.MapFaction == null)
+            return false;
+
+        return PartiesResolved(mapEvent.AttackerSide) && PartiesResolved(mapEvent.DefenderSide);
+    }
+
+    private static bool PartiesResolved(MapEventSide side)
+    {
+        foreach (var mapEventParty in side.Parties)
+        {
+            if (mapEventParty?.Party?.MapFaction == null)
+                return false;
+        }
+
+        return true;
+    }
+
+    [HarmonyPatch(typeof(MapEvent), nameof(MapEvent.CanPartyJoinBattle))]
     [HarmonyPostfix]
     private static void Postfix_CanPartyJoinBattle(
         MapEvent __instance,
@@ -214,8 +258,9 @@ internal class InteractionPatches
         // Always allow a player party to join, on both client and server. The joining client evaluates this when
         // building the encounter "join the battle" menu options; native can return false there (e.g. war state /
         // side expectations not matching on the client), which would hide the join option. Force it true so the
-        // player can always join.
-        if (party.MobileParty?.IsPlayerParty() == true)
+        // player can always join. party can be null here when the prefix above skipped vanilla for an
+        // unresolved map-event party, so guard it.
+        if (party?.MobileParty?.IsPlayerParty() == true)
         {
             __result = true;
             return;

--- a/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
@@ -250,8 +250,7 @@ internal class InteractionPatches
         // Always allow a player party to join, on both client and server. The joining client evaluates this when
         // building the encounter "join the battle" menu options; native can return false there (e.g. war state /
         // side expectations not matching on the client), which would hide the join option. Force it true so the
-        // player can always join. party can be null here when the prefix above skipped vanilla for an
-        // unresolved map-event party, so guard it.
+        // player can always join.
         if (party?.MobileParty?.IsPlayerParty() == true)
         {
             __result = true;

--- a/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
@@ -208,14 +208,6 @@ internal class InteractionPatches
     [HarmonyPrefix]
     private static bool Prefix_CanPartyJoinBattle(MapEvent __instance, PartyBase party, ref bool __result)
     {
-        // Vanilla CanPartyJoinBattle runs All(...) over both sides, dereferencing party.MapFaction and,
-        // for every MapEventParty, x.Party and x.Party.MapFaction. On a receiving co-op machine a
-        // MapEventParty can sit in a side before its Party/MapFaction has synced, so the lambda hits a
-        // null and throws when a war is declared mid-battle (issue #1538). While anything the check needs
-        // is still unresolved, skip vanilla and answer true ("can stay") so the diplomacy-continuity sweep
-        // in CheckMapEvents leaves the half-synced event intact instead of tearing it down; the server
-        // replicates the real side membership separately. Once everything is resolved (always on the
-        // server) this is a no-op and vanilla computes the real answer.
         if (CanEvaluateJoinBattle(__instance, party))
             return true;
 


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

Declaring war while a player is in or just starting a battle could crash other players in the session to the main menu with a null-reference error. It happened intermittently, whenever a battle's parties hadn't finished syncing on a client at the moment the war was declared.

## What is the new behavior?

Resolves #1538

Declaring war no longer crashes anyone. If a battle is still syncing in when the war is declared, it is left intact instead of throwing, and play continues normally. War declarations with no battle in progress, and battles that have fully synced, behave exactly as before.
