### PR TITLE
[1614] Stop clients hanging on a loading screen entering a town with an owned alley

### DIFF
--- a/source/GameInterface/Services/Alleys/Handlers/AlleyInitializationHandler.cs
+++ b/source/GameInterface/Services/Alleys/Handlers/AlleyInitializationHandler.cs
@@ -4,8 +4,6 @@ using GameInterface.Services.Alleys.Interfaces;
 using GameInterface.Services.Alleys.Messages;
 using GameInterface.Services.Heroes.Messages;
 using GameInterface.Services.ObjectManager;
-using HarmonyLib;
-using System.Reflection;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Settlements;
 
@@ -18,11 +16,6 @@ namespace GameInterface.Services.Alleys.Handlers;
 /// </summary>
 internal class AlleyInitializationHandler : IHandler
 {
-    // Alley.State is a private-setter, non-saved, MainHero-relative enum. The host saves it as
-    // OccupiedByGangLeader (host has no main hero) and vanilla's load re-derive runs before this client's
-    // main hero exists, so owned alleys load gang-occupied. We re-set it for the owning client on load.
-    private static readonly MethodInfo StateSetter = AccessTools.PropertySetter(typeof(Alley), nameof(Alley.State));
-
     private readonly IMessageBroker messageBroker;
     private readonly IObjectManager objectManager;
     private readonly IAlleyCampaignBehaviorInterface behaviorInterface;
@@ -61,18 +54,10 @@ internal class AlleyInitializationHandler : IHandler
         if (newHero == null) return;
 
         var managementData = alleyPlayerData?.ManagementDataPerAlley;
+        if (managementData == null) return;
 
         GameThread.RunSafe(() =>
         {
-            // Re-derive State for every alley this client owns (owner is saved, so OwnedAlleys is correct),
-            // independent of whether we have management data for it.
-            foreach (var alley in newHero.OwnedAlleys)
-            {
-                StateSetter?.Invoke(alley, new object[] { Alley.AreaState.OccupiedByPlayer });
-            }
-
-            if (managementData == null) return;
-
             foreach (var pair in managementData)
             {
                 if (!objectManager.TryGetObjectWithLogging<Alley>(pair.Key, out var alley)) continue;

--- a/source/GameInterface/Services/Alleys/Handlers/AlleySessionSeedHandler.cs
+++ b/source/GameInterface/Services/Alleys/Handlers/AlleySessionSeedHandler.cs
@@ -4,17 +4,18 @@ using Common.Messaging;
 using GameInterface.Registry.Messages;
 using GameInterface.Services.Alleys.Interfaces;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.TroopRosters.Data;
 using Serilog;
+using System;
 
 namespace GameInterface.Services.Alleys.Handlers;
 
 /// <summary>
 /// On the host, seeds the authoritative CoopSession alley management data for the loaded save's
-/// player-owned alleys once the loaded objects are registered. A save that was never played in co-op
-/// has empty session alley data, so without this the joining client that adopts an alley's owner gets
-/// no management entry and (with the State/entry lockstep) the alley shows gang-occupied with no manage
-/// menu. Seeding here lets that client restore the overseer + garrison and keep the alley manageable.
-/// The owning client mirror is restored in AlleyInitializationHandler.
+/// player-owned alleys once the loaded objects are registered. When the session has no entry for an
+/// owned alley, the joining client that adopts its owner gets no management entry and (with the
+/// State/entry lockstep) the alley shows gang-occupied with no manage menu; seeding the owner as the
+/// overseer keeps it manageable. The owning client mirror is restored in AlleyInitializationHandler.
 /// </summary>
 internal class AlleySessionSeedHandler : IHandler
 {
@@ -52,21 +53,22 @@ internal class AlleySessionSeedHandler : IHandler
         if (ModInformation.IsClient) return;
 
         int seeded = 0;
-        foreach (var (alley, overseer, garrison) in behaviorInterface.GetPlayerOwnedAlleys())
+        foreach (var alley in behaviorInterface.GetPlayerOwnedAlleys())
         {
             if (!objectManager.TryGetIdWithLogging(alley, out var alleyId)) continue;
 
-            // Only fill alleys the session doesn't know about yet, so a co-op save's transferred data
-            // or a live in-session change is never clobbered by the loaded snapshot.
+            // Only fill alleys the session doesn't know about yet, so existing management data is never
+            // clobbered by the loaded snapshot.
             if (sessionInterface.TryGetManagementData(alleyId, out _)) continue;
 
-            string overseerId = null;
-            if (overseer != null) objectManager.TryGetId(overseer, out overseerId);
+            if (!objectManager.TryGetIdWithLogging(alley.Owner, out var ownerId)) continue;
 
-            sessionInterface.SetManagementData(alleyId, overseerId, AlleyGarrisonData.ToData(garrison, objectManager));
+            // The owner runs the alley by default; the garrison starts empty (the client adds the owner
+            // to the roster when it restores the entry).
+            sessionInterface.SetManagementData(alleyId, ownerId, Array.Empty<TroopRosterElementData>());
             seeded++;
         }
 
-        if (seeded > 0) Logger.Information("Seeded co-op alley management data for {Count} owned alley(s) from the loaded save", seeded);
+        if (seeded > 0) Logger.Information("Seeded co-op alley management data for {Count} owned alley(s)", seeded);
     }
 }

--- a/source/GameInterface/Services/Alleys/Handlers/AlleySessionSeedHandler.cs
+++ b/source/GameInterface/Services/Alleys/Handlers/AlleySessionSeedHandler.cs
@@ -1,21 +1,25 @@
 ﻿using Common;
+using Common.Logging;
 using Common.Messaging;
 using GameInterface.Registry.Messages;
 using GameInterface.Services.Alleys.Interfaces;
 using GameInterface.Services.ObjectManager;
+using Serilog;
 
 namespace GameInterface.Services.Alleys.Handlers;
 
 /// <summary>
-/// On the host, seeds the authoritative CoopSession alley management data from the loaded campaign's
-/// AlleyCampaignBehavior._playerOwnedCommonAreaData once the loaded objects are registered. A save that
-/// was never played in co-op has empty session alley data, so without this the joining client that
-/// adopts an alley's owner gets no management entry and (with the State/entry lockstep) the alley shows
-/// gang-occupied with no manage menu. Seeding here lets that client restore the garrison + overseer and
-/// keep the alley manageable. The owning client mirror is restored in AlleyInitializationHandler.
+/// On the host, seeds the authoritative CoopSession alley management data for the loaded save's
+/// player-owned alleys once the loaded objects are registered. A save that was never played in co-op
+/// has empty session alley data, so without this the joining client that adopts an alley's owner gets
+/// no management entry and (with the State/entry lockstep) the alley shows gang-occupied with no manage
+/// menu. Seeding here lets that client restore the overseer + garrison and keep the alley manageable.
+/// The owning client mirror is restored in AlleyInitializationHandler.
 /// </summary>
 internal class AlleySessionSeedHandler : IHandler
 {
+    private static readonly ILogger Logger = LogManager.GetLogger<AlleySessionSeedHandler>();
+
     private readonly IMessageBroker messageBroker;
     private readonly IObjectManager objectManager;
     private readonly ISessionAlleyPlayerDataInterface sessionInterface;
@@ -47,11 +51,9 @@ internal class AlleySessionSeedHandler : IHandler
         // early on the host: it is what triggers registration).
         if (ModInformation.IsClient) return;
 
+        int seeded = 0;
         foreach (var (alley, overseer, garrison) in behaviorInterface.GetPlayerOwnedAlleys())
         {
-            // The host's _playerOwnedCommonAreaData is a frozen load snapshot that abandon doesn't clean,
-            // so an ownerless entry is a stale abandoned alley; don't resurrect its management data.
-            if (alley.Owner == null) continue;
             if (!objectManager.TryGetIdWithLogging(alley, out var alleyId)) continue;
 
             // Only fill alleys the session doesn't know about yet, so a co-op save's transferred data
@@ -62,6 +64,9 @@ internal class AlleySessionSeedHandler : IHandler
             if (overseer != null) objectManager.TryGetId(overseer, out overseerId);
 
             sessionInterface.SetManagementData(alleyId, overseerId, AlleyGarrisonData.ToData(garrison, objectManager));
+            seeded++;
         }
+
+        if (seeded > 0) Logger.Information("Seeded co-op alley management data for {Count} owned alley(s) from the loaded save", seeded);
     }
 }

--- a/source/GameInterface/Services/Alleys/Handlers/AlleySessionSeedHandler.cs
+++ b/source/GameInterface/Services/Alleys/Handlers/AlleySessionSeedHandler.cs
@@ -49,6 +49,9 @@ internal class AlleySessionSeedHandler : IHandler
 
         foreach (var (alley, overseer, garrison) in behaviorInterface.GetPlayerOwnedAlleys())
         {
+            // The host's _playerOwnedCommonAreaData is a frozen load snapshot that abandon doesn't clean,
+            // so an ownerless entry is a stale abandoned alley; don't resurrect its management data.
+            if (alley.Owner == null) continue;
             if (!objectManager.TryGetIdWithLogging(alley, out var alleyId)) continue;
 
             // Only fill alleys the session doesn't know about yet, so a co-op save's transferred data

--- a/source/GameInterface/Services/Alleys/Handlers/AlleySessionSeedHandler.cs
+++ b/source/GameInterface/Services/Alleys/Handlers/AlleySessionSeedHandler.cs
@@ -1,0 +1,64 @@
+﻿using Common;
+using Common.Messaging;
+using GameInterface.Registry.Messages;
+using GameInterface.Services.Alleys.Interfaces;
+using GameInterface.Services.ObjectManager;
+
+namespace GameInterface.Services.Alleys.Handlers;
+
+/// <summary>
+/// On the host, seeds the authoritative CoopSession alley management data from the loaded campaign's
+/// AlleyCampaignBehavior._playerOwnedCommonAreaData once the loaded objects are registered. A save that
+/// was never played in co-op has empty session alley data, so without this the joining client that
+/// adopts an alley's owner gets no management entry and (with the State/entry lockstep) the alley shows
+/// gang-occupied with no manage menu. Seeding here lets that client restore the garrison + overseer and
+/// keep the alley manageable. The owning client mirror is restored in AlleyInitializationHandler.
+/// </summary>
+internal class AlleySessionSeedHandler : IHandler
+{
+    private readonly IMessageBroker messageBroker;
+    private readonly IObjectManager objectManager;
+    private readonly ISessionAlleyPlayerDataInterface sessionInterface;
+    private readonly IAlleyCampaignBehaviorInterface behaviorInterface;
+
+    public AlleySessionSeedHandler(
+        IMessageBroker messageBroker,
+        IObjectManager objectManager,
+        ISessionAlleyPlayerDataInterface sessionInterface,
+        IAlleyCampaignBehaviorInterface behaviorInterface)
+    {
+        this.messageBroker = messageBroker;
+        this.objectManager = objectManager;
+        this.sessionInterface = sessionInterface;
+        this.behaviorInterface = behaviorInterface;
+
+        messageBroker.Subscribe<AllGameObjectsRegistered>(Handle_AllGameObjectsRegistered);
+    }
+
+    public void Dispose()
+    {
+        messageBroker.Unsubscribe<AllGameObjectsRegistered>(Handle_AllGameObjectsRegistered);
+    }
+
+    private void Handle_AllGameObjectsRegistered(MessagePayload<AllGameObjectsRegistered> payload)
+    {
+        // The host holds the authoritative management data; clients restore their mirror from it. This
+        // fires once the loaded objects are registered, so the alley ids resolve (CampaignReady is too
+        // early on the host: it is what triggers registration).
+        if (ModInformation.IsClient) return;
+
+        foreach (var (alley, overseer, garrison) in behaviorInterface.GetPlayerOwnedAlleys())
+        {
+            if (!objectManager.TryGetIdWithLogging(alley, out var alleyId)) continue;
+
+            // Only fill alleys the session doesn't know about yet, so a co-op save's transferred data
+            // or a live in-session change is never clobbered by the loaded snapshot.
+            if (sessionInterface.TryGetManagementData(alleyId, out _)) continue;
+
+            string overseerId = null;
+            if (overseer != null) objectManager.TryGetId(overseer, out overseerId);
+
+            sessionInterface.SetManagementData(alleyId, overseerId, AlleyGarrisonData.ToData(garrison, objectManager));
+        }
+    }
+}

--- a/source/GameInterface/Services/Alleys/Interfaces/AlleyCampaignBehaviorInterface.cs
+++ b/source/GameInterface/Services/Alleys/Interfaces/AlleyCampaignBehaviorInterface.cs
@@ -6,6 +6,7 @@ using SandBox.CampaignBehaviors;
 using Serilog;
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Reflection;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Roster;
@@ -14,16 +15,22 @@ using TaleWorlds.CampaignSystem.Settlements;
 namespace GameInterface.Services.Alleys.Interfaces;
 
 /// <summary>
-/// Client-side access to the owning player's alley management state, which lives in the
-/// (internal, nested) <c>AlleyCampaignBehavior.PlayerAlleyData</c> entries of its private
-/// <c>_playerOwnedCommonAreaData</c> list. Reached by reflection because that type is internal.
-/// Populating this list is what lights up the in-game manage-alley menus on the owning client.
+/// Access to the owning player's alley management state, which lives in the (internal, nested)
+/// <c>AlleyCampaignBehavior.PlayerAlleyData</c> entries of its private <c>_playerOwnedCommonAreaData</c>
+/// list. Reached by reflection because that type is internal. Populating this list is what lights up the
+/// in-game manage-alley menus on the owning client; the host reads it to seed the authoritative session.
 /// </summary>
 public interface IAlleyCampaignBehaviorInterface : IGameAbstraction
 {
     void AddOrUpdatePlayerAlleyData(Alley alley, Hero overseer, TroopRoster garrison);
     void RemovePlayerAlleyData(Alley alley);
     bool TryGetCurrentSettlementAlley(out Alley alley);
+
+    /// <summary>
+    /// Reads the loaded behavior's player-owned alleys (alley, overseer, garrison) so the host can seed
+    /// the authoritative CoopSession management data from a save that was never played in co-op.
+    /// </summary>
+    IEnumerable<(Alley alley, Hero overseer, TroopRoster garrison)> GetPlayerOwnedAlleys();
 }
 
 /// <inheritdoc cref="IAlleyCampaignBehaviorInterface"/>
@@ -42,6 +49,10 @@ public class AlleyCampaignBehaviorInterface : IAlleyCampaignBehaviorInterface
         PlayerAlleyDataType != null ? AccessTools.Field(PlayerAlleyDataType, "Alley") : null;
     private static readonly FieldInfo AssignedClanMemberField =
         PlayerAlleyDataType != null ? AccessTools.Field(PlayerAlleyDataType, "AssignedClanMember") : null;
+    private static readonly FieldInfo TroopRosterField =
+        PlayerAlleyDataType != null ? AccessTools.Field(PlayerAlleyDataType, "TroopRoster") : null;
+    private static readonly MethodInfo StateSetter =
+        AccessTools.PropertySetter(typeof(Alley), nameof(Alley.State));
 
     private static AlleyCampaignBehavior Behavior => Campaign.Current?.GetCampaignBehavior<AlleyCampaignBehavior>();
 
@@ -79,6 +90,12 @@ public class AlleyCampaignBehaviorInterface : IAlleyCampaignBehaviorInterface
                 var data = PlayerAlleyDataCtor.Invoke(new object[] { alley, garrison });
                 if (overseer != null) AssignedClanMemberField.SetValue(data, overseer);
                 list.Add(data);
+
+                // Promote State in lockstep with the entry. Vanilla's AddPlayerAlleyCharacters does an
+                // unguarded _playerOwnedCommonAreaData.First(x => x.Alley == alley), so an OccupiedByPlayer
+                // alley with no entry throws; setting State only here means OccupiedByPlayer always has a
+                // matching entry, and an alley with no entry stays at its loaded gang-occupied State.
+                StateSetter.Invoke(alley, new object[] { Alley.AreaState.OccupiedByPlayer });
             }
         });
     }
