### PR TITLE
[1610] Prevent periodic looted caravan deletion errors

### DIFF
--- a/source/GameInterface/Services/Caravans/Handlers/CaravansCampaignBehaviorHandler.cs
+++ b/source/GameInterface/Services/Caravans/Handlers/CaravansCampaignBehaviorHandler.cs
@@ -190,12 +190,16 @@ internal class CaravansCampaignBehaviorHandler : IHandler
 
                 deletedLootedCaravansIdsList.Add(caravanPartyId);
             }
+            if (deletedLootedCaravansIdsList.Count == 0) return;
+
             network.SendAll(new NetworkDeleteExpiredLootedCaravans(deletedLootedCaravansIdsList));
         });
     }
 
     private void Handle_NetworkDeleteExpiredLootedCaravans(MessagePayload<NetworkDeleteExpiredLootedCaravans> obj)
     {
+        if (obj.What.DeletedLootedCaravansIdsList == null) return;
+
         GameThread.RunSafe(() =>
         {
             if (!TryGetCaravansBehavior(out var caravansBehavior)) return;


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

Clients log a `NullReferenceException` every 20 seconds when no looted caravans expire.

## What is the new behavior?

Clients no longer log an error when the server checks for expired looted caravans and finds none.

Resolves #1610
