### PR TITLE
[1633] Fix coop battle side sized to zero when its reserve arrives late

### DIFF
--- a/source/E2E.Tests/Services/Missions/CoopBattleMissionSpawnHandlerSizingTests.cs
+++ b/source/E2E.Tests/Services/Missions/CoopBattleMissionSpawnHandlerSizingTests.cs
@@ -4,10 +4,8 @@ using Xunit;
 namespace E2E.Tests.Services.Missions;
 
 /// <summary>
-/// Unit tests (game-independent) for <see cref="CoopBattleMissionSpawnHandler.DecideJointSizing"/> — the pure
-/// decision that gates the single joint sizing pass. Sizing is deferred until BOTH sides' reserves have landed
-/// (both suppliers populated), because the engine's battle-size cap and wave split are joint; and it runs the
-/// real Init only when the combined total is positive, so Init never divides by a zero total.
+/// Game-independent tests for <see cref="CoopBattleMissionSpawnHandler.DecideJointSizing"/>: sizing waits until
+/// both reserves land (the joint cap needs both totals) and only runs Init on a positive combined total.
 /// </summary>
 public class CoopBattleMissionSpawnHandlerSizingTests
 {

--- a/source/E2E.Tests/Services/Missions/CoopBattleMissionSpawnHandlerSizingTests.cs
+++ b/source/E2E.Tests/Services/Missions/CoopBattleMissionSpawnHandlerSizingTests.cs
@@ -4,48 +4,54 @@ using Xunit;
 namespace E2E.Tests.Services.Missions;
 
 /// <summary>
-/// Unit tests (game-independent) for <see cref="CoopBattleMissionSpawnHandler.ResolvePendingSide"/> — the
-/// per-tick decision that grows a coop battle side once its reserve lands after AfterStart sized it to zero.
-/// Covers the reserve not yet arrived, an owned reserve arriving late, and an empty non-owned side.
+/// Unit tests (game-independent) for <see cref="CoopBattleMissionSpawnHandler.DecideJointSizing"/> — the pure
+/// decision that gates the single joint sizing pass. Sizing is deferred until BOTH sides' reserves have landed
+/// (both suppliers populated), because the engine's battle-size cap and wave split are joint; and it runs the
+/// real Init only when the combined total is positive, so Init never divides by a zero total.
 /// </summary>
 public class CoopBattleMissionSpawnHandlerSizingTests
 {
     [Fact]
-    public void ReserveNotArrived_StaysPending_NoResize()
+    public void OneSideNotPopulated_NotReady_HoldsBothSides()
     {
-        var (stillPending, resize, _) = CoopBattleMissionSpawnHandler.ResolvePendingSide(populated: false, ownedTotal: 0);
+        // Own side already has its reserve but the enemy side's (empty) reserve is still in flight: not ready,
+        // so both sides stay held at zero until the second reserve lands.
+        var decision = CoopBattleMissionSpawnHandler.DecideJointSizing(
+            defenderPopulated: true, attackerPopulated: false, defenderOwned: 7, attackerOwned: 0);
 
-        Assert.True(stillPending);
-        Assert.False(resize);
+        Assert.False(decision.Ready);
+        Assert.False(decision.SizeNow);
     }
 
     [Fact]
-    public void OwnedReserveArrivedLate_Settles_AndResizesToOwnedTotal()
+    public void NeitherPopulated_NotReady()
     {
-        var (stillPending, resize, newTotal) = CoopBattleMissionSpawnHandler.ResolvePendingSide(populated: true, ownedTotal: 7);
+        var decision = CoopBattleMissionSpawnHandler.DecideJointSizing(
+            defenderPopulated: false, attackerPopulated: false, defenderOwned: 0, attackerOwned: 0);
 
-        Assert.False(stillPending);
-        Assert.True(resize);
-        Assert.Equal(7, newTotal);
+        Assert.False(decision.Ready);
+        Assert.False(decision.SizeNow);
     }
 
     [Fact]
-    public void EmptyNonOwnedSide_Settles_WithoutResize()
+    public void BothPopulated_WithTroops_SizesJointly()
     {
-        // A side this client owns nothing on gets an empty reserve; it settles at zero and its troops arrive as puppets.
-        var (stillPending, resize, _) = CoopBattleMissionSpawnHandler.ResolvePendingSide(populated: true, ownedTotal: 0);
+        // A non-host: own defender side owns troops, enemy attacker side is an empty (but populated) reserve.
+        var decision = CoopBattleMissionSpawnHandler.DecideJointSizing(
+            defenderPopulated: true, attackerPopulated: true, defenderOwned: 7, attackerOwned: 0);
 
-        Assert.False(stillPending);
-        Assert.False(resize);
+        Assert.True(decision.Ready);
+        Assert.True(decision.SizeNow);
     }
 
     [Fact]
-    public void NotPopulated_IgnoresTransientTotal_StaysPending()
+    public void BothPopulated_BothEmpty_ReadyButDoesNotRunInit()
     {
-        // populated gates everything: a count seen before the supplier flips populated is not acted on.
-        var (stillPending, resize, _) = CoopBattleMissionSpawnHandler.ResolvePendingSide(populated: false, ownedTotal: 5);
+        // Defensive: both sides owning nothing must not hand Init a 0/0 total (which would divide by zero).
+        var decision = CoopBattleMissionSpawnHandler.DecideJointSizing(
+            defenderPopulated: true, attackerPopulated: true, defenderOwned: 0, attackerOwned: 0);
 
-        Assert.True(stillPending);
-        Assert.False(resize);
+        Assert.True(decision.Ready);
+        Assert.False(decision.SizeNow);
     }
 }

--- a/source/E2E.Tests/Services/Missions/CoopBattleMissionSpawnHandlerSizingTests.cs
+++ b/source/E2E.Tests/Services/Missions/CoopBattleMissionSpawnHandlerSizingTests.cs
@@ -1,0 +1,51 @@
+using Missions.Battles;
+using Xunit;
+
+namespace E2E.Tests.Services.Missions;
+
+/// <summary>
+/// Unit tests (game-independent) for <see cref="CoopBattleMissionSpawnHandler.ResolvePendingSide"/> — the
+/// per-tick decision that grows a coop battle side once its reserve lands after AfterStart sized it to zero.
+/// Covers the reserve not yet arrived, an owned reserve arriving late, and an empty non-owned side.
+/// </summary>
+public class CoopBattleMissionSpawnHandlerSizingTests
+{
+    [Fact]
+    public void ReserveNotArrived_StaysPending_NoResize()
+    {
+        var (stillPending, resize, _) = CoopBattleMissionSpawnHandler.ResolvePendingSide(populated: false, ownedTotal: 0);
+
+        Assert.True(stillPending);
+        Assert.False(resize);
+    }
+
+    [Fact]
+    public void OwnedReserveArrivedLate_Settles_AndResizesToOwnedTotal()
+    {
+        var (stillPending, resize, newTotal) = CoopBattleMissionSpawnHandler.ResolvePendingSide(populated: true, ownedTotal: 7);
+
+        Assert.False(stillPending);
+        Assert.True(resize);
+        Assert.Equal(7, newTotal);
+    }
+
+    [Fact]
+    public void EmptyNonOwnedSide_Settles_WithoutResize()
+    {
+        // A side this client owns nothing on gets an empty reserve; it settles at zero and its troops arrive as puppets.
+        var (stillPending, resize, _) = CoopBattleMissionSpawnHandler.ResolvePendingSide(populated: true, ownedTotal: 0);
+
+        Assert.False(stillPending);
+        Assert.False(resize);
+    }
+
+    [Fact]
+    public void NotPopulated_IgnoresTransientTotal_StaysPending()
+    {
+        // populated gates everything: a count seen before the supplier flips populated is not acted on.
+        var (stillPending, resize, _) = CoopBattleMissionSpawnHandler.ResolvePendingSide(populated: false, ownedTotal: 5);
+
+        Assert.True(stillPending);
+        Assert.False(resize);
+    }
+}

--- a/source/E2E.Tests/Services/Missions/CoopBattleMissionSpawnHandlerSizingTests.cs
+++ b/source/E2E.Tests/Services/Missions/CoopBattleMissionSpawnHandlerSizingTests.cs
@@ -1,11 +1,11 @@
-using Missions.Battles;
+﻿using Missions.Battles;
 using Xunit;
 
 namespace E2E.Tests.Services.Missions;
 
 /// <summary>
-/// Game-independent tests for <see cref="CoopBattleMissionSpawnHandler.DecideJointSizing"/>: sizing waits until
-/// both reserves land (the joint cap needs both totals) and only runs Init on a positive combined total.
+/// Game-independent tests for <see cref="CoopBattleMissionSpawnHandler.SideSizing"/>: sizing waits until both
+/// reserves land (the joint cap needs both totals) and only runs Init on a positive combined total.
 /// </summary>
 public class CoopBattleMissionSpawnHandlerSizingTests
 {
@@ -14,42 +14,42 @@ public class CoopBattleMissionSpawnHandlerSizingTests
     {
         // Own side already has its reserve but the enemy side's (empty) reserve is still in flight: not ready,
         // so both sides stay held at zero until the second reserve lands.
-        var decision = CoopBattleMissionSpawnHandler.DecideJointSizing(
+        var sizing = new CoopBattleMissionSpawnHandler.SideSizing(
             defenderPopulated: true, attackerPopulated: false, defenderOwned: 7, attackerOwned: 0);
 
-        Assert.False(decision.Ready);
-        Assert.False(decision.SizeNow);
+        Assert.False(sizing.Ready);
+        Assert.False(sizing.SizeNow);
     }
 
     [Fact]
     public void NeitherPopulated_NotReady()
     {
-        var decision = CoopBattleMissionSpawnHandler.DecideJointSizing(
+        var sizing = new CoopBattleMissionSpawnHandler.SideSizing(
             defenderPopulated: false, attackerPopulated: false, defenderOwned: 0, attackerOwned: 0);
 
-        Assert.False(decision.Ready);
-        Assert.False(decision.SizeNow);
+        Assert.False(sizing.Ready);
+        Assert.False(sizing.SizeNow);
     }
 
     [Fact]
     public void BothPopulated_WithTroops_SizesJointly()
     {
         // A non-host: own defender side owns troops, enemy attacker side is an empty (but populated) reserve.
-        var decision = CoopBattleMissionSpawnHandler.DecideJointSizing(
+        var sizing = new CoopBattleMissionSpawnHandler.SideSizing(
             defenderPopulated: true, attackerPopulated: true, defenderOwned: 7, attackerOwned: 0);
 
-        Assert.True(decision.Ready);
-        Assert.True(decision.SizeNow);
+        Assert.True(sizing.Ready);
+        Assert.True(sizing.SizeNow);
     }
 
     [Fact]
     public void BothPopulated_BothEmpty_ReadyButDoesNotRunInit()
     {
         // Defensive: both sides owning nothing must not hand Init a 0/0 total (which would divide by zero).
-        var decision = CoopBattleMissionSpawnHandler.DecideJointSizing(
+        var sizing = new CoopBattleMissionSpawnHandler.SideSizing(
             defenderPopulated: true, attackerPopulated: true, defenderOwned: 0, attackerOwned: 0);
 
-        Assert.True(decision.Ready);
-        Assert.False(decision.SizeNow);
+        Assert.True(sizing.Ready);
+        Assert.False(sizing.SizeNow);
     }
 }

--- a/source/Missions/Battles/CoopBattleDeploymentMissionController.cs
+++ b/source/Missions/Battles/CoopBattleDeploymentMissionController.cs
@@ -1,3 +1,6 @@
+using Common.Logging;
+using Serilog;
+using TaleWorlds.Core;
 using TaleWorlds.MountAndBlade;
 
 namespace Missions.Battles;
@@ -22,6 +25,8 @@ namespace Missions.Battles;
 /// </summary>
 public class CoopBattleDeploymentMissionController : BattleDeploymentMissionController
 {
+    private static readonly ILogger Logger = LogManager.GetLogger<CoopBattleDeploymentMissionController>();
+
     private CoopBattleMissionSpawnHandler _spawnHandler;
 
     public CoopBattleDeploymentMissionController(bool isPlayerAttacker)
@@ -43,6 +48,36 @@ public class CoopBattleDeploymentMissionController : BattleDeploymentMissionCont
         // the same frame, running SetupTeams against still-empty phases and latching the player onto no units.
         if (_spawnHandler != null && !_spawnHandler.IsSized) return;
 
+        bool setupWasOver = TeamSetupOver;
         base.OnMissionTick(dt);
+
+        // On the tick the deferred SetupTeams completes, re-assert the deployment AI-pause over every agent. Native
+        // freezes each side once, in SetupAgentAIStatesForSide, and only the agents already counted in a formation
+        // when its per-side pass runs. On the joint deferred re-Init path both sides' phases are enabled together
+        // (Init sets TroopSpawnActive for both), so the first side's enforced spawn puts the OTHER side's troops on
+        // the field before that side's own pause pass runs, and any agent a per-side pass doesn't cover keeps the
+        // isAlarmed state it spawned with and drifts the moment AI ticks. Pausing over Mission.Agents covers every
+        // deployed agent regardless of formation, so nothing is left un-paused until Start Battle. Skip when
+        // SetupTeams finished deployment outright (no Order of Battle) — that already released the field
+        // (AllowAiTicking is back on) and re-freezing would fight it. FinishDeployment un-pauses per agent later, so
+        // the Start-Battle release is unaffected; the hero is Controller.None (not IsAIControlled) so command holds.
+        if (!setupWasOver && TeamSetupOver && !base.Mission.AllowAiTicking)
+            FreezeDeployedAgents();
+    }
+
+    // Mirror of the native deployment freeze, applied to every agent rather than only the ones each per-side
+    // SetupAgentAIStatesForSide pass covered. One-shot on the setup-complete edge above.
+    private void FreezeDeployedAgents()
+    {
+        int def = 0, atk = 0;
+        foreach (Agent agent in base.Mission.Agents)
+        {
+            if (!agent.IsHuman || !agent.IsActive() || !agent.IsAIControlled) continue;
+            agent.SetAlarmState(Agent.AIStateFlag.None);
+            agent.SetIsAIPaused(isPaused: true);
+            if (agent.Team?.Side == BattleSideEnum.Defender) def++;
+            else if (agent.Team?.Side == BattleSideEnum.Attacker) atk++;
+        }
+        Logger.Information("[BattleSync] Deferred deployment freeze: re-paused Defender={Def}, Attacker={Atk} AI agents", def, atk);
     }
 }

--- a/source/Missions/Battles/CoopBattleDeploymentMissionController.cs
+++ b/source/Missions/Battles/CoopBattleDeploymentMissionController.cs
@@ -1,6 +1,3 @@
-using Common.Logging;
-using Serilog;
-using TaleWorlds.Core;
 using TaleWorlds.MountAndBlade;
 
 namespace Missions.Battles;
@@ -15,8 +12,6 @@ namespace Missions.Battles;
 /// </summary>
 public class CoopBattleDeploymentMissionController : BattleDeploymentMissionController
 {
-    private static readonly ILogger Logger = LogManager.GetLogger<CoopBattleDeploymentMissionController>();
-
     private CoopBattleMissionSpawnHandler _spawnHandler;
 
     public CoopBattleDeploymentMissionController(bool isPlayerAttacker)
@@ -33,32 +28,10 @@ public class CoopBattleDeploymentMissionController : BattleDeploymentMissionCont
     public override void OnMissionTick(float dt)
     {
         // Hold SetupTeams until the sides are sized. Gate on the handler's game-thread IsSized, not the suppliers'
-        // network-thread IsPopulated (which could read true mid-frame before Init has sized).
+        // network-thread IsPopulated (which could read true mid-frame before Init has sized). The handler bounds the
+        // wait with its own deadline, so IsSized always latches and this never defers SetupTeams indefinitely.
         if (_spawnHandler != null && !_spawnHandler.IsSized) return;
 
-        bool setupWasOver = TeamSetupOver;
         base.OnMissionTick(dt);
-
-        // Re-pause every agent when the deferred SetupTeams first completes. The joint re-Init enters SetupTeams
-        // with both sides spawn-active, so the first side's spawn puts the other side on the field before its own
-        // pause pass, and the native per-formation freeze can miss agents, which then drift once AI ticks. Skip if
-        // SetupTeams released the field outright (no Order of Battle).
-        if (!setupWasOver && TeamSetupOver && !base.Mission.AllowAiTicking)
-            FreezeDeployedAgents();
-    }
-
-    // The native deployment freeze applied over every agent, not just the ones each per-side pass covered.
-    private void FreezeDeployedAgents()
-    {
-        int def = 0, atk = 0;
-        foreach (Agent agent in base.Mission.Agents)
-        {
-            if (!agent.IsHuman || !agent.IsActive() || !agent.IsAIControlled) continue;
-            agent.SetAlarmState(Agent.AIStateFlag.None);
-            agent.SetIsAIPaused(isPaused: true);
-            if (agent.Team?.Side == BattleSideEnum.Defender) def++;
-            else if (agent.Team?.Side == BattleSideEnum.Attacker) atk++;
-        }
-        Logger.Information("[BattleSync] Deferred deployment freeze: re-paused Defender={Def}, Attacker={Atk} AI agents", def, atk);
     }
 }

--- a/source/Missions/Battles/CoopBattleDeploymentMissionController.cs
+++ b/source/Missions/Battles/CoopBattleDeploymentMissionController.cs
@@ -1,0 +1,48 @@
+using TaleWorlds.MountAndBlade;
+
+namespace Missions.Battles;
+
+/// <summary>
+/// Coop <see cref="BattleDeploymentMissionController"/> that holds the one-time team + player-command setup until
+/// <see cref="CoopBattleMissionSpawnHandler"/> has sized the sides. The native <see cref="DeploymentMissionController"/>
+/// runs <c>SetupTeams</c> on the first tick where the scene exists, with no troop-count gate. <c>SetupTeams</c> drives
+/// <c>OnSetupTeamsOfSide -&gt; DefaultBattleMissionAgentSpawnLogic.OnSideDeploymentOver -&gt; Mission.OnTeamDeployed -&gt;
+/// AssignPlayerRoleInTeamMissionController.OnTeamDeployed</c>, the sole grant of player command during deployment: the
+/// spawn logic's own re-fire is dead while <c>Mission.Mode == Deployment</c> because its <c>IsDeploymentOver</c> guard
+/// is always false there. In coop the owned reserve can land after that first tick, so the setup would run against
+/// empty teams with a null <c>Agent.Main</c> and latch the player commanding nothing.
+/// <para>
+/// Gating the tick on the spawn handler's <see cref="CoopBattleMissionSpawnHandler.IsSized"/> defers <c>SetupTeams</c>
+/// to the tick the handler jointly sized the sides. On that same tick the handler (earlier in the behavior list) has
+/// already re-run Init, so <c>SetupTeams -&gt; OnSetupTeamsOfSide(PlayerSide)</c> spawns our troops and hero — the hero
+/// becomes <c>Agent.Main</c> inside that synchronous <c>SetSpawnTroops(enforceSpawning)</c> call — before
+/// <c>OnTeamDeployed</c> grants command over the now-populated player formations. The on-time path is unchanged: the
+/// handler sizes in <c>AfterStart</c>, so the gate is already open on the first tick.
+/// </para>
+/// </summary>
+public class CoopBattleDeploymentMissionController : BattleDeploymentMissionController
+{
+    private CoopBattleMissionSpawnHandler _spawnHandler;
+
+    public CoopBattleDeploymentMissionController(bool isPlayerAttacker)
+        : base(isPlayerAttacker)
+    {
+    }
+
+    public override void OnBehaviorInitialize()
+    {
+        base.OnBehaviorInitialize();
+        _spawnHandler = base.Mission.GetMissionBehavior<CoopBattleMissionSpawnHandler>();
+    }
+
+    public override void OnMissionTick(float dt)
+    {
+        // Hold the native team/command setup until the handler has sized the sides. Gating on the handler's IsSized
+        // (set on the game thread after Init) rather than the suppliers' IsPopulated keeps setup strictly after
+        // sizing: IsPopulated flips on the network thread and could read true between the handler's tick and ours in
+        // the same frame, running SetupTeams against still-empty phases and latching the player onto no units.
+        if (_spawnHandler != null && !_spawnHandler.IsSized) return;
+
+        base.OnMissionTick(dt);
+    }
+}

--- a/source/Missions/Battles/CoopBattleDeploymentMissionController.cs
+++ b/source/Missions/Battles/CoopBattleDeploymentMissionController.cs
@@ -6,22 +6,12 @@ using TaleWorlds.MountAndBlade;
 namespace Missions.Battles;
 
 /// <summary>
-/// Coop <see cref="BattleDeploymentMissionController"/> that holds the one-time team + player-command setup until
-/// <see cref="CoopBattleMissionSpawnHandler"/> has sized the sides. The native <see cref="DeploymentMissionController"/>
-/// runs <c>SetupTeams</c> on the first tick where the scene exists, with no troop-count gate. <c>SetupTeams</c> drives
-/// <c>OnSetupTeamsOfSide -&gt; DefaultBattleMissionAgentSpawnLogic.OnSideDeploymentOver -&gt; Mission.OnTeamDeployed -&gt;
-/// AssignPlayerRoleInTeamMissionController.OnTeamDeployed</c>, the sole grant of player command during deployment: the
-/// spawn logic's own re-fire is dead while <c>Mission.Mode == Deployment</c> because its <c>IsDeploymentOver</c> guard
-/// is always false there. In coop the owned reserve can land after that first tick, so the setup would run against
-/// empty teams with a null <c>Agent.Main</c> and latch the player commanding nothing.
-/// <para>
-/// Gating the tick on the spawn handler's <see cref="CoopBattleMissionSpawnHandler.IsSized"/> defers <c>SetupTeams</c>
-/// to the tick the handler jointly sized the sides. On that same tick the handler (earlier in the behavior list) has
-/// already re-run Init, so <c>SetupTeams -&gt; OnSetupTeamsOfSide(PlayerSide)</c> spawns our troops and hero — the hero
-/// becomes <c>Agent.Main</c> inside that synchronous <c>SetSpawnTroops(enforceSpawning)</c> call — before
-/// <c>OnTeamDeployed</c> grants command over the now-populated player formations. The on-time path is unchanged: the
-/// handler sizes in <c>AfterStart</c>, so the gate is already open on the first tick.
-/// </para>
+/// Coop <see cref="BattleDeploymentMissionController"/> that defers the native one-time team/command setup
+/// (<c>SetupTeams</c>, which grants player command via <c>OnTeamDeployed</c>) until the spawn handler has sized the
+/// sides. Native runs it on the first tick regardless of troops; in coop a late reserve would run it against empty
+/// teams with a null <c>Agent.Main</c> and latch the player commanding nothing. Gating on
+/// <see cref="CoopBattleMissionSpawnHandler.IsSized"/> holds it until the troops and hero have spawned; the on-time
+/// path is unchanged (IsSized is already true on the first tick).
 /// </summary>
 public class CoopBattleDeploymentMissionController : BattleDeploymentMissionController
 {
@@ -42,31 +32,22 @@ public class CoopBattleDeploymentMissionController : BattleDeploymentMissionCont
 
     public override void OnMissionTick(float dt)
     {
-        // Hold the native team/command setup until the handler has sized the sides. Gating on the handler's IsSized
-        // (set on the game thread after Init) rather than the suppliers' IsPopulated keeps setup strictly after
-        // sizing: IsPopulated flips on the network thread and could read true between the handler's tick and ours in
-        // the same frame, running SetupTeams against still-empty phases and latching the player onto no units.
+        // Hold SetupTeams until the sides are sized. Gate on the handler's game-thread IsSized, not the suppliers'
+        // network-thread IsPopulated (which could read true mid-frame before Init has sized).
         if (_spawnHandler != null && !_spawnHandler.IsSized) return;
 
         bool setupWasOver = TeamSetupOver;
         base.OnMissionTick(dt);
 
-        // On the tick the deferred SetupTeams completes, re-assert the deployment AI-pause over every agent. Native
-        // freezes each side once, in SetupAgentAIStatesForSide, and only the agents already counted in a formation
-        // when its per-side pass runs. On the joint deferred re-Init path both sides' phases are enabled together
-        // (Init sets TroopSpawnActive for both), so the first side's enforced spawn puts the OTHER side's troops on
-        // the field before that side's own pause pass runs, and any agent a per-side pass doesn't cover keeps the
-        // isAlarmed state it spawned with and drifts the moment AI ticks. Pausing over Mission.Agents covers every
-        // deployed agent regardless of formation, so nothing is left un-paused until Start Battle. Skip when
-        // SetupTeams finished deployment outright (no Order of Battle) — that already released the field
-        // (AllowAiTicking is back on) and re-freezing would fight it. FinishDeployment un-pauses per agent later, so
-        // the Start-Battle release is unaffected; the hero is Controller.None (not IsAIControlled) so command holds.
+        // Re-pause every agent when the deferred SetupTeams first completes. The joint re-Init enters SetupTeams
+        // with both sides spawn-active, so the first side's spawn puts the other side on the field before its own
+        // pause pass, and the native per-formation freeze can miss agents, which then drift once AI ticks. Skip if
+        // SetupTeams released the field outright (no Order of Battle).
         if (!setupWasOver && TeamSetupOver && !base.Mission.AllowAiTicking)
             FreezeDeployedAgents();
     }
 
-    // Mirror of the native deployment freeze, applied to every agent rather than only the ones each per-side
-    // SetupAgentAIStatesForSide pass covered. One-shot on the setup-complete edge above.
+    // The native deployment freeze applied over every agent, not just the ones each per-side pass covered.
     private void FreezeDeployedAgents()
     {
         int def = 0, atk = 0;

--- a/source/Missions/Battles/CoopBattleMissionSpawnHandler.cs
+++ b/source/Missions/Battles/CoopBattleMissionSpawnHandler.cs
@@ -1,4 +1,4 @@
-using Common.Logging;
+﻿using Common.Logging;
 using GameInterface.Services.MapEvents.TroopSupply;
 using SandBox.Missions.MissionLogics;
 using Serilog;
@@ -47,24 +47,24 @@ public class CoopBattleMissionSpawnHandler : SandBoxMissionSpawnHandler
         _missionAgentSpawnLogic.SetSpawnHorses(BattleSideEnum.Defender, !_mapEvent.IsSiegeAssault);
         _missionAgentSpawnLogic.SetSpawnHorses(BattleSideEnum.Attacker, !_mapEvent.IsSiegeAssault);
 
-        var (defenderPopulated, attackerPopulated, defenderOwned, attackerOwned, decision) = ReadSizing();
+        var sizing = ReadSizing();
 
-        if (decision.Ready)
+        if (sizing.Ready)
         {
             // On-time (common): both reserves present, so size via Init before the first tick.
-            if (decision.SizeNow)
-                RunJointInit(defenderOwned, attackerOwned);
+            if (sizing.SizeNow)
+                RunJointInit(sizing.DefenderOwned, sizing.AttackerOwned);
             else
                 AddHeldPhases(); // both sides own nothing: keep phases so ticks don't NRE, spawn nothing
             _sized = true;
-            Logger.Information("[BattleSync] Coop spawn sized on start: Defender={Def}, Attacker={Atk}", defenderOwned, attackerOwned);
+            Logger.Information("[BattleSync] Coop spawn sized on start: Defender={Def}, Attacker={Atk}", sizing.DefenderOwned, sizing.AttackerOwned);
             return;
         }
 
         // A reserve is still in flight — hold both sides at zero until OnMissionTick sizes them (or the deadline).
         AddHeldPhases();
         Logger.Warning("[BattleSync] Coop spawn handler started before reserves arrived (Def populated={Def}, Atk populated={Atk}) — sizing on tick once both land",
-            defenderPopulated, attackerPopulated);
+            sizing.DefenderPopulated, sizing.AttackerPopulated);
     }
 
     // Size once both suppliers populate, then latch. If a reserve never lands, force-size with whatever arrived
@@ -76,33 +76,32 @@ public class CoopBattleMissionSpawnHandler : SandBoxMissionSpawnHandler
         if (_sized) return;
 
         _heldSeconds += dt;
-        var (defenderPopulated, attackerPopulated, defenderOwned, attackerOwned, decision) = ReadSizing();
-        if (!decision.Ready && _heldSeconds < ReserveHoldDeadlineSeconds) return;
+        var sizing = ReadSizing();
+        if (!sizing.Ready && _heldSeconds < ReserveHoldDeadlineSeconds) return;
 
         // Ready, or the deadline expired with a partial/missing reserve. Size with what landed when anything did
         // (a positive total keeps Init off its 0/0 split); if nothing landed, leave the held zero phases — latching
         // still lets the deployment controller run SetupTeams so the client isn't stuck on the loading screen.
-        if (defenderOwned + attackerOwned > 0)
-            RunJointInit(defenderOwned, attackerOwned);
+        if (sizing.DefenderOwned + sizing.AttackerOwned > 0)
+            RunJointInit(sizing.DefenderOwned, sizing.AttackerOwned);
 
-        if (decision.Ready)
-            Logger.Information("[BattleSync] Reserves landed after start; sized sides jointly: Defender={Def}, Attacker={Atk}", defenderOwned, attackerOwned);
+        if (sizing.Ready)
+            Logger.Information("[BattleSync] Reserves landed after start; sized sides jointly: Defender={Def}, Attacker={Atk}", sizing.DefenderOwned, sizing.AttackerOwned);
         else
             Logger.Warning("[BattleSync] Reserves incomplete after {Sec}s hold (Def populated={DefP}, Atk populated={AtkP}) — sizing with what landed: Defender={Def}, Attacker={Atk}",
-                ReserveHoldDeadlineSeconds, defenderPopulated, attackerPopulated, defenderOwned, attackerOwned);
+                ReserveHoldDeadlineSeconds, sizing.DefenderPopulated, sizing.AttackerPopulated, sizing.DefenderOwned, sizing.AttackerOwned);
         _sized = true;
     }
 
-    // Read the suppliers (populated before owned so the pair can't tear: SetReserve commits the entries then flips
-    // populated under one lock) and compute the joint sizing decision. Shared by AfterStart and OnMissionTick.
-    private (bool defenderPopulated, bool attackerPopulated, int defenderOwned, int attackerOwned, JointSizingDecision decision) ReadSizing()
+    // Snapshot both suppliers into a SideSizing. Read populated before owned so the pair can't tear: SetReserve
+    // commits the entries then flips populated under one lock. Shared by AfterStart and OnMissionTick.
+    private SideSizing ReadSizing()
     {
         bool defenderPopulated = _defenderSupplier.IsPopulated;
         bool attackerPopulated = _attackerSupplier.IsPopulated;
         int defenderOwned = _defenderSupplier.TotalTroops;
         int attackerOwned = _attackerSupplier.TotalTroops;
-        return (defenderPopulated, attackerPopulated, defenderOwned, attackerOwned,
-            DecideJointSizing(defenderPopulated, attackerPopulated, defenderOwned, attackerOwned));
+        return new SideSizing(defenderPopulated, attackerPopulated, defenderOwned, attackerOwned);
     }
 
     // Re-run the engine's Init with the real totals (initial == total; Init applies the joint cap, wave split and
@@ -131,26 +130,29 @@ public class CoopBattleMissionSpawnHandler : SandBoxMissionSpawnHandler
     }
 
     /// <summary>
-    /// Pure sizing decision (unit-testable). Ready = both reserves landed; SizeNow additionally requires a positive
-    /// combined total, so Init is never handed a 0/0 battle-size split.
+    /// Snapshot of both suppliers plus the joint sizing derived from it (unit-testable — pure over its readings).
+    /// Ready = both reserves landed; SizeNow additionally requires a positive combined total, so Init is never
+    /// handed a 0/0 battle-size split.
     /// </summary>
-    public static JointSizingDecision DecideJointSizing(bool defenderPopulated, bool attackerPopulated, int defenderOwned, int attackerOwned)
+    public readonly struct SideSizing
     {
-        bool ready = defenderPopulated && attackerPopulated;
-        return new JointSizingDecision(ready, ready && defenderOwned + attackerOwned > 0);
-    }
+        public readonly bool DefenderPopulated;
+        public readonly bool AttackerPopulated;
+        public readonly int DefenderOwned;
+        public readonly int AttackerOwned;
 
-    public readonly struct JointSizingDecision
-    {
-        // Both reserves landed: commit the joint sizing now (else keep holding both sides at zero).
-        public readonly bool Ready;
-        // Ready and at least one side owns troops: run the real Init (a positive sum avoids Init's 0/0 NaN).
-        public readonly bool SizeNow;
-
-        public JointSizingDecision(bool ready, bool sizeNow)
+        public SideSizing(bool defenderPopulated, bool attackerPopulated, int defenderOwned, int attackerOwned)
         {
-            Ready = ready;
-            SizeNow = sizeNow;
+            DefenderPopulated = defenderPopulated;
+            AttackerPopulated = attackerPopulated;
+            DefenderOwned = defenderOwned;
+            AttackerOwned = attackerOwned;
         }
+
+        // Both reserves landed: commit the joint sizing now (else keep holding both sides at zero).
+        public bool Ready => DefenderPopulated && AttackerPopulated;
+
+        // Ready and at least one side owns troops: run the real Init (a positive sum avoids Init's 0/0 NaN).
+        public bool SizeNow => Ready && DefenderOwned + AttackerOwned > 0;
     }
 }