@@ -133,6 +150,25 @@ public class AlleyCampaignBehaviorInterface : IAlleyCampaignBehaviorInterface
         return false;
     }
 
+    public IEnumerable<(Alley alley, Hero overseer, TroopRoster garrison)> GetPlayerOwnedAlleys()
+    {
+        if (!ReflectionReady()) yield break;
+
+        var behavior = Behavior;
+        if (behavior == null) yield break;
+        if (PlayerOwnedDataField.GetValue(behavior) is not IList list) yield break;
+
+        foreach (var data in list)
+        {
+            if (data == null) continue;
+            if (AlleyField.GetValue(data) is not Alley alley) continue;
+
+            var overseer = AssignedClanMemberField.GetValue(data) as Hero;
+            var garrison = TroopRosterField.GetValue(data) as TroopRoster;
+            yield return (alley, overseer, garrison);
+        }
+    }
+
     private static void RemoveByAlley(IList list, Alley alley)
     {
         // Walk forward, only advancing when we keep an entry, so removing one doesn't skip the next.
@@ -153,7 +189,8 @@ public class AlleyCampaignBehaviorInterface : IAlleyCampaignBehaviorInterface
     private static bool ReflectionReady()
     {
         if (PlayerAlleyDataType == null || PlayerOwnedDataField == null ||
-            PlayerAlleyDataCtor == null || AlleyField == null || AssignedClanMemberField == null)
+            PlayerAlleyDataCtor == null || AlleyField == null || AssignedClanMemberField == null ||
+            TroopRosterField == null || StateSetter == null)
         {
             Logger.Error("AlleyCampaignBehavior.PlayerAlleyData reflection members could not be resolved; alley management cannot be applied");
             return false;

--- a/source/GameInterface/Services/Alleys/Interfaces/AlleyCampaignBehaviorInterface.cs
+++ b/source/GameInterface/Services/Alleys/Interfaces/AlleyCampaignBehaviorInterface.cs
@@ -27,14 +27,13 @@ public interface IAlleyCampaignBehaviorInterface : IGameAbstraction
     bool TryGetCurrentSettlementAlley(out Alley alley);
 
     /// <summary>
-    /// Enumerates the currently player-owned alleys (alley, overseer, garrison) so the host can seed the
-    /// authoritative CoopSession from a save it doesn't already cover. Ownership is read from the
-    /// replicated/saved <c>Alley.Owner</c>, because the host's own <c>_playerOwnedCommonAreaData</c> is
-    /// empty in co-op (it has no main hero); gang-occupied alleys are excluded. The overseer + garrison
-    /// come from <c>_playerOwnedCommonAreaData</c> when the loaded behavior still has them (an SP-origin
-    /// save), otherwise the owner is the overseer and the garrison starts empty.
+    /// Enumerates the currently player-owned alleys so the host can add management data for them to the
+    /// authoritative CoopSession when it has no entry yet (an owned alley the session never recorded).
+    /// Ownership is read from the replicated/saved <c>Alley.Owner</c> (the host's own
+    /// <c>_playerOwnedCommonAreaData</c> is empty in co-op, it has no main hero); gang-occupied alleys
+    /// are excluded.
     /// </summary>
-    IEnumerable<(Alley alley, Hero overseer, TroopRoster garrison)> GetPlayerOwnedAlleys();
+    IEnumerable<Alley> GetPlayerOwnedAlleys();
 }
 
 /// <inheritdoc cref="IAlleyCampaignBehaviorInterface"/>
@@ -53,8 +52,6 @@ public class AlleyCampaignBehaviorInterface : IAlleyCampaignBehaviorInterface
         PlayerAlleyDataType != null ? AccessTools.Field(PlayerAlleyDataType, "Alley") : null;
     private static readonly FieldInfo AssignedClanMemberField =
         PlayerAlleyDataType != null ? AccessTools.Field(PlayerAlleyDataType, "AssignedClanMember") : null;
-    private static readonly FieldInfo TroopRosterField =
-        PlayerAlleyDataType != null ? AccessTools.Field(PlayerAlleyDataType, "TroopRoster") : null;
     private static readonly MethodInfo StateSetter =
         AccessTools.PropertySetter(typeof(Alley), nameof(Alley.State));
 
@@ -154,15 +151,8 @@ public class AlleyCampaignBehaviorInterface : IAlleyCampaignBehaviorInterface
         return false;
     }
 
