### PR TITLE
[1576] Add reusable per-tick send coalescer

### DIFF
--- a/source/Common.Tests/Network/Coalescing/SendCoalescerTests.cs
+++ b/source/Common.Tests/Network/Coalescing/SendCoalescerTests.cs
@@ -1,0 +1,228 @@
+﻿using Common.Messaging;
+using Common.Network;
+using Common.Network.Coalescing;
+using Moq;
+
+namespace Common.Tests.Network.Coalescing;
+
+public class SendCoalescerTests
+{
+    private sealed class TestMessage : IMessage
+    {
+        public string Tag { get; }
+        public int Value { get; }
+
+        public TestMessage(string tag, int value)
+        {
+            Tag = tag;
+            Value = value;
+        }
+    }
+
+    private static (SendCoalescer coalescer, INetwork network, List<IMessage> sent) NewFixture()
+    {
+        var sent = new List<IMessage>();
+        var network = new Mock<INetwork>();
+        network.Setup(n => n.SendAll(It.IsAny<IMessage>())).Callback<IMessage>(sent.Add);
+        return (new SendCoalescer(), network.Object, sent);
+    }
+
+    private static int ValueOf(IMessage message) => Assert.IsType<TestMessage>(message).Value;
+
+    private static string TagOf(IMessage message) => Assert.IsType<TestMessage>(message).Tag;
+
+    [Fact]
+    public void LatestWins_CollapsesToTheLastValue()
+    {
+        var (coalescer, network, sent) = NewFixture();
+        var key = new CoalesceKey("hero", "h1", "Power");
+
+        coalescer.Enqueue(key, new LatestWinsPayload(new TestMessage("Power", 1)));
+        coalescer.Enqueue(key, new LatestWinsPayload(new TestMessage("Power", 2)));
+        coalescer.Enqueue(key, new LatestWinsPayload(new TestMessage("Power", 3)));
+
+        coalescer.Flush(network);
+
+        Assert.Equal(3, ValueOf(Assert.Single(sent)));
+    }
+
+    [Fact]
+    public void Summed_AccumulatesDeltas()
+    {
+        var (coalescer, network, sent) = NewFixture();
+        var key = new CoalesceKey("xp", "roster1", "char1");
+
+        coalescer.Enqueue(key, Xp(5));
+        coalescer.Enqueue(key, Xp(3));
+        coalescer.Enqueue(key, Xp(2));
+
+        coalescer.Flush(network);
+
+        Assert.Equal(10, ValueOf(Assert.Single(sent)));
+    }
+
+    [Fact]
+    public void Snapshot_BuildsFromTheLatestStateAtFlush()
+    {
+        var (coalescer, network, sent) = NewFixture();
+        var key = new CoalesceKey("roster", "r1");
+        int live = 1;
+
+        coalescer.Enqueue(key, new SnapshotPayload(() => new TestMessage("roster", live)));
+        live = 2;
+        coalescer.Enqueue(key, new SnapshotPayload(() => new TestMessage("roster", live)));
+        live = 99; // mutate after the last enqueue; the producer is only invoked at flush
+
+        coalescer.Flush(network);
+
+        Assert.Equal(99, ValueOf(Assert.Single(sent)));
+    }
+
+    [Fact]
+    public void DistinctKeys_AreNotMerged()
+    {
+        var (coalescer, network, sent) = NewFixture();
+
+        coalescer.Enqueue(new CoalesceKey("hero", "h1", "Power"), new LatestWinsPayload(new TestMessage("a", 1)));
+        coalescer.Enqueue(new CoalesceKey("hero", "h1", "Morale"), new LatestWinsPayload(new TestMessage("b", 2)));
+        coalescer.Enqueue(new CoalesceKey("hero", "h2", "Power"), new LatestWinsPayload(new TestMessage("c", 3)));
+
+        coalescer.Flush(network);
+
+        Assert.Equal(3, sent.Count);
+    }
+
+    [Fact]
+    public void Flush_ClearsPending()
+    {
+        var (coalescer, network, sent) = NewFixture();
+        coalescer.Enqueue(new CoalesceKey("hero", "h1", "Power"), new LatestWinsPayload(new TestMessage("a", 1)));
+
+        coalescer.Flush(network);
+        coalescer.Flush(network);
+
+        Assert.Single(sent);
+    }
+
+    [Fact]
+    public void FlushInstance_SendsOnlyThatInstanceAndLeavesOthersPending()
+    {
+        var (coalescer, network, sent) = NewFixture();
+        coalescer.Enqueue(new CoalesceKey("hero", "h1", "Power"), new LatestWinsPayload(new TestMessage("h1Power", 1)));
+        coalescer.Enqueue(new CoalesceKey("hero", "h1", "Morale"), new LatestWinsPayload(new TestMessage("h1Morale", 2)));
+        coalescer.Enqueue(new CoalesceKey("hero", "h2", "Power"), new LatestWinsPayload(new TestMessage("h2Power", 3)));
+
+        coalescer.FlushInstance("h1", network);
+
+        Assert.Equal(2, sent.Count);
+        Assert.DoesNotContain(sent, m => TagOf(m) == "h2Power");
+        Assert.True(coalescer.HasPending);
+
+        sent.Clear();
+        coalescer.Flush(network);
+        Assert.Equal("h2Power", TagOf(Assert.Single(sent)));
+    }
+
+    [Fact]
+    public void DropInstance_DiscardsWithoutSending()
+    {
+        var (coalescer, network, sent) = NewFixture();
+        coalescer.Enqueue(new CoalesceKey("hero", "h1", "Power"), new LatestWinsPayload(new TestMessage("h1", 1)));
+        coalescer.Enqueue(new CoalesceKey("hero", "h2", "Power"), new LatestWinsPayload(new TestMessage("h2", 2)));
+
+        coalescer.DropInstance("h1");
+        coalescer.Flush(network);
+
+        Assert.Equal("h2", TagOf(Assert.Single(sent)));
+    }
+
+    [Fact]
+    public void HasPending_TracksBufferState()
+    {
+        var (coalescer, network, _) = NewFixture();
+
+        Assert.False(coalescer.HasPending);
+        coalescer.Enqueue(new CoalesceKey("hero", "h1", "Power"), new LatestWinsPayload(new TestMessage("a", 1)));
+        Assert.True(coalescer.HasPending);
+        coalescer.Flush(network);
+        Assert.False(coalescer.HasPending);
+    }
+
+    [Fact]
+    public void Flush_OnEmptyBuffer_SendsNothing()
+    {
+        var (coalescer, network, sent) = NewFixture();
+
+        coalescer.Flush(network);
+
+        Assert.Empty(sent);
+    }
+
+    [Fact]
+    public void Summed_MergeWithMismatchedPayloadType_Throws()
+    {
+        var (coalescer, _, _) = NewFixture();
+        var key = new CoalesceKey("xp", "r1", "c1");
+        coalescer.Enqueue(key, Xp(5));
+
+        Assert.Throws<ArgumentException>(() =>
+            coalescer.Enqueue(key, new LatestWinsPayload(new TestMessage("xp", 1))));
+    }
+
+    [Fact]
+    public void LatestWins_MergeWithMismatchedPayloadType_Throws()
+    {
+        var (coalescer, _, _) = NewFixture();
+        var key = new CoalesceKey("hero", "h1", "Power");
+        coalescer.Enqueue(key, new LatestWinsPayload(new TestMessage("Power", 1)));
+
+        Assert.Throws<ArgumentException>(() => coalescer.Enqueue(key, Xp(5)));
+    }
+
+    [Fact]
+    public void Snapshot_MergeWithMismatchedPayloadType_Throws()
+    {
+        var (coalescer, _, _) = NewFixture();
+        var key = new CoalesceKey("roster", "r1");
+        coalescer.Enqueue(key, new SnapshotPayload(() => new TestMessage("roster", 1)));
+
+        Assert.Throws<ArgumentException>(() =>
+            coalescer.Enqueue(key, new LatestWinsPayload(new TestMessage("roster", 2))));
+    }
+
+    [Fact]
+    public void CoalesceKey_HasValueEqualityAndHashing()
+    {
+        var a = new CoalesceKey("c", "i", "m");
+        var b = new CoalesceKey("c", "i", "m");
+        var c = new CoalesceKey("c", "i", "other");
+
+        Assert.Equal(a, b);
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+        Assert.NotEqual(a, c);
+    }
+
+    [Fact]
+    public void Enqueue_IsThreadSafe()
+    {
+        var (coalescer, network, sent) = NewFixture();
+        const int threads = 8;
+        const int perThread = 1000;
+        var key = new CoalesceKey("xp", "r1", "c1");
+
+        Parallel.For(0, threads, _ =>
+        {
+            for (int i = 0; i < perThread; i++)
+            {
+                coalescer.Enqueue(key, Xp(1));
+            }
+        });
+
+        coalescer.Flush(network);
+
+        Assert.Equal(threads * perThread, ValueOf(Assert.Single(sent)));
+    }
+
+    private static SummedPayload<int> Xp(int delta) =>
+        new SummedPayload<int>(delta, (a, b) => a + b, total => new TestMessage("xp", total));
+}

