### PR TITLE
#1581 P2P interaction bug fix

### DIFF
--- a/source/GameInterface.Tests/Services/MobileParties/OnPartyInteractionHandlerTests.cs
+++ b/source/GameInterface.Tests/Services/MobileParties/OnPartyInteractionHandlerTests.cs
@@ -1,5 +1,7 @@
+using Common.Tests.Utils;
 using Common.Util;
 using GameInterface.Services.MobileParties.Handlers;
+using GameInterface.Services.MobileParties.Messages;
 using GameInterface.Services.ObjectManager;
 using Moq;
 using TaleWorlds.CampaignSystem.Party;
@@ -9,12 +11,13 @@ namespace GameInterface.Tests.Services.MobileParties;
 
 public class PlayerPartyInteractionHandlerTests
 {
+    private readonly TestMessageBroker messageBroker = new();
     private readonly Mock<IObjectManager> objectManager = new();
     private readonly PlayerPartyInteractionHandler handler;
 
     public PlayerPartyInteractionHandlerTests()
     {
-        handler = new PlayerPartyInteractionHandler(objectManager.Object);
+        handler = new PlayerPartyInteractionHandler(messageBroker, objectManager.Object);
     }
 
     [Fact]
@@ -53,6 +56,19 @@ public class PlayerPartyInteractionHandlerTests
         var shouldInitiate = handler.ShouldInitiateReciprocalPlayerInteraction(engagingParty, targetParty);
 
         Assert.False(shouldInitiate);
+    }
+
+    [Fact]
+    public void ReciprocalPlayerPartyInteractionAttempted_PublishedMessage_MarksHandled()
+    {
+        var engagingParty = CreatePartyBase();
+        var targetParty = CreatePartyBase();
+        SetupNoId(engagingParty);
+        var message = new ReciprocalPlayerPartyInteractionAttempted(targetParty, engagingParty);
+
+        messageBroker.Publish(this, message);
+
+        Assert.True(message.Handled);
     }
 
     private static PartyBase CreatePartyBase()

--- a/source/GameInterface.Tests/Services/MobileParties/OnPartyInteractionHandlerTests.cs
+++ b/source/GameInterface.Tests/Services/MobileParties/OnPartyInteractionHandlerTests.cs
@@ -1,0 +1,71 @@
+using Common.Util;
+using GameInterface.Services.MobileParties.Handlers;
+using GameInterface.Services.ObjectManager;
+using Moq;
+using TaleWorlds.CampaignSystem.Party;
+using Xunit;
+
+namespace GameInterface.Tests.Services.MobileParties;
+
+public class OnPartyInteractionHandlerTests
+{
+    private readonly Mock<IObjectManager> objectManager = new();
+    private readonly OnPartyInteractionHandler handler;
+
+    public OnPartyInteractionHandlerTests()
+    {
+        handler = new OnPartyInteractionHandler(objectManager.Object);
+    }
+
+    [Fact]
+    public void ShouldInitiateReciprocalPlayerInteraction_EngagingIdSortsBeforeTarget_ReturnsTrue()
+    {
+        var engagingParty = CreatePartyBase();
+        var targetParty = CreatePartyBase();
+        SetupId(engagingParty, "party-a");
+        SetupId(targetParty, "party-b");
+
+        var shouldInitiate = handler.ShouldInitiateReciprocalPlayerInteraction(engagingParty, targetParty);
+
+        Assert.True(shouldInitiate);
+    }
+
+    [Fact]
+    public void ShouldInitiateReciprocalPlayerInteraction_EngagingIdSortsAfterTarget_ReturnsFalse()
+    {
+        var engagingParty = CreatePartyBase();
+        var targetParty = CreatePartyBase();
+        SetupId(engagingParty, "party-b");
+        SetupId(targetParty, "party-a");
+
+        var shouldInitiate = handler.ShouldInitiateReciprocalPlayerInteraction(engagingParty, targetParty);
+
+        Assert.False(shouldInitiate);
+    }
+
+    [Fact]
+    public void ShouldInitiateReciprocalPlayerInteraction_UnresolvableParty_ReturnsFalse()
+    {
+        var engagingParty = CreatePartyBase();
+        var targetParty = CreatePartyBase();
+        SetupNoId(engagingParty);
+
+        var shouldInitiate = handler.ShouldInitiateReciprocalPlayerInteraction(engagingParty, targetParty);
+
+        Assert.False(shouldInitiate);
+    }
+
+    private static PartyBase CreatePartyBase()
+        => ObjectHelper.SkipConstructor<PartyBase>();
+
+    private void SetupId(object party, string id)
+    {
+        objectManager.Setup(o => o.TryGetId(party, out id)).Returns(true);
+    }
+
+    private void SetupNoId(object party)
+    {
+        string unused = string.Empty;
+        objectManager.Setup(o => o.TryGetId(party, out unused)).Returns(false);
+    }
+}