--- a/source/Missions/Battles/CoopBattleMissionSpawnHandler.cs
+++ b/source/Missions/Battles/CoopBattleMissionSpawnHandler.cs
@@ -8,23 +8,11 @@ using TaleWorlds.MountAndBlade;
 namespace Missions.Battles;
 
 /// <summary>
-/// Coop replacement for <see cref="SandBoxBattleMissionSpawnHandler"/>. The native handler sizes each side
-/// from <c>MapEvent.GetNumberOfInvolvedMen(side)</c> — the FULL side — and feeds that to the spawn logic,
-/// which then refuses to spawn a side until that many troops are reserved from the side's single supplier.
-/// In coop each client supplies only the troops it OWNS (its own party; plus the AI/enemy side for the host),
-/// so the full count is never reached and the side never spawns (the 22-vs-7 deadlock). This handler instead
-/// sizes each side to exactly what THIS client's supplier provides, so the client fields its own troops at
-/// once; every other party's troops arrive as puppets broadcast by their owner.
-/// <para>
-/// Reserves arrive on a separate network round trip from the mission-open message (both sides in one batch), so
-/// they can land after the mission is built. Because the engine's battle-size cap and reinforcement-wave split
-/// are JOINT — one side's initial budget depends on the other side's total — this sizes both sides in a single
-/// pass, and only once BOTH reserves are populated. If both are ready at <see cref="AfterStart"/> (the on-time
-/// path) it sizes immediately; otherwise both sides are held at zero (a zero-initial phase spawns nothing) until
-/// <see cref="OnMissionTick"/> sees both land and runs the engine's own Init once — so a late side ends up
-/// identical to an on-time one (same cap, same waves, same agent counts). The deployment controller decides WHEN
-/// the sized troops spawn (frozen during deployment, released on Start Battle).
-/// </para>
+/// Coop replacement for <see cref="SandBoxBattleMissionSpawnHandler"/>: sizes each side to what THIS client's
+/// supplier owns (its party, plus the AI/enemy side for the host), not the full side the native handler waits on
+/// and never fills. The engine's battle-size cap and wave split are joint across both sides, so both are sized in
+/// one pass once both reserves land: at <see cref="AfterStart"/> if already present, else held at zero until
+/// <see cref="OnMissionTick"/> sees them, so a late side ends up identical to an on-time one.
 /// </summary>
 public class CoopBattleMissionSpawnHandler : SandBoxMissionSpawnHandler
 {
@@ -33,15 +21,11 @@ public class CoopBattleMissionSpawnHandler : SandBoxMissionSpawnHandler
     private readonly CoopTroopSupplier _defenderSupplier;
     private readonly CoopTroopSupplier _attackerSupplier;
 
-    // The joint battle-size cap and reinforcement-wave split depend on BOTH sides' totals, so we size once, when
-    // both reserves have landed. Until then both sides are held at zero (a zero-initial phase spawns nothing) and
-    // this stays false; OnMissionTick runs the single joint Init the moment both are populated, then latches.
+    // Latched once the sides are sized jointly; both are held at zero until then.
     private bool _sized;
 
-    // Set on the game thread right after the joint sizing commits. CoopBattleDeploymentMissionController gates its
-    // one-time team/command setup on this so that setup runs only once the sides are sized. A raw supplier
-    // IsPopulated check wouldn't be safe there: SetReserve flips populated on the network thread, so it can read
-    // true between this handler's tick and the controller's tick in the same frame, before Init has sized.
+    // Gated on by CoopBattleDeploymentMissionController: a game-thread latch, not the suppliers' network-thread
+    // IsPopulated (which could read true mid-frame before Init has actually sized).
     public bool IsSized => _sized;
 
     public CoopBattleMissionSpawnHandler(CoopTroopSupplier defenderSupplier, CoopTroopSupplier attackerSupplier)
@@ -55,8 +39,7 @@ public class CoopBattleMissionSpawnHandler : SandBoxMissionSpawnHandler
         _missionAgentSpawnLogic.SetSpawnHorses(BattleSideEnum.Defender, !_mapEvent.IsSiegeAssault);
         _missionAgentSpawnLogic.SetSpawnHorses(BattleSideEnum.Attacker, !_mapEvent.IsSiegeAssault);
 
-        // Read populated before owned so the pair can't tear: SetReserve commits a side's entries and only then
-        // flips populated (both under one lock), so once populated reads true a later TotalTroops read sees them.
+        // Read populated before owned: SetReserve sets the entries then flips populated under one lock.
         bool defenderPopulated = _defenderSupplier.IsPopulated;
         bool attackerPopulated = _attackerSupplier.IsPopulated;
         int defenderOwned = _defenderSupplier.TotalTroops;
@@ -65,35 +48,30 @@ public class CoopBattleMissionSpawnHandler : SandBoxMissionSpawnHandler
 
         if (decision.Ready)
         {
-            // On-time (the common path): both reserves landed during scene load, so let the engine's own Init do
-            // the battle-size cap, wave staging and agent-count setup before the first tick.
+            // On-time (common): both reserves present, so size via Init before the first tick.
             if (decision.SizeNow)
                 RunJointInit(defenderOwned, attackerOwned);
             else
-                AddHeldPhases(); // both sides own nothing (defensive): keep phases so ticks don't NRE, spawn nothing
+                AddHeldPhases(); // both sides own nothing: keep phases so ticks don't NRE, spawn nothing
             _sized = true;
             Logger.Information("[BattleSync] Coop spawn sized on start: Defender={Def}, Attacker={Atk}", defenderOwned, attackerOwned);
             return;
         }
 
-        // A reserve is still in flight. Hold BOTH sides at zero (so neither spawns against a not-yet-known enemy
-        // total) with harmless zero phases the first CheckDeployment tick can read; OnMissionTick sizes once both land.
+        // A reserve is still in flight — hold both sides at zero until OnMissionTick sizes them.
         AddHeldPhases();
         Logger.Warning("[BattleSync] Coop spawn handler started before reserves arrived (Def populated={Def}, Atk populated={Atk}) — sizing on tick once both land",
             defenderPopulated, attackerPopulated);
     }
 