--- a/source/Common/Network/Coalescing/CoalesceKey.cs
+++ b/source/Common/Network/Coalescing/CoalesceKey.cs
@@ -39,9 +39,9 @@ public readonly struct CoalesceKey : IEquatable<CoalesceKey>
         unchecked
         {
             int hash = 17;
-            hash = hash * 31 + (Channel?.GetHashCode() ?? 0);
-            hash = hash * 31 + (InstanceId?.GetHashCode() ?? 0);
-            hash = hash * 31 + (Member?.GetHashCode() ?? 0);
+            hash = (hash * 31) + (Channel?.GetHashCode() ?? 0);
+            hash = (hash * 31) + (InstanceId?.GetHashCode() ?? 0);
+            hash = (hash * 31) + (Member?.GetHashCode() ?? 0);
             return hash;
         }
     }

--- a/source/Common/Network/Coalescing/CoalesceKey.cs
+++ b/source/Common/Network/Coalescing/CoalesceKey.cs
@@ -22,8 +22,8 @@ public readonly struct CoalesceKey : IEquatable<CoalesceKey>
 
     public CoalesceKey(string channel, string instanceId, string member = "")
     {
-        Channel = channel ?? throw new ArgumentNullException(nameof(channel));
-        InstanceId = instanceId ?? throw new ArgumentNullException(nameof(instanceId));
+        Channel = channel;
+        InstanceId = instanceId;
         Member = member ?? string.Empty;
     }
 