--- a/source/GameInterface.Tests/Services/MobileParties/OnPartyInteractionHandlerTests.cs
+++ b/source/GameInterface.Tests/Services/MobileParties/OnPartyInteractionHandlerTests.cs
@@ -59,7 +59,7 @@ public class PlayerPartyInteractionHandlerTests
     }
 
     [Fact]
-    public void ReciprocalPlayerPartyInteractionAttempted_PublishedMessage_MarksHandled()
+    public void ReciprocalPlayerPartyInteractionAttempted_PublishedMessage_ChecksInteractionEligibility()
     {
         var engagingParty = CreatePartyBase();
         var targetParty = CreatePartyBase();
@@ -68,7 +68,8 @@ public class PlayerPartyInteractionHandlerTests
 
         messageBroker.Publish(this, message);
 
-        Assert.True(message.Handled);
+        objectManager.Verify(o => o.TryGetId(engagingParty, out It.Ref<string>.IsAny), Times.Once);
+        objectManager.Verify(o => o.TryGetId(targetParty, out It.Ref<string>.IsAny), Times.Never);
     }
 
     private static PartyBase CreatePartyBase()

--- a/source/GameInterface.Tests/Services/MobileParties/OnPartyInteractionHandlerTests.cs
+++ b/source/GameInterface.Tests/Services/MobileParties/OnPartyInteractionHandlerTests.cs
@@ -7,14 +7,14 @@ using Xunit;
 
 namespace GameInterface.Tests.Services.MobileParties;
 
