### PR TITLE
[1565-PART1] Strip the redundant type prefix from autosynced object ids

### DIFF
--- a/source/GameInterface.Tests/Utils/IdCompactionTests.cs
+++ b/source/GameInterface.Tests/Utils/IdCompactionTests.cs
@@ -1,0 +1,103 @@
+﻿using GameInterface.Services.ObjectManager;
+using GameInterface.Utils.NetworkEvents;
+using Moq;
+using Serilog;
+using Xunit;
+
+namespace GameInterface.Tests.Utils;
+
+/// <summary>
+/// Wire-id compaction: <see cref="ObjectManager.Compact"/> strips the redundant "{TypeName}_" prefix
+/// on send, the AutoSync message ctors apply it, and <see cref="ObjectManager.TryGetObject{T}"/>
+/// re-resolves a compacted id back to the registered object (preferring the prefixed key so a bare id
+/// can't resolve to a colliding un-prefixed key).
+/// </summary>
+public class IdCompactionTests
+{
+    // Local stand-ins so the test needs no game types; only their Name matters for the prefix.
+    private sealed class MobileParty { }
+    private sealed class Settlement { }
+
+    private static ObjectManager NewObjectManager() => new ObjectManager(Mock.Of<ILogger>());
+
+    [Fact]
+    public void Compact_StripsMatchingTypePrefix()
+    {
+        Assert.Equal("looters1_1", ObjectManager.Compact("MobileParty_looters1_1", typeof(MobileParty)));
+        Assert.Equal("town_ES1", ObjectManager.Compact("Settlement_town_ES1", typeof(Settlement)));
+    }
+
+    [Fact]
+    public void Compact_LeavesNonMatchingPrefixUntouched()
+    {
+        // Concrete type differs from the wire type: no strip, so the full id round-trips as-is.
+        Assert.Equal("Settlement_town_ES1", ObjectManager.Compact("Settlement_town_ES1", typeof(MobileParty)));
+    }
+
+    [Fact]
+    public void Compact_LeavesAlreadyCompactIdUntouched()
+    {
+        Assert.Equal("looters1_1", ObjectManager.Compact("looters1_1", typeof(MobileParty)));
+    }
+
+    [Fact]
+    public void Compact_HandlesNullAndEmpty()
+    {
+        Assert.Null(ObjectManager.Compact(null, typeof(MobileParty)));
+        Assert.Equal(string.Empty, ObjectManager.Compact(string.Empty, typeof(MobileParty)));
+    }
+
+    [Fact]
+    public void CompactedId_ResolvesBackToTheRegisteredObject()
+    {
+        var objectManager = NewObjectManager();
+        var party = new MobileParty();
+        objectManager.AddExisting("MobileParty_looters1_1", party);
+
+        var wireId = ObjectManager.Compact("MobileParty_looters1_1", typeof(MobileParty));
+
+        Assert.True(objectManager.TryGetObject<MobileParty>(wireId, out var resolved));
+        Assert.Same(party, resolved);
+    }
+
+    [Fact]
+    public void CompactedId_PrefersPrefixedKeyOverCollidingBareKey()
+    {
+        // A bare id can collide with an un-prefixed key registered for a different object; the resolver
+        // must still return the type-correct object stored under "{TypeName}_{id}".
+        var objectManager = NewObjectManager();
+        var party = new MobileParty();
+        objectManager.AddExisting("MobileParty_looters1_1", party);
+        objectManager.AddExisting("looters1_1", new Settlement()); // colliding un-prefixed key
+
+        Assert.True(objectManager.TryGetObject<MobileParty>("looters1_1", out var resolved));
+        Assert.Same(party, resolved);
+    }
+
+    [Fact]
+    public void ValueEventCtor_CompactsInstanceId()
+    {
+        Assert.Equal("looters1_1", new TestValueEvent("MobileParty_looters1_1").InstanceId);
+    }
+
+    [Fact]
+    public void ReferenceEventCtor_CompactsInstanceIdAndValueId()
+    {
+        var message = new TestReferenceEvent("MobileParty_looters1_1", "Settlement_town_ES1");
+        Assert.Equal("looters1_1", message.InstanceId);
+        Assert.Equal("town_ES1", message.ValueId);
+    }
+
+    private record TestValueEvent : GenericNetworkEvent<MobileParty, byte[]>
+    {
+        public override string InstanceId { get; set; } = null!; // set by the base ctor
+        public TestValueEvent(string instanceId) : base(instanceId) { }
+    }
+
+    private record TestReferenceEvent : GenericNetworkReferenceEvent<MobileParty, Settlement>
+    {
+        public override string InstanceId { get; set; } = null!; // set by the base ctor
+        public override string ValueId { get; set; } = null!; // set by the base ctor
+        public TestReferenceEvent(string instanceId, string valueId) : base(instanceId, valueId) { }
+    }
+}