--- a/source/Common/Network/Coalescing/CoalesceKey.cs
+++ b/source/Common/Network/Coalescing/CoalesceKey.cs
@@ -1,0 +1,50 @@
+﻿using System;
+
+namespace Common.Network.Coalescing;
+
+/// <summary>
+/// Identifies one coalesced update slot. Repeated enqueues with an equal key collapse into a single
+/// merged payload that is flushed once per server tick.
+/// </summary>
+/// <remarks>
+/// <para><see cref="Channel"/> names the logical send path, one per consumer / message family.</para>
+/// <para><see cref="InstanceId"/> is the network id of the object being updated (the object-manager
+/// string id).</para>
+/// <para><see cref="Member"/> is the part of the object being updated: a field name, or a composite
+/// element id encoded into the string (for example "itemId:modifierId"). It is empty when the whole
+/// object is the unit being sent, such as a snapshot.</para>
+/// </remarks>
+public readonly struct CoalesceKey : IEquatable<CoalesceKey>
+{
+    public string Channel { get; }
+    public string InstanceId { get; }
+    public string Member { get; }
+
+    public CoalesceKey(string channel, string instanceId, string member = "")
+    {
+        Channel = channel ?? throw new ArgumentNullException(nameof(channel));
+        InstanceId = instanceId ?? throw new ArgumentNullException(nameof(instanceId));
+        Member = member ?? string.Empty;
+    }
+
+    public bool Equals(CoalesceKey other) =>
+        string.Equals(Channel, other.Channel, StringComparison.Ordinal) &&
+        string.Equals(InstanceId, other.InstanceId, StringComparison.Ordinal) &&
+        string.Equals(Member, other.Member, StringComparison.Ordinal);
+
+    public override bool Equals(object obj) => obj is CoalesceKey other && Equals(other);
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            int hash = 17;
+            hash = hash * 31 + (Channel?.GetHashCode() ?? 0);
+            hash = hash * 31 + (InstanceId?.GetHashCode() ?? 0);
+            hash = hash * 31 + (Member?.GetHashCode() ?? 0);
+            return hash;
+        }
+    }
+
+    public override string ToString() => $"{Channel}/{InstanceId}/{Member}";
+}