-    public IEnumerable<(Alley alley, Hero overseer, TroopRoster garrison)> GetPlayerOwnedAlleys()
+    public IEnumerable<Alley> GetPlayerOwnedAlleys()
     {
-        if (!ReflectionReady()) yield break;
-
-        var behavior = Behavior;
-        if (behavior == null) yield break;
-
-        var storedDetail = PlayerOwnedDataField.GetValue(behavior) as IList;
-
         foreach (var settlement in Settlement.All)
         {
             var alleys = settlement.Alleys;
@@ -171,26 +161,12 @@ public class AlleyCampaignBehaviorInterface : IAlleyCampaignBehaviorInterface
             foreach (var alley in alleys)
             {
                 // Alley.Owner is the replicated/saved source of truth. Skip the unowned (e.g. abandoned)
-                // and the gang-occupied (owner is a gang leader, not a player); only seed player-owned.
+                // and the gang-occupied (owner is a gang leader, not a player); only yield player-owned.
                 if (alley?.Owner == null || alley.Owner.IsGangLeader) continue;
 
-                var (overseer, garrison) = FindStoredDetail(storedDetail, alley);
-                yield return (alley, overseer ?? alley.Owner, garrison);
+                yield return alley;
             }
         }
-    }
-
-    // The overseer + garrison only survive on the host for an SP-origin save (the loaded behavior still
-    // carries _playerOwnedCommonAreaData); a co-op save has none, so the caller falls back to owner-only.
-    private static (Hero overseer, TroopRoster garrison) FindStoredDetail(IList storedDetail, Alley alley)
-    {
-        if (storedDetail == null) return (null, null);
-        foreach (var data in storedDetail)
-        {
-            if (data != null && AlleyField.GetValue(data) as Alley == alley)
-                return (AssignedClanMemberField.GetValue(data) as Hero, TroopRosterField.GetValue(data) as TroopRoster);
-        }
-        return (null, null);
     }
 
     private static void RemoveByAlley(IList list, Alley alley)