-public class OnPartyInteractionHandlerTests
+public class PlayerPartyInteractionHandlerTests
 {
     private readonly Mock<IObjectManager> objectManager = new();
-    private readonly OnPartyInteractionHandler handler;
+    private readonly PlayerPartyInteractionHandler handler;
 
-    public OnPartyInteractionHandlerTests()
+    public PlayerPartyInteractionHandlerTests()
     {
-        handler = new OnPartyInteractionHandler(objectManager.Object);
+        handler = new PlayerPartyInteractionHandler(objectManager.Object);
     }
 
     [Fact]

--- a/source/GameInterface.Tests/Services/MobileParties/OnPartyInteractionPatchTests.cs
+++ b/source/GameInterface.Tests/Services/MobileParties/OnPartyInteractionPatchTests.cs
@@ -1,0 +1,39 @@
+using Common.Util;
+using GameInterface.Services.MobileParties.Patches;
+using TaleWorlds.CampaignSystem.Party;
+using Xunit;
+
+namespace GameInterface.Tests.Services.MobileParties;
+
+public class OnPartyInteractionPatchTests
+{
+    [Fact]
+    public void GetEffectiveInteractionTargetParty_AttachedPartyEngagedByOtherParty_UsesAttachedLeader()
+    {
+        var attachedParty = CreateParty();
+        var leaderParty = CreateParty();
+        var engagingParty = CreateParty();
+
+        attachedParty._attachedTo = leaderParty;
+
+        var targetParty = OnPartyInteractionPatch.GetEffectiveInteractionTargetParty(attachedParty, engagingParty);
+
+        Assert.Same(leaderParty, targetParty);
+    }
+
+    [Fact]
+    public void GetEffectiveInteractionTargetParty_AttachedPartyEngagedByLeader_UsesOriginalParty()
+    {
+        var attachedParty = CreateParty();
+        var leaderParty = CreateParty();
+
+        attachedParty._attachedTo = leaderParty;
+
+        var targetParty = OnPartyInteractionPatch.GetEffectiveInteractionTargetParty(attachedParty, leaderParty);
+
+        Assert.Same(attachedParty, targetParty);
+    }
+
+    private static MobileParty CreateParty()
+        => ObjectHelper.SkipConstructor<MobileParty>();
+}

--- a/source/GameInterface/Services/MobileParties/Handlers/OnPartyInteractionHandler.cs
+++ b/source/GameInterface/Services/MobileParties/Handlers/OnPartyInteractionHandler.cs
@@ -1,0 +1,77 @@
+using Common;
+using Common.Messaging;
+using GameInterface.Services.MobileParties.Extensions;
+using GameInterface.Services.ObjectManager;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Party;
+
+namespace GameInterface.Services.MobileParties.Handlers;
+
+internal class OnPartyInteractionHandler : IHandler
+{
+    private readonly IObjectManager objectManager;
+
+    public OnPartyInteractionHandler(IObjectManager objectManager)
+    {
+        this.objectManager = objectManager;
+    }
+
+    public void Dispose()
+    {
+    }
+
+    public bool TryHandleReciprocalPlayerInteraction(MobileParty targetParty, MobileParty engagingParty)
+    {
+        if (!CanHandleReciprocalPlayerInteraction(targetParty, engagingParty)) return false;
+        if (!IsReciprocalPlayerInteractionReady(targetParty, engagingParty)) return false;
+        if (!TryGetPartyBases(targetParty, engagingParty, out var targetPartyBase, out var engagingPartyBase))
+            return false;
+
+        if (ShouldInitiateReciprocalPlayerInteraction(engagingPartyBase, targetPartyBase))
+            EncounterManager.StartPartyEncounter(engagingPartyBase, targetPartyBase);
+
+        return true;
+    }
+
+    internal static bool CanHandleReciprocalPlayerInteraction(MobileParty targetParty, MobileParty engagingParty)
+    {
+        if (ModInformation.IsServer) return false;
+        if (targetParty == null || engagingParty == null) return false;
+        if (targetParty == engagingParty) return false;
+        if (!engagingParty.IsMainParty) return false;
+        if (!engagingParty.IsControlledByThisInstance()) return false;
+        if (!targetParty.IsPlayerParty()) return false;
+
+        return true;
+    }
+
+    internal static bool IsReciprocalPlayerInteractionReady(MobileParty targetParty, MobileParty engagingParty)
+    {
+        if (targetParty.CurrentSettlement != null) return false;
+        if (targetParty.MapEvent != null || engagingParty.MapEvent != null) return false;
+        if (!targetParty.IsEngaging) return false;
+        if (targetParty.ShortTermTargetParty != engagingParty) return false;
+
+        return true;
+    }
+
+    internal static bool TryGetPartyBases(
+        MobileParty targetParty,
+        MobileParty engagingParty,
+        out PartyBase targetPartyBase,
+        out PartyBase engagingPartyBase)
+    {
+        targetPartyBase = targetParty.Party;
+        engagingPartyBase = engagingParty.Party;
+
+        return targetPartyBase != null && engagingPartyBase != null;
+    }
+
+    internal bool ShouldInitiateReciprocalPlayerInteraction(PartyBase engagingParty, PartyBase targetParty)
+    {
+        if (!objectManager.TryGetId(engagingParty, out var engagingPartyId)) return false;
+        if (!objectManager.TryGetId(targetParty, out var targetPartyId)) return false;
+
+        return string.CompareOrdinal(engagingPartyId, targetPartyId) <= 0;
+    }
+}

--- a/source/GameInterface/Services/MobileParties/Handlers/OnPartyInteractionHandler.cs
+++ b/source/GameInterface/Services/MobileParties/Handlers/OnPartyInteractionHandler.cs
@@ -1,4 +1,5 @@
 using Common.Messaging;
+using GameInterface.Services.MobileParties.Messages;
 using GameInterface.Services.ObjectManager;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
@@ -7,23 +8,29 @@ namespace GameInterface.Services.MobileParties.Handlers;
 
 internal class PlayerPartyInteractionHandler : IHandler
 {
+    private readonly IMessageBroker messageBroker;
     private readonly IObjectManager objectManager;
 
-    public PlayerPartyInteractionHandler(IObjectManager objectManager)
+    public PlayerPartyInteractionHandler(IMessageBroker messageBroker, IObjectManager objectManager)
     {
+        this.messageBroker = messageBroker;
         this.objectManager = objectManager;
+
+        messageBroker.Subscribe<ReciprocalPlayerPartyInteractionAttempted>(Handle_ReciprocalPlayerPartyInteractionAttempted);
     }
 
     public void Dispose()
     {
+        messageBroker.Unsubscribe<ReciprocalPlayerPartyInteractionAttempted>(Handle_ReciprocalPlayerPartyInteractionAttempted);
     }
 
-    public bool TryHandleReciprocalPlayerInteraction(PartyBase targetParty, PartyBase engagingParty)
+    private void Handle_ReciprocalPlayerPartyInteractionAttempted(MessagePayload<ReciprocalPlayerPartyInteractionAttempted> payload)
     {
-        if (ShouldInitiateReciprocalPlayerInteraction(engagingParty, targetParty))
-            EncounterManager.StartPartyEncounter(engagingParty, targetParty);
+        var message = payload.What;
+        message.SetHandled();
 
-        return true;
+        if (ShouldInitiateReciprocalPlayerInteraction(message.EngagingParty, message.TargetParty))
+            EncounterManager.StartPartyEncounter(message.EngagingParty, message.TargetParty);
     }
 
     internal bool ShouldInitiateReciprocalPlayerInteraction(PartyBase engagingParty, PartyBase targetParty)

--- a/source/GameInterface/Services/MobileParties/Handlers/OnPartyInteractionHandler.cs
+++ b/source/GameInterface/Services/MobileParties/Handlers/OnPartyInteractionHandler.cs
@@ -27,7 +27,6 @@ internal class PlayerPartyInteractionHandler : IHandler
     private void Handle_ReciprocalPlayerPartyInteractionAttempted(MessagePayload<ReciprocalPlayerPartyInteractionAttempted> payload)
     {
         var message = payload.What;
-        message.SetHandled();
 
         if (ShouldInitiateReciprocalPlayerInteraction(message.EngagingParty, message.TargetParty))
             EncounterManager.StartPartyEncounter(message.EngagingParty, message.TargetParty);

--- a/source/GameInterface/Services/MobileParties/Handlers/OnPartyInteractionHandler.cs
+++ b/source/GameInterface/Services/MobileParties/Handlers/OnPartyInteractionHandler.cs
@@ -1,17 +1,15 @@
-using Common;
 using Common.Messaging;
-using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Services.ObjectManager;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
 
 namespace GameInterface.Services.MobileParties.Handlers;
 
-internal class OnPartyInteractionHandler : IHandler
+internal class PlayerPartyInteractionHandler : IHandler
 {
     private readonly IObjectManager objectManager;
 
-    public OnPartyInteractionHandler(IObjectManager objectManager)
+    public PlayerPartyInteractionHandler(IObjectManager objectManager)
     {
         this.objectManager = objectManager;
     }
@@ -20,51 +18,12 @@ internal class OnPartyInteractionHandler : IHandler
     {
     }
 
-    public bool TryHandleReciprocalPlayerInteraction(MobileParty targetParty, MobileParty engagingParty)
+    public bool TryHandleReciprocalPlayerInteraction(PartyBase targetParty, PartyBase engagingParty)
     {
-        if (!CanHandleReciprocalPlayerInteraction(targetParty, engagingParty)) return false;
-        if (!IsReciprocalPlayerInteractionReady(targetParty, engagingParty)) return false;
-        if (!TryGetPartyBases(targetParty, engagingParty, out var targetPartyBase, out var engagingPartyBase))
-            return false;
-
-        if (ShouldInitiateReciprocalPlayerInteraction(engagingPartyBase, targetPartyBase))
-            EncounterManager.StartPartyEncounter(engagingPartyBase, targetPartyBase);
+        if (ShouldInitiateReciprocalPlayerInteraction(engagingParty, targetParty))
+            EncounterManager.StartPartyEncounter(engagingParty, targetParty);
 
         return true;
-    }
-
-    internal static bool CanHandleReciprocalPlayerInteraction(MobileParty targetParty, MobileParty engagingParty)
-    {
-        if (ModInformation.IsServer) return false;
-        if (targetParty == null || engagingParty == null) return false;
-        if (targetParty == engagingParty) return false;
-        if (!engagingParty.IsMainParty) return false;
-        if (!engagingParty.IsControlledByThisInstance()) return false;
-        if (!targetParty.IsPlayerParty()) return false;
-
-        return true;
-    }
-
-    internal static bool IsReciprocalPlayerInteractionReady(MobileParty targetParty, MobileParty engagingParty)
-    {
-        if (targetParty.CurrentSettlement != null) return false;
-        if (targetParty.MapEvent != null || engagingParty.MapEvent != null) return false;
-        if (!targetParty.IsEngaging) return false;
-        if (targetParty.ShortTermTargetParty != engagingParty) return false;
-
-        return true;
-    }
-
-    internal static bool TryGetPartyBases(
-        MobileParty targetParty,
-        MobileParty engagingParty,
-        out PartyBase targetPartyBase,
-        out PartyBase engagingPartyBase)
-    {
-        targetPartyBase = targetParty.Party;
-        engagingPartyBase = engagingParty.Party;
-
-        return targetPartyBase != null && engagingPartyBase != null;
     }
 
     internal bool ShouldInitiateReciprocalPlayerInteraction(PartyBase engagingParty, PartyBase targetParty)

--- a/source/GameInterface/Services/MobileParties/Messages/ReciprocalPlayerPartyInteractionAttempted.cs
+++ b/source/GameInterface/Services/MobileParties/Messages/ReciprocalPlayerPartyInteractionAttempted.cs
@@ -1,0 +1,23 @@
+using Common.Messaging;
+using TaleWorlds.CampaignSystem.Party;
+
+namespace GameInterface.Services.MobileParties.Messages;
+
+internal class ReciprocalPlayerPartyInteractionAttempted : IEvent
+{
+    public readonly PartyBase TargetParty;
+    public readonly PartyBase EngagingParty;
+
+    public bool Handled { get; private set; }
+
+    public ReciprocalPlayerPartyInteractionAttempted(PartyBase targetParty, PartyBase engagingParty)
+    {
+        TargetParty = targetParty;
+        EngagingParty = engagingParty;
+    }
+
+    public void SetHandled()
+    {
+        Handled = true;
+    }
+}

--- a/source/GameInterface/Services/MobileParties/Messages/ReciprocalPlayerPartyInteractionAttempted.cs
+++ b/source/GameInterface/Services/MobileParties/Messages/ReciprocalPlayerPartyInteractionAttempted.cs
@@ -8,16 +8,9 @@ internal class ReciprocalPlayerPartyInteractionAttempted : IEvent
     public readonly PartyBase TargetParty;
     public readonly PartyBase EngagingParty;
 
-    public bool Handled { get; private set; }
-
     public ReciprocalPlayerPartyInteractionAttempted(PartyBase targetParty, PartyBase engagingParty)
     {
         TargetParty = targetParty;
         EngagingParty = engagingParty;
-    }
-
-    public void SetHandled()
-    {
-        Handled = true;
     }
 }

--- a/source/GameInterface/Services/MobileParties/Patches/OnPartyInteractionPatch.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/OnPartyInteractionPatch.cs
@@ -1,5 +1,6 @@
 using Common;
 using Common.Logging;
+using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Services.MobileParties.Handlers;
 using HarmonyLib;
 using Serilog;
@@ -29,8 +30,13 @@ internal class OnPartyInteractionPatch
             return false;
         }
 
-        if (ContainerProvider.TryResolve<OnPartyInteractionHandler>(out var handler) &&
-            handler.TryHandleReciprocalPlayerInteraction(targetParty, engagingParty))
+        if (!CanHandleReciprocalPlayerInteraction(targetParty, engagingParty)) return true;
+        if (!IsReciprocalPlayerInteractionReady(targetParty, engagingParty)) return true;
+        if (!TryGetPartyBases(targetParty, engagingParty, out var targetPartyBase, out var engagingPartyBase))
+            return true;
+
+        if (ContainerProvider.TryResolve<PlayerPartyInteractionHandler>(out var handler) &&
+            handler.TryHandleReciprocalPlayerInteraction(targetPartyBase, engagingPartyBase))
             return false;
 
         return true;
@@ -42,5 +48,39 @@ internal class OnPartyInteractionPatch
             return targetParty.AttachedTo;
 
         return targetParty;
+    }
+
+    internal static bool CanHandleReciprocalPlayerInteraction(MobileParty targetParty, MobileParty engagingParty)
+    {
+        if (ModInformation.IsServer) return false;
+        if (targetParty == null || engagingParty == null) return false;
+        if (targetParty == engagingParty) return false;
+        if (!engagingParty.IsMainParty) return false;
+        if (!engagingParty.IsControlledByThisInstance()) return false;
+        if (!targetParty.IsPlayerParty()) return false;
+
+        return true;
+    }
+
+    internal static bool IsReciprocalPlayerInteractionReady(MobileParty targetParty, MobileParty engagingParty)
+    {
+        if (targetParty.CurrentSettlement != null) return false;
+        if (targetParty.MapEvent != null || engagingParty.MapEvent != null) return false;
+        if (!targetParty.IsEngaging) return false;
+        if (targetParty.ShortTermTargetParty != engagingParty) return false;
+
+        return true;
+    }
+
+    internal static bool TryGetPartyBases(
+        MobileParty targetParty,
+        MobileParty engagingParty,
+        out PartyBase targetPartyBase,
+        out PartyBase engagingPartyBase)
+    {
+        targetPartyBase = targetParty.Party;
+        engagingPartyBase = engagingParty.Party;
+
+        return targetPartyBase != null && engagingPartyBase != null;
     }
 }