--- a/source/Common/Network/Coalescing/CoalescedPayloads.cs
+++ b/source/Common/Network/Coalescing/CoalescedPayloads.cs
@@ -35,8 +35,7 @@ public sealed class LatestWinsPayload : ICoalescedPayload
 
 /// <summary>
 /// Keeps the most recent message producer and invokes it at flush time, so a large message is built
-/// once from the latest live state instead of on every change. Use for whole-object / whole-roster
-/// snapshots.
+/// once from the latest live state instead of on every change.
 /// </summary>
 public sealed class SnapshotPayload : ICoalescedPayload
 {

--- a/source/Common/Network/Coalescing/CoalescedPayloads.cs
+++ b/source/Common/Network/Coalescing/CoalescedPayloads.cs
@@ -1,0 +1,97 @@
+﻿using Common.Messaging;
+using System;
+
+namespace Common.Network.Coalescing;
+
+/// <summary>
+/// Keeps the most recent value; older pending values for the key are discarded. Use for absolute-value
+/// sets, where each update carries the new value of a field and only the latest one matters.
+/// </summary>
+public sealed class LatestWinsPayload : ICoalescedPayload
+{
+    private readonly IMessage message;
+
+    public LatestWinsPayload(IMessage message)
+    {
+        this.message = message ?? throw new ArgumentNullException(nameof(message));
+    }
+
+    public ICoalescedPayload Merge(ICoalescedPayload incoming)
+    {
+        if (incoming is not LatestWinsPayload)
+        {
+            throw new ArgumentException(
+                $"Cannot merge {incoming?.GetType().Name ?? "null"} into LatestWinsPayload; " +
+                "a coalesce key must use a single payload type.",
+                nameof(incoming));
+        }
+
+        return incoming;
+    }
+
+    public IMessage ToMessage() => message;
+}
+
+/// <summary>
+/// Keeps the most recent message producer and invokes it at flush time, so a large message is built
+/// once from the latest live state instead of on every change. Use for whole-object / whole-roster
+/// snapshots.
+/// </summary>
+public sealed class SnapshotPayload : ICoalescedPayload
+{
+    private readonly Func<IMessage> producer;
+
+    public SnapshotPayload(Func<IMessage> producer)
+    {
+        this.producer = producer ?? throw new ArgumentNullException(nameof(producer));
+    }
+
+    public ICoalescedPayload Merge(ICoalescedPayload incoming)
+    {
+        if (incoming is not SnapshotPayload)
+        {
+            throw new ArgumentException(
+                $"Cannot merge {incoming?.GetType().Name ?? "null"} into SnapshotPayload; " +
+                "a coalesce key must use a single payload type.",
+                nameof(incoming));
+        }
+
+        return incoming;
+    }
+
+    public IMessage ToMessage() => producer();
+}
+
+/// <summary>
+/// Accumulates additive deltas. Use for summed quantities (xp gained, gold change) where the merged
+/// value is the running total of every delta enqueued for the key this tick.
+/// </summary>
+/// <typeparam name="T">The delta value type, for example <see cref="int"/>.</typeparam>
+public sealed class SummedPayload<T> : ICoalescedPayload
+{
+    private readonly T value;
+    private readonly Func<T, T, T> add;
+    private readonly Func<T, IMessage> build;
+
+    public SummedPayload(T value, Func<T, T, T> add, Func<T, IMessage> build)
+    {
+        this.value = value;
+        this.add = add ?? throw new ArgumentNullException(nameof(add));
+        this.build = build ?? throw new ArgumentNullException(nameof(build));
+    }
+
+    public ICoalescedPayload Merge(ICoalescedPayload incoming)
+    {
+        if (incoming is not SummedPayload<T> other)
+        {
+            throw new ArgumentException(
+                $"Cannot merge {incoming?.GetType().Name ?? "null"} into SummedPayload<{typeof(T).Name}>; " +
+                "a coalesce key must use a single payload type.",
+                nameof(incoming));
+        }
+
+        return new SummedPayload<T>(add(value, other.value), add, build);
+    }
+
+    public IMessage ToMessage() => build(value);
+}

--- a/source/Common/Network/Coalescing/CoalescedPayloads.cs
+++ b/source/Common/Network/Coalescing/CoalescedPayloads.cs
@@ -13,7 +13,8 @@ public sealed class LatestWinsPayload : ICoalescedPayload
 
     public LatestWinsPayload(IMessage message)
     {
-        this.message = message ?? throw new ArgumentNullException(nameof(message));
+        if (message == null) throw new ArgumentNullException(nameof(message));
+        this.message = message;
     }
 
     public ICoalescedPayload Merge(ICoalescedPayload incoming)
@@ -43,7 +44,8 @@ public sealed class SnapshotPayload : ICoalescedPayload
 
     public SnapshotPayload(Func<IMessage> producer)
     {
-        this.producer = producer ?? throw new ArgumentNullException(nameof(producer));
+        if (producer == null) throw new ArgumentNullException(nameof(producer));
+        this.producer = producer;
     }
 
     public ICoalescedPayload Merge(ICoalescedPayload incoming)
@@ -75,9 +77,11 @@ public sealed class SummedPayload<T> : ICoalescedPayload
 
     public SummedPayload(T value, Func<T, T, T> add, Func<T, IMessage> build)
     {
+        if (add == null) throw new ArgumentNullException(nameof(add));
+        if (build == null) throw new ArgumentNullException(nameof(build));
         this.value = value;
-        this.add = add ?? throw new ArgumentNullException(nameof(add));
-        this.build = build ?? throw new ArgumentNullException(nameof(build));
+        this.add = add;
+        this.build = build;
     }
 
     public ICoalescedPayload Merge(ICoalescedPayload incoming)

--- a/source/Common/Network/Coalescing/ICoalescedPayload.cs
+++ b/source/Common/Network/Coalescing/ICoalescedPayload.cs
@@ -1,0 +1,25 @@
+﻿using Common.Messaging;
+
+namespace Common.Network.Coalescing;
+
+/// <summary>
+/// A pending coalesced update together with the strategy for merging successive updates to the same
+/// <see cref="CoalesceKey"/> within a server tick. Implementations decide how two updates combine
+/// (<see cref="Merge"/>) and how the final pending value becomes a wire message (<see cref="ToMessage"/>).
+/// </summary>
+public interface ICoalescedPayload
+{
+    /// <summary>
+    /// Combines this payload, the value already pending for the key, with a newer one and returns the
+    /// merged result. Called on every re-enqueue of an already-pending key. Implementations require
+    /// <paramref name="incoming"/> to be the same payload type, since one coalesce key uses a single
+    /// strategy for its whole life.
+    /// </summary>
+    ICoalescedPayload Merge(ICoalescedPayload incoming);
+
+    /// <summary>
+    /// Builds the message to broadcast for the final merged value. Invoked once per key at flush time,
+    /// so a snapshot payload can defer reading live state until here.
+    /// </summary>
+    IMessage ToMessage();
+}

--- a/source/Common/Network/Coalescing/ISendCoalescer.cs
+++ b/source/Common/Network/Coalescing/ISendCoalescer.cs
@@ -1,0 +1,43 @@
+﻿namespace Common.Network.Coalescing;
+
+/// <summary>
+/// Buffers per-change network sends and collapses many updates to the same <see cref="CoalesceKey"/>
+/// into one merged send per server tick. A send path enqueues instead of calling
+/// <see cref="INetwork"/>.SendAll directly; the server flushes the buffer once per tick.
+/// </summary>
+/// <remarks>
+/// Ordering obligations the consumers rely on:
+/// <list type="bullet">
+/// <item>The flush must run on the same thread that sends object creates and destroys, so a coalesced
+/// update never reorders ahead of its object's create or after its destroy on the reliable-ordered
+/// channel.</item>
+/// <item>Before an object's destroy is sent, its pending updates must be sent (see
+/// <see cref="FlushInstance"/>) or dropped (see <see cref="DropInstance"/>).</item>
+/// </list>
+/// </remarks>
+public interface ISendCoalescer
+{
+    /// <summary>True when at least one update is buffered and awaiting a flush.</summary>
+    bool HasPending { get; }
+
+    /// <summary>
+    /// Buffers an update for <paramref name="key"/>, merging it into any update already pending for that
+    /// key via the payload's strategy.
+    /// </summary>
+    void Enqueue(CoalesceKey key, ICoalescedPayload payload);
+
+    /// <summary>
+    /// Broadcasts the merged message for every pending key and clears the buffer. Call once per server
+    /// tick, on the thread that sends object creates and destroys.
+    /// </summary>
+    void Flush(INetwork network);
+
+    /// <summary>
+    /// Broadcasts and clears the pending updates for one instance only. Call before sending that
+    /// instance's destroy so its final state reaches clients ahead of the destroy.
+    /// </summary>
+    void FlushInstance(string instanceId, INetwork network);
+
+    /// <summary>Discards the pending updates for one instance without sending them.</summary>
+    void DropInstance(string instanceId);
+}

--- a/source/Common/Network/Coalescing/SendCoalescer.cs
+++ b/source/Common/Network/Coalescing/SendCoalescer.cs
@@ -46,8 +46,6 @@ public sealed class SendCoalescer : ISendCoalescer
             pending.Clear();
         }
 
