### PR TITLE
[1602] Log the build commit at startup so bug reports identify the build

### DIFF
--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -111,7 +111,6 @@ namespace Coop
 
             Logger = LogManager.GetLogger<CoopMod>();
 
-            // Pin the build for bug triage: read the commit SHA off Common (Coop.dll carries none), at Information so it survives Release.
             var informationalVersion = typeof(ModInformation).Assembly
                 .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
                 ?.InformationalVersion ?? "unknown";

--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -110,6 +110,13 @@ namespace Coop
 #endif
 
             Logger = LogManager.GetLogger<CoopMod>();
+
+            // Pin the build for bug triage: read the commit SHA off Common (Coop.dll carries none), at Information so it survives Release.
+            var informationalVersion = typeof(ModInformation).Assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                ?.InformationalVersion ?? "unknown";
+            Logger.Information("BannerlordCoop build {Build}", informationalVersion);
+
             Logger.Verbose("Coop Mod Module Started");
         }
 


### PR DESCRIPTION
## PR Type

- [x] Other... Please describe: logging / diagnostics

## What is the current behavior?

nothing in `Coop_client.log` / `Coop_server.log` identifies the build, so when someone reports a bug theres no way to tell if theyre already on a build that has the fix. the commit SHA is already baked into `AssemblyInformationalVersion` on the SDK assemblies, its just never logged.

## What is the new behavior?

Resolves #1602

`SetupLogging` now logs the commit at startup, so every log opens with `BannerlordCoop build 1.0.0+<sha>` and a report's log self-identifies the exact build. 
<img width="717" height="161" alt="image" src="https://github.com/user-attachments/assets/3edddbb8-4bb8-4f84-a829-4fce3512d8b2" />


caveat: only populates when built from a git checkout, and a dirty tree shows the last commit not the uncommitted diff.
