### PR TITLE
[1679] Compact object ids in hand-written sync messages

### DIFF
--- a/source/Coop.Core/Server/Services/ItemRosters/Handlers/ItemRosterMessageHandler.cs
+++ b/source/Coop.Core/Server/Services/ItemRosters/Handlers/ItemRosterMessageHandler.cs
@@ -4,6 +4,9 @@ using Common.Network.Coalescing;
 using Coop.Core.Server.Services.ItemRosters.Messages;
 using GameInterface.Services.ItemRosters.Messages;
 using GameInterface.Services.ObjectManager;
+using static GameInterface.Services.ObjectManager.ObjectManager;
+using TaleWorlds.CampaignSystem.Roster;
+using TaleWorlds.Core;
 
 namespace Coop.Core.Server.Services.ItemRosters.Handlers;
 
@@ -44,6 +47,10 @@ public class ItemRosterMessageHandler : IHandler
             return;
         }
 
+        itemRosterId = Compact(itemRosterId, typeof(ItemRoster));
+        itemId = Compact(itemId, typeof(ItemObject));
+        itemModifierId = Compact(itemModifierId, typeof(ItemModifier));
+
         // Sum this tick's deltas for the element and send one update at flush instead of one per AddToCounts.
         var key = new CoalesceKey(ItemRosterUpdateChannel, itemRosterId, $"{itemId}:{itemModifierId}");
         coalescer.Enqueue(key, new SummedPayload<int>(
@@ -57,6 +64,7 @@ public class ItemRosterMessageHandler : IHandler
         var message = payload.What;
 
         if (!objectManager.TryGetIdWithLogging(message.ItemRoster, out var itemRosterId)) return;
+        itemRosterId = Compact(itemRosterId, typeof(ItemRoster));
 
         // A clear supersedes this roster's pending updates; drop them so the clear isn't trailed by a stale update.
         coalescer.DropInstance(itemRosterId);

--- a/source/Coop.Core/Server/Services/Kingdoms/Handlers/ServerKingdomHandler.cs
+++ b/source/Coop.Core/Server/Services/Kingdoms/Handlers/ServerKingdomHandler.cs
@@ -8,6 +8,7 @@ using GameInterface.Services.Kingdoms;
 using GameInterface.Services.Kingdoms.Messages;
 using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Services.ObjectManager;
+using static GameInterface.Services.ObjectManager.ObjectManager;
 using GameInterface.Services.Players;
 using LiteNetLib;
 using System;
@@ -149,7 +150,9 @@ public class ServerKingdomHandler : IHandler
             }
         });
 
-        network.SendAll(new NetworkPartyEnterSettlement(settlementId, partyId));
+        network.SendAll(new NetworkPartyEnterSettlement(
+            Compact(settlementId, typeof(Settlement)),
+            Compact(partyId, typeof(MobileParty))));
     }
 
     private static void RunSettlementMutation(Action action)

--- a/source/Coop.Core/Server/Services/MobileParties/Handlers/ServerSettlementExitEnterHandler.cs
+++ b/source/Coop.Core/Server/Services/MobileParties/Handlers/ServerSettlementExitEnterHandler.cs
@@ -7,6 +7,7 @@ using Coop.Core.Server.Services.MobileParties.Messages;
 using GameInterface.Services.Kingdoms;
 using GameInterface.Services.MobileParties.Messages.Behavior;
 using GameInterface.Services.ObjectManager;
+using static GameInterface.Services.ObjectManager.ObjectManager;
 using GameInterface.Services.Settlements.Interfaces;
 using LiteNetLib;
 using Serilog;
@@ -64,7 +65,9 @@ public class ServerSettlementExitEnterHandler : IHandler
 
         // Tell the other clients to apply the entry synchronously here, so the broadcast does not depend
         // on the game-loop pump (the server's own apply below is marshalled onto the game thread).