-        // Build and send outside the lock: ToMessage and SendAll do real work and we never hold the
-        // buffer lock across network I/O.
         foreach (var payload in toSend)
         {
             network.SendAll(payload.ToMessage());

--- a/source/Common/Network/Coalescing/SendCoalescer.cs
+++ b/source/Common/Network/Coalescing/SendCoalescer.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Common.Network.Coalescing;
+
+/// <inheritdoc cref="ISendCoalescer"/>
+public sealed class SendCoalescer : ISendCoalescer
+{
+    private readonly Dictionary<CoalesceKey, ICoalescedPayload> pending = new();
+    private readonly object gate = new();
+
+    public bool HasPending
+    {
+        get
+        {
+            lock (gate)
+            {
+                return pending.Count > 0;
+            }
+        }
+    }
+
+    public void Enqueue(CoalesceKey key, ICoalescedPayload payload)
+    {
+        if (payload == null) throw new ArgumentNullException(nameof(payload));
+
+        lock (gate)
+        {
+            pending[key] = pending.TryGetValue(key, out var existing)
+                ? existing.Merge(payload)
+                : payload;
+        }
+    }
+
+    public void Flush(INetwork network)
+    {
+        if (network == null) throw new ArgumentNullException(nameof(network));
+
+        ICoalescedPayload[] toSend;
+        lock (gate)
+        {
+            if (pending.Count == 0) return;
+
+            toSend = new ICoalescedPayload[pending.Count];
+            pending.Values.CopyTo(toSend, 0);
+            pending.Clear();
+        }
+
+        // Build and send outside the lock: ToMessage and SendAll do real work and we never hold the
+        // buffer lock across network I/O.
+        foreach (var payload in toSend)
+        {
+            network.SendAll(payload.ToMessage());
+        }
+    }
+
+    public void FlushInstance(string instanceId, INetwork network)
+    {
+        if (network == null) throw new ArgumentNullException(nameof(network));
+
+        List<ICoalescedPayload> toSend = ExtractInstance(instanceId);
+        if (toSend == null) return;
+
+        foreach (var payload in toSend)
+        {
+            network.SendAll(payload.ToMessage());
+        }
+    }
+
+    public void DropInstance(string instanceId)
+    {
+        ExtractInstance(instanceId);
+    }
+
+    // Removes and returns every pending payload for the instance, or null if none. The caller decides
+    // whether to send them (FlushInstance) or discard them (DropInstance).
+    private List<ICoalescedPayload> ExtractInstance(string instanceId)
+    {
+        lock (gate)
+        {
+            List<CoalesceKey> keys = null;
+            foreach (var key in pending.Keys)
+            {
+                if (string.Equals(key.InstanceId, instanceId, StringComparison.Ordinal))
+                {
+                    (keys ??= new List<CoalesceKey>()).Add(key);
+                }
+            }
+
+            if (keys == null) return null;
+
+            var payloads = new List<ICoalescedPayload>(keys.Count);
+            foreach (var key in keys)
+            {
+                payloads.Add(pending[key]);
+                pending.Remove(key);
+            }
+
+            return payloads;
+        }
+    }
+}

--- a/source/Coop.Core/Server/CoopServer.cs
+++ b/source/Coop.Core/Server/CoopServer.cs
@@ -1,6 +1,8 @@
-﻿using Common.Logging;
+﻿using Common;
+using Common.Logging;
 using Common.Messaging;
 using Common.Network;
+using Common.Network.Coalescing;
 using Common.Network.Messages;
 using Common.PacketHandlers;
 using Common.Serialization;
@@ -37,6 +39,8 @@ public class CoopServer : CoopNetworkBase, ICoopServer
     private readonly IMessageBroker messageBroker;
     private readonly IPacketManager packetManager;
     private readonly IConnectionMessageQueue connectionMessageQueue;
+    // Buffers per-change sends and merges them into one send per key. Drained each tick in Update.
+    private readonly ISendCoalescer coalescer;
     // Lazy breaks the construction cycle: the manager depends on ITimeControlInterface, which depends
     // on INetwork (this server). It is only needed each Update, so deferring construction is fine.
     private readonly Lazy<IOverloadedPeerManager> overloadedPeerManager;
@@ -53,6 +57,7 @@ public class CoopServer : CoopNetworkBase, ICoopServer
         IControllerIdProvider controllerIdProvider,
         IMissionManager missionManager,
         Lazy<IOverloadedPeerManager> overloadedPeerManager,
+        ISendCoalescer coalescer,
         ICommonSerializer serializer) : base(configuration, serializer)
     {
         // Dependancy assignment
@@ -61,6 +66,7 @@ public class CoopServer : CoopNetworkBase, ICoopServer
         this.connectionMessageQueue = connectionMessageQueue;
         this.missionManager = missionManager;
         this.overloadedPeerManager = overloadedPeerManager;
+        this.coalescer = coalescer;
 
         // Netmanager initialization
         netManager.NatPunchEnabled = true;
@@ -124,6 +130,15 @@ public class CoopServer : CoopNetworkBase, ICoopServer
 
         netManager.PollEvents();
         netManager.NatPunchModule.PollEvents();
+
+        // Drain this tick's coalesced sends. Update runs on the poll thread, but creates and destroys
+        // send on the game thread, so we marshal the flush there too: that keeps each merged SendAll
+        // ordered behind an object's create and ahead of its destroy, and off netPeer.Send's non-thread-safe
+        // path. Inert until a send path enqueues, so the guard avoids queueing an empty flush every tick.
+        if (coalescer.HasPending)
+        {
+            GameThread.RunSafe(() => coalescer.Flush(this));
+        }
     }
 
     public override void Start()

