### PR TITLE
[1491] Show the loading screen while the host and client applies patches

### DIFF
--- a/source/Coop.Core/CoopartiveMultiplayerExperience.cs
+++ b/source/Coop.Core/CoopartiveMultiplayerExperience.cs
@@ -124,7 +124,6 @@ namespace Coop.Core
         private void PatchAllOffGameThread(IGameInterface gameInterface, ILoadingInterface loadingInterface, Action continueStart)
         {
             coopStarting = true;
-            var startedContainer = container;
 
             Task.Factory.StartNew(() =>
             {
@@ -144,13 +143,6 @@ namespace Coop.Core
                 {
                     try
                     {
-                        // Torn down or replaced while patching; only hide the window when nothing replaced this start
-                        if (container != startedContainer)
-                        {
-                            if (container == null) loadingInterface.HideLoadingScreen();
-                            return;
-                        }
-
                         continueStart();
                     }
                     catch

--- a/source/Coop.Core/CoopartiveMultiplayerExperience.cs
+++ b/source/Coop.Core/CoopartiveMultiplayerExperience.cs
@@ -1,5 +1,6 @@
 ﻿using Autofac;
 using Common;
+using Common.Logging;
 using Common.LogicStates;
 using Common.Messaging;
 using Common.Network;
@@ -10,16 +11,22 @@ using Coop.Core.Server;
 using GameInterface;
 using GameInterface.AutoSync;
 using GameInterface.Services.GameState.Interfaces;
+using GameInterface.Services.UI.Interfaces;
 using GameInterface.Services.UI.Messages;
+using Serilog;
 using System;
+using System.Threading.Tasks;
 
 namespace Coop.Core
 {
     public class CoopartiveMultiplayerExperience : IDisposable
     {
+        private static readonly ILogger Logger = LogManager.GetLogger<CoopartiveMultiplayerExperience>();
+
         private IMessageBroker messageBroker;
         private INetworkConfig configuration;
         private IContainer container;
+        private volatile bool serverStarting;
 
         public CoopartiveMultiplayerExperience()
         {
@@ -59,11 +66,11 @@ namespace Coop.Core
 
         private void Handle(MessagePayload<HostSaveGame> obj)
         {
-            StartAsServer();
+            var saveName = obj.What.SaveName;
 
-            container
+            StartAsServer(() => container
                 .Resolve<IGameStateInterface>()
-                .LoadGame(obj.What.SaveName);
+                .LoadGame(saveName));
         }
 
         private void Handle(MessagePayload<EndCoopMode> payload)
@@ -75,8 +82,11 @@ namespace Coop.Core
 
         public int Priority => 0;
 
-        public void StartAsServer()
+        public void StartAsServer(Action afterStart = null)
         {
+            // A second Host click while patches are still applying would tear down the in-flight start
+            if (serverStarting) return;
+
             DestroyContainer();
 
             ModInformation.IsServer = true;
@@ -88,11 +98,63 @@ namespace Coop.Core
 
             GameInterface.ContainerProvider.SetContainer(container);
 
-            // Create harmony patches
-            container.Resolve<IGameInterface>().PatchAll();
+            var gameInterface = container.Resolve<IGameInterface>();
+            var loadingInterface = container.Resolve<ILoadingInterface>();
 
-            var logic = container.Resolve<ILogic>();
-            logic.Start();
+            // Headless server has no loading window to keep alive; patch synchronously
+            if (!loadingInterface.IsLoadingScreenAvailable)
+            {
+                gameInterface.PatchAll();
+                container.Resolve<ILogic>().Start();
+                afterStart?.Invoke();
+                return;
+            }
+
+            loadingInterface.ShowLoadingScreen("Hosting Coop Server", "Applying patches...");
+            serverStarting = true;
+            var startedContainer = container;
+
+            // The ~30s patch compile must stay off the game thread so the loading window keeps drawing, like the client patching on its network thread
+            Task.Factory.StartNew(() =>
+            {
+                try
+                {
+                    gameInterface.PatchAll();
+                }
+                catch (Exception e)
+                {
+                    Logger.Error(e, "Applying patches failed while starting the coop server");
+                    serverStarting = false;
+                    GameThread.RunSafe(loadingInterface.HideLoadingScreen);
+                    return;
+                }
+
+                GameThread.RunSafe(() =>
+                {
+                    try
+                    {
+                        // Torn down or replaced while patching; only hide the window when nothing replaced this start
+                        if (container != startedContainer)
+                        {
+                            if (container == null) loadingInterface.HideLoadingScreen();
+                            return;
+                        }
+
+                        loadingInterface.SetLoadingMessage("Hosting Coop Server", "Loading campaign save...");
+                        container.Resolve<ILogic>().Start();
+                        afterStart?.Invoke();
+                    }
+                    catch
+                    {
+                        loadingInterface.HideLoadingScreen();
+                        throw;
+                    }
+                    finally
+                    {
+                        serverStarting = false;
+                    }
+                });
+            }, TaskCreationOptions.LongRunning);
         }
 
         public void StartAsClient(INetworkConfig configuration = null)

--- a/source/Coop.Core/CoopartiveMultiplayerExperience.cs
+++ b/source/Coop.Core/CoopartiveMultiplayerExperience.cs
@@ -26,7 +26,7 @@ namespace Coop.Core
         private IMessageBroker messageBroker;
         private INetworkConfig configuration;
         private IContainer container;
-        private volatile bool serverStarting;
+        private volatile bool coopStarting;
 
         public CoopartiveMultiplayerExperience()
         {
@@ -84,8 +84,8 @@ namespace Coop.Core
 
         public void StartAsServer(Action afterStart = null)
         {
-            // A second Host click while patches are still applying would tear down the in-flight start
-            if (serverStarting) return;
+            // A second Host or Join click while patches are still applying would tear down the in-flight start
+            if (coopStarting) return;
 
             DestroyContainer();
 
@@ -111,10 +111,21 @@ namespace Coop.Core
             }
 
             loadingInterface.ShowLoadingScreen("Hosting Coop Server", "Applying patches...");
-            serverStarting = true;
+
+            PatchAllOffGameThread(gameInterface, loadingInterface, () =>
+            {
+                loadingInterface.SetLoadingMessage("Hosting Coop Server", "Loading campaign save...");
+                container.Resolve<ILogic>().Start();
+                afterStart?.Invoke();
+            });
+        }
+
+        // The ~30s patch compile must stay off the game thread so the loading window keeps drawing, like the client patching on its network thread
+        private void PatchAllOffGameThread(IGameInterface gameInterface, ILoadingInterface loadingInterface, Action continueStart)
+        {
+            coopStarting = true;
             var startedContainer = container;
 
-            // The ~30s patch compile must stay off the game thread so the loading window keeps drawing, like the client patching on its network thread
             Task.Factory.StartNew(() =>
             {
                 try
@@ -123,8 +134,8 @@ namespace Coop.Core
                 }
                 catch (Exception e)
                 {
-                    Logger.Error(e, "Applying patches failed while starting the coop server");
-                    serverStarting = false;
+                    Logger.Error(e, "Applying patches failed while starting coop");
+                    coopStarting = false;
                     GameThread.RunSafe(loadingInterface.HideLoadingScreen);
                     return;
                 }
@@ -140,9 +151,7 @@ namespace Coop.Core
                             return;
                         }
 
-                        loadingInterface.SetLoadingMessage("Hosting Coop Server", "Loading campaign save...");
-                        container.Resolve<ILogic>().Start();
-                        afterStart?.Invoke();
+                        continueStart();
                     }
                     catch
                     {
@@ -151,7 +160,7 @@ namespace Coop.Core
                     }
                     finally
                     {
-                        serverStarting = false;
+                        coopStarting = false;
                     }
                 });
             }, TaskCreationOptions.LongRunning);
@@ -159,6 +168,9 @@ namespace Coop.Core
 
         public void StartAsClient(INetworkConfig configuration = null)
         {
+            // A second Host or Join click while patches are still applying would tear down the in-flight start
+            if (coopStarting) return;
+
             DestroyContainer();
 
             ModInformation.IsServer = false;
@@ -182,7 +194,18 @@ namespace Coop.Core
 
 #if DEBUG
             // For debugging faster, normally this is done after connection
-            container.Resolve<IGameInterface>().PatchAll();
+            var gameInterface = container.Resolve<IGameInterface>();
+            var loadingInterface = container.Resolve<ILoadingInterface>();
+
+            if (loadingInterface.IsLoadingScreenAvailable)
+            {
+                loadingInterface.ShowLoadingScreen("Connecting to Coop Server", "Applying patches...");
+
+                PatchAllOffGameThread(gameInterface, loadingInterface, () => container.Resolve<ILogic>().Start());
+                return;
+            }
+
+            gameInterface.PatchAll();
 #endif
 
             var logic = container.Resolve<ILogic>();

--- a/source/Coop.Core/CoopartiveMultiplayerExperience.cs
+++ b/source/Coop.Core/CoopartiveMultiplayerExperience.cs
@@ -66,11 +66,7 @@ namespace Coop.Core
 
         private void Handle(MessagePayload<HostSaveGame> obj)
         {
-            var saveName = obj.What.SaveName;
-
-            StartAsServer(() => container
-                .Resolve<IGameStateInterface>()
-                .LoadGame(saveName));
+            StartAsServer(obj.What.SaveName);
         }
 
         private void Handle(MessagePayload<EndCoopMode> payload)
@@ -82,7 +78,7 @@ namespace Coop.Core
 
         public int Priority => 0;
 
-        public void StartAsServer(Action afterStart = null)
+        public void StartAsServer(string saveName = null)
         {
             // A second Host or Join click while patches are still applying would tear down the in-flight start
             if (coopStarting) return;
@@ -105,8 +101,7 @@ namespace Coop.Core
             if (!loadingInterface.IsLoadingScreenAvailable)
             {
                 gameInterface.PatchAll();
-                container.Resolve<ILogic>().Start();
-                afterStart?.Invoke();
+                StartServerLogic(saveName);
                 return;
             }
 
@@ -115,9 +110,19 @@ namespace Coop.Core
             PatchAllOffGameThread(gameInterface, loadingInterface, () =>
             {
                 loadingInterface.SetLoadingMessage("Hosting Coop Server", "Loading campaign save...");
-                container.Resolve<ILogic>().Start();
-                afterStart?.Invoke();
+                StartServerLogic(saveName);
             });
+        }
+
+        // LoadGame must follow PatchAll (the LoadPatches postfix publishes GameLoaded), so it runs here, after patching, not at the caller
+        private void StartServerLogic(string saveName)
+        {
+            container.Resolve<ILogic>().Start();
+
+            if (saveName != null)
+            {
+                container.Resolve<IGameStateInterface>().LoadGame(saveName);
+            }
         }
 
         // The ~30s patch compile must stay off the game thread so the loading window keeps drawing, like the client patching on its network thread

--- a/source/Coop.Core/Server/States/InitialServerState.cs
+++ b/source/Coop.Core/Server/States/InitialServerState.cs
@@ -61,8 +61,12 @@ public class InitialServerState : ServerStateBase
         // Remove server party
         messageBroker.Publish(this, new RemoveMainParty());
 
+        loadingInterface.SetLoadingMessage("Hosting Coop Server", "Registering campaign objects...");
+
         // Register all objects after main party is removed to keep order
         registryManager.RegisterAllGameObjects();
+
+        loadingInterface.SetLoadingMessage("Hosting Coop Server", "Applying synced object lifetimes...");
         registryManager.PatchLifetimes();
 
         Logic.SetState<ServerRunningState>();

--- a/source/Coop.Tests/Server/States/InitialStateTests.cs
+++ b/source/Coop.Tests/Server/States/InitialStateTests.cs
@@ -3,8 +3,6 @@ using Common.Messaging;
 using Coop.Core.Server;
 using Coop.Core.Server.States;
 using GameInterface.Services.GameState.Messages;
-using GameInterface.Services.UI.Interfaces;
-using Moq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -36,26 +34,6 @@ namespace Coop.Tests.Server.States
 
             // Assert
             Assert.IsType<ServerRunningState>(serverLogic.State);
-        }
-
-        [Fact]
-        public void CampaignReady_SetsLoadingMessages()
-        {
-            // Arrange
-            IServerLogic serverLogic = serverComponent.Container.Resolve<IServerLogic>();
-            var loadingInterfaceMock = serverComponent.Container.Resolve<Mock<ILoadingInterface>>();
-            var initialState = Assert.IsType<InitialServerState>(serverLogic.State);
-
-            // Act
-            initialState.Handle_CampaignReady(new MessagePayload<CampaignReady>(null, new CampaignReady()));
-
-            // Assert
-            loadingInterfaceMock.Verify(x => x.SetLoadingMessage(
-                "Hosting Coop Server",
-                "Registering campaign objects..."), Times.Once);
-            loadingInterfaceMock.Verify(x => x.SetLoadingMessage(
-                "Hosting Coop Server",
-                "Applying synced object lifetimes..."), Times.Once);
         }
 
         [Fact]

--- a/source/Coop.Tests/Server/States/InitialStateTests.cs
+++ b/source/Coop.Tests/Server/States/InitialStateTests.cs
@@ -3,6 +3,8 @@ using Common.Messaging;
 using Coop.Core.Server;
 using Coop.Core.Server.States;
 using GameInterface.Services.GameState.Messages;
+using GameInterface.Services.UI.Interfaces;
+using Moq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -34,6 +36,26 @@ namespace Coop.Tests.Server.States
 
             // Assert
             Assert.IsType<ServerRunningState>(serverLogic.State);
+        }
+
+        [Fact]
+        public void CampaignReady_SetsLoadingMessages()
+        {
+            // Arrange
+            IServerLogic serverLogic = serverComponent.Container.Resolve<IServerLogic>();
+            var loadingInterfaceMock = serverComponent.Container.Resolve<Mock<ILoadingInterface>>();
+            var initialState = Assert.IsType<InitialServerState>(serverLogic.State);
+
+            // Act
+            initialState.Handle_CampaignReady(new MessagePayload<CampaignReady>(null, new CampaignReady()));
+
+            // Assert
+            loadingInterfaceMock.Verify(x => x.SetLoadingMessage(
+                "Hosting Coop Server",
+                "Registering campaign objects..."), Times.Once);
+            loadingInterfaceMock.Verify(x => x.SetLoadingMessage(
+                "Hosting Coop Server",
+                "Applying synced object lifetimes..."), Times.Once);
         }
 
         [Fact]

--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -7,6 +7,7 @@ using GameInterface;
 using GameInterface.Services.MapEvents.PlayerPartyInteractions;
 using GameInterface.Services.UI;
 using GameInterface.Utils;
+using HarmonyLib;
 using Serilog;
 using System;
 using System.IO;
@@ -79,6 +80,10 @@ namespace Coop
                 Logger.Information("[AutoConnect] isServer={IsServer} isAutoConnect={IsAutoConnect}", isServer, isAutoConnect);
                 EnsureSafeExitConfig();
             }
+
+            // Boot-apply the loading-window patches so the keepalive guard exists before a host or join waits on PatchAll
+            new Harmony("Coop.UILoading").PatchCategory(
+                typeof(IGameInterface).Assembly, GameInterface.GameInterface.HARMONY_UI_LOADING_CATEGORY);
 
             GameThread.Instance.MarkGameThread();
         }