--- a/source/GameInterface/Services/MobileParties/Patches/OnPartyInteractionPatch.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/OnPartyInteractionPatch.cs
@@ -22,17 +22,27 @@ internal class OnPartyInteractionPatch
     [HarmonyPrefix]
     private static bool Prefix(MobileParty __instance, MobileParty engagingParty)
     {
-        if (__instance?.MemberRoster == null || __instance.MemberRoster.Count == 0)
+        var targetParty = GetEffectiveInteractionTargetParty(__instance, engagingParty);
+
+        if (targetParty?.MemberRoster == null || targetParty.MemberRoster.Count == 0)
         {
             Logger.Verbose("Skipping {Method} for party '{Party}' because its MemberRoster is empty",
-                nameof(MobileParty.OnPartyInteraction), __instance?.StringId ?? "<null>");
+                nameof(MobileParty.OnPartyInteraction), targetParty?.StringId ?? "<null>");
             return false;
         }
 
-        if (TryHandleReciprocalPlayerInteraction(__instance, engagingParty))
+        if (TryHandleReciprocalPlayerInteraction(targetParty, engagingParty))
             return false;
 
         return true;
+    }
+
+    internal static MobileParty GetEffectiveInteractionTargetParty(MobileParty targetParty, MobileParty engagingParty)
+    {
+        if (targetParty?.AttachedTo != null && engagingParty != targetParty.AttachedTo)
+            return targetParty.AttachedTo;
+
+        return targetParty;
     }
 
     private static bool TryHandleReciprocalPlayerInteraction(MobileParty targetParty, MobileParty engagingParty)