-    // Once both suppliers are populated, run the single joint Init. Runs on the game thread (after AfterStart, so
-    // placeholder phases exist), reading the suppliers' lock-guarded getters that the network-thread SetReserve
-    // writes — no callback or marshaling. Latches after the first sizing; a mid-battle migration re-feed (which
-    // re-populates an already-sized supplier) is left to the adopt/puppet path.
+    // Run the single joint Init once both suppliers populate, then latch. A mid-battle migration re-feed
+    // re-populates an already-sized supplier and is left to the adopt path.
     public override void OnMissionTick(float dt)
     {
         base.OnMissionTick(dt);
         if (_sized) return;
 
-        // Read populated before owned, same reason as AfterStart: reading owned first could tear and latch a
-        // populated side as empty, stranding its troops because _sized then blocks any re-read.
+        // Populated before owned, as in AfterStart.
         bool defenderPopulated = _defenderSupplier.IsPopulated;
         bool attackerPopulated = _attackerSupplier.IsPopulated;
         int defenderOwned = _defenderSupplier.TotalTroops;
@@ -109,11 +87,9 @@ public class CoopBattleMissionSpawnHandler : SandBoxMissionSpawnHandler
         _sized = true;
     }
 
-    // Size both sides in one shot by re-running the engine's own Init with the real owned totals (initial == total;
-    // Init applies the joint battle-size cap and moves the excess into wave-staged RemainingSpawnNumber, and sets
-    // the Mission agent counts). Clearing the (empty or placeholder) phases and running totals first is required
-    // because InitWithSinglePhase APPENDS a phase per side — a leftover placeholder would leave two active phases.
-    // Nothing has spawned while the sides were held at zero, so this cannot double-spawn.
+    // Re-run the engine's Init with the real totals (initial == total; Init applies the joint cap, wave split and
+    // agent counts). Clear the placeholder phases/totals first — InitWithSinglePhase appends. Nothing spawned while
+    // held, so no double-spawn.
     private void RunJointInit(int defenderOwned, int attackerOwned)
     {
         _missionAgentSpawnLogic._phases[(int)BattleSideEnum.Defender].Clear();
@@ -124,17 +100,14 @@ public class CoopBattleMissionSpawnHandler : SandBoxMissionSpawnHandler
         var settings = CreateSandBoxBattleWaveSpawnSettings();
         _missionAgentSpawnLogic.InitWithSinglePhase(defenderOwned, attackerOwned, defenderOwned, attackerOwned, spawnDefenders: true, spawnAttackers: true, in settings);
 
-        // Init's tail leaves both sides' TroopSpawnActive true. On the on-time path the deployment controller's
-        // OnAfterStart runs after this and clears them, so SetupTeams enables, spawns and AI-pauses each side one at
-        // a time. On this deferred path nothing runs after us to clear them, so the first OnSetupTeamsOfSide would
-        // spawn BOTH sides at once and the per-side freeze could miss the other side. Restore the native invariant.
+        // Init leaves both sides spawn-active; the native path clears them after Init but nothing does here, so
+        // restore it — else SetupTeams's first side spawns both at once and the per-side freeze misses one.
         _missionAgentSpawnLogic.SetSpawnTroops(BattleSideEnum.Defender, spawnTroops: false);
         _missionAgentSpawnLogic.SetSpawnTroops(BattleSideEnum.Attacker, spawnTroops: false);
     }
 