--- a/source/Coop.Core/Server/ServerModule.cs
+++ b/source/Coop.Core/Server/ServerModule.cs
@@ -2,6 +2,7 @@
 using Common.LogicStates;
 using Common.Messaging;
 using Common.Network;
+using Common.Network.Coalescing;
 using Common.PacketHandlers;
 using Coop.Core.Common;
 using Coop.Core.Server.Connections;
@@ -29,6 +30,9 @@ public class ServerModule : CommonModule
         builder.RegisterType<ServerContext>().AsSelf().InstancePerLifetimeScope();
         builder.RegisterType<ServerLogic>().As<IServerLogic>().As<ILogic>().InstancePerLifetimeScope();
         builder.RegisterType<CoopServer>().As<ICoopServer>().As<INetwork>().As<INetEventListener>().InstancePerLifetimeScope();
+        // Per-tick send coalescer. Same scope as CoopServer and the handlers so they share one buffer:
+        // a send path enqueues, CoopServer.Update flushes.
+        builder.RegisterType<SendCoalescer>().As<ISendCoalescer>().InstancePerLifetimeScope();
         builder.RegisterType<CoopSaveManager>().As<ICoopSaveManager>().InstancePerLifetimeScope();
 
         // Withholds world broadcasts from a peer until it has the transfer save and has entered the

