### PR TITLE
[1571-PART1] Drop the duplicate UpdatePartyBehaviorPacket broadcast

### DIFF
--- a/source/Coop.Core/Server/Services/MobileParties/Handlers/ServerMobilePartyBehaviorHandler.cs
+++ b/source/Coop.Core/Server/Services/MobileParties/Handlers/ServerMobilePartyBehaviorHandler.cs
@@ -1,6 +1,4 @@
 ﻿using Common.Messaging;
-using Common.Network;
-using Coop.Core.Client.Services.MobileParties.Packets;
 using GameInterface.Services.MobileParties.Messages.Behavior;
 
 namespace Coop.Core.Server.Services.MobileParties.Handlers;
@@ -13,14 +11,11 @@ namespace Coop.Core.Server.Services.MobileParties.Handlers;
 public class ServerMobilePartyBehaviorHandler : IHandler
 {
     private readonly IMessageBroker messageBroker;
-    private readonly INetwork network;
 
-    public ServerMobilePartyBehaviorHandler(IMessageBroker messageBroker, INetwork network)
+    public ServerMobilePartyBehaviorHandler(IMessageBroker messageBroker)
     {
         this.messageBroker = messageBroker;
-        this.network = network;
         messageBroker.Subscribe<ControlledPartyBehaviorUpdated>(Handle);
-
     }
     public void Dispose()
     {
@@ -30,8 +25,6 @@ public class ServerMobilePartyBehaviorHandler : IHandler
     private void Handle(MessagePayload<ControlledPartyBehaviorUpdated> obj)
     {
         var data = obj.What.BehaviorUpdateData;
-
-        network.SendAll(new UpdatePartyBehaviorPacket(ref data));
 
         messageBroker.Publish(this, new UpdatePartyBehavior(ref data));
     }


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Refactoring (no functional changes, no api changes)

## What is the current behavior?

UpdatePartyBehaviorPacket  double sent

Part of #1571

## What is the new behavior?

no double send

| UpdatePartyBehaviorPacket, per 10 seconds | Before | After |
|---|---|---|
| Packets | ~2,421 | ~1,201 |
| Size | ~226 KB | ~112 KB |