@@ -214,7 +190,7 @@ public class AlleyCampaignBehaviorInterface : IAlleyCampaignBehaviorInterface
     {
         if (PlayerAlleyDataType == null || PlayerOwnedDataField == null ||
             PlayerAlleyDataCtor == null || AlleyField == null || AssignedClanMemberField == null ||
-            TroopRosterField == null || StateSetter == null)
+            StateSetter == null)
         {
             Logger.Error("AlleyCampaignBehavior.PlayerAlleyData reflection members could not be resolved; alley management cannot be applied");
             return false;

--- a/source/GameInterface/Services/Alleys/Interfaces/AlleyCampaignBehaviorInterface.cs
+++ b/source/GameInterface/Services/Alleys/Interfaces/AlleyCampaignBehaviorInterface.cs
@@ -1,13 +1,9 @@
 ﻿using Common;
 using Common.Logging;
 using Common.Util;
-using HarmonyLib;
 using SandBox.CampaignBehaviors;
 using Serilog;
-using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Reflection;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Roster;
 using TaleWorlds.CampaignSystem.Settlements;
@@ -15,10 +11,10 @@ using TaleWorlds.CampaignSystem.Settlements;
 namespace GameInterface.Services.Alleys.Interfaces;
 
 /// <summary>
-/// Access to the owning player's alley management state, which lives in the (internal, nested)
-/// <c>AlleyCampaignBehavior.PlayerAlleyData</c> entries of its private <c>_playerOwnedCommonAreaData</c>
-/// list. Reached by reflection because that type is internal. Populating this list is what lights up the
-/// in-game manage-alley menus on the owning client; the host reads it to seed the authoritative session.
+/// Access to the owning player's alley management state, which lives in the
+/// <c>AlleyCampaignBehavior.PlayerAlleyData</c> entries of its <c>_playerOwnedCommonAreaData</c> list
+/// (both reached directly through the publicizer). Populating this list is what lights up the in-game
+/// manage-alley menus on the owning client; the host reads it to seed the authoritative session.
 /// </summary>
 public interface IAlleyCampaignBehaviorInterface : IGameAbstraction
 {
@@ -41,25 +37,10 @@ public class AlleyCampaignBehaviorInterface : IAlleyCampaignBehaviorInterface
 {
     private static readonly ILogger Logger = LogManager.GetLogger<AlleyCampaignBehaviorInterface>();
 
-    private static readonly Type PlayerAlleyDataType =
-        typeof(AlleyCampaignBehavior).GetNestedType("PlayerAlleyData", BindingFlags.NonPublic);
-    private static readonly FieldInfo PlayerOwnedDataField =
-        AccessTools.Field(typeof(AlleyCampaignBehavior), "_playerOwnedCommonAreaData");
-    private static readonly ConstructorInfo PlayerAlleyDataCtor = PlayerAlleyDataType != null
-        ? AccessTools.Constructor(PlayerAlleyDataType, new[] { typeof(Alley), typeof(TroopRoster) })
-        : null;
-    private static readonly FieldInfo AlleyField =
-        PlayerAlleyDataType != null ? AccessTools.Field(PlayerAlleyDataType, "Alley") : null;
-    private static readonly FieldInfo AssignedClanMemberField =
-        PlayerAlleyDataType != null ? AccessTools.Field(PlayerAlleyDataType, "AssignedClanMember") : null;
-    private static readonly MethodInfo StateSetter =
-        AccessTools.PropertySetter(typeof(Alley), nameof(Alley.State));
-
     private static AlleyCampaignBehavior Behavior => Campaign.Current?.GetCampaignBehavior<AlleyCampaignBehavior>();
 
     public void AddOrUpdatePlayerAlleyData(Alley alley, Hero overseer, TroopRoster garrison)
     {
-        if (!ReflectionReady()) return;
         if (alley == null || garrison == null)
         {
             Logger.Error("Cannot add alley management data with a null alley/garrison");
@@ -70,7 +51,8 @@ public class AlleyCampaignBehaviorInterface : IAlleyCampaignBehaviorInterface
         {
             var behavior = Behavior;
             if (behavior == null) return;
-            if (PlayerOwnedDataField.GetValue(behavior) is not IList list) return;
+            var list = behavior._playerOwnedCommonAreaData;
+            if (list == null) return;
 
             using (new AllowedThread())
             {
@@ -88,15 +70,15 @@ public class AlleyCampaignBehaviorInterface : IAlleyCampaignBehaviorInterface
                 }
 
                 RemoveByAlley(list, alley);
-                var data = PlayerAlleyDataCtor.Invoke(new object[] { alley, garrison });
-                if (overseer != null) AssignedClanMemberField.SetValue(data, overseer);
+                var data = new AlleyCampaignBehavior.PlayerAlleyData(alley, garrison);
+                if (overseer != null) data.AssignedClanMember = overseer;
                 list.Add(data);
 
                 // Promote State in lockstep with the entry. Vanilla's AddPlayerAlleyCharacters does an
                 // unguarded _playerOwnedCommonAreaData.First(x => x.Alley == alley), so an OccupiedByPlayer
                 // alley with no entry throws; setting State only here means OccupiedByPlayer always has a
                 // matching entry, and an alley with no entry stays at its loaded gang-occupied State.
-                StateSetter.Invoke(alley, new object[] { Alley.AreaState.OccupiedByPlayer });
+                alley.State = Alley.AreaState.OccupiedByPlayer;
             }
         });
     }
@@ -112,13 +94,14 @@ public class AlleyCampaignBehaviorInterface : IAlleyCampaignBehaviorInterface
 
     public void RemovePlayerAlleyData(Alley alley)
     {
-        if (!ReflectionReady() || alley == null) return;
+        if (alley == null) return;
 
         GameThread.RunSafe(() =>
         {
             var behavior = Behavior;
             if (behavior == null) return;
-            if (PlayerOwnedDataField.GetValue(behavior) is not IList list) return;
+            var list = behavior._playerOwnedCommonAreaData;
+            if (list == null) return;
 
             using (new AllowedThread())
             {
@@ -130,7 +113,6 @@ public class AlleyCampaignBehaviorInterface : IAlleyCampaignBehaviorInterface
     public bool TryGetCurrentSettlementAlley(out Alley alley)
     {
         alley = null;
-        if (!ReflectionReady()) return false;
 
         var behavior = Behavior;
         if (behavior == null) return false;
@@ -138,13 +120,14 @@ public class AlleyCampaignBehaviorInterface : IAlleyCampaignBehaviorInterface
         var settlement = Settlement.CurrentSettlement;
         if (settlement == null) return false;
 
-        if (PlayerOwnedDataField.GetValue(behavior) is not IList list) return false;
+        var list = behavior._playerOwnedCommonAreaData;
+        if (list == null) return false;
 
         foreach (var data in list)
         {
-            if (AlleyField.GetValue(data) is Alley a && a.Settlement == settlement)
+            if (data.Alley != null && data.Alley.Settlement == settlement)
             {
-                alley = a;
+                alley = data.Alley;
                 return true;
             }
         }
@@ -171,13 +154,13 @@ public class AlleyCampaignBehaviorInterface : IAlleyCampaignBehaviorInterface
         return owned;
     }
 
-    private static void RemoveByAlley(IList list, Alley alley)
+    private static void RemoveByAlley(List<AlleyCampaignBehavior.PlayerAlleyData> list, Alley alley)
     {
         // Walk forward, only advancing when we keep an entry, so removing one doesn't skip the next.
         int i = 0;
         while (i < list.Count)
         {
-            if (AlleyField.GetValue(list[i]) as Alley == alley)
+            if (list[i].Alley == alley)
             {
                 list.RemoveAt(i);
             }
@@ -186,17 +169,5 @@ public class AlleyCampaignBehaviorInterface : IAlleyCampaignBehaviorInterface
                 i++;
             }
         }
-    }
-
-    private static bool ReflectionReady()
-    {
-        if (PlayerAlleyDataType == null || PlayerOwnedDataField == null ||
-            PlayerAlleyDataCtor == null || AlleyField == null || AssignedClanMemberField == null ||
-            StateSetter == null)
-        {
-            Logger.Error("AlleyCampaignBehavior.PlayerAlleyData reflection members could not be resolved; alley management cannot be applied");
-            return false;
-        }
-        return true;
     }
 }

--- a/source/GameInterface/Services/Alleys/Interfaces/AlleyCampaignBehaviorInterface.cs
+++ b/source/GameInterface/Services/Alleys/Interfaces/AlleyCampaignBehaviorInterface.cs
@@ -33,7 +33,7 @@ public interface IAlleyCampaignBehaviorInterface : IGameAbstraction
     /// <c>_playerOwnedCommonAreaData</c> is empty in co-op, it has no main hero); gang-occupied alleys
     /// are excluded.
     /// </summary>
-    IEnumerable<Alley> GetPlayerOwnedAlleys();
+    IReadOnlyList<Alley> GetPlayerOwnedAlleys();
 }
 
 /// <inheritdoc cref="IAlleyCampaignBehaviorInterface"/>
@@ -151,8 +151,9 @@ public class AlleyCampaignBehaviorInterface : IAlleyCampaignBehaviorInterface
         return false;
     }
 
-    public IEnumerable<Alley> GetPlayerOwnedAlleys()
+    public IReadOnlyList<Alley> GetPlayerOwnedAlleys()
     {
+        var owned = new List<Alley>();
         foreach (var settlement in Settlement.All)
         {
             var alleys = settlement.Alleys;
@@ -161,12 +162,13 @@ public class AlleyCampaignBehaviorInterface : IAlleyCampaignBehaviorInterface
             foreach (var alley in alleys)
             {
                 // Alley.Owner is the replicated/saved source of truth. Skip the unowned (e.g. abandoned)
-                // and the gang-occupied (owner is a gang leader, not a player); only yield player-owned.
+                // and the gang-occupied (owner is a gang leader, not a player); keep only player-owned.
                 if (alley?.Owner == null || alley.Owner.IsGangLeader) continue;
 
-                yield return alley;
+                owned.Add(alley);
             }
         }
+        return owned;
     }
 
     private static void RemoveByAlley(IList list, Alley alley)

--- a/source/GameInterface/Services/Alleys/Interfaces/AlleyCampaignBehaviorInterface.cs
+++ b/source/GameInterface/Services/Alleys/Interfaces/AlleyCampaignBehaviorInterface.cs
@@ -27,8 +27,12 @@ public interface IAlleyCampaignBehaviorInterface : IGameAbstraction
     bool TryGetCurrentSettlementAlley(out Alley alley);
 
     /// <summary>
-    /// Reads the loaded behavior's player-owned alleys (alley, overseer, garrison) so the host can seed
-    /// the authoritative CoopSession management data from a save that was never played in co-op.
+    /// Enumerates the currently player-owned alleys (alley, overseer, garrison) so the host can seed the
+    /// authoritative CoopSession from a save it doesn't already cover. Ownership is read from the
+    /// replicated/saved <c>Alley.Owner</c>, because the host's own <c>_playerOwnedCommonAreaData</c> is
+    /// empty in co-op (it has no main hero); gang-occupied alleys are excluded. The overseer + garrison
+    /// come from <c>_playerOwnedCommonAreaData</c> when the loaded behavior still has them (an SP-origin
+    /// save), otherwise the owner is the overseer and the garrison starts empty.
     /// </summary>
     IEnumerable<(Alley alley, Hero overseer, TroopRoster garrison)> GetPlayerOwnedAlleys();
 }
@@ -156,17 +160,37 @@ public class AlleyCampaignBehaviorInterface : IAlleyCampaignBehaviorInterface
 
         var behavior = Behavior;
         if (behavior == null) yield break;
-        if (PlayerOwnedDataField.GetValue(behavior) is not IList list) yield break;
 
-        foreach (var data in list)
+        var storedDetail = PlayerOwnedDataField.GetValue(behavior) as IList;
+
+        foreach (var settlement in Settlement.All)
         {
-            if (data == null) continue;
-            if (AlleyField.GetValue(data) is not Alley alley) continue;
+            var alleys = settlement.Alleys;
+            if (alleys == null) continue;
 
-            var overseer = AssignedClanMemberField.GetValue(data) as Hero;
-            var garrison = TroopRosterField.GetValue(data) as TroopRoster;
-            yield return (alley, overseer, garrison);
+            foreach (var alley in alleys)
+            {
+                // Alley.Owner is the replicated/saved source of truth. Skip the unowned (e.g. abandoned)
+                // and the gang-occupied (owner is a gang leader, not a player); only seed player-owned.
+                if (alley?.Owner == null || alley.Owner.IsGangLeader) continue;
+
+                var (overseer, garrison) = FindStoredDetail(storedDetail, alley);
+                yield return (alley, overseer ?? alley.Owner, garrison);
+            }
         }
+    }
+
+    // The overseer + garrison only survive on the host for an SP-origin save (the loaded behavior still
+    // carries _playerOwnedCommonAreaData); a co-op save has none, so the caller falls back to owner-only.
+    private static (Hero overseer, TroopRoster garrison) FindStoredDetail(IList storedDetail, Alley alley)
+    {
+        if (storedDetail == null) return (null, null);
+        foreach (var data in storedDetail)
+        {
+            if (data != null && AlleyField.GetValue(data) as Alley == alley)
+                return (AssignedClanMemberField.GetValue(data) as Hero, TroopRosterField.GetValue(data) as TroopRoster);
+        }
+        return (null, null);
     }
 
     private static void RemoveByAlley(IList list, Alley alley)


### PR DESCRIPTION
## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

Some alley data is lost between saves and if a client loads into a save where he owns an alley then tries to walk around in that settlement, the client will get stuck on the loading screen

## What is the new behavior?

Resolves #1614.

`State = OccupiedByPlayer` is now set only when the `_playerOwnedCommonAreaData` entry is added, so the two can't diverge and vanilla's `.First` always matches. an owned alley with no entry stays gang-occupied (no crash) instead of throwing.

the host also seeds the session's management data for the save's owned alleys, read from `Alley.Owner` (gang-occupied ones excluded) once its objects register, so they transfer to the client that adopts the owner and stay manageable instead of just non-crashing.

