### PR TITLE
[1645] Stop the movement poller at mission end to fix a battle-teardown crash

### DIFF
--- a/source/Common.Tests/Utils/PollerTests.cs
+++ b/source/Common.Tests/Utils/PollerTests.cs
@@ -1,0 +1,54 @@
+﻿using Common.Util;
+
+namespace Common.Tests.Utils
+{
+    public class PollerTests
+    {
+        [Fact]
+        public void StopAndWait_BlocksUntilInFlightPollCompletes()
+        {
+            // The poll enters, then parks until the test releases it — simulating a poll iteration that is
+            // still running when teardown asks the poller to stop.
+            var pollEntered = new ManualResetEventSlim(false);
+            var releasePoll = new ManualResetEventSlim(false);
+            var pollCompleted = false;
+
+            var poller = new Poller(_ =>
+            {
+                pollEntered.Set();
+                releasePoll.Wait();
+                Volatile.Write(ref pollCompleted, true);
+            }, TimeSpan.FromMilliseconds(5));
+            poller.Start();
+
+            Assert.True(pollEntered.Wait(TimeSpan.FromSeconds(5)), "poll never started");
+
+            // StopAndWait must not return while the poll iteration is still in flight.
+            var stopTask = Task.Run(() => poller.StopAndWait(TimeSpan.FromSeconds(5)));
+            Assert.False(stopTask.Wait(TimeSpan.FromMilliseconds(200)), "StopAndWait returned before the in-flight poll finished");
+            Assert.False(Volatile.Read(ref pollCompleted));
+
+            // Releasing the poll lets the iteration finish; only then may StopAndWait return.
+            releasePoll.Set();
+            Assert.True(stopTask.Wait(TimeSpan.FromSeconds(5)), "StopAndWait did not return after the poll finished");
+            Assert.True(Volatile.Read(ref pollCompleted));
+        }
+
+        [Fact]
+        public void StopAndWait_NoPollRunsAfterItReturns()
+        {
+            var count = 0;
+            var poller = new Poller(_ => Interlocked.Increment(ref count), TimeSpan.FromMilliseconds(5));
+            poller.Start();
+
+            Thread.Sleep(50);
+            poller.StopAndWait(TimeSpan.FromSeconds(5));
+
+            // The join guarantees any in-flight iteration finished before StopAndWait returned, so the
+            // count is now final — no later poll can bump it.
+            var settled = Volatile.Read(ref count);
+            Thread.Sleep(50);
+            Assert.Equal(settled, Volatile.Read(ref count));
+        }
+    }
+}

--- a/source/Common/Util/Poller.cs
+++ b/source/Common/Util/Poller.cs
@@ -64,7 +64,8 @@ public class Poller
         }
 
         cts = new CancellationTokenSource();
-        pollingTask = Task.Factory.StartNew(PollAsync);
+        // Task.Run unwraps PollAsync so pollingTask completes when the loop exits (not at the first await), which StopAndWait joins on.
+        pollingTask = Task.Run(PollAsync);
     }
 
     private async Task PollAsync()
@@ -124,5 +125,23 @@ public class Poller
     {
         // Cancel the cancellation token
         cts?.Cancel();
+    }
+
+    /// <summary>
+    /// Cancels polling and blocks until any in-flight poll iteration has finished, so the caller can rely
+    /// on the polling function no longer running once this returns. Bounded by <paramref name="timeout"/>
+    /// so a stuck poll can't strand the caller. Use this instead of <see cref="Stop"/> when the state the
+    /// poll reads is about to become invalid (e.g. mission teardown freeing the agents PollAgents reads).
+    /// </summary>
+    public void StopAndWait(TimeSpan timeout)
+    {
+        var task = pollingTask;
+        Stop();
+
+        if (task == null) return;
+
+        // A timeout means the in-flight poll didn't finish, so the join failed and the caller's state isn't safe yet.
+        if (!task.Wait(timeout))
+            Logger.Warning("Polling task did not stop within {Timeout}", timeout);
     }
 }

