### PR TITLE
[1611] Play vanilla relation-change sound on notification

### DIFF
--- a/source/GameInterface/Services/Heroes/Handlers/CharacterRelationManagerHandler.cs
+++ b/source/GameInterface/Services/Heroes/Handlers/CharacterRelationManagerHandler.cs
@@ -79,7 +79,7 @@ namespace GameInterface.Services.Heroes.Handlers
             text.SetTextVariable("HERO", other.Name);
             text.SetTextVariable("AMOUNT", (delta > 0 ? "+" : "") + delta);
             text.SetTextVariable("TOTAL", newValue);
-            MBInformationManager.AddQuickInformation(text, 0, other.CharacterObject);
+            MBInformationManager.AddQuickInformation(text, 0, other.CharacterObject, null, "event:/ui/notification/relation");
         }
     }
 }


### PR DESCRIPTION
## PR Checklist

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

The quick-information popup that appears when relation with another hero changes plays no sound.

## What is the new behavior?

Resolves #1611

The popup now plays the vanilla relation-change sound, matching single-player behavior.