-    // Zero phases so the first CheckDeployment tick has active phases to read (else DefenderActivePhase NREs)
-    // without calling Init on a 0/0 total, whose battle-size split divides by zero and (via MathF.Ceiling on NaN
-    // under Mono) yields a negative agent-count sentinel.
+    // Zero phases so the first tick has active phases to read (else DefenderActivePhase NREs), without feeding Init
+    // a 0/0 total (its battle-size split divides by zero, giving a negative sentinel under Mono).
     private void AddHeldPhases()
     {
         _missionAgentSpawnLogic._phases[(int)BattleSideEnum.Defender].Add(new MissionSpawnPhase());
@@ -142,10 +115,8 @@ public class CoopBattleMissionSpawnHandler : SandBoxMissionSpawnHandler
     }
 
     /// <summary>
-    /// Pure sizing decision, split out so it is unit-testable without a live mission. <see cref="JointSizingDecision.Ready"/>
-    /// is true once both reserves have landed (both suppliers populated) — the point at which both totals are final and the
-    /// joint cap can be computed. <see cref="JointSizingDecision.SizeNow"/> additionally requires a positive combined total,
-    /// so we never hand the engine's Init a 0/0 battle-size split.
+    /// Pure sizing decision (unit-testable). Ready = both reserves landed; SizeNow additionally requires a positive
+    /// combined total, so Init is never handed a 0/0 battle-size split.
     /// </summary>
     public static JointSizingDecision DecideJointSizing(bool defenderPopulated, bool attackerPopulated, int defenderOwned, int attackerOwned)
     {
@@ -155,9 +126,9 @@ public class CoopBattleMissionSpawnHandler : SandBoxMissionSpawnHandler
 
     public readonly struct JointSizingDecision
     {
-        // Both reserves have landed: commit the joint sizing now (else keep holding both sides at zero).
+        // Both reserves landed: commit the joint sizing now (else keep holding both sides at zero).
         public readonly bool Ready;
-        // Ready AND at least one side owns troops: run the real Init (a positive sum avoids Init's 0/0 NaN).
+        // Ready and at least one side owns troops: run the real Init (a positive sum avoids Init's 0/0 NaN).
         public readonly bool SizeNow;
 
         public JointSizingDecision(bool ready, bool sizeNow)

--- a/source/Missions/Battles/CoopBattleMissionSpawnHandler.cs
+++ b/source/Missions/Battles/CoopBattleMissionSpawnHandler.cs
@@ -2,7 +2,6 @@ using Common.Logging;
 using GameInterface.Services.MapEvents.TroopSupply;
 using SandBox.Missions.MissionLogics;
 using Serilog;
-using System;
 using TaleWorlds.Core;
 using TaleWorlds.MountAndBlade;
 
@@ -17,12 +16,14 @@ namespace Missions.Battles;
 /// sizes each side to exactly what THIS client's supplier provides, so the client fields its own troops at
 /// once; every other party's troops arrive as puppets broadcast by their owner.
 /// <para>
-/// The reserve arrives on a separate network round trip from the mission-open message, so a side can be sized
-/// before its reserve lands — <see cref="AfterStart"/> then sizes it to zero and it would never spawn.
-/// <see cref="OnMissionTick"/> polls each such side and grows its spawn phase to the owned total once the
-/// reserve arrives, so the side ends up correct no matter how the two messages interleave. Initial == total
-/// (no staged reinforcement waves); the deployment controller decides WHEN the sized troops spawn (frozen
-/// during deployment, released on Start Battle).
+/// Reserves arrive on a separate network round trip from the mission-open message (both sides in one batch), so
+/// they can land after the mission is built. Because the engine's battle-size cap and reinforcement-wave split
+/// are JOINT — one side's initial budget depends on the other side's total — this sizes both sides in a single
+/// pass, and only once BOTH reserves are populated. If both are ready at <see cref="AfterStart"/> (the on-time
+/// path) it sizes immediately; otherwise both sides are held at zero (a zero-initial phase spawns nothing) until
+/// <see cref="OnMissionTick"/> sees both land and runs the engine's own Init once — so a late side ends up
+/// identical to an on-time one (same cap, same waves, same agent counts). The deployment controller decides WHEN
+/// the sized troops spawn (frozen during deployment, released on Start Battle).
 /// </para>
 /// </summary>
 public class CoopBattleMissionSpawnHandler : SandBoxMissionSpawnHandler
@@ -32,11 +33,10 @@ public class CoopBattleMissionSpawnHandler : SandBoxMissionSpawnHandler
     private readonly CoopTroopSupplier _defenderSupplier;
     private readonly CoopTroopSupplier _attackerSupplier;
 
-    // A side whose reserve had not arrived when AfterStart sized it (sized to zero) stays pending until its
-    // reserve lands and OnMissionTick grows the spawn phase. A side sized to a real count is never pending, so
-    // a healthy side (and any battle-size distribution the native Init applied to it) is left untouched.
-    private bool _defenderReservePending;
-    private bool _attackerReservePending;
+    // The joint battle-size cap and reinforcement-wave split depend on BOTH sides' totals, so we size once, when
+    // both reserves have landed. Until then both sides are held at zero (a zero-initial phase spawns nothing) and
+    // this stays false; OnMissionTick runs the single joint Init the moment both are populated, then latches.
+    private bool _sized;
 
     public CoopBattleMissionSpawnHandler(CoopTroopSupplier defenderSupplier, CoopTroopSupplier attackerSupplier)
     {
@@ -46,88 +46,111 @@ public class CoopBattleMissionSpawnHandler : SandBoxMissionSpawnHandler
 
     public override void AfterStart()
     {
-        int defenderOwned = _defenderSupplier.TotalTroops;
-        int attackerOwned = _attackerSupplier.TotalTroops;
-
-        if (!_defenderSupplier.IsPopulated || !_attackerSupplier.IsPopulated)
-            Logger.Warning("[BattleSync] Coop spawn handler started before reserves arrived (Def populated={Def}, Atk populated={Atk}) — resizing on tick once they land",
-                _defenderSupplier.IsPopulated, _attackerSupplier.IsPopulated);
-
         _missionAgentSpawnLogic.SetSpawnHorses(BattleSideEnum.Defender, !_mapEvent.IsSiegeAssault);
         _missionAgentSpawnLogic.SetSpawnHorses(BattleSideEnum.Attacker, !_mapEvent.IsSiegeAssault);
 
-        // initial == total: size the whole owned set as one (no staged reinforcement waves). The deployment
-        // controller gates when these actually spawn — frozen in formation during deployment, released on
-        // Start Battle (FinishDeployment).
-        var settings = CreateSandBoxBattleWaveSpawnSettings();
-        _missionAgentSpawnLogic.InitWithSinglePhase(defenderOwned, attackerOwned, defenderOwned, attackerOwned, spawnDefenders: true, spawnAttackers: true, in settings);
+        // Read populated before owned so the pair can't tear: SetReserve commits a side's entries and only then
+        // flips populated (both under one lock), so once populated reads true a later TotalTroops read sees them.
+        bool defenderPopulated = _defenderSupplier.IsPopulated;
+        bool attackerPopulated = _attackerSupplier.IsPopulated;
+        int defenderOwned = _defenderSupplier.TotalTroops;
+        int attackerOwned = _attackerSupplier.TotalTroops;
+        var decision = DecideJointSizing(defenderPopulated, attackerPopulated, defenderOwned, attackerOwned);
 
-        // A side sized to zero here had no reserve yet; grow it on tick once the reserve arrives. A side sized
-        // to a real count is final (the reserve replaces the whole owned set in one SetReserve), so it is not pending.
-        _defenderReservePending = defenderOwned == 0;
-        _attackerReservePending = attackerOwned == 0;
+        if (decision.Ready)
+        {
+            // On-time (the common path): both reserves landed during scene load, so let the engine's own Init do
+            // the battle-size cap, wave staging and agent-count setup before the first tick.
+            if (decision.SizeNow)
+                RunJointInit(defenderOwned, attackerOwned);
+            else
+                AddHeldPhases(); // both sides own nothing (defensive): keep phases so ticks don't NRE, spawn nothing
+            _sized = true;
+            Logger.Information("[BattleSync] Coop spawn sized on start: Defender={Def}, Attacker={Atk}", defenderOwned, attackerOwned);
+            return;
+        }
 
-        Logger.Information("[BattleSync] Coop spawn sized to owned counts: Defender={Def}, Attacker={Atk}", defenderOwned, attackerOwned);
+        // A reserve is still in flight. Hold BOTH sides at zero (so neither spawns against a not-yet-known enemy
+        // total) with harmless zero phases the first CheckDeployment tick can read; OnMissionTick sizes once both land.
+        AddHeldPhases();
+        Logger.Warning("[BattleSync] Coop spawn handler started before reserves arrived (Def populated={Def}, Atk populated={Atk}) — sizing on tick once both land",
+            defenderPopulated, attackerPopulated);
     }
 
-    // Grow a side whose reserve landed after AfterStart sized it to zero. Runs on the game thread (after
-    // AfterStart, so the phases exist), reading the supplier's lock-guarded getters that the network-thread
-    // SetReserve writes — no callback or marshaling. Each side latches once settled, so a mid-battle migration
-    // re-feed (which grows a supplier that is already populated) is left to the adopt/puppet path.
+    // Once both suppliers are populated, run the single joint Init. Runs on the game thread (after AfterStart, so
+    // placeholder phases exist), reading the suppliers' lock-guarded getters that the network-thread SetReserve
+    // writes — no callback or marshaling. Latches after the first sizing; a mid-battle migration re-feed (which
+    // re-populates an already-sized supplier) is left to the adopt/puppet path.
     public override void OnMissionTick(float dt)
     {
         base.OnMissionTick(dt);
+        if (_sized) return;
 
-        if (_defenderReservePending)
-            _defenderReservePending = TryResolvePendingSide(BattleSideEnum.Defender, _defenderSupplier, _missionAgentSpawnLogic.DefenderActivePhase);
-        if (_attackerReservePending)
-            _attackerReservePending = TryResolvePendingSide(BattleSideEnum.Attacker, _attackerSupplier, _missionAgentSpawnLogic.AttackerActivePhase);
-    }
+        // Read populated before owned, same reason as AfterStart: reading owned first could tear and latch a
+        // populated side as empty, stranding its troops because _sized then blocks any re-read.
+        bool defenderPopulated = _defenderSupplier.IsPopulated;
+        bool attackerPopulated = _attackerSupplier.IsPopulated;
+        int defenderOwned = _defenderSupplier.TotalTroops;
+        int attackerOwned = _attackerSupplier.TotalTroops;
+        var decision = DecideJointSizing(defenderPopulated, attackerPopulated, defenderOwned, attackerOwned);
+        if (!decision.Ready) return;
 
-    // Returns whether the side is still pending. Once the supplier is populated the side settles: if it owns
-    // troops the phase is grown to the owned total (CheckDeployment then reserves and spawns the difference),
-    // and an empty non-owned side just settles with no growth (its troops arrive as puppets).
-    private bool TryResolvePendingSide(BattleSideEnum side, CoopTroopSupplier supplier, MissionSpawnPhase phase)
-    {
-        var (stillPending, resize, newTotal) = ResolvePendingSide(supplier.IsPopulated, supplier.TotalTroops);
-        if (resize)
+        if (decision.SizeNow)
         {
-            if (phase == null) return true; // phase not built yet (not expected after AfterStart) — retry next tick
-            GrowSide(side, phase, newTotal);
+            RunJointInit(defenderOwned, attackerOwned);
+            Logger.Information("[BattleSync] Reserves landed after start; sized sides jointly: Defender={Def}, Attacker={Atk}", defenderOwned, attackerOwned);
         }
-        return stillPending;
+        _sized = true;
     }
 
-    private void GrowSide(BattleSideEnum side, MissionSpawnPhase phase, int ownedTotal)
+    // Size both sides in one shot by re-running the engine's own Init with the real owned totals (initial == total;
+    // Init applies the joint battle-size cap and moves the excess into wave-staged RemainingSpawnNumber, and sets
+    // the Mission agent counts). Clearing the (empty or placeholder) phases and running totals first is required
+    // because InitWithSinglePhase APPENDS a phase per side — a leftover placeholder would leave two active phases.
+    // Nothing has spawned while the sides were held at zero, so this cannot double-spawn.
+    private void RunJointInit(int defenderOwned, int attackerOwned)
     {
-        // Native Init sizes the phase AND the Mission's agent counts together; it sized this side to zero, so
-        // mirror both here (_numberOfTroopsInTotal is the reported side strength; the two agent counts feed the
-        // casualty-ratio morale model, which otherwise stays at a zero ratio). The battle count is the min of
-        // both sides' totals, so a non-owned empty side keeps it at zero, as native Init does on the on-time path.
-        _missionAgentSpawnLogic._numberOfTroopsInTotal[(int)side] += ownedTotal - phase.TotalSpawnNumber;
-        phase.TotalSpawnNumber = ownedTotal;
-        phase.InitialSpawnNumber = ownedTotal;
-        phase.RemainingSpawnNumber = 0;
+        _missionAgentSpawnLogic._phases[(int)BattleSideEnum.Defender].Clear();
+        _missionAgentSpawnLogic._phases[(int)BattleSideEnum.Attacker].Clear();
+        _missionAgentSpawnLogic._numberOfTroopsInTotal[(int)BattleSideEnum.Defender] = 0;
+        _missionAgentSpawnLogic._numberOfTroopsInTotal[(int)BattleSideEnum.Attacker] = 0;
 
-        Mission.SetInitialAgentCountForSide(side, ownedTotal);
-        // Assign the battle count directly rather than via SetBattleAgentCount: when both sides start empty, Init's
-        // 0/0 battle-size split can leave it at a negative sentinel, and that setter only lowers or replaces zero,
-        // so it could not raise it back.
-        Mission._agentCount = Math.Min(
-            _missionAgentSpawnLogic.DefenderActivePhase.TotalSpawnNumber,
-            _missionAgentSpawnLogic.AttackerActivePhase.TotalSpawnNumber);
+        var settings = CreateSandBoxBattleWaveSpawnSettings();
+        _missionAgentSpawnLogic.InitWithSinglePhase(defenderOwned, attackerOwned, defenderOwned, attackerOwned, spawnDefenders: true, spawnAttackers: true, in settings);
+    }
 
-        Logger.Information("[BattleSync] {Side} reserve arrived after sizing; grew spawn to {Count}", side, ownedTotal);
+    // Zero phases so the first CheckDeployment tick has active phases to read (else DefenderActivePhase NREs)
+    // without calling Init on a 0/0 total, whose battle-size split divides by zero and (via MathF.Ceiling on NaN
+    // under Mono) yields a negative agent-count sentinel.
+    private void AddHeldPhases()
+    {
+        _missionAgentSpawnLogic._phases[(int)BattleSideEnum.Defender].Add(new MissionSpawnPhase());
+        _missionAgentSpawnLogic._phases[(int)BattleSideEnum.Attacker].Add(new MissionSpawnPhase());
     }
 
     /// <summary>
-    /// Pure per-tick decision for a pending side, split out so it is unit-testable without a live mission. While
-    /// the reserve has not arrived (<paramref name="populated"/> false) the side stays pending. Once it has, the
-    /// side settles; a resize is requested only when the owned total is positive (an empty non-owned side reports
-    /// zero and is left for puppet spawns).
+    /// Pure sizing decision, split out so it is unit-testable without a live mission. <see cref="JointSizingDecision.Ready"/>
+    /// is true once both reserves have landed (both suppliers populated) — the point at which both totals are final and the
+    /// joint cap can be computed. <see cref="JointSizingDecision.SizeNow"/> additionally requires a positive combined total,
+    /// so we never hand the engine's Init a 0/0 battle-size split.
     /// </summary>
-    public static (bool stillPending, bool resize, int newTotal) ResolvePendingSide(bool populated, int ownedTotal)
+    public static JointSizingDecision DecideJointSizing(bool defenderPopulated, bool attackerPopulated, int defenderOwned, int attackerOwned)
     {
-        return (stillPending: !populated, resize: populated && ownedTotal > 0, newTotal: ownedTotal);
+        bool ready = defenderPopulated && attackerPopulated;
+        return new JointSizingDecision(ready, ready && defenderOwned + attackerOwned > 0);
+    }
+
+    public readonly struct JointSizingDecision
+    {
+        // Both reserves have landed: commit the joint sizing now (else keep holding both sides at zero).
+        public readonly bool Ready;
+        // Ready AND at least one side owns troops: run the real Init (a positive sum avoids Init's 0/0 NaN).
+        public readonly bool SizeNow;
+
+        public JointSizingDecision(bool ready, bool sizeNow)
+        {
+            Ready = ready;
+            SizeNow = sizeNow;
+        }
     }
 }

--- a/source/Missions/Battles/CoopBattleMissionSpawnHandler.cs
+++ b/source/Missions/Battles/CoopBattleMissionSpawnHandler.cs
@@ -2,7 +2,9 @@ using Common.Logging;
 using GameInterface.Services.MapEvents.TroopSupply;
 using SandBox.Missions.MissionLogics;
 using Serilog;
+using System;
 using TaleWorlds.Core;
+using TaleWorlds.MountAndBlade;
 
 namespace Missions.Battles;
 
@@ -15,9 +17,12 @@ namespace Missions.Battles;
 /// sizes each side to exactly what THIS client's supplier provides, so the client fields its own troops at
 /// once; every other party's troops arrive as puppets broadcast by their owner.
 /// <para>
-/// Relies on the reserve being fed before the mission starts (bundled into the mission-start message), so the
-/// suppliers are populated by <see cref="AfterStart"/>. Initial == total (no staged reinforcement waves); the
-/// deployment controller decides WHEN the sized troops spawn (frozen during deployment, released on Start Battle).
+/// The reserve arrives on a separate network round trip from the mission-open message, so a side can be sized
+/// before its reserve lands — <see cref="AfterStart"/> then sizes it to zero and it would never spawn.
+/// <see cref="OnMissionTick"/> polls each such side and grows its spawn phase to the owned total once the
+/// reserve arrives, so the side ends up correct no matter how the two messages interleave. Initial == total
+/// (no staged reinforcement waves); the deployment controller decides WHEN the sized troops spawn (frozen
+/// during deployment, released on Start Battle).
 /// </para>
 /// </summary>
 public class CoopBattleMissionSpawnHandler : SandBoxMissionSpawnHandler
@@ -26,6 +31,12 @@ public class CoopBattleMissionSpawnHandler : SandBoxMissionSpawnHandler
 
     private readonly CoopTroopSupplier _defenderSupplier;
     private readonly CoopTroopSupplier _attackerSupplier;
+
+    // A side whose reserve had not arrived when AfterStart sized it (sized to zero) stays pending until its
+    // reserve lands and OnMissionTick grows the spawn phase. A side sized to a real count is never pending, so
+    // a healthy side (and any battle-size distribution the native Init applied to it) is left untouched.
+    private bool _defenderReservePending;
+    private bool _attackerReservePending;
 
     public CoopBattleMissionSpawnHandler(CoopTroopSupplier defenderSupplier, CoopTroopSupplier attackerSupplier)
     {
@@ -39,7 +50,7 @@ public class CoopBattleMissionSpawnHandler : SandBoxMissionSpawnHandler
         int attackerOwned = _attackerSupplier.TotalTroops;
 
         if (!_defenderSupplier.IsPopulated || !_attackerSupplier.IsPopulated)
-            Logger.Warning("[BattleSync] Coop spawn handler started before reserves arrived (Def populated={Def}, Atk populated={Atk}) — sizing may be wrong",
+            Logger.Warning("[BattleSync] Coop spawn handler started before reserves arrived (Def populated={Def}, Atk populated={Atk}) — resizing on tick once they land",
                 _defenderSupplier.IsPopulated, _attackerSupplier.IsPopulated);
 
         _missionAgentSpawnLogic.SetSpawnHorses(BattleSideEnum.Defender, !_mapEvent.IsSiegeAssault);
@@ -51,6 +62,72 @@ public class CoopBattleMissionSpawnHandler : SandBoxMissionSpawnHandler
         var settings = CreateSandBoxBattleWaveSpawnSettings();
         _missionAgentSpawnLogic.InitWithSinglePhase(defenderOwned, attackerOwned, defenderOwned, attackerOwned, spawnDefenders: true, spawnAttackers: true, in settings);
 
+        // A side sized to zero here had no reserve yet; grow it on tick once the reserve arrives. A side sized
+        // to a real count is final (the reserve replaces the whole owned set in one SetReserve), so it is not pending.
+        _defenderReservePending = defenderOwned == 0;
+        _attackerReservePending = attackerOwned == 0;
+
         Logger.Information("[BattleSync] Coop spawn sized to owned counts: Defender={Def}, Attacker={Atk}", defenderOwned, attackerOwned);
+    }
+
+    // Grow a side whose reserve landed after AfterStart sized it to zero. Runs on the game thread (after
+    // AfterStart, so the phases exist), reading the supplier's lock-guarded getters that the network-thread
+    // SetReserve writes — no callback or marshaling. Each side latches once settled, so a mid-battle migration
+    // re-feed (which grows a supplier that is already populated) is left to the adopt/puppet path.
+    public override void OnMissionTick(float dt)
+    {
+        base.OnMissionTick(dt);
+
+        if (_defenderReservePending)
+            _defenderReservePending = TryResolvePendingSide(BattleSideEnum.Defender, _defenderSupplier, _missionAgentSpawnLogic.DefenderActivePhase);
+        if (_attackerReservePending)
+            _attackerReservePending = TryResolvePendingSide(BattleSideEnum.Attacker, _attackerSupplier, _missionAgentSpawnLogic.AttackerActivePhase);
+    }
+
+    // Returns whether the side is still pending. Once the supplier is populated the side settles: if it owns
+    // troops the phase is grown to the owned total (CheckDeployment then reserves and spawns the difference),
+    // and an empty non-owned side just settles with no growth (its troops arrive as puppets).
+    private bool TryResolvePendingSide(BattleSideEnum side, CoopTroopSupplier supplier, MissionSpawnPhase phase)
+    {
+        var (stillPending, resize, newTotal) = ResolvePendingSide(supplier.IsPopulated, supplier.TotalTroops);
+        if (resize)
+        {
+            if (phase == null) return true; // phase not built yet (not expected after AfterStart) — retry next tick
+            GrowSide(side, phase, newTotal);
+        }
+        return stillPending;
+    }
+
+    private void GrowSide(BattleSideEnum side, MissionSpawnPhase phase, int ownedTotal)
+    {
+        // Native Init sizes the phase AND the Mission's agent counts together; it sized this side to zero, so
+        // mirror both here (_numberOfTroopsInTotal is the reported side strength; the two agent counts feed the
+        // casualty-ratio morale model, which otherwise stays at a zero ratio). The battle count is the min of
+        // both sides' totals, so a non-owned empty side keeps it at zero, as native Init does on the on-time path.
+        _missionAgentSpawnLogic._numberOfTroopsInTotal[(int)side] += ownedTotal - phase.TotalSpawnNumber;
+        phase.TotalSpawnNumber = ownedTotal;
+        phase.InitialSpawnNumber = ownedTotal;
+        phase.RemainingSpawnNumber = 0;
+
+        Mission.SetInitialAgentCountForSide(side, ownedTotal);
+        // Assign the battle count directly rather than via SetBattleAgentCount: when both sides start empty, Init's
+        // 0/0 battle-size split can leave it at a negative sentinel, and that setter only lowers or replaces zero,
+        // so it could not raise it back.
+        Mission._agentCount = Math.Min(
+            _missionAgentSpawnLogic.DefenderActivePhase.TotalSpawnNumber,
+            _missionAgentSpawnLogic.AttackerActivePhase.TotalSpawnNumber);
+
+        Logger.Information("[BattleSync] {Side} reserve arrived after sizing; grew spawn to {Count}", side, ownedTotal);
+    }
+
+    /// <summary>
+    /// Pure per-tick decision for a pending side, split out so it is unit-testable without a live mission. While
+    /// the reserve has not arrived (<paramref name="populated"/> false) the side stays pending. Once it has, the
+    /// side settles; a resize is requested only when the owned total is positive (an empty non-owned side reports
+    /// zero and is left for puppet spawns).
+    /// </summary>
+    public static (bool stillPending, bool resize, int newTotal) ResolvePendingSide(bool populated, int ownedTotal)
+    {
+        return (stillPending: !populated, resize: populated && ownedTotal > 0, newTotal: ownedTotal);
     }
 }

--- a/source/Missions/Battles/CoopBattleMissionSpawnHandler.cs
+++ b/source/Missions/Battles/CoopBattleMissionSpawnHandler.cs
@@ -51,7 +51,7 @@ public class CoopBattleMissionSpawnHandler : SandBoxMissionSpawnHandler
 
         if (sizing.Ready)
         {
-            // On-time (common): both reserves present, so size via Init before the first tick.
+            // On-time (common): both reserves present, so size before the first tick.
             if (sizing.SizeNow)
                 RunJointInit(sizing.DefenderOwned, sizing.AttackerOwned);
             else

--- a/source/Missions/Battles/CoopBattleMissionSpawnHandler.cs
+++ b/source/Missions/Battles/CoopBattleMissionSpawnHandler.cs
@@ -18,11 +18,19 @@ public class CoopBattleMissionSpawnHandler : SandBoxMissionSpawnHandler
 {
     private static readonly ILogger Logger = LogManager.GetLogger<CoopBattleMissionSpawnHandler>();
 
+    // Hold this long for a still-in-flight reserve before sizing with whatever landed. A dropped or server-rejected
+    // reserve request would otherwise never populate a supplier, and the deployment controller (which gates on
+    // IsSized) would wedge on the loading screen forever; the deadline degrades that to a mis-sized battle instead.
+    private const float ReserveHoldDeadlineSeconds = 15f;
+
     private readonly CoopTroopSupplier _defenderSupplier;
     private readonly CoopTroopSupplier _attackerSupplier;
 
     // Latched once the sides are sized jointly; both are held at zero until then.
     private bool _sized;
+
+    // Time spent holding both sides while a reserve is in flight (only accrues on the held path).
+    private float _heldSeconds;
 
     // Gated on by CoopBattleDeploymentMissionController: a game-thread latch, not the suppliers' network-thread
     // IsPopulated (which could read true mid-frame before Init has actually sized).
@@ -39,12 +47,7 @@ public class CoopBattleMissionSpawnHandler : SandBoxMissionSpawnHandler
         _missionAgentSpawnLogic.SetSpawnHorses(BattleSideEnum.Defender, !_mapEvent.IsSiegeAssault);
         _missionAgentSpawnLogic.SetSpawnHorses(BattleSideEnum.Attacker, !_mapEvent.IsSiegeAssault);
 
-        // Read populated before owned: SetReserve sets the entries then flips populated under one lock.
-        bool defenderPopulated = _defenderSupplier.IsPopulated;
-        bool attackerPopulated = _attackerSupplier.IsPopulated;
-        int defenderOwned = _defenderSupplier.TotalTroops;
-        int attackerOwned = _attackerSupplier.TotalTroops;
-        var decision = DecideJointSizing(defenderPopulated, attackerPopulated, defenderOwned, attackerOwned);
+        var (defenderPopulated, attackerPopulated, defenderOwned, attackerOwned, decision) = ReadSizing();
 
         if (decision.Ready)
         {
@@ -58,44 +61,57 @@ public class CoopBattleMissionSpawnHandler : SandBoxMissionSpawnHandler
             return;
         }
 
-        // A reserve is still in flight — hold both sides at zero until OnMissionTick sizes them.
+        // A reserve is still in flight — hold both sides at zero until OnMissionTick sizes them (or the deadline).
         AddHeldPhases();
         Logger.Warning("[BattleSync] Coop spawn handler started before reserves arrived (Def populated={Def}, Atk populated={Atk}) — sizing on tick once both land",
             defenderPopulated, attackerPopulated);
     }
 
-    // Run the single joint Init once both suppliers populate, then latch. A mid-battle migration re-feed
+    // Size once both suppliers populate, then latch. If a reserve never lands, force-size with whatever arrived
+    // after ReserveHoldDeadlineSeconds so deployment degrades instead of hanging. A mid-battle migration re-feed
     // re-populates an already-sized supplier and is left to the adopt path.
     public override void OnMissionTick(float dt)
     {
         base.OnMissionTick(dt);
         if (_sized) return;
 
-        // Populated before owned, as in AfterStart.
+        _heldSeconds += dt;
+        var (defenderPopulated, attackerPopulated, defenderOwned, attackerOwned, decision) = ReadSizing();
+        if (!decision.Ready && _heldSeconds < ReserveHoldDeadlineSeconds) return;
+
+        // Ready, or the deadline expired with a partial/missing reserve. Size with what landed when anything did
+        // (a positive total keeps Init off its 0/0 split); if nothing landed, leave the held zero phases — latching
+        // still lets the deployment controller run SetupTeams so the client isn't stuck on the loading screen.
+        if (defenderOwned + attackerOwned > 0)
+            RunJointInit(defenderOwned, attackerOwned);
+
+        if (decision.Ready)
+            Logger.Information("[BattleSync] Reserves landed after start; sized sides jointly: Defender={Def}, Attacker={Atk}", defenderOwned, attackerOwned);
+        else
+            Logger.Warning("[BattleSync] Reserves incomplete after {Sec}s hold (Def populated={DefP}, Atk populated={AtkP}) — sizing with what landed: Defender={Def}, Attacker={Atk}",
+                ReserveHoldDeadlineSeconds, defenderPopulated, attackerPopulated, defenderOwned, attackerOwned);
+        _sized = true;
+    }
+
+    // Read the suppliers (populated before owned so the pair can't tear: SetReserve commits the entries then flips
+    // populated under one lock) and compute the joint sizing decision. Shared by AfterStart and OnMissionTick.
+    private (bool defenderPopulated, bool attackerPopulated, int defenderOwned, int attackerOwned, JointSizingDecision decision) ReadSizing()
+    {
         bool defenderPopulated = _defenderSupplier.IsPopulated;
         bool attackerPopulated = _attackerSupplier.IsPopulated;
         int defenderOwned = _defenderSupplier.TotalTroops;
         int attackerOwned = _attackerSupplier.TotalTroops;
-        var decision = DecideJointSizing(defenderPopulated, attackerPopulated, defenderOwned, attackerOwned);
-        if (!decision.Ready) return;
-
-        if (decision.SizeNow)
-        {
-            RunJointInit(defenderOwned, attackerOwned);
-            Logger.Information("[BattleSync] Reserves landed after start; sized sides jointly: Defender={Def}, Attacker={Atk}", defenderOwned, attackerOwned);
-        }
-        _sized = true;
+        return (defenderPopulated, attackerPopulated, defenderOwned, attackerOwned,
+            DecideJointSizing(defenderPopulated, attackerPopulated, defenderOwned, attackerOwned));
     }
 
     // Re-run the engine's Init with the real totals (initial == total; Init applies the joint cap, wave split and
-    // agent counts). Clear the placeholder phases/totals first — InitWithSinglePhase appends. Nothing spawned while
-    // held, so no double-spawn.
+    // agent counts). Clear the placeholder phases first — InitWithSinglePhase appends, so a leftover held phase
+    // would leave two active phases. Nothing spawned while held, so no double-spawn.
     private void RunJointInit(int defenderOwned, int attackerOwned)
     {
         _missionAgentSpawnLogic._phases[(int)BattleSideEnum.Defender].Clear();
         _missionAgentSpawnLogic._phases[(int)BattleSideEnum.Attacker].Clear();
-        _missionAgentSpawnLogic._numberOfTroopsInTotal[(int)BattleSideEnum.Defender] = 0;
-        _missionAgentSpawnLogic._numberOfTroopsInTotal[(int)BattleSideEnum.Attacker] = 0;
 
         var settings = CreateSandBoxBattleWaveSpawnSettings();
         _missionAgentSpawnLogic.InitWithSinglePhase(defenderOwned, attackerOwned, defenderOwned, attackerOwned, spawnDefenders: true, spawnAttackers: true, in settings);

--- a/source/Missions/Battles/CoopBattleMissionSpawnHandler.cs
+++ b/source/Missions/Battles/CoopBattleMissionSpawnHandler.cs
@@ -38,6 +38,12 @@ public class CoopBattleMissionSpawnHandler : SandBoxMissionSpawnHandler
     // this stays false; OnMissionTick runs the single joint Init the moment both are populated, then latches.
     private bool _sized;
 
+    // Set on the game thread right after the joint sizing commits. CoopBattleDeploymentMissionController gates its
+    // one-time team/command setup on this so that setup runs only once the sides are sized. A raw supplier
+    // IsPopulated check wouldn't be safe there: SetReserve flips populated on the network thread, so it can read
+    // true between this handler's tick and the controller's tick in the same frame, before Init has sized.
+    public bool IsSized => _sized;
+
     public CoopBattleMissionSpawnHandler(CoopTroopSupplier defenderSupplier, CoopTroopSupplier attackerSupplier)
     {
         _defenderSupplier = defenderSupplier;

--- a/source/Missions/Battles/CoopBattleMissionSpawnHandler.cs
+++ b/source/Missions/Battles/CoopBattleMissionSpawnHandler.cs
@@ -122,7 +122,7 @@ public class CoopBattleMissionSpawnHandler : SandBoxMissionSpawnHandler
     }
 
     // Zero phases so the first tick has active phases to read (else DefenderActivePhase NREs), without feeding Init
-    // a 0/0 total (its battle-size split divides by zero, giving a negative sentinel under Mono).
+    // a 0/0 total: its float battle-size split yields NaN, which Mono casts to int.MinValue (desktop .NET gives 0).
     private void AddHeldPhases()
     {
         _missionAgentSpawnLogic._phases[(int)BattleSideEnum.Defender].Add(new MissionSpawnPhase());

--- a/source/Missions/Battles/CoopBattleMissionSpawnHandler.cs
+++ b/source/Missions/Battles/CoopBattleMissionSpawnHandler.cs
@@ -123,6 +123,13 @@ public class CoopBattleMissionSpawnHandler : SandBoxMissionSpawnHandler
 
         var settings = CreateSandBoxBattleWaveSpawnSettings();
         _missionAgentSpawnLogic.InitWithSinglePhase(defenderOwned, attackerOwned, defenderOwned, attackerOwned, spawnDefenders: true, spawnAttackers: true, in settings);
+
+        // Init's tail leaves both sides' TroopSpawnActive true. On the on-time path the deployment controller's
+        // OnAfterStart runs after this and clears them, so SetupTeams enables, spawns and AI-pauses each side one at
+        // a time. On this deferred path nothing runs after us to clear them, so the first OnSetupTeamsOfSide would
+        // spawn BOTH sides at once and the per-side freeze could miss the other side. Restore the native invariant.
+        _missionAgentSpawnLogic.SetSpawnTroops(BattleSideEnum.Defender, spawnTroops: false);
+        _missionAgentSpawnLogic.SetSpawnTroops(BattleSideEnum.Attacker, spawnTroops: false);
     }
 
     // Zero phases so the first CheckDeployment tick has active phases to read (else DefenderActivePhase NREs)

--- a/source/Missions/Battles/CoopFieldBattleLauncher.cs
+++ b/source/Missions/Battles/CoopFieldBattleLauncher.cs
@@ -143,7 +143,7 @@ internal class CoopFieldBattleLauncher : ICoopFieldBattleLauncher
                 // Battle), spawn both sides frozen during SetupTeams, hold Mission.AllowAiTicking off, and start
                 // the spawners + un-pause AI only on Start Battle (FinishDeployment). This replaces the coop
                 // force-spawn shortcut (CoopBattleController.EnsureSidesSpawning), now removed.
-                new BattleDeploymentMissionController(isPlayerAttacker),
+                new CoopBattleDeploymentMissionController(isPlayerAttacker),
                 new BattleDeploymentHandler(isPlayerAttacker),
             };
 


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

There is a race condition that could cause reserves to not spawn

## What is the new behavior?

Resolves #1633

Each side now always fields its full set of troops regardless of that timing. If a side's troops are not ready the moment the battle loads, they spawn as soon as their data arrives a moment later, in formation, instead of being missing for the whole battle.