--- a/source/GameInterface/Services/MobileParties/Patches/OnPartyInteractionPatch.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/OnPartyInteractionPatch.cs
@@ -39,7 +39,7 @@ internal class OnPartyInteractionPatch
         var message = new ReciprocalPlayerPartyInteractionAttempted(targetPartyBase, engagingPartyBase);
         MessageBroker.Instance.Publish(__instance, message);
 
-        return !message.Handled;
+        return false;
     }
 
     internal static MobileParty GetEffectiveInteractionTargetParty(MobileParty targetParty, MobileParty engagingParty)

--- a/source/GameInterface/Services/MobileParties/Patches/OnPartyInteractionPatch.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/OnPartyInteractionPatch.cs
@@ -37,22 +37,49 @@ internal class OnPartyInteractionPatch
 
     private static bool TryHandleReciprocalPlayerInteraction(MobileParty targetParty, MobileParty engagingParty)
     {
+        if (!CanHandleReciprocalPlayerInteraction(targetParty, engagingParty)) return false;
+        if (!IsReciprocalPlayerInteractionReady(targetParty, engagingParty)) return false;
+        if (!TryGetPartyBases(targetParty, engagingParty, out var targetPartyBase, out var engagingPartyBase))
+            return false;
+
+        if (ShouldInitiateReciprocalPlayerInteraction(engagingPartyBase, targetPartyBase))
+            EncounterManager.StartPartyEncounter(engagingPartyBase, targetPartyBase);
+
+        return true;
+    }
+
+    private static bool CanHandleReciprocalPlayerInteraction(MobileParty targetParty, MobileParty engagingParty)
+    {
         if (!ModInformation.IsClient) return false;
         if (targetParty == null || engagingParty == null) return false;
         if (targetParty == engagingParty) return false;
         if (!engagingParty.IsMainParty) return false;
         if (!engagingParty.IsControlledByThisInstance()) return false;
         if (!targetParty.IsPlayerParty()) return false;
+
+        return true;
+    }
+
+    private static bool IsReciprocalPlayerInteractionReady(MobileParty targetParty, MobileParty engagingParty)
+    {
         if (targetParty.CurrentSettlement != null) return false;
         if (targetParty.MapEvent != null || engagingParty.MapEvent != null) return false;
         if (!targetParty.IsEngaging) return false;
         if (targetParty.ShortTermTargetParty != engagingParty) return false;
-        if (targetParty.Party == null || engagingParty.Party == null) return false;
-
-        if (ShouldInitiateReciprocalPlayerInteraction(engagingParty.Party, targetParty.Party))
-            EncounterManager.StartPartyEncounter(engagingParty.Party, targetParty.Party);
 
         return true;
+    }
+
+    private static bool TryGetPartyBases(
+        MobileParty targetParty,
+        MobileParty engagingParty,
+        out PartyBase targetPartyBase,
+        out PartyBase engagingPartyBase)
+    {
+        targetPartyBase = targetParty.Party;
+        engagingPartyBase = engagingParty.Party;
+
+        return targetPartyBase != null && engagingPartyBase != null;
     }
 
     private static bool ShouldInitiateReciprocalPlayerInteraction(PartyBase engagingParty, PartyBase targetParty)

