### PR TITLE
Minor Fixes for Governors

### DIFF
--- a/source/GameInterface/Services/Companions/Patches/CompanionRolesPatches.cs
+++ b/source/GameInterface/Services/Companions/Patches/CompanionRolesPatches.cs
@@ -124,4 +124,18 @@ internal class CompanionRolesPatches
 
         return false;
     }
+
+    [HarmonyPatch(nameof(CompanionRolesCampaignBehavior.companion_rejoin_after_emprisonment_role_on_condition))]
+    [HarmonyPrefix]
+    public static bool CompanionRejoinAfterEmprisonmentRoleOnConditionPrefix(ref CompanionRolesCampaignBehavior __instance, ref bool __result)
+    {
+        // Prevent players of other clans returning a companion to their party
+        if (Hero.OneToOneConversationHero.Clan != Clan.PlayerClan)
+        {
+            __result = false;
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/source/GameInterface/Services/Heroes/Patches/GovernorCampaignBehaviorPatches.cs
+++ b/source/GameInterface/Services/Heroes/Patches/GovernorCampaignBehaviorPatches.cs
@@ -1,0 +1,27 @@
+﻿using Common;
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using TaleWorlds.CampaignSystem.CampaignBehaviors;
+
+namespace GameInterface.Services.Heroes.Patches;
+
+[HarmonyPatch(typeof(GovernorCampaignBehavior))]
+internal class GovernorCampaignBehaviorPatches
+{
+    private static IEnumerable<MethodBase> TargetMethods() => new MethodBase[]
+    {
+        //AccessTools.Method(typeof(GovernorCampaignBehavior), nameof(GovernorCampaignBehavior.OnSessionLaunched)), // Needed to load dialogue for clients
+        AccessTools.Method(typeof(GovernorCampaignBehavior), nameof(GovernorCampaignBehavior.OnHeroKilled)),
+        AccessTools.Method(typeof(GovernorCampaignBehavior), nameof(GovernorCampaignBehavior.DailyTickSettlement)),
+        AccessTools.Method(typeof(GovernorCampaignBehavior), nameof(GovernorCampaignBehavior.OnHeroChangedClan)),
+        AccessTools.Method(typeof(GovernorCampaignBehavior), nameof(GovernorCampaignBehavior.OnGameLoadFinished))
+    };
+
+    static bool Prefix()
+    {
+        return ModInformation.IsServer;
+    }
+}


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- GovernorCampaignBehavior is currently allowed to register all events on clients which causes logic that should be managed by the server to run on clients.
- Talking to another player's companion/governor in a location gives the option to recall to your own party.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
- Disable most of GovernorCampaignBehavior on clients except for loading dialogue.
- Prevent players of other clans recalling a companion/governor to their party.

## Other information
