### PR TITLE
[1624] Trim redundant party-icon rebuilds on client leader changes

### DIFF
--- a/source/GameInterface/Services/MobileParties/Commands/MobilePartyDebugCommand.cs
+++ b/source/GameInterface/Services/MobileParties/Commands/MobilePartyDebugCommand.cs
@@ -83,6 +83,44 @@ internal class MobilePartyDebugCommand
         return stringBuilder.ToString();
     }
 
+    // coop.debug.mobileparty.change_leader <PartyStringID> <HeroStringID>
+    // Run on the server: drives ChangePartyLeader so the leader-change sync fires to clients. The new
+    // leader must already be a member of the party's roster (vanilla no-ops otherwise).
+    [CommandLineArgumentFunction("change_leader", "coop.debug.mobileparty")]
+    public static string ChangeLeader(List<string> args)
+    {
+        if (ModInformation.IsClient)
+        {
+            return "Change leader is only to be called on the server";
+        }
+
+        if (args.Count < 2)
+        {
+            return "Usage: coop.debug.mobileparty.change_leader <PartyStringID> <HeroStringID>";
+        }
+
+        MobileParty mobileParty = Campaign.Current.CampaignObjectManager.Find<MobileParty>(args[0]);
+        if (mobileParty == null)
+        {
+            return string.Format("Argument1: MobileParty not found by ID: {0}", args[0]);
+        }
+
+        Hero newLeader = Campaign.Current.CampaignObjectManager.Find<Hero>(args[1]);
+        if (newLeader == null)
+        {
+            return string.Format("Argument2: Hero not found by ID: {0}", args[1]);
+        }
+
+        if (!mobileParty.MemberRoster.Contains(newLeader.CharacterObject))
+        {
+            return $"{newLeader.Name} is not a member of {mobileParty.Name}; pick a hero from its member roster.";
+        }
+
+        mobileParty.ChangePartyLeader(newLeader);
+
+        return $"{mobileParty.Name} leader set to {newLeader.Name}";
+    }
+
     // coop.debug.mobileparty.attachment_ids <PartyStringID>
     // Prints the network ObjectManager id THIS machine holds for a party and each of its non-MBObjectBase
     // attachments. Run on the server and on each client and compare: a party the client got via live create

--- a/source/GameInterface/Services/MobileParties/Handlers/PartyLeaderHandler.cs
+++ b/source/GameInterface/Services/MobileParties/Handlers/PartyLeaderHandler.cs
@@ -65,13 +65,16 @@ internal class PartyLeaderHandler : IHandler
             if (payload.What.LeaderHeroId != null && !objectManager.TryGetObjectWithLogging(payload.What.LeaderHeroId, out newLeader))
                 return;
 
+            var previousLeader = mobileParty.LeaderHero;
+
             using (new AllowedThread())
             {
                 mobileParty.ChangePartyLeader(newLeader);
             }
 
-            // The leader drives the party's map figure; rebuild it so the change is reflected visually.
-            mobileParty.Party.SetVisualAsDirty();
+            // Rebuild the map figure only when the leader actually changed; nothing else marks it dirty.
+            if (mobileParty.LeaderHero != previousLeader)
+                mobileParty.Party.SetVisualAsDirty();
         });
     }
 }

--- a/source/GameInterface/Services/PartyComponents/Handlers/PartyComponentHandler.cs
+++ b/source/GameInterface/Services/PartyComponents/Handlers/PartyComponentHandler.cs
@@ -266,8 +266,12 @@ internal class PartyComponentHandler : IHandler
 
                 using (new AllowedThread())
                 {
+                    var previousLeader = partyComponent.Leader;
                     partyComponent.OnChangePartyLeader(newLeader);
-                    partyComponent.Party?.SetVisualAsDirty();
+
+                    // Rebuild the map figure only when the leader actually changed; nothing else marks it dirty.
+                    if (partyComponent.Leader != previousLeader)
+                        partyComponent.Party?.SetVisualAsDirty();
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

When a party's leader changes on the client, the party's whole map icon is torn down and rebuilt. That rebuild also runs when an update arrives that doesn't actually change the leader, and a player's own party rebuilds its icon twice for a single leader change. These extra rebuilds are wasteful and add to the recurring caught icon-refresh error spam in the client log.

## What is the new behavior?

Resolves #1624

The client rebuilds a party's map icon only when the leader actually changed, and only once per change. A genuine leader change still updates the icon to the new leader; redundant or no-op updates no longer trigger a rebuild.
