### PR TITLE
[1586] Only show Coop saves in Host Co-op Sandbox

### DIFF
--- a/source/Coop.Tests/Server/Services/Save/SaveGameHandlerTests.cs
+++ b/source/Coop.Tests/Server/Services/Save/SaveGameHandlerTests.cs
@@ -1,0 +1,41 @@
+using Common.Tests.Utils;
+using Coop.Core.Server.Services.Save;
+using Coop.Core.Server.Services.Save.Handlers;
+using GameInterface.CoopSessionData;
+using GameInterface.Services.Heroes.Messages;
+using GameInterface.Services.Players;
+using Moq;
+using System;
+using Xunit;
+
+namespace Coop.Tests.Server.Services.Save;
+
+/// <summary>
+/// Verifies co-op session initialization when campaign saves have no sidecar data.
+/// </summary>
+public class SaveGameHandlerTests
+{
+    [Fact]
+    public void GameLoaded_WithoutSidecar_InitializesEmptyCoopSession()
+    {
+        var messageBroker = new TestMessageBroker();
+        var saveManager = new CoopSaveManager();
+        var sessionProvider = new CoopSessionProvider();
+        var playerManager = new Mock<IPlayerManager>();
+        string saveName = $"ConvertedVanilla_{Guid.NewGuid():N}";
+
+        using var handler = new SaveGameHandler(
+            messageBroker,
+            saveManager,
+            sessionProvider,
+            playerManager.Object);
+
+        messageBroker.Publish(this, new GameLoaded(saveName));
+
+        Assert.Equal(saveName, sessionProvider.CoopSession.UniqueGameId);
+        Assert.Empty(sessionProvider.CoopSession.Players);
+        Assert.NotNull(sessionProvider.CoopSession.CraftingPlayerData);
+        Assert.NotNull(sessionProvider.CoopSession.WorkshopPlayerData);
+        Assert.NotNull(sessionProvider.CoopSession.CaravansPlayerData);
+    }
+}

--- a/source/GameInterface.Tests/Services/UI/CoopSaveMetadataTests.cs
+++ b/source/GameInterface.Tests/Services/UI/CoopSaveMetadataTests.cs
@@ -1,0 +1,45 @@
+using Coop.UI.LoadGameUI;
+using TaleWorlds.SaveSystem;
+using Xunit;
+
+namespace GameInterface.Tests.Services.UI;
+
+/// <summary>
+/// Verifies the module marker used to identify saves that can be hosted.
+/// </summary>
+public class CoopSaveMetadataTests
+{
+    [Fact]
+    public void ContainsCoopModule_ReturnsFalse_WhenMetadataIsNull()
+    {
+        Assert.False(CoopSaveMetadata.ContainsCoopModule(null));
+    }
+
+    [Fact]
+    public void ContainsCoopModule_ReturnsFalse_WhenModuleListIsMissing()
+    {
+        Assert.False(CoopSaveMetadata.ContainsCoopModule(new MetaData()));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("Native;SandBoxCore;Sandbox;StoryMode")]
+    [InlineData("Native;Cooperative;Sandbox")]
+    [InlineData("Native;coop;Sandbox")]
+    public void ContainsCoopModule_ReturnsFalse_WhenCoopModuleIsMissing(string modules)
+    {
+        var metadata = new MetaData();
+        metadata.Add("Modules", modules);
+
+        Assert.False(CoopSaveMetadata.ContainsCoopModule(metadata));
+    }
+
+    [Fact]
+    public void ContainsCoopModule_ReturnsTrue_WhenCoopModuleIsPresent()
+    {
+        var metadata = new MetaData();
+        metadata.Add("Modules", "Native;SandBoxCore;Sandbox;StoryMode;Coop");
+
+        Assert.True(CoopSaveMetadata.ContainsCoopModule(metadata));
+    }
+}

--- a/source/GameInterface/Services/UI/LoadGameUI/CoopLoadUI.cs
+++ b/source/GameInterface/Services/UI/LoadGameUI/CoopLoadUI.cs
@@ -59,15 +59,25 @@ namespace Coop.UI.LoadGameUI
         {
             Initialize();
 
-            foreach (var group in SaveGroups)
+            for (int groupIndex = SaveGroups.Count - 1; groupIndex >= 0; groupIndex--)
             {
+                var group = SaveGroups[groupIndex];
                 var saves = group.SavedGamesList;
-                for (int i = 0; i < saves.Count; i++)
+                for (int saveIndex = saves.Count - 1; saveIndex >= 0; saveIndex--)
                 {
-                    saves[i] = new SelectedGameVM(saves[i].Save, IsSaving, OnDeleteSavedGame, OnSaveSelection, OnCancelLoadSave, ExecuteDone);
+                    var save = saves[saveIndex].Save;
+                    if (!CoopSaveMetadata.ContainsCoopModule(save.MetaData))
+                    {
+                        saves.RemoveAt(saveIndex);
+                        continue;
+                    }
+
+                    saves[saveIndex] = new SelectedGameVM(save, IsSaving, OnDeleteSavedGame, OnSaveSelection, OnCancelLoadSave, ExecuteDone);
                 }
+
+                if (saves.Count == 0) SaveGroups.RemoveAt(groupIndex);
             }
-            OnSaveSelection(GetSavedGames().FirstOrDefault());
+            OnSaveSelection(GetSavedGames()?.FirstOrDefault());
             RefreshValues();
         }
 