-        network.SendAllBut(peer, new NetworkPartyEnterSettlement(payload.SettlementId, payload.PartyId));
+        network.SendAllBut(peer, new NetworkPartyEnterSettlement(
+            Compact(payload.SettlementId, typeof(Settlement)),
+            Compact(payload.PartyId, typeof(MobileParty))));
 
         GameThread.RunSafe(() =>
         {
@@ -91,7 +94,8 @@ public class ServerSettlementExitEnterHandler : IHandler
         // slightly differently from ai or other clients parties
         network.Send(peer, new NetworkEndSettlementEncounter());
 
-        network.SendAllBut(peer, new NetworkPartyLeaveSettlement(payload.PartyId));
+        network.SendAllBut(peer, new NetworkPartyLeaveSettlement(
+            Compact(payload.PartyId, typeof(MobileParty))));
 
         GameThread.RunSafe(() =>
         {
@@ -107,6 +111,9 @@ public class ServerSettlementExitEnterHandler : IHandler
 
         if (!objectManager.TryGetIdWithLogging(payload.Settlement, out var settlementId)) return;
         if (!objectManager.TryGetIdWithLogging(payload.MobileParty, out var mobilePartyId)) return;
+
+        settlementId = Compact(settlementId, typeof(Settlement));
+        mobilePartyId = Compact(mobilePartyId, typeof(MobileParty));
 
         network.SendAll(new NetworkPartyEnterSettlement(settlementId, mobilePartyId));
 
@@ -124,7 +131,8 @@ public class ServerSettlementExitEnterHandler : IHandler
             return;
         }
 
-        network.SendAll(new NetworkPartyLeaveSettlement(mobilePartyId));
+        network.SendAll(new NetworkPartyLeaveSettlement(
+            Compact(mobilePartyId, typeof(MobileParty))));
 
         settlementInterface.OnPartyLeftSettlement(payload.MobileParty);
     }

--- a/source/Coop.Core/Server/Services/Settlements/Handlers/ServerSettlementHandler.cs
+++ b/source/Coop.Core/Server/Services/Settlements/Handlers/ServerSettlementHandler.cs
@@ -3,9 +3,12 @@ using Common.Network;
 using Coop.Core.Client.Services.Settlements.Messages;
 using Coop.Core.Server.Services.Settlements.Messages;
 using GameInterface.Services.ObjectManager;
+using static GameInterface.Services.ObjectManager.ObjectManager;
 using GameInterface.Services.Settlements.Audit;
 using GameInterface.Services.Settlements.Messages;
 using LiteNetLib;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Settlements;
 
 namespace Coop.Core.Server.Services.Settlements.Handlers;
 
@@ -117,6 +120,9 @@ internal class ServerSettlementHandler : IHandler
         if (!objectManager.TryGetIdWithLogging(obj.Settlement, out var settlementId)) return;
         if (!objectManager.TryGetIdWithLogging(obj.MobileParty, out var mobilePartyId)) return;
 
+        settlementId = Compact(settlementId, typeof(Settlement));
+        mobilePartyId = Compact(mobilePartyId, typeof(MobileParty));
+
         var message = new NetworkChangeSettlementMobileParty(settlementId, mobilePartyId, obj.AddMobileParty);
         network.SendAll(message);
     }
@@ -137,6 +143,7 @@ internal class ServerSettlementHandler : IHandler
         var obj = payload.What;
 
         if (!objectManager.TryGetIdWithLogging(obj.Settlement, out var settlementId)) return;
+        settlementId = Compact(settlementId, typeof(Settlement));
 
         var message = new NetworkChangeSettlementMilitia(settlementId, obj.Militia);
         network.SendAll(message);

--- a/source/Coop.Core/Server/Services/Villages/Handlers/ServerVillageHandler.cs
+++ b/source/Coop.Core/Server/Services/Villages/Handlers/ServerVillageHandler.cs
@@ -2,7 +2,9 @@
 using Common.Network;
 using Coop.Core.Server.Services.Villages.Messages;
 using GameInterface.Services.ObjectManager;
+using static GameInterface.Services.ObjectManager.ObjectManager;
 using GameInterface.Services.Villages.Messages;
+using TaleWorlds.CampaignSystem.Settlements;
 
 namespace Coop.Core.Server.Services.Villages.Handlers;
 
@@ -72,6 +74,7 @@ internal class ServerVillageHandler : IHandler
         var obj = payload.What;
 
         if (!objectManager.TryGetIdWithLogging(obj.Village, out var villageId)) return;
+        villageId = Compact(villageId, typeof(Village));
 
         var networkMessage = new NetworkChangeVillageHearth(
             villageId,

--- a/source/GameInterface/Services/Caravans/Handlers/CaravansCampaignBehaviorHandler.cs
+++ b/source/GameInterface/Services/Caravans/Handlers/CaravansCampaignBehaviorHandler.cs
@@ -8,6 +8,7 @@ using GameInterface.Services.Caravans.Messages;
 using GameInterface.Services.MobileParties.Interfaces;
 using GameInterface.Services.MobileParties.Messages;
 using GameInterface.Services.ObjectManager;
+using static GameInterface.Services.ObjectManager.ObjectManager;
 using Serilog;
 using System.Collections.Generic;
 using TaleWorlds.CampaignSystem;
@@ -220,6 +221,7 @@ internal class CaravansCampaignBehaviorHandler : IHandler
     private void Handle_UpdateTradeActionLogsForParty(MessagePayload<UpdateTradeActionLogsForParty> obj)
     {
         if (!objectManager.TryGetIdWithLogging(obj.What.MobileParty, out var mobilePartyId)) return;
+        mobilePartyId = Compact(mobilePartyId, typeof(MobileParty));
 
         var tradeActionLogsData = new List<TradeActionLogData>();
         foreach (var tradeActionLog in obj.What.TradeActionLogs)
@@ -273,6 +275,9 @@ internal class CaravansCampaignBehaviorHandler : IHandler
 
         string soldSettlementId = null;
         if (tradeActionLog.SoldSettlement != null && !objectManager.TryGetIdWithLogging(tradeActionLog.SoldSettlement, out soldSettlementId)) return false;
+
+        boughtSettlementId = Compact(boughtSettlementId, typeof(Settlement));
+        soldSettlementId = Compact(soldSettlementId, typeof(Settlement));
 
         tradeActionLogData = new TradeActionLogData(
             boughtSettlementId,

--- a/source/GameInterface/Services/HeroDevelopers/Handlers/HeroDeveloperHandler.cs
+++ b/source/GameInterface/Services/HeroDevelopers/Handlers/HeroDeveloperHandler.cs
@@ -5,6 +5,7 @@ using Common.Network;
 using Common.Util;
 using GameInterface.Services.HeroDevelopers.Messages;
 using GameInterface.Services.ObjectManager;
+using static GameInterface.Services.ObjectManager.ObjectManager;
 using Serilog;
 using System;
 using TaleWorlds.CampaignSystem;
@@ -167,6 +168,9 @@ namespace GameInterface.Services.HeroDevelopers.Handlers
                 return;
             }
 
+            heroId = Compact(heroId, typeof(Hero));
+            skillObjectId = Compact(skillObjectId, typeof(SkillObject));
+
             // Send to server from client
             NetworkSetSkillXpServer message = new(
                 heroId,
@@ -268,6 +272,8 @@ namespace GameInterface.Services.HeroDevelopers.Handlers
                 Logger.Error("Unable to get network ID for instance of type {type}", obj.HeroDeveloper.Hero?.GetType());
                 return;
             }
+
+            heroId = Compact(heroId, typeof(Hero));
 
             // Send to server from client
             NetworkRawXpGainServer message = new(

--- a/source/GameInterface/Services/Heroes/Handlers/HeroCollectionHandler.cs
+++ b/source/GameInterface/Services/Heroes/Handlers/HeroCollectionHandler.cs
@@ -5,6 +5,7 @@ using Common.Network;
 using Common.Util;
 using GameInterface.Services.Heroes.Messages.Collections;
 using GameInterface.Services.ObjectManager;
+using static GameInterface.Services.ObjectManager.ObjectManager;
 using Serilog;
 using System;
 using TaleWorlds.CampaignSystem;
@@ -73,6 +74,8 @@ namespace GameInterface.Services.Heroes.Handlers
             if (!TryGetId(data.Instance, out string HeroId)) return;
             if (!TryGetId(data.Value, out string CharacterObjectId) && data.Value != null) return;
 
+            HeroId = Compact(HeroId, typeof(Hero));
+            CharacterObjectId = Compact(CharacterObjectId, typeof(CharacterObject));
             network.SendAll(new NetworkUpdateArray(HeroId, CharacterObjectId, data.Index));
         }
 

--- a/source/GameInterface/Services/MobileParties/Handlers/MobilePartyBehaviorHandler.cs
+++ b/source/GameInterface/Services/MobileParties/Handlers/MobilePartyBehaviorHandler.cs
@@ -10,6 +10,7 @@ using GameInterface.Services.MobileParties.Messages.Behavior;
 using GameInterface.Services.MobilePartyAIs;
 using GameInterface.Services.MobilePartyAIs.Patches;
 using GameInterface.Services.ObjectManager;
+using static GameInterface.Services.ObjectManager.ObjectManager;
 using Serilog;
 using System;
 using TaleWorlds.CampaignSystem.Party;
@@ -69,10 +70,14 @@ internal class MobilePartyBehaviorHandler : IHandler
         if (!partyAi._mobileParty.IsControlledByThisInstance())
             return;
 
+        partyId = Compact(partyId, typeof(MobileParty));
+
         string interactablePointId = null;
         if (interactablePoint is PartyBase partyBase &&
             !objectManager.TryGetId(partyBase, out interactablePointId))
             return;
+
+        interactablePointId = Compact(interactablePointId, typeof(PartyBase));
 
         PartyBehaviorUpdateData data = new PartyBehaviorUpdateData(
             partyId,

--- a/source/GameInterface/Services/MobileParties/Handlers/VolunteerTypesHandler.cs
+++ b/source/GameInterface/Services/MobileParties/Handlers/VolunteerTypesHandler.cs
@@ -4,6 +4,7 @@ using Common.Network;
 using Common.Util;
 using GameInterface.Services.MobileParties.Messages;
 using GameInterface.Services.ObjectManager;
+using static GameInterface.Services.ObjectManager.ObjectManager;
 using HarmonyLib;
 using System.Collections.Generic;
 using TaleWorlds.CampaignSystem;
@@ -69,6 +70,7 @@ internal class VolunteerTypesHandler : IHandler
         foreach (KeyValuePair<Hero, CharacterObject[]> keyValuePair in obj.What.UpdatedVolunteerTypes)
         {
             if (!objectManager.TryGetIdWithLogging(keyValuePair.Key, out var currentHeroId)) continue;
+            currentHeroId = Compact(currentHeroId, typeof(Hero));
 
             CharacterObject[] volunteerTypes = keyValuePair.Value;
             string[] volunteerTypeIds = new string[volunteerTypes.Length];
@@ -77,7 +79,7 @@ internal class VolunteerTypesHandler : IHandler
                 CharacterObject character = volunteerTypes[i];
                 if (character != null && objectManager.TryGetIdWithLogging(character, out var currentCharacterId))
                 {
-                    volunteerTypeIds[i] = currentCharacterId;
+                    volunteerTypeIds[i] = Compact(currentCharacterId, typeof(CharacterObject));
                 }
                 else
                 {

--- a/source/GameInterface/Services/MobilePartyAIs/Handlers/MobilePartyAiHandler.cs
+++ b/source/GameInterface/Services/MobilePartyAIs/Handlers/MobilePartyAiHandler.cs
@@ -5,6 +5,7 @@ using Common.Network;
 using Common.Util;
 using GameInterface.Services.MobilePartyAIs.Messages;
 using GameInterface.Services.ObjectManager;
+using static GameInterface.Services.ObjectManager.ObjectManager;
 using Serilog;
 using TaleWorlds.CampaignSystem.Party;
 
@@ -40,6 +41,7 @@ internal class MobilePartyAiHandler : IHandler
         {
             return;
         }
+        partyAiId = Compact(partyAiId, typeof(MobilePartyAi));
 
         if (interactablePoint is null)
         {
@@ -58,6 +60,7 @@ internal class MobilePartyAiHandler : IHandler
         {
             return;
         }
+        interactablePointId = Compact(interactablePointId, typeof(PartyBase));
 
         network.SendAll(new UpdateAiBehaviorInteractablePoint(partyAiId, interactablePointId));
     }

--- a/source/GameInterface/Services/TroopRosters/Handlers/TroopRosterDeltaHandler.cs
+++ b/source/GameInterface/Services/TroopRosters/Handlers/TroopRosterDeltaHandler.cs
@@ -4,6 +4,7 @@ using Common.Messaging;
 using Common.Network;
 using Common.Util;
 using GameInterface.Services.ObjectManager;
+using static GameInterface.Services.ObjectManager.ObjectManager;
 using GameInterface.Services.TroopRosters.Messages;
 using Serilog;
 using System;
@@ -106,6 +107,7 @@ internal class TroopRosterDeltaHandler : IHandler
         // Resolve silently: an unregistered roster is a scratch/dummy roster (see TryResolve) with nothing
         // to replicate, not an error.
         if (!objectManager.TryGetId(payload.What.TroopRoster, out var rosterId)) return;
+        rosterId = Compact(rosterId, typeof(TroopRoster));
         network.SendAll(new NetworkTroopRosterRemoveZeroCounts(rosterId));
     }
 
@@ -124,7 +126,10 @@ internal class TroopRosterDeltaHandler : IHandler
         characterId = null;
         if (roster == null || character == null) return false;
         if (!objectManager.TryGetId(roster, out rosterId)) return false;
-        return objectManager.TryGetIdWithLogging(character, out characterId);
+        if (!objectManager.TryGetIdWithLogging(character, out characterId)) return false;
+        rosterId = Compact(rosterId, typeof(TroopRoster));
+        characterId = Compact(characterId, typeof(CharacterObject));
+        return true;
     }
 
     private void Handle_NetworkAddCounts(MessagePayload<NetworkTroopRosterAddCounts> payload)


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [x] Other... Please describe: Performance, reduces steady-state network traffic

## What is the current behavior?

Object ids on the wire repeat the object's type as a prefix, like `Settlement_town_ES1`. The auto-synced messages already drop it (#1672); the hand-written sync messages still send the full id, so those packets are bigger than they need to be.

## What is the new behavior?

Resolves #1679

The hand-written messages now send the short id and the receiver re-adds the prefix, so everything stays in sync. Measured on a live server + client run (per 10s profiler window, AI parties moving):

| Metric (per 10s window, AI parties moving) | Current | New (this PR) |
|---|---|---|
| hand-written sync bytes/packet | 95.5 B | 57.5 B (-40%) |
| hand-written sync bytes/window | ~555 KB | ~331 KB (-40%) |
| party-behavior bytes/packet | 95.3 B | 79.3 B (-17%) |

Packet counts are unchanged; the saving is entirely per-packet size. Nothing changes for players.
