### PR TITLE
#1253 Opening battle retreat confirmation no longer stops time

### DIFF
--- a/source/GameInterface/Services/MapEvents/Patches/Disable/DisableRetreatConfirmationPausePatch.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/Disable/DisableRetreatConfirmationPausePatch.cs
@@ -1,0 +1,23 @@
+using HarmonyLib;
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.MountAndBlade.Source.Missions.Handlers;
+
+namespace GameInterface.Services.MapEvents.Patches.Disable;
+
+[HarmonyPatch(typeof(BasicMissionHandler), nameof(BasicMissionHandler.CreateWarningWidgetForResult))]
+internal class DisableRetreatConfirmationPausePatch
+{
+    [HarmonyPrefix]
+    private static bool Prefix(BasicMissionHandler __instance, BattleEndLogic.ExitResult result)
+    {
+        if (result != BattleEndLogic.ExitResult.NeedsPlayerConfirmation)
+        {
+            return true;
+        }
+
+        __instance._isSurrender = false;
+        InformationManager.ShowInquiry(__instance.GetRetreatPopUpData(), false, false);
+        return false;
+    }
+}

--- a/source/GameInterface/Services/MapEvents/Patches/Disable/DisableRetreatConfirmationPausePatch.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/Disable/DisableRetreatConfirmationPausePatch.cs
@@ -17,7 +17,7 @@ internal class DisableRetreatConfirmationPausePatch
         }
 
         __instance._isSurrender = false;
-        InformationManager.ShowInquiry(__instance.GetRetreatPopUpData(), false, false);
+        InformationManager.ShowInquiry(__instance.GetRetreatPopUpData());
         return false;
     }
 }


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When trying to surrender in a battle, when the confirmation dialog popped up, the time would stop

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #1253 
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
The time no longer stops when the surrender confirmation dialog is open

## Other information