--- a/source/GameInterface/Services/MobileParties/Patches/OnPartyInteractionPatch.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/OnPartyInteractionPatch.cs
@@ -1,6 +1,10 @@
+using Common;
 using Common.Logging;
+using GameInterface.Services.MobileParties.Extensions;
+using GameInterface.Services.ObjectManager;
 using HarmonyLib;
 using Serilog;
+using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
 
 namespace GameInterface.Services.MobileParties.Patches;
@@ -16,7 +20,7 @@ internal class OnPartyInteractionPatch
     private static readonly ILogger Logger = LogManager.GetLogger<OnPartyInteractionPatch>();
 
     [HarmonyPrefix]
-    private static bool Prefix(MobileParty __instance)
+    private static bool Prefix(MobileParty __instance, MobileParty engagingParty)
     {
         if (__instance?.MemberRoster == null || __instance.MemberRoster.Count == 0)
         {
@@ -25,6 +29,38 @@ internal class OnPartyInteractionPatch
             return false;
         }
 
+        if (TryHandleReciprocalPlayerInteraction(__instance, engagingParty))
+            return false;
+
         return true;
+    }
+
+    private static bool TryHandleReciprocalPlayerInteraction(MobileParty targetParty, MobileParty engagingParty)
+    {
+        if (!ModInformation.IsClient) return false;
+        if (targetParty == null || engagingParty == null) return false;
+        if (targetParty == engagingParty) return false;
+        if (!engagingParty.IsMainParty) return false;
+        if (!engagingParty.IsControlledByThisInstance()) return false;
+        if (!targetParty.IsPlayerParty()) return false;
+        if (targetParty.CurrentSettlement != null) return false;
+        if (targetParty.MapEvent != null || engagingParty.MapEvent != null) return false;
+        if (!targetParty.IsEngaging) return false;
+        if (targetParty.ShortTermTargetParty != engagingParty) return false;
+        if (targetParty.Party == null || engagingParty.Party == null) return false;
+
+        if (ShouldInitiateReciprocalPlayerInteraction(engagingParty.Party, targetParty.Party))
+            EncounterManager.StartPartyEncounter(engagingParty.Party, targetParty.Party);
+
+        return true;
+    }
+
+    private static bool ShouldInitiateReciprocalPlayerInteraction(PartyBase engagingParty, PartyBase targetParty)
+    {
+        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)) return false;
+        if (!objectManager.TryGetId(engagingParty, out var engagingPartyId)) return false;
+        if (!objectManager.TryGetId(targetParty, out var targetPartyId)) return false;
+
+        return string.CompareOrdinal(engagingPartyId, targetPartyId) <= 0;
     }
 }