--- a/source/Missions/Agents/Handlers/AgentMovementHandler.cs
+++ b/source/Missions/Agents/Handlers/AgentMovementHandler.cs
@@ -36,6 +36,9 @@ public class AgentMovementHandler : IAgentMovementHandler
     // the send path promotes any chunk that still overflows to a fragmentable reliable channel.
     private const int MaxAgentsPerMovementPacket = 4;
 
+    // Cap on how long Dispose blocks joining the poll thread; matches the game's 30s BlockingTimeout so it only trips if a poll is genuinely wedged.
+    private static readonly TimeSpan PollerStopTimeout = TimeSpan.FromSeconds(30);
+
     private readonly Poller poller;
     private readonly IPacketManager packetManager;
     private readonly IBattleNetwork client;
@@ -47,6 +50,8 @@ public class AgentMovementHandler : IAgentMovementHandler
     // same one. Touched only on the game thread (inside HandlePacket's apply), so no lock; per-mission
     // (this handler is transient), so it can't leak across missions.
     private readonly Dictionary<Agent, Agent> _dismountedHorses = new Dictionary<Agent, Agent>();
+
+    private bool _disposed;
 
     public AgentMovementHandler(
         IBattleNetwork client,
@@ -82,13 +87,19 @@ public class AgentMovementHandler : IAgentMovementHandler
 
     public void Dispose()
     {
+        if (_disposed) return;
+        _disposed = true;
+
         Logger.Verbose("Disposing {handlerType}", typeof(AgentMovementHandler));
 
         packetManager.RemovePacketHandler(this);
         messageBroker.Unsubscribe<NetworkMissionPeerEntered>(Handle_PeerEntered);
         messageBroker.Unsubscribe<MissionPeerLeft>(Handle_PeerLeft);
         messageBroker.Unsubscribe<MissionPeerDisconnected>(Handle_PeerDisconnected);
-        poller.Stop();
+
+        // Join the poll thread, not just cancel it: an in-flight PollAgents must finish before teardown frees the agents it reads.
+        poller.StopAndWait(PollerStopTimeout);
+        GC.SuppressFinalize(this);
     }
 
     public PacketType PacketType => PacketType.Movement;

--- a/source/Missions/CoopMissionController.cs
+++ b/source/Missions/CoopMissionController.cs
@@ -47,6 +47,9 @@ public abstract class CoopMissionController : MissionBehavior, IDisposable
     {
         messageBroker.Unsubscribe<NetworkMissionPeerEntered>(Handle_MissionPeerEntered);
         messageBroker.Unsubscribe<NetworkMissionJoinInfo>(Handle_JoinInfo);
+
+        // Stop and join the movement poller before the mission frees its agents, otherwise PollAgents can read a freed native agent on its background thread.
+        coopMissionComponent.AgentMovementHandler.Dispose();
     }
 
     private void Handle_MissionPeerEntered(MessagePayload<NetworkMissionPeerEntered> payload)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

Finishing a field battle sometimes crashes a client to the main menu with `System.AccessViolationException: Attempted to read or write protected memory` (source `TaleWorlds.MountAndBlade`, thrown from `Agent.IsActive()`) as the battle screen closes back to the map.

The client broadcasts agent movement on a background poll thread (`AgentMovementHandler.PollAgents`, ~10ms cadence). At mission end the game thread frees the mission's native agents, but that poller keeps running: it was only ever stopped by the handler's finalizer, which the game doesn't run at teardown. So the poll thread reaches into a native agent (`agent.IsActive()` / `agent.Mission`) whose memory the game thread just freed, and the read faults. The existing per-agent guard can't prevent it, because the guard call is itself the native read that touches the freed memory.

It's a race between the poll thread and the game thread freeing agents, so it's timing dependent, the same battle doesn't always crash.

## What is the new behavior?

Resolves #1645

Battles now tear down cleanly and clients stay connected, so finishing a battle no longer crashes anyone back to the menu.
