### PR TITLE
[1566] Stop double serializing IMessages

### DIFF
--- a/source/Common/PacketHandlers/MessagePacketHandler.cs
+++ b/source/Common/PacketHandlers/MessagePacketHandler.cs
@@ -13,7 +13,11 @@ using System.Runtime.ExceptionServices;
 
 namespace Common.PacketHandlers;
 
-public interface IMessagePacketHandler : IPacketHandler { }
+public interface IMessagePacketHandler : IPacketHandler
+{
+    // Also invoked from OnNetworkReceive for a bare received message that arrived without a MessagePacket layer.
+    void PublishEvent(NetPeer peer, IMessage message);
+}
 
 public class MessagePacketHandler : IMessagePacketHandler
 {
@@ -49,7 +53,7 @@ public class MessagePacketHandler : IMessagePacketHandler
     }
     private readonly ConcurrentDictionary<Type, Action<IMessageBroker, NetPeer, IMessage>> publishFunctionCache = new();
 
-    internal virtual void PublishEvent(NetPeer peer, IMessage message)
+    public virtual void PublishEvent(NetPeer peer, IMessage message)
     {
         if (message is null)
             throw new ArgumentNullException(nameof(message));

--- a/source/Coop.Core/Client/CoopClient.cs
+++ b/source/Coop.Core/Client/CoopClient.cs
@@ -73,8 +73,6 @@ public class CoopClient : CoopNetworkBase, ICoopClient
         {
             object received = serializer.Deserialize(reader.GetRemainingBytes());
 
-            // A campaign message now travels as its own wrapper, so it deserializes to a bare IMessage;
-            // publish it directly. Real IPackets (and relay-tunneled MessagePackets) still dispatch by type.
             if (received is IPacket packet)
             {
                 packetManager.HandleReceive(peer, packet);

--- a/source/Coop.Core/Client/CoopClient.cs
+++ b/source/Coop.Core/Client/CoopClient.cs
@@ -33,6 +33,7 @@ public class CoopClient : CoopNetworkBase, ICoopClient
 
     private readonly IMessageBroker messageBroker;
     private readonly IPacketManager packetManager;
+    private readonly IMessagePacketHandler messagePacketHandler;
     private bool isConnected = false;
     private bool reconnectPending = false;
     private DateTime reconnectAfter = DateTime.MinValue;
@@ -41,10 +42,12 @@ public class CoopClient : CoopNetworkBase, ICoopClient
         INetworkConfig config,
         IMessageBroker messageBroker,
         IPacketManager packetManager,
+        IMessagePacketHandler messagePacketHandler,
         ICommonSerializer serializer) : base(config, serializer)
     {
         this.messageBroker = messageBroker;
         this.packetManager = packetManager;
+        this.messagePacketHandler = messagePacketHandler;
     }
 
     public override void OnConnectionRequest(ConnectionRequest request)
@@ -68,9 +71,22 @@ public class CoopClient : CoopNetworkBase, ICoopClient
     {
         try
         {
-            IPacket packet = (IPacket)serializer.Deserialize(reader.GetRemainingBytes());
+            object received = serializer.Deserialize(reader.GetRemainingBytes());
 
-            packetManager.HandleReceive(peer, packet);
+            // A campaign message now travels as its own wrapper, so it deserializes to a bare IMessage;
+            // publish it directly. Real IPackets (and relay-tunneled MessagePackets) still dispatch by type.
+            if (received is IPacket packet)
+            {
+                packetManager.HandleReceive(peer, packet);
+            }
+            else if (received is IMessage message)
+            {
+                messagePacketHandler.PublishEvent(peer, message);
+            }
+            else
+            {
+                Logger.Error("Received payload deserialized to neither IPacket nor IMessage: {Type}", received?.GetType());
+            }
         }
         catch (Exception ex)
         {

--- a/source/Coop.Core/Common/CommonModule.cs
+++ b/source/Coop.Core/Common/CommonModule.cs
@@ -31,7 +31,7 @@ public abstract class CommonModule : Module
 
         #region Communication
         builder.RegisterType<PacketManager>().As<IPacketManager>().InstancePerLifetimeScope();
-        builder.RegisterType<MessagePacketHandler>().AsSelf().InstancePerLifetimeScope().AutoActivate();
+        builder.RegisterType<MessagePacketHandler>().AsSelf().As<IMessagePacketHandler>().InstancePerLifetimeScope().AutoActivate();
         builder.RegisterInstance(MessageBroker.Instance).As<IMessageBroker>().SingleInstance().ExternallyOwned();
         #endregion
 

--- a/source/Coop.Core/Common/Network/CoopNetworkBase.cs
+++ b/source/Coop.Core/Common/Network/CoopNetworkBase.cs
@@ -112,8 +112,11 @@ public abstract class CoopNetworkBase : INetwork, INetEventListener
 
     private void SendInternal(NetPeer netPeer, IPacket packet)
     {
-        // Serialize data
-        byte[] data = serializer.Serialize(packet);
+        // A MessagePacket already holds a fully serialized, self-identifying message wrapper in Data; send
+        // that directly instead of serializing the packet a second time (which double-wraps every message).
+        byte[] data = packet is MessagePacket messagePacket
+            ? messagePacket.Data
+            : serializer.Serialize(packet);
 
         // Profile every outbound packet (server only). MessagePacket carries its message type, so the
         // profile breaks message traffic out by message type rather than one opaque MessagePacket bucket.

--- a/source/Coop.Core/Server/CoopServer.cs
+++ b/source/Coop.Core/Server/CoopServer.cs
@@ -38,6 +38,7 @@ public class CoopServer : CoopNetworkBase, ICoopServer
 
     private readonly IMessageBroker messageBroker;
     private readonly IPacketManager packetManager;
+    private readonly IMessagePacketHandler messagePacketHandler;
     private readonly IConnectionMessageQueue connectionMessageQueue;
     // Buffers per-change sends and merges them into one send per key. Drained each tick in Update.
     private readonly ISendCoalescer coalescer;
@@ -53,6 +54,7 @@ public class CoopServer : CoopNetworkBase, ICoopServer
         INetworkConfig configuration,
         IMessageBroker messageBroker,
         IPacketManager packetManager,
+        IMessagePacketHandler messagePacketHandler,
         IConnectionMessageQueue connectionMessageQueue,
         IControllerIdProvider controllerIdProvider,
         IMissionManager missionManager,
@@ -63,6 +65,7 @@ public class CoopServer : CoopNetworkBase, ICoopServer
         // Dependancy assignment
         this.messageBroker = messageBroker;
         this.packetManager = packetManager;
+        this.messagePacketHandler = messagePacketHandler;
         this.connectionMessageQueue = connectionMessageQueue;
         this.missionManager = missionManager;
         this.overloadedPeerManager = overloadedPeerManager;
@@ -103,8 +106,22 @@ public class CoopServer : CoopNetworkBase, ICoopServer
 
     public override void OnNetworkReceive(NetPeer peer, NetPacketReader reader, byte channelNumber, DeliveryMethod deliveryMethod)
     {
-        IPacket packet = (IPacket)serializer.Deserialize(reader.GetRemainingBytes());
-        packetManager.HandleReceive(peer, packet);
+        object received = serializer.Deserialize(reader.GetRemainingBytes());
+
+        // A campaign message now travels as its own wrapper, so it deserializes to a bare IMessage;
+        // publish it directly. Real IPackets (and relay-tunneled MessagePackets) still dispatch by type.
+        if (received is IPacket packet)
+        {
+            packetManager.HandleReceive(peer, packet);
+        }
+        else if (received is IMessage message)
+        {
+            messagePacketHandler.PublishEvent(peer, message);
+        }
+        else
+        {
+            Logger.Error("Received payload deserialized to neither IPacket nor IMessage: {Type}", received?.GetType());
+        }
     }
 
     public override void OnNetworkReceiveUnconnected(IPEndPoint remoteEndPoint, NetPacketReader reader, UnconnectedMessageType messageType)

--- a/source/Coop.Core/Server/CoopServer.cs
+++ b/source/Coop.Core/Server/CoopServer.cs
@@ -108,8 +108,6 @@ public class CoopServer : CoopNetworkBase, ICoopServer
     {
         object received = serializer.Deserialize(reader.GetRemainingBytes());
 
-        // A campaign message now travels as its own wrapper, so it deserializes to a bare IMessage;
-        // publish it directly. Real IPackets (and relay-tunneled MessagePackets) still dispatch by type.
         if (received is IPacket packet)
         {
             packetManager.HandleReceive(peer, packet);


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Other... Please describe: Bandwidth optimization (wire-encoding change, no functional/gameplay change)

## What is the current behavior?

`IMessage` gets serialized into a `ProtoMessageWrapper` (`byte[]`)
`ProtoMessageWrapper` gets stored as `MessagePacket.Data`
`MessagePacket` gets serialized into `ProtoMessageWrapper` again
that `ProtoMessageWrapper` gets sent through the network

this double serialization accounts for ~10% of our current total throughput 

## What is the new behavior?

Resolves #1566

`IMessage` gets serialized into a `ProtoMessageWrapper`
that `ProtoMessageWrapper` gets sent through the network

| per 10 seconds | Before | After |
|---|---|---|
| Sync messages sent | ~22,200 | ~22,200 |
| Message traffic | ~1,415 KB | ~1,236 KB |
| Avg bytes per message | ~65 | ~57 |