--- a/source/GameInterface/Services/MobileParties/Patches/OnPartyInteractionPatch.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/OnPartyInteractionPatch.cs
@@ -1,10 +1,8 @@
 using Common;
 using Common.Logging;
-using GameInterface.Services.MobileParties.Extensions;
-using GameInterface.Services.ObjectManager;
+using GameInterface.Services.MobileParties.Handlers;
 using HarmonyLib;
 using Serilog;
-using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
 
 namespace GameInterface.Services.MobileParties.Patches;
@@ -31,7 +29,8 @@ internal class OnPartyInteractionPatch
             return false;
         }
 
-        if (TryHandleReciprocalPlayerInteraction(targetParty, engagingParty))
+        if (ContainerProvider.TryResolve<OnPartyInteractionHandler>(out var handler) &&
+            handler.TryHandleReciprocalPlayerInteraction(targetParty, engagingParty))
             return false;
 
         return true;
@@ -43,61 +42,5 @@ internal class OnPartyInteractionPatch
             return targetParty.AttachedTo;
 
         return targetParty;
-    }
-
-    private static bool TryHandleReciprocalPlayerInteraction(MobileParty targetParty, MobileParty engagingParty)
-    {
-        if (!CanHandleReciprocalPlayerInteraction(targetParty, engagingParty)) return false;
-        if (!IsReciprocalPlayerInteractionReady(targetParty, engagingParty)) return false;
-        if (!TryGetPartyBases(targetParty, engagingParty, out var targetPartyBase, out var engagingPartyBase))
-            return false;
-
-        if (ShouldInitiateReciprocalPlayerInteraction(engagingPartyBase, targetPartyBase))
-            EncounterManager.StartPartyEncounter(engagingPartyBase, targetPartyBase);
-
-        return true;
-    }
-
-    private static bool CanHandleReciprocalPlayerInteraction(MobileParty targetParty, MobileParty engagingParty)
-    {
-        if (!ModInformation.IsClient) return false;
-        if (targetParty == null || engagingParty == null) return false;
-        if (targetParty == engagingParty) return false;
-        if (!engagingParty.IsMainParty) return false;
-        if (!engagingParty.IsControlledByThisInstance()) return false;
-        if (!targetParty.IsPlayerParty()) return false;
-
-        return true;
-    }
-
-    private static bool IsReciprocalPlayerInteractionReady(MobileParty targetParty, MobileParty engagingParty)
-    {
-        if (targetParty.CurrentSettlement != null) return false;
-        if (targetParty.MapEvent != null || engagingParty.MapEvent != null) return false;
-        if (!targetParty.IsEngaging) return false;
-        if (targetParty.ShortTermTargetParty != engagingParty) return false;
-
-        return true;
-    }
-
-    private static bool TryGetPartyBases(
-        MobileParty targetParty,
-        MobileParty engagingParty,
-        out PartyBase targetPartyBase,
-        out PartyBase engagingPartyBase)
-    {
-        targetPartyBase = targetParty.Party;
-        engagingPartyBase = engagingParty.Party;
-
-        return targetPartyBase != null && engagingPartyBase != null;
-    }
-
-    private static bool ShouldInitiateReciprocalPlayerInteraction(PartyBase engagingParty, PartyBase targetParty)
-    {
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)) return false;
-        if (!objectManager.TryGetId(engagingParty, out var engagingPartyId)) return false;
-        if (!objectManager.TryGetId(targetParty, out var targetPartyId)) return false;
-
-        return string.CompareOrdinal(engagingPartyId, targetPartyId) <= 0;
     }
 }

