### PR TITLE
[1665] Fix caravan NRE race condition when loading in from client

### DIFF
--- a/source/Coop.Core/Server/Services/Save/Handlers/SaveGameHandler.cs
+++ b/source/Coop.Core/Server/Services/Save/Handlers/SaveGameHandler.cs
@@ -2,14 +2,8 @@
 using GameInterface.CoopSessionData;
 using GameInterface.CoopSessionData.Save.Data;
 using GameInterface.Registry.Messages;
-using GameInterface.Services.Alleys;
-using GameInterface.Services.Caravans;
 using GameInterface.Services.Heroes.Messages;
-using GameInterface.Services.MobileParties;
 using GameInterface.Services.Players;
-using GameInterface.Services.Players.Data;
-using GameInterface.Services.Smithing;
-using GameInterface.Services.Workshops;
 using System.Linq;
 
 namespace Coop.Core.Server.Services.Save.Handlers;
@@ -53,15 +47,16 @@ internal class SaveGameHandler : IHandler
     {
         var saveName = obj.What.SaveName;
         var current = coopSessionProvider.CoopSession;
+        var empty = CoopSession.Empty;
 
         CoopSession session = new CoopSession(
             saveName,
             playerRegistry.Players.ToArray(),
-            current?.CraftingPlayerData ?? new CraftingPlayerData(new(), new(), new()),
-            current?.WorkshopPlayerData ?? new WorkshopPlayerData(new()),
-            current?.CaravansPlayerData ?? new CaravansPlayerData(new(), new()),
-            current?.AlleyPlayerData ?? new AlleyPlayerData(new()),
-            current?.InteractionsPlayerData ?? new InteractionsPlayerData(new(), new(), new(), new()));
+            current?.CraftingPlayerData ?? empty.CraftingPlayerData,
+            current?.WorkshopPlayerData ?? empty.WorkshopPlayerData,
+            current?.CaravansPlayerData ?? empty.CaravansPlayerData,
+            current?.AlleyPlayerData ?? empty.AlleyPlayerData,
+            current?.InteractionsPlayerData ?? empty.InteractionsPlayerData);
 
         coopSessionProvider.CoopSession = session;
 
@@ -72,15 +67,16 @@ internal class SaveGameHandler : IHandler
     private void Handle_GameLoaded(MessagePayload<GameLoaded> obj)
     {
         var loaded = saveManager.LoadCoopSession(obj.What.SaveName);
+        var empty = CoopSession.Empty;
 
         savedSession = new CoopSession(
             loaded?.UniqueGameId ?? obj.What.SaveName,
-            loaded?.Players ?? new Player[0],
-            loaded?.CraftingPlayerData ?? new CraftingPlayerData(new(), new(), new()),
-            loaded?.WorkshopPlayerData ?? new WorkshopPlayerData(new()),
-            loaded?.CaravansPlayerData ?? new CaravansPlayerData(new(), new()),
-            loaded?.AlleyPlayerData ?? new AlleyPlayerData(new()),
-            loaded?.InteractionsPlayerData ?? new InteractionsPlayerData(new(), new(), new(), new()));
+            loaded?.Players ?? empty.Players,
+            loaded?.CraftingPlayerData ?? empty.CraftingPlayerData,
+            loaded?.WorkshopPlayerData ?? empty.WorkshopPlayerData,
+            loaded?.CaravansPlayerData ?? empty.CaravansPlayerData,
+            loaded?.AlleyPlayerData ?? empty.AlleyPlayerData,
+            loaded?.InteractionsPlayerData ?? empty.InteractionsPlayerData);
 
         coopSessionProvider.CoopSession = savedSession;
     }

--- a/source/GameInterface/CoopSessionData/ICoopSessionProvider.cs
+++ b/source/GameInterface/CoopSessionData/ICoopSessionProvider.cs
@@ -10,5 +10,7 @@ public interface ICoopSessionProvider : IGameAbstraction
 
 public class CoopSessionProvider : ICoopSessionProvider
 {
-    public ICoopSession CoopSession { get; set;}
+    // Defaults to an empty session instead of null, otherwise a fresh campaign (no GameSaved/GameLoaded yet)
+    // NREs the first time a joining client's data is read before the host's first save.
+    public ICoopSession CoopSession { get; set; } = Save.Data.CoopSession.Empty;
 }

--- a/source/GameInterface/CoopSessionData/Save/Data/CoopSession.cs
+++ b/source/GameInterface/CoopSessionData/Save/Data/CoopSession.cs
@@ -5,6 +5,7 @@ using GameInterface.Services.Players.Data;
 using GameInterface.Services.Smithing;
 using GameInterface.Services.Workshops;
 using ProtoBuf;
+using System;
 
 namespace GameInterface.CoopSessionData.Save.Data;
 
@@ -27,6 +28,18 @@ public interface ICoopSession
 [ProtoContract]
 public class CoopSession : ICoopSession
 {
+    // Shared "no data yet" shape for a fresh session (before any GameSaved/GameLoaded). A property,
+    // not a static instance, otherwise every caller aliases the same mutable dictionaries and
+    // AddPlayerKeys-style in-place edits leak into every other reader for the life of the process.
+    public static CoopSession Empty => new CoopSession(
+        string.Empty,
+        Array.Empty<Player>(),
+        new CraftingPlayerData(new(), new(), new()),
+        new WorkshopPlayerData(new()),
+        new CaravansPlayerData(new(), new()),
+        new AlleyPlayerData(new()),
+        new InteractionsPlayerData(new(), new(), new(), new()));
+
     [ProtoMember(1)]
     public string UniqueGameId { get; }
     [ProtoMember(2)]


### PR DESCRIPTION
## PR Checklist

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

Occasional NRE on save load from client

## What is the new behavior?

Resolves #1665

No NRE