@@ -115,12 +125,12 @@ namespace Coop.UI.LoadGameUI
             InformationManager.ShowInquiry(new InquiryData(titleText, text, true, true, new TextObject("{=aeouhelq}Yes", null).ToString(), new TextObject("{=8OkPHu4f}No", null).ToString(), delegate ()
             {
                 MBSaveLoad.DeleteSaveGame(savedGame.Save.Name);
-                GetSavedGames().Remove(savedGame);
-                OnSaveSelection(GetSavedGames().FirstOrDefault());
+                GetSavedGames()?.Remove(savedGame);
+                OnSaveSelection(GetSavedGames()?.FirstOrDefault());
             }, null, ""), false);
         }
 
-        private MBBindingList<SavedGameVM> GetSavedGames() => SaveGroups.FirstOrDefault().SavedGamesList;
+        private MBBindingList<SavedGameVM> GetSavedGames() => SaveGroups.FirstOrDefault()?.SavedGamesList;
 	}
 
 	public class CoopLoadScreen : SaveLoadScreen

--- a/source/GameInterface/Services/UI/LoadGameUI/CoopLoadUI.cs
+++ b/source/GameInterface/Services/UI/LoadGameUI/CoopLoadUI.cs
@@ -59,11 +59,11 @@ namespace Coop.UI.LoadGameUI
         {
             Initialize();
 
-            for (int groupIndex = SaveGroups.Count - 1; groupIndex >= 0; groupIndex--)
+            for (int groupIndex = 0; groupIndex < SaveGroups.Count;)
             {
                 var group = SaveGroups[groupIndex];
                 var saves = group.SavedGamesList;
-                for (int saveIndex = saves.Count - 1; saveIndex >= 0; saveIndex--)
+                for (int saveIndex = 0; saveIndex < saves.Count;)
                 {
                     var save = saves[saveIndex].Save;
                     if (!CoopSaveMetadata.ContainsCoopModule(save.MetaData))
@@ -73,9 +73,16 @@ namespace Coop.UI.LoadGameUI
                     }
 
                     saves[saveIndex] = new SelectedGameVM(save, IsSaving, OnDeleteSavedGame, OnSaveSelection, OnCancelLoadSave, ExecuteDone);
+                    saveIndex++;
                 }
 
-                if (saves.Count == 0) SaveGroups.RemoveAt(groupIndex);
+                if (saves.Count == 0)
+                {
+                    SaveGroups.RemoveAt(groupIndex);
+                    continue;
+                }
+
+                groupIndex++;
             }
             OnSaveSelection(GetSavedGames()?.FirstOrDefault());
             RefreshValues();

--- a/source/GameInterface/Services/UI/LoadGameUI/CoopSaveMetadata.cs
+++ b/source/GameInterface/Services/UI/LoadGameUI/CoopSaveMetadata.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Linq;
+using TaleWorlds.Core;
+using TaleWorlds.SaveSystem;
+
+namespace Coop.UI.LoadGameUI;
+
+/// <summary>
+/// Identifies campaign saves created with the Coop module enabled.
+/// </summary>
+public static class CoopSaveMetadata
+{
+    private const string CoopModuleId = "Coop";
+
+    /// <summary>
+    /// Checks whether the save metadata records the Coop module id.
+    /// </summary>
+    public static bool ContainsCoopModule(MetaData metadata)
+    {
+        return metadata?.GetModules().Contains(CoopModuleId, StringComparer.Ordinal) == true;
+    }
+}


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

`Host Co-op Sandbox` lists saves that were never saved with Coop enabled, so they can be selected for hosting.

This can cause a cascade of issues. One example is that the vanilla save could have active MapEvents which won't register  network IDs when the save gets loaded.

## What is the new behavior?

Resolves #1586

`Host Co-op Sandbox` only lists saves that were saved with Coop enabled. A vanilla campaign can be prepared by loading and saving it once with Coop enabled.