--- a/source/GameInterface/Services/MobileParties/Patches/OnPartyInteractionPatch.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/OnPartyInteractionPatch.cs
@@ -1,7 +1,8 @@
 using Common;
 using Common.Logging;
+using Common.Messaging;
 using GameInterface.Services.MobileParties.Extensions;
-using GameInterface.Services.MobileParties.Handlers;
+using GameInterface.Services.MobileParties.Messages;
 using HarmonyLib;
 using Serilog;
 using TaleWorlds.CampaignSystem.Party;
@@ -35,11 +36,10 @@ internal class OnPartyInteractionPatch
         if (!TryGetPartyBases(targetParty, engagingParty, out var targetPartyBase, out var engagingPartyBase))
             return true;
 
-        if (ContainerProvider.TryResolve<PlayerPartyInteractionHandler>(out var handler) &&
-            handler.TryHandleReciprocalPlayerInteraction(targetPartyBase, engagingPartyBase))
-            return false;
+        var message = new ReciprocalPlayerPartyInteractionAttempted(targetPartyBase, engagingPartyBase);
+        MessageBroker.Instance.Publish(__instance, message);
 
-        return true;
+        return !message.Handled;
     }
 
     internal static MobileParty GetEffectiveInteractionTargetParty(MobileParty targetParty, MobileParty engagingParty)


### PR DESCRIPTION
fixed bug when two player parties clicked each other at same time the p2p interaction would not open

## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When two players clicked eachother on the campaign map, after their parties met, a P2P dialog was not starting properly.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #1581 
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
P2P dialog now starts properly

## Other information