--- a/source/Coop.Core/Server/ServerModule.cs
+++ b/source/Coop.Core/Server/ServerModule.cs
@@ -30,8 +30,6 @@ public class ServerModule : CommonModule
         builder.RegisterType<ServerContext>().AsSelf().InstancePerLifetimeScope();
         builder.RegisterType<ServerLogic>().As<IServerLogic>().As<ILogic>().InstancePerLifetimeScope();
         builder.RegisterType<CoopServer>().As<ICoopServer>().As<INetwork>().As<INetEventListener>().InstancePerLifetimeScope();
-        // Per-tick send coalescer. Same scope as CoopServer and the handlers so they share one buffer:
-        // a send path enqueues, CoopServer.Update flushes.
         builder.RegisterType<SendCoalescer>().As<ISendCoalescer>().InstancePerLifetimeScope();
         builder.RegisterType<CoopSaveManager>().As<ICoopSaveManager>().InstancePerLifetimeScope();
 


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] New feature (non-breaking change that adds functionality)

## What is the current behavior?

When the server replicates a change, it sends it the moment it happens, so a value that changes several times within one server tick goes out as several separate network messages. There is no shared way to batch those repeated sends.

Resolves #1576

## What is the new behavior?

Adds a reusable per-tick send coalescer the server can buffer outbound sends through, so repeated changes to the same thing within one tick collapse into a single merged message flushed at the end of the tick. It offers three merge strategies: keep the latest value, sum additive deltas, and take a whole-object snapshot.

On its own this changes nothing a player can observe: no send path is wired through it yet, so the game replicates exactly as before. It is the shared mechanism the follow-up changes (#1570, #1571, #1572, #1574) each plug into to cut redundant traffic, part of the performance epic (#1369 / #1557).