--- a/source/GameInterface/Services/ObjectManager/ObjectManager.cs
+++ b/source/GameInterface/Services/ObjectManager/ObjectManager.cs
@@ -231,8 +231,10 @@ public class ObjectManager : IObjectManager
 
         if (string.IsNullOrEmpty(id)) return false;
 
-        if (!idObjs.TryGetValue(id, out var storedObj)
-            && !idObjs.TryGetValue($"{typeof(T).Name}_{id}", out storedObj)) // If object not found also attempt with prefixed type name
+        // Compacted ids arrive without their "{TypeName}_" prefix, so try the prefixed key first;
+        // a bare id could otherwise collide with an un-prefixed key registered for another object.
+        if (!idObjs.TryGetValue($"{typeof(T).Name}_{id}", out var storedObj)
+            && !idObjs.TryGetValue(id, out storedObj))
         {
             return false;
         }
@@ -246,6 +248,21 @@ public class ObjectManager : IObjectManager
         obj = castedObject;
 
         return true;
+    }
+
+    /// <summary>
+    /// Strips the redundant leading "{type.Name}_" prefix from a registered id for the wire; the
+    /// receiver re-adds it by type in <see cref="TryGetObject{T}"/>. Conditional, so a full id whose
+    /// concrete type differs from the wire type is transmitted untouched.
+    /// </summary>
+    public static string Compact(string id, Type type)
+    {
+        if (string.IsNullOrEmpty(id) || type == null) return id;
+
+        var prefix = type.Name + "_";
+        return id.StartsWith(prefix, StringComparison.Ordinal)
+            ? id.Substring(prefix.Length)
+            : id;
     }
 
     public bool Remove(object obj)

--- a/source/GameInterface/Utils/NetworkEvents/GenericNetworkEvent.cs
+++ b/source/GameInterface/Utils/NetworkEvents/GenericNetworkEvent.cs
@@ -1,4 +1,5 @@
 ﻿using Common.Messaging;
+using GameInterface.Services.ObjectManager;
 
 namespace GameInterface.Utils.NetworkEvents
 {
@@ -12,7 +13,8 @@ namespace GameInterface.Utils.NetworkEvents
 
         public GenericNetworkEvent(string instanceId)
         {
-            InstanceId = instanceId;
+            // Compact the id for the wire; the receiver re-adds the "{TInstance}_" prefix by type.
+            InstanceId = ObjectManager.Compact(instanceId, typeof(TInstance));
         }
     }
 }

--- a/source/GameInterface/Utils/NetworkEvents/GenericNetworkReferenceEvent.cs
+++ b/source/GameInterface/Utils/NetworkEvents/GenericNetworkReferenceEvent.cs
@@ -1,4 +1,6 @@
-﻿namespace GameInterface.Utils.NetworkEvents
+﻿using GameInterface.Services.ObjectManager;
+
+namespace GameInterface.Utils.NetworkEvents
 {
     public abstract record GenericNetworkReferenceEvent<TInstance, TValue> : GenericNetworkEvent<TInstance, TValue>
     {
@@ -6,7 +8,8 @@
 
         protected GenericNetworkReferenceEvent(string instanceId, string valueId) : base(instanceId)
         {
-            ValueId = valueId;
+            // Compact the id for the wire; the receiver re-adds the "{TValue}_" prefix by type.
+            ValueId = ObjectManager.Compact(valueId, typeof(TValue));
         }
     }
 }


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [x] Other... Please describe: Network bandwidth optimization (compacts the id encoding on the wire)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

each AutoSync message carries the object id beginning with a redundant type-name prefix (e.g. `MobileParty_looters1_1`, `Settlement_town_ES1`).

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
part of #1565

for autosync, the redundant prefix is stripped and the receiver derives it from the message type.

| | Before | After |
|---|---|---|
| Sync packets | ~24,100 | ~24,100 (unchanged) |
| Total size | ~1,614 KB | ~1,423 KB (-12%) |
| AutoSync `*_SetNetworkMessage` size | ~709 KB | ~535 KB (-25%) |

