### PR TITLE
[1646] Guard BattleAgentLogic against null player map event during battle teardown

### DIFF
--- a/source/GameInterface/Services/MapEvents/Patches/BattleAgentLogicNullMapEventPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/BattleAgentLogicNullMapEventPatches.cs
@@ -1,0 +1,29 @@
+﻿using HarmonyLib;
+using SandBox.Missions.MissionLogics;
+using TaleWorlds.CampaignSystem.MapEvents;
+
+namespace GameInterface.Services.MapEvents.Patches;
+
+/// <summary>
+/// Skips BattleAgentLogic's upgrade-reward path when there is no player map event during a coop battle. Its tracker
+/// getter is <c>MapEvent.PlayerMapEvent.TroopUpgradeTracker</c>, which NREs once the coop client tears its map event
+/// down mid-mission (OnClientDestroyed nulls MainParty's side while the mission is still live), throwing every tick
+/// and wedging the client on the loading screen. The authoritative reward/upgrade outcome comes from the host anyway.
+/// </summary>
+internal class BattleAgentLogicNullMapEventPatches
+{
+    [HarmonyPatch(typeof(BattleAgentLogic), nameof(BattleAgentLogic.OnScoreHit))]
+    [HarmonyPrefix]
+    private static bool Prefix_OnScoreHit() => PlayerMapEventReady;
+
+    [HarmonyPatch(typeof(BattleAgentLogic), nameof(BattleAgentLogic.OnAgentBuild))]
+    [HarmonyPrefix]
+    private static bool Prefix_OnAgentBuild() => PlayerMapEventReady;
+
+    // Guard CheckUpgrade rather than the whole OnAgentRemoved so its kill/wound/rout bookkeeping still runs.
+    [HarmonyPatch(typeof(BattleAgentLogic), "CheckUpgrade")]
+    [HarmonyPrefix]
+    private static bool Prefix_CheckUpgrade() => PlayerMapEventReady;
+
+    private static bool PlayerMapEventReady => !(MapEvent.PlayerMapEvent == null && BattleSpawnGate.IsCoopBattleActive);
+}

--- a/source/GameInterface/Services/MapEvents/Patches/BattleAgentLogicNullMapEventPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/BattleAgentLogicNullMapEventPatches.cs
@@ -8,7 +8,7 @@ namespace GameInterface.Services.MapEvents.Patches;
 /// Skips BattleAgentLogic's upgrade-reward path when there is no player map event during a coop battle. Its tracker
 /// getter is <c>MapEvent.PlayerMapEvent.TroopUpgradeTracker</c>, which NREs once the coop client tears its map event
 /// down mid-mission (OnClientDestroyed nulls MainParty's side while the mission is still live), throwing every tick
-/// and wedging the client on the loading screen. The authoritative reward/upgrade outcome comes from the host anyway.
+/// and wedging the client on the loading screen. The guard only fires in that teardown tail (the battle has already finalized); during the fight PlayerMapEvent is non-null and vanilla runs normally.
 /// </summary>
 internal class BattleAgentLogicNullMapEventPatches
 {


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

Sometimes when a client's field battle ends, the client is thrown to a loading screen and hangs there permanently, and the only way out is to force-quit. While it is stuck, the client log floods with tens of thousands of identical per-tick errors.

## What is the new behavior?

Resolves #1646

The client's field battle now ends normally and returns to the campaign map instead of hanging on the loading screen, and the log flood is gone.
