### PR TITLE
[1680] Stop client party jittering on the campaign map

### DIFF
--- a/source/GameInterface/Services/MobileParties/Handlers/MobilePartyBehaviorHandler.cs
+++ b/source/GameInterface/Services/MobileParties/Handlers/MobilePartyBehaviorHandler.cs
@@ -29,6 +29,11 @@ internal class MobilePartyBehaviorHandler : IHandler
 {
     private static readonly ILogger Logger = LogManager.GetLogger<MobilePartyBehaviorHandler>();
 
+    // Owner-party position resync threshold, in campaign-map units. The per-click prediction lead is
+    // a small fraction of a unit while map features sit tens of units apart, so 1 unit stays above
+    // normal prediction drift but still catches a genuine desync.
+    private const float OwnerPositionResyncThreshold = 1f;
+
     private readonly IMessageBroker messageBroker;
     private readonly IControllerIdProvider controllerIdProvider;
     private readonly IMobilePartyInterface mobilePartyInterface;
@@ -123,7 +128,16 @@ internal class MobilePartyBehaviorHandler : IHandler
 
                     if (ModInformation.IsClient)
                     {
-                        party.Ai._mobileParty.Position = data.PartyPosition;
+                        // The local player's own party is client-predicted and runs slightly ahead of the
+                        // server's relayed position; snapping it mid-move is the jitter. Snap when it's at rest,
+                        // on a nav-layer (land/sea) change, or once it's drifted far enough to be a real desync.
+                        if (!party.IsControlledByThisInstance() ||
+                            !party.IsMoving ||
+                            party.Position.IsOnLand != data.PartyPosition.IsOnLand ||
+                            party.Position.Distance(data.PartyPosition) > OwnerPositionResyncThreshold)
+                        {
+                            party.Position = data.PartyPosition;
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

On a client, moving your party around the campaign map makes it jitter and snap backward for a moment on almost every click before continuing toward where you clicked. It happens constantly during normal map travel.

## What is the new behavior?

Resolves #1680

Your own party now moves smoothly toward each destination with no backward snap. Other parties, both AI parties and other players' parties, still appear exactly where the server has them.