--- a/source/GameInterface/GameInterface.cs
+++ b/source/GameInterface/GameInterface.cs
@@ -14,6 +14,9 @@ public interface IGameInterface : IDisposable
 public class GameInterface : IGameInterface
 {
     public const string HARMONY_STATIC_FIXES_CATEGORY = "HarmonyStaticFixes";
+
+    // Applied at boot by CoopMod, not by PatchAll: the loading-window keepalive must already be live while a host waits on PatchAll itself
+    public const string HARMONY_UI_LOADING_CATEGORY = "UILoadingPatches";
     
     private readonly Harmony harmony;
     private readonly IAutoSyncPatchCollector patchCollector;

--- a/source/GameInterface/Services/UI/Interfaces/LoadingInterface.cs
+++ b/source/GameInterface/Services/UI/Interfaces/LoadingInterface.cs
@@ -8,6 +8,7 @@ namespace GameInterface.Services.UI.Interfaces;
 
 public interface ILoadingInterface : IGameAbstraction
 {
+    bool IsLoadingScreenAvailable { get; }
     void HideLoadingScreen();
     void ShowLoadingScreen();
     void ShowLoadingScreen(string titleText, string descriptionText = "");
@@ -22,6 +23,8 @@ internal class LoadingInterface : ILoadingInterface
 
     private static readonly FieldInfo LoadingWindowViewModelField =
         AccessTools.Field(typeof(GauntletDefaultLoadingWindowManager), "_loadingWindowViewModel");
+
+    public bool IsLoadingScreenAvailable => LoadingWindow.LoadingWindowManager != null;
 
     public void ShowLoadingScreen()
     {

--- a/source/GameInterface/Services/UI/Patches/LoadingWindowPatches.cs
+++ b/source/GameInterface/Services/UI/Patches/LoadingWindowPatches.cs
@@ -8,7 +8,7 @@ namespace GameInterface.Services.UI.Patches;
 
 /// <summary>
 /// Keeps the global loading window visible across game-state transitions while a coop
-/// client is joining a server.
+/// session is starting (a client joining, or the host applying patches before its save loads).
 /// </summary>
 /// <remarks>
 /// The engine destroys and recreates its loading window manager during state changes
@@ -18,9 +18,13 @@ namespace GameInterface.Services.UI.Patches;
 /// <see cref="LoadingWindow.DisableGlobalLoadingWindow"/>. So, by keeping the flag active
 /// and blocking native disables while <see cref="ForceLoadingWindow"/> is set, the loading
 /// screen stays up consistently instead of flickering as the client's local world is
-/// swapped for the server world.
+/// swapped for the server world. These patches are applied at boot (see CoopMod) through
+/// <see cref="GameInterface.HARMONY_UI_LOADING_CATEGORY"/> so the guard already exists while
+/// the host's own PatchAll is still compiling; they do nothing until a coop flow sets
+/// <see cref="ForceLoadingWindow"/> or a loading message.
 /// </remarks>
 [HarmonyPatch(typeof(LoadingWindow))]
+[HarmonyPatchCategory(GameInterface.HARMONY_UI_LOADING_CATEGORY)]
 internal static class LoadingWindowPatches
 {
     /// <summary>
@@ -49,6 +53,7 @@ internal static class LoadingWindowPatches
 /// loading window manager.
 /// </summary>
 [HarmonyPatch]
+[HarmonyPatchCategory(GameInterface.HARMONY_UI_LOADING_CATEGORY)]
 internal static class GauntletDefaultLoadingWindowManagerPatches
 {
     private static MethodBase TargetMethod()


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

Clicking Host Co-op Campaign or Join Co-op Campaign freezes the game for about 30 seconds: the main menu sits there unresponsive with no loading screen or feedback until the campaign load finally starts.

## What is the new behavior?

Resolves #1491

Clicking Host or Join immediately brings up the game's normal loading screen showing "Applying patches...", which stays up and animated through the whole wait and ends on the campaign map. The menu never sits frozen.

Server-
<img width="902" height="735" alt="image" src="https://github.com/user-attachments/assets/e8dfd133-e857-4f2d-9d92-bfc224002b51" />

Client-
<img width="1001" height="723" alt="image" src="https://github.com/user-attachments/assets/8a59543f-2d6f-4e22-82a4-a20b0ee64dad" />


