### PR TITLE
[1668] Steam integration phase 2: Tunnel sessions over Steam P2P so friends can join without host port forwarding

### DIFF
--- a/source/Common.Tests/Network/Session/TunnelAdvertisementTests.cs
+++ b/source/Common.Tests/Network/Session/TunnelAdvertisementTests.cs
@@ -1,0 +1,90 @@
+﻿using Common.Network;
+using Common.Network.Session;
+using Moq;
+
+namespace Common.Tests.Network.Session;
+
+public class TunnelAdvertisementTests
+{
+    private sealed class FakeTunnelHost : ISessionTunnelHost
+    {
+        public bool StartThrows;
+        public bool Listening;
+        public int? StartedPort;
+
+        public bool IsListening => Listening;
+        public int PeerCount => 0;
+
+        public void Start(int serverPort)
+        {
+            if (StartThrows) throw new InvalidOperationException("no relay");
+
+            StartedPort = serverPort;
+            Listening = true;
+        }
+
+        public void Stop() => Listening = false;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private static INetworkConfig Config(string address, bool tunneled = false)
+    {
+        var config = new Mock<INetworkConfig>();
+        config.Setup(c => c.Address).Returns(address);
+        config.Setup(c => c.Port).Returns(4200);
+        config.Setup(c => c.IsTunneled).Returns(tunneled);
+        return config.Object;
+    }
+
+    [Theory]
+    [InlineData("localhost")]
+    [InlineData("127.0.0.1")]
+    public void LoopbackSession_StartsTunnelAndKeepsTunnelVersion(string address)
+    {
+        var host = new FakeTunnelHost();
+        var info = new SessionJoinInfo { Port = 4200 };
+
+        TunnelAdvertisement.StartAndStamp(host, Config(address), info);
+
+        Assert.Equal(4200, host.StartedPort);
+        Assert.Equal(SessionJoinInfo.CurrentVersion, info.Version);
+    }
+
+    [Fact]
+    public void RemoteSession_NeverStartsTunnelAndAdvertisesDirectOnly()
+    {
+        var host = new FakeTunnelHost();
+        var info = new SessionJoinInfo { Address = "203.0.113.7", Port = 4200 };
+
+        TunnelAdvertisement.StartAndStamp(host, Config("203.0.113.7"), info);
+
+        Assert.Null(host.StartedPort);
+        Assert.True(info.Version < SessionJoinInfo.MinTunnelVersion);
+    }
+
+    [Fact]
+    public void TunneledJoiner_NeverStartsTunnelDespiteLoopbackAddress()
+    {
+        var host = new FakeTunnelHost();
+        var info = new SessionJoinInfo { Port = 4200 };
+
+        TunnelAdvertisement.StartAndStamp(host, Config("127.0.0.1", tunneled: true), info);
+
+        Assert.Null(host.StartedPort);
+        Assert.True(info.Version < SessionJoinInfo.MinTunnelVersion);
+    }
+
+    [Fact]
+    public void FailedTunnelStart_IsCaughtAndAdvertisesDirectOnly()
+    {
+        var host = new FakeTunnelHost { StartThrows = true };
+        var info = new SessionJoinInfo { Address = "203.0.113.7", Port = 4200 };
+
+        TunnelAdvertisement.StartAndStamp(host, Config("localhost"), info);
+
+        Assert.True(info.Version < SessionJoinInfo.MinTunnelVersion);
+    }
+}

--- a/source/Common/Network/INetworkConfig.cs
+++ b/source/Common/Network/INetworkConfig.cs
@@ -10,6 +10,12 @@ public interface INetworkConfig
     int Port { get; }
     string Token { get; }
     string P2PToken { get; }
+    /// <summary>
+    /// True when the session is reached through a local tunnel pump (Steam P2P) instead of
+    /// a direct address. Tunneled peers cannot NAT-punch each other, so mission traffic
+    /// stays on the server relay.
+    /// </summary>
+    bool IsTunneled { get; }
     TimeSpan ConnectionTimeout { get; }
     int MaxPacketsInQueue { get; }
     int ResumePacketsInQueue { get; }

--- a/source/Common/Network/Session/ISessionTunnelHost.cs
+++ b/source/Common/Network/Session/ISessionTunnelHost.cs
@@ -1,0 +1,68 @@
+﻿using Common.Logging;
+using Common.Network;
+using Serilog;
+using System;
+using System.Net;
+
+namespace Common.Network.Session;
+
+/// <summary>
+/// Shared advertise-time gate: a lobby must never claim a tunnel that is not listening,
+/// and the tunnel may only start when the advertising client is connected to a local
+/// server, because the host pump forwards to loopback.
+/// </summary>
+public static class TunnelAdvertisement
+{
+    private static readonly ILogger Logger = LogManager.GetLogger(typeof(TunnelAdvertisement));
+
+    public static void StartAndStamp(ISessionTunnelHost tunnelHost, INetworkConfig config, SessionJoinInfo info)
+    {
+        // A tunneled joiner's loopback address is its own join pump, not a local server,
+        // so it must never host a tunnel of its own.
+        if (!config.IsTunneled && IsLoopbackAddress(config.Address))
+        {
+            try
+            {
+                tunnelHost.Start(config.Port);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Session tunnel host failed to start; the lobby will be advertised direct-only");
+            }
+        }
+
+        if (!tunnelHost.IsListening)
+        {
+            // Advertise as a pre-tunnel lobby so joiners use the address instead of
+            // connecting to a tunnel that isn't there.
+            info.Version = SessionJoinInfo.MinTunnelVersion - 1;
+        }
+    }
+
+    public static bool IsLoopbackAddress(string address)
+    {
+        return address == "localhost" ||
+            (IPAddress.TryParse(address, out var ip) && IPAddress.IsLoopback(ip));
+    }
+}
+
+/// <summary>
+/// Hosts the joiner-facing end of a session tunnel on the hosting player's client: remote
+/// peers connect through a relay transport (a Steam P2P listen socket; no-op for plain
+/// direct-IP hosting) and their datagrams are forwarded to the local server port.
+/// </summary>
+public interface ISessionTunnelHost : IDisposable
+{
+    bool IsListening { get; }
+
+    /// <summary>Remote peers currently connected through the tunnel.</summary>
+    int PeerCount { get; }
+
+    /// <summary>
+    /// Starts listening and forwards each connected peer's datagrams to the local server
+    /// port. Safe to call again while listening.
+    /// </summary>
+    void Start(int serverPort);
+
+    void Stop();
+}

--- a/source/Common/Network/Session/SessionJoinInfo.cs
+++ b/source/Common/Network/Session/SessionJoinInfo.cs
@@ -6,11 +6,25 @@
 /// </summary>
 public class SessionJoinInfo
 {
-    public const int CurrentVersion = 1;
+    public const int CurrentVersion = 2;
+
+    /// <summary>
+    /// Sessions advertised at or above this version have a Steam tunnel listening, so a
+    /// joiner can connect to the lobby owner instead of dialing the address.
+    /// </summary>
+    public const int MinTunnelVersion = 2;
 
     public int Version { get; set; } = CurrentVersion;
     public string Address { get; set; }
     public int Port { get; set; }
 
+    /// <summary>Steam id of the player hosting the tunnel; 0 when the session is direct-only.</summary>
+    public ulong HostSteamId { get; set; }
+
+    /// <summary>Set on prepared join info when the returned endpoint is a local tunnel pump.</summary>
+    public bool Tunneled { get; set; }
+
     public bool HasAddress => !string.IsNullOrEmpty(Address);
+
+    public bool HasHostSteamId => HostSteamId != 0;
 }

--- a/source/Coop.Core/Client/ClientModule.cs
+++ b/source/Coop.Core/Client/ClientModule.cs
@@ -14,6 +14,7 @@ using Coop.Steam;
 using GameInterface.Policies;
 using LiteNetLib;
 using Missions;
+using System.Runtime.CompilerServices;
 
 namespace Coop.Core.Client;
 
@@ -38,12 +39,12 @@ public class ClientModule : CommonModule
         // Steam registrations only when the boot probe found Steam, so tests and non-Steam installs never load Steamworks types.
         if (SessionDiscovery.SteamAvailable)
         {
-            builder.RegisterType<SteamLobbyApi>().As<ISteamLobbyApi>().InstancePerLifetimeScope();
-            builder.RegisterType<SteamLobbyAdvertiser>().As<ISessionAdvertiser>().InstancePerLifetimeScope();
+            RegisterSteamSessionServices(builder);
         }
         else
         {
             builder.RegisterType<NoopSessionAdvertiser>().As<ISessionAdvertiser>().InstancePerLifetimeScope();
+            builder.RegisterType<NoopSessionTunnelHost>().As<ISessionTunnelHost>().InstancePerLifetimeScope();
         }
 
         builder.RegisterType<ConfiguredSessionJoinInfoSource>().As<ISessionJoinInfoSource>().InstancePerLifetimeScope();
@@ -51,5 +52,17 @@ public class ClientModule : CommonModule
 
         RegisterAllTypesWithInterface<ClientModule, IHandler>(builder, autoInstantiate: true);
         RegisterAllTypesWithInterface<ClientModule, IPacketHandler>(builder, autoInstantiate: true);
+    }
+
+    // The tunnel transport's layout embeds Steamworks value types, so mentioning it in Load
+    // would pull in Steamworks.NET while JIT-compiling Load even when the Steam branch is
+    // never taken; this non-inlined helper is only compiled once Steam is known to be present.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void RegisterSteamSessionServices(ContainerBuilder builder)
+    {
+        builder.RegisterType<SteamLobbyApi>().As<ISteamLobbyApi>().InstancePerLifetimeScope();
+        builder.RegisterType<SteamLobbyAdvertiser>().As<ISessionAdvertiser>().InstancePerLifetimeScope();
+        builder.RegisterType<SteamNetworkingTunnelTransport>().As<ISteamTunnelTransport>().InstancePerLifetimeScope();
+        builder.RegisterType<SteamTunnelHost>().As<ISessionTunnelHost>().InstancePerLifetimeScope();
     }
 }

--- a/source/Coop.Core/Client/Services/Session/SessionAdvertisementHandler.cs
+++ b/source/Coop.Core/Client/Services/Session/SessionAdvertisementHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Common;
 using Common.Messaging;
+using Common.Network;
 using Common.Network.Session;
 using Coop.Core.Client.Messages;
 using Coop.Core.Common.Configuration;
@@ -8,27 +9,34 @@ using GameInterface.Services.GameDebug.Messages;
 namespace Coop.Core.Client.Services.Session;
 
 /// <summary>
-/// Drives the session advertisement lifecycle on the hosting player's client: advertise
-/// once the connection to the server is up, withdraw on disconnect. Steam calls run on the
-/// game thread because the game's own pump dispatches Steam callbacks there.
+/// Drives the session advertisement lifecycle on the hosting player's client: start the
+/// tunnel and advertise once the connection to the server is up, withdraw on disconnect.
+/// Steam calls run on the game thread because the game's own pump dispatches Steam
+/// callbacks there.
 /// </summary>
 public class SessionAdvertisementHandler : IHandler
 {
     private readonly IMessageBroker messageBroker;
     private readonly ISessionAdvertiser sessionAdvertiser;
+    private readonly ISessionTunnelHost sessionTunnelHost;
     private readonly ISessionJoinInfoSource joinInfoSource;
     private readonly SessionAdvertisementConfig advertisementConfig;
+    private readonly INetworkConfig networkConfig;
 
     public SessionAdvertisementHandler(
         IMessageBroker messageBroker,
         ISessionAdvertiser sessionAdvertiser,
+        ISessionTunnelHost sessionTunnelHost,
         ISessionJoinInfoSource joinInfoSource,
-        SessionAdvertisementConfig advertisementConfig)
+        SessionAdvertisementConfig advertisementConfig,
+        INetworkConfig networkConfig)
     {
         this.messageBroker = messageBroker;
         this.sessionAdvertiser = sessionAdvertiser;
+        this.sessionTunnelHost = sessionTunnelHost;
         this.joinInfoSource = joinInfoSource;
         this.advertisementConfig = advertisementConfig;
+        this.networkConfig = networkConfig;
 
         messageBroker.Subscribe<NetworkConnected>(Handle_NetworkConnected);
         messageBroker.Subscribe<NetworkDisconnected>(Handle_NetworkDisconnected);
@@ -48,9 +56,12 @@ public class SessionAdvertisementHandler : IHandler
 
         GameThread.RunSafe(() =>
         {
+            // The tunnel must listen before the lobby exists, so no joiner can race it.
+            TunnelAdvertisement.StartAndStamp(sessionTunnelHost, networkConfig, info);
+
             sessionAdvertiser.Advertise(info);
 
-            if (!info.HasAddress)
+            if (!info.HasAddress && !sessionTunnelHost.IsListening)
             {
                 messageBroker.Publish(this, new SendInformationMessage(
                     "Steam invites are on but no public address is set; friends cannot connect until you set one on the co-op screen"));
@@ -60,6 +71,10 @@ public class SessionAdvertisementHandler : IHandler
 
     internal void Handle_NetworkDisconnected(MessagePayload<NetworkDisconnected> obj)
     {
-        GameThread.RunSafe(sessionAdvertiser.StopAdvertising, context: "StopAdvertisingSession");
+        GameThread.RunSafe(() =>
+        {
+            sessionAdvertiser.StopAdvertising();
+            sessionTunnelHost.Stop();
+        }, context: "StopAdvertisingSession");
     }
 }

--- a/source/Coop.Core/Client/Services/Session/SteamJoinWatchdog.cs
+++ b/source/Coop.Core/Client/Services/Session/SteamJoinWatchdog.cs
@@ -28,6 +28,7 @@ public class SteamJoinWatchdog : IHandler
     private volatile bool disposed;
     private string address;
     private int port;
+    private bool tunneled;
 
     public SteamJoinWatchdog(IMessageBroker messageBroker)
     {
@@ -44,12 +45,13 @@ public class SteamJoinWatchdog : IHandler
         timer = null;
     }
 
-    public void Arm(string address, int port)
+    public void Arm(string address, int port, bool tunneled = false)
     {
         if (connected) return;
 
         this.address = address;
         this.port = port;
+        this.tunneled = tunneled;
         timer = new Timer(_ => OnTimeout(), null, Timeout, System.Threading.Timeout.InfiniteTimeSpan);
 
         // The connect can complete while the timer is being created; drop it then.
@@ -76,11 +78,15 @@ public class SteamJoinWatchdog : IHandler
             // Also skip when disposed: a stale queued action must never end a newer session.
             if (connected || disposed) return;
 
-            Logger.Warning("Steam-initiated join to {Address}:{Port} timed out", address, port);
+            Logger.Warning("Steam-initiated join to {Address}:{Port} (tunneled={Tunneled}) timed out", address, port, tunneled);
 
-            messageBroker.Publish(this, new SendPopupMessage(
-                $"Could not reach the co-op host at {address}:{port}. " +
-                $"The host must port-forward UDP {port} and set their public address on the co-op screen."));
+            // A tunneled join dials a local pump, so port-forwarding advice would be wrong there.
+            string popupText = tunneled
+                ? "Could not reach the co-op host through Steam. Make sure the host is still in their session, then try the invite again."
+                : $"Could not reach the co-op host at {address}:{port}. " +
+                  $"The host must port-forward UDP {port} and set their public address on the co-op screen.";
+
+            messageBroker.Publish(this, new SendPopupMessage(popupText));
             messageBroker.Publish(this, new EndCoopMode());
         }, context: "SteamJoinTimeout");
     }

--- a/source/Coop.Core/Common/Configuration/NetworkConfig.cs
+++ b/source/Coop.Core/Common/Configuration/NetworkConfig.cs
@@ -23,6 +23,8 @@ public class NetworkConfig : INetworkConfig
     // TODO find better token
     public string Token { get; set; } = "TempToken";
 
+    public bool IsTunneled { get; set; }
+
     public string P2PToken => throw new NotImplementedException();
 
     public int MaxPacketsInQueue => 10000;

--- a/source/Coop.Core/Common/Session/NoopSessionTunnelHost.cs
+++ b/source/Coop.Core/Common/Session/NoopSessionTunnelHost.cs
@@ -1,0 +1,26 @@
+﻿using Common.Network.Session;
+
+namespace Coop.Core.Common.Session;
+
+/// <summary>
+/// Tunnel host for sessions without a relay transport (no Steam): direct-IP joiners dial
+/// the server themselves.
+/// </summary>
+public class NoopSessionTunnelHost : ISessionTunnelHost
+{
+    public bool IsListening => false;
+
+    public int PeerCount => 0;
+
+    public void Start(int serverPort)
+    {
+    }
+
+    public void Stop()
+    {
+    }
+
+    public void Dispose()
+    {
+    }
+}

--- a/source/Coop.Core/Common/Session/SteamOrDirectJoinEndpointPreparer.cs
+++ b/source/Coop.Core/Common/Session/SteamOrDirectJoinEndpointPreparer.cs
@@ -1,0 +1,50 @@
+﻿using Common.Messaging;
+using Common.Network.Session;
+using Common.Network.Session.Messages;
+using Coop.Core.Common.Services.Connection.Messages;
+using Coop.Steam;
+using System.Threading.Tasks;
+
+namespace Coop.Core.Common.Session;
+
+/// <summary>
+/// Picks the join transport: the Steam tunnel when the lobby advertised a tunnel-capable
+/// host and Steam is available, otherwise the direct address. Also ends the active tunnel
+/// when the session ends or the join fails.
+/// </summary>
+public class SteamOrDirectJoinEndpointPreparer : IJoinEndpointPreparer
+{
+    private readonly IJoinEndpointPreparer direct = new DirectJoinEndpointPreparer();
+
+    public SteamOrDirectJoinEndpointPreparer()
+    {
+        MessageBroker.Instance.Subscribe<EndCoopMode>(Handle_EndCoopMode);
+        MessageBroker.Instance.Subscribe<SessionJoinFailed>(Handle_SessionJoinFailed);
+    }
+
+    public Task<SessionJoinInfo> PrepareAsync(SessionJoinInfo info)
+    {
+        if (SessionDiscovery.SteamAvailable && info.HasHostSteamId && SteamBoot.TunnelPreparer != null)
+        {
+            return SteamBoot.TunnelPreparer.PrepareAsync(info);
+        }
+
+        return direct.PrepareAsync(info);
+    }
+
+    /// <summary>Closes the active tunnel; for failure exits that publish no session message.</summary>
+    public void TearDownActiveTunnel()
+    {
+        SteamBoot.TunnelPreparer?.TearDown();
+    }
+
+    private void Handle_EndCoopMode(MessagePayload<EndCoopMode> payload)
+    {
+        SteamBoot.TunnelPreparer?.TearDown();
+    }
+
+    private void Handle_SessionJoinFailed(MessagePayload<SessionJoinFailed> payload)
+    {
+        SteamBoot.TunnelPreparer?.TearDown();
+    }
+}

--- a/source/Coop.Core/CoopartiveMultiplayerExperience.cs
+++ b/source/Coop.Core/CoopartiveMultiplayerExperience.cs
@@ -32,7 +32,7 @@ namespace Coop.Core
         private IMessageBroker messageBroker;
         private INetworkConfig configuration;
         private IContainer container;
-        private readonly IJoinEndpointPreparer joinEndpointPreparer = new DirectJoinEndpointPreparer();
+        private readonly SteamOrDirectJoinEndpointPreparer joinEndpointPreparer = new SteamOrDirectJoinEndpointPreparer();
         private volatile bool coopStarting;
 
         public CoopartiveMultiplayerExperience()
@@ -98,23 +98,35 @@ namespace Coop.Core
 
             var prepared = joinEndpointPreparer.PrepareAsync(obj.What.JoinInfo).GetAwaiter().GetResult();
 
+            // A failed tunnel setup falls back to the advertised address, which a
+            // tunnel-only lobby doesn't have; an empty address would resolve to this machine.
+            if (!prepared.HasAddress)
+            {
+                InformationManager.DisplayMessage(new InformationMessage(
+                    "Could not set up the Steam connection to the host, and the host has not shared a public address to fall back to"));
+                return;
+            }
+
             configuration = new NetworkConfig()
             {
                 Address = prepared.Address,
                 Port = prepared.Port,
+                IsTunneled = prepared.Tunneled,
             };
 
             try
             {
                 StartAsClient(configuration);
 
-                container.Resolve<SteamJoinWatchdog>().Arm(prepared.Address, prepared.Port);
+                container.Resolve<SteamJoinWatchdog>().Arm(prepared.Address, prepared.Port, prepared.Tunneled);
             }
             catch (Exception ex)
             {
                 // Tear down the half-built container, otherwise it blocks every later Steam join.
                 Logger.Error(ex, "Steam-initiated join to {Address}:{Port} failed to start", prepared.Address, prepared.Port);
                 DestroyContainer();
+                // This failure exit publishes no session message, so the tunnel is closed here.
+                joinEndpointPreparer.TearDownActiveTunnel();
                 InformationManager.DisplayMessage(new InformationMessage(
                     $"Could not connect to the advertised address '{prepared.Address}:{prepared.Port}'"));
             }

--- a/source/Coop.Steam/ISteamLobbyApi.cs
+++ b/source/Coop.Steam/ISteamLobbyApi.cs
@@ -15,6 +15,8 @@ public interface ISteamLobbyApi : IDisposable
     void LeaveLobby(ulong lobbyId);
     bool SetLobbyData(ulong lobbyId, string key, string value);
     string GetLobbyData(ulong lobbyId, string key);
+    /// <summary>Steam id of the lobby's owner; only valid while a member of the lobby.</summary>
+    ulong GetLobbyOwner(ulong lobbyId);
     void OpenInviteDialog(ulong lobbyId);
     bool SetRichPresenceConnect(string value);
     void ClearRichPresenceConnect();

--- a/source/Coop.Steam/ISteamTunnelTransport.cs
+++ b/source/Coop.Steam/ISteamTunnelTransport.cs
@@ -28,9 +28,14 @@ public static class SteamTunnel
     public const int SendBufferBytes = 8 * 1024 * 1024;
 
     /// <summary>
-    /// Ceiling for Steam's send pacing. The default caps around 1 MB/s, which would stretch
-    /// a ~40 MB join save into minutes on links that can go much faster.
+    /// Floor for Steam's send pacing, and in practice the effective transfer rate: this
+    /// Steam build never raises the rate toward the ceiling on its own (observed pinned at
+    /// the 256 KB/s default while saturated on a 3 ms link), so the floor is what carries
+    /// the ~55 MB join payload in seconds instead of minutes.
     /// </summary>
+    public const int SendRateMinBytesPerSecond = 2 * 1024 * 1024;
+
+    /// <summary>Ceiling for Steam's send pacing, headroom above the floor.</summary>
     public const int SendRateMaxBytesPerSecond = 20 * 1024 * 1024;
 
     /// <summary>

--- a/source/Coop.Steam/ISteamTunnelTransport.cs
+++ b/source/Coop.Steam/ISteamTunnelTransport.cs
@@ -1,0 +1,61 @@
+﻿using System;
+
+namespace Coop.Steam;
+
+/// <summary>
+/// Shared constants for the Steam tunnel.
+/// </summary>
+public static class SteamTunnel
+{
+    /// <summary>Virtual port the host listens on and joiners connect to.</summary>
+    public const int VirtualPort = 0;
+
+    /// <summary>
+    /// Upper bound for a tunneled datagram; comfortably above LiteNetLib's 1432-byte
+    /// maximum packet size.
+    /// </summary>
+    public const int MaxDatagramBytes = 2048;
+
+    /// <summary>
+    /// Each pump pass adds at most this much one-way latency on top of the Steam link.
+    /// </summary>
+    public static readonly TimeSpan PumpInterval = TimeSpan.FromMilliseconds(2);
+}
+
+public enum TunnelConnectionState
+{
+    Connecting,
+    Connected,
+    Closed,
+}
+
+/// <summary>
+/// Minimal seam over the Steam networking-sockets surface the tunnel pumps use, so they can
+/// be tested against a fake and a differently-flavored implementation can slot in later.
+/// Implementations only raise <see cref="ConnectionStateChanged"/> for connections they own:
+/// ones opened via <see cref="ConnectToHost"/> or arriving on <see cref="ListenForClients"/>.
+/// </summary>
+public interface ISteamTunnelTransport : IDisposable
+{
+    /// <summary>Raised from the Steam callback pump (the game thread) on state changes.</summary>
+    event Action<uint, TunnelConnectionState> ConnectionStateChanged;
+
+    /// <summary>Asks the relay network to warm up so the first connection doesn't pay for it.</summary>
+    void EnsureRelayAccess();
+
+    /// <summary>Opens a P2P connection to the host identity; returns the connection handle.</summary>
+    uint ConnectToHost(ulong hostSteamId, int virtualPort);
+
+    void ListenForClients(int virtualPort);
+
+    void StopListening();
+
+    void AcceptConnection(uint connection);
+
+    void CloseConnection(uint connection);
+
+    bool SendDatagram(uint connection, byte[] data, int length);
+
+    /// <summary>Reads one queued datagram into the buffer; returns its length, or 0 when none.</summary>
+    int ReceiveDatagram(uint connection, byte[] buffer);
+}

--- a/source/Coop.Steam/ISteamTunnelTransport.cs
+++ b/source/Coop.Steam/ISteamTunnelTransport.cs
@@ -28,12 +28,13 @@ public static class SteamTunnel
     public const int SendBufferBytes = 8 * 1024 * 1024;
 
     /// <summary>
-    /// Floor for Steam's send pacing, and in practice the effective transfer rate: this
-    /// Steam build never raises the rate toward the ceiling on its own (observed pinned at
-    /// the 256 KB/s default while saturated on a 3 ms link), so the floor is what carries
-    /// the ~55 MB join payload in seconds instead of minutes.
+    /// Send-pacing floor while a join-sized reliable backlog is draining. The pacer's
+    /// estimate never rises on its own in the game's Steam build (observed pinned at the
+    /// 256 KB/s default while saturated on a 3 ms link), so this floor is what carries the
+    /// ~55 MB join payload in seconds instead of minutes; the tunnel host's governor
+    /// applies it only under backlog and backs it off when delivery quality sags.
     /// </summary>
-    public const int SendRateMinBytesPerSecond = 2 * 1024 * 1024;
+    public const int TransferFloorBytesPerSecond = 2 * 1024 * 1024;
 
     /// <summary>Ceiling for Steam's send pacing, headroom above the floor.</summary>
     public const int SendRateMaxBytesPerSecond = 20 * 1024 * 1024;
@@ -106,4 +107,13 @@ public interface ISteamTunnelTransport : IDisposable
 
     /// <summary>One-line live status (effective send rate, backlog, throughput, ping) for logs.</summary>
     string DescribeConnection(uint connection);
+
+    /// <summary>Sets the connection's send-pacing floor.</summary>
+    void SetSendRateFloor(uint connection, int bytesPerSecond);
+
+    /// <summary>
+    /// Live send-side health; false when unavailable. Quality is the delivered fraction of
+    /// our sends, negative until Steam has a measurement.
+    /// </summary>
+    bool TryGetSendHealth(uint connection, out int pendingReliableBytes, out float quality);
 }

--- a/source/Coop.Steam/ISteamTunnelTransport.cs
+++ b/source/Coop.Steam/ISteamTunnelTransport.cs
@@ -20,6 +20,40 @@ public static class SteamTunnel
     /// Each pump pass adds at most this much one-way latency on top of the Steam link.
     /// </summary>
     public static readonly TimeSpan PumpInterval = TimeSpan.FromMilliseconds(2);
+
+    /// <summary>
+    /// Steam send buffer per tunnel connection. The join-save transfer bursts megabytes of
+    /// fragments at once; the 512 KB default overflows and stalls the join.
+    /// </summary>
+    public const int SendBufferBytes = 8 * 1024 * 1024;
+
+    /// <summary>
+    /// Ceiling for Steam's send pacing. The default caps around 1 MB/s, which would stretch
+    /// a ~40 MB join save into minutes on links that can go much faster.
+    /// </summary>
+    public const int SendRateMaxBytesPerSecond = 20 * 1024 * 1024;
+
+    /// <summary>
+    /// Kernel buffers on the pump sockets. Must absorb what LiteNetLib keeps in flight
+    /// while a full Steam send buffer parks the pump, or the kernel silently drops there.
+    /// </summary>
+    public const int LoopbackBufferBytes = 2 * 1024 * 1024;
+
+    /// <summary>
+    /// True when the datagram's sender tolerates loss, so the tunnel may keep it off the
+    /// reliable Steam lane and drop it under pressure instead of stalling newer traffic.
+    /// LiteNetLib 1.3.1 wire format: the packet property is the low five bits of the first
+    /// byte; Unreliable (0), Ping (3), and Pong (4) are droppable by contract. Anything
+    /// else — channeled traffic, acks, handshake, merged datagrams — and any unknown value
+    /// is delivered reliably.
+    /// </summary>
+    public static bool IsDroppableDatagram(byte[] data, int length)
+    {
+        if (length < 1) return true;
+
+        int property = data[0] & 0x1F;
+        return property == 0 || property == 3 || property == 4;
+    }
 }
 
 public enum TunnelConnectionState
@@ -54,7 +88,13 @@ public interface ISteamTunnelTransport : IDisposable
 
     void CloseConnection(uint connection);
 
-    bool SendDatagram(uint connection, byte[] data, int length);
+    /// <summary>
+    /// Queues one datagram for delivery. A droppable datagram may be discarded when the
+    /// send buffer is full (its sender tolerates loss); otherwise false means the buffer is
+    /// full and the caller must retry the same datagram later — never drop it. A dead
+    /// connection swallows the datagram, so a retry loop can never wedge on it.
+    /// </summary>
+    bool SendDatagram(uint connection, byte[] data, int length, bool droppable);
 
     /// <summary>Reads one queued datagram into the buffer; returns its length, or 0 when none.</summary>
     int ReceiveDatagram(uint connection, byte[] buffer);

--- a/source/Coop.Steam/ISteamTunnelTransport.cs
+++ b/source/Coop.Steam/ISteamTunnelTransport.cs
@@ -98,4 +98,7 @@ public interface ISteamTunnelTransport : IDisposable
 
     /// <summary>Reads one queued datagram into the buffer; returns its length, or 0 when none.</summary>
     int ReceiveDatagram(uint connection, byte[] buffer);
+
+    /// <summary>One-line live status (effective send rate, backlog, throughput, ping) for logs.</summary>
+    string DescribeConnection(uint connection);
 }

--- a/source/Coop.Steam/SteamBoot.cs
+++ b/source/Coop.Steam/SteamBoot.cs
@@ -17,6 +17,9 @@ public static class SteamBoot
     // reachable for the process lifetime or its subscriptions silently die.
     public static SteamJoinListener JoinListener { get; private set; }
 
+    // Created before any session container exists, so it lives here rather than in DI.
+    public static SteamTunnelJoinEndpointPreparer TunnelPreparer { get; private set; }
+
     public static bool TryStart(IMessageBroker messageBroker, string commandLine)
     {
         if (JoinListener != null) return true;
@@ -48,6 +51,7 @@ public static class SteamBoot
     private static void CreateServices(IMessageBroker messageBroker, string commandLine)
     {
         JoinListener = new SteamJoinListener(messageBroker, new SteamLobbyApi());
+        TunnelPreparer = new SteamTunnelJoinEndpointPreparer();
         JoinListener.ProcessLaunchArguments(commandLine);
     }
 }

--- a/source/Coop.Steam/SteamJoinListener.cs
+++ b/source/Coop.Steam/SteamJoinListener.cs
@@ -101,6 +101,13 @@ public class SteamJoinListener : IDisposable
 
             // Membership is only needed to read the join info; leaving keeps the host's slots free.
             bool decoded = LobbyDataCodec.TryDecode(key => lobbyApi.GetLobbyData(lobbyId, key), out var info, out var error);
+
+            // The owner runs the tunnel on tunnel-capable lobbies; readable only while still a member.
+            if (decoded && info.Version >= SessionJoinInfo.MinTunnelVersion)
+            {
+                info.HostSteamId = lobbyApi.GetLobbyOwner(lobbyId);
+            }
+
             lobbyApi.LeaveLobby(lobbyId);
 
             if (!decoded)
@@ -109,7 +116,7 @@ public class SteamJoinListener : IDisposable
                 return;
             }
 
-            if (!info.HasAddress)
+            if (!info.HasAddress && !info.HasHostSteamId)
             {
                 messageBroker.Publish(this, new SessionJoinFailed(
                     "The host has not set a public address on their co-op screen, so this session cannot be joined yet"));

--- a/source/Coop.Steam/SteamLobbyApi.cs
+++ b/source/Coop.Steam/SteamLobbyApi.cs
@@ -171,6 +171,11 @@ public class SteamLobbyApi : ISteamLobbyApi
         return SteamMatchmaking.GetLobbyData(new CSteamID(lobbyId), key);
     }
 
+    public ulong GetLobbyOwner(ulong lobbyId)
+    {
+        return SteamMatchmaking.GetLobbyOwner(new CSteamID(lobbyId)).m_SteamID;
+    }
+
     public void OpenInviteDialog(ulong lobbyId)
     {
         SteamFriends.ActivateGameOverlayInviteDialog(new CSteamID(lobbyId));

--- a/source/Coop.Steam/SteamNetworkingTunnelTransport.cs
+++ b/source/Coop.Steam/SteamNetworkingTunnelTransport.cs
@@ -58,20 +58,22 @@ public class SteamNetworkingTunnelTransport : ISteamTunnelTransport
     // cannot observe locally, so the same values are also set globally.
     private static void ApplyGlobalTunnelConfig()
     {
-        SetGlobalInt32(ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendBufferSize, SteamTunnel.SendBufferBytes);
-        SetGlobalInt32(ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendRateMax, SteamTunnel.SendRateMaxBytesPerSecond);
+        SetConfigInt32(ESteamNetworkingConfigScope.k_ESteamNetworkingConfig_Global, IntPtr.Zero,
+            ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendBufferSize, SteamTunnel.SendBufferBytes);
+        SetConfigInt32(ESteamNetworkingConfigScope.k_ESteamNetworkingConfig_Global, IntPtr.Zero,
+            ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendRateMax, SteamTunnel.SendRateMaxBytesPerSecond);
     }
 
-    private static void SetGlobalInt32(ESteamNetworkingConfigValue key, int value)
+    private static void SetConfigInt32(ESteamNetworkingConfigScope scope, IntPtr scopeObj,
+        ESteamNetworkingConfigValue key, int value)
     {
         var handle = GCHandle.Alloc(value, GCHandleType.Pinned);
         try
         {
-            if (!SteamNetworkingUtils.SetConfigValue(key,
-                ESteamNetworkingConfigScope.k_ESteamNetworkingConfig_Global, IntPtr.Zero,
+            if (!SteamNetworkingUtils.SetConfigValue(key, scope, scopeObj,
                 ESteamNetworkingConfigDataType.k_ESteamNetworkingConfig_Int32, handle.AddrOfPinnedObject()))
             {
-                Logger.Warning("Steam refused global tunnel config {Key}", key);
+                Logger.Warning("Steam refused tunnel config {Key} at scope {Scope}", key, scope);
             }
         }
         finally
@@ -135,7 +137,16 @@ public class SteamNetworkingTunnelTransport : ISteamTunnelTransport
         {
             Logger.Error("Accepting tunnel connection {Connection} failed: {Result}", connection, result);
             CloseConnection(connection);
+            return;
         }
+
+        // Observed live: an accepted connection ignores both the listen-socket options and
+        // the global values (it stayed pinned at the 256 KB/s default), while connection
+        // scope provably works, so the config is applied straight onto it.
+        SetConfigInt32(ESteamNetworkingConfigScope.k_ESteamNetworkingConfig_Connection, (IntPtr)connection,
+            ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendBufferSize, SteamTunnel.SendBufferBytes);
+        SetConfigInt32(ESteamNetworkingConfigScope.k_ESteamNetworkingConfig_Connection, (IntPtr)connection,
+            ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendRateMax, SteamTunnel.SendRateMaxBytesPerSecond);
     }
 
     public void CloseConnection(uint connection)

--- a/source/Coop.Steam/SteamNetworkingTunnelTransport.cs
+++ b/source/Coop.Steam/SteamNetworkingTunnelTransport.cs
@@ -11,7 +11,10 @@ namespace Coop.Steam;
 /// <remarks>
 /// User-flavor sockets under the player's own Steam identity, so the game's per-frame
 /// SteamAPI.RunCallbacks pump dispatches the status callback with no pump of our own.
-/// Datagrams are sent unreliable: LiteNetLib runs its own reliability on top.
+/// Reliable-class datagrams (the join save, campaign sync) ride Steam's reliable lane so
+/// Steam owns pacing, retransmission, and flow control — the join-save burst overwhelms an
+/// unreliable pipe. Droppable classes (movement snapshots, pings) stay unreliable so a
+/// lost packet never head-of-line-blocks newer ones behind a retransmit.
 /// </remarks>
 public class SteamNetworkingTunnelTransport : ISteamTunnelTransport
 {
@@ -37,7 +40,8 @@ public class SteamNetworkingTunnelTransport : ISteamTunnelTransport
         var identity = new SteamNetworkingIdentity();
         identity.SetSteamID64(hostSteamId);
 
-        var connection = SteamNetworkingSockets.ConnectP2P(ref identity, virtualPort, 0, null);
+        var options = TunnelConnectionOptions();
+        var connection = SteamNetworkingSockets.ConnectP2P(ref identity, virtualPort, options.Length, options);
         if (connection == HSteamNetConnection.Invalid)
         {
             throw new InvalidOperationException("Steam refused the tunnel connection");
@@ -57,7 +61,8 @@ public class SteamNetworkingTunnelTransport : ISteamTunnelTransport
         {
             if (listenSocket != HSteamListenSocket.Invalid) return;
 
-            var socket = SteamNetworkingSockets.CreateListenSocketP2P(virtualPort, 0, null);
+            var options = TunnelConnectionOptions();
+            var socket = SteamNetworkingSockets.CreateListenSocketP2P(virtualPort, options.Length, options);
             if (socket == HSteamListenSocket.Invalid)
             {
                 throw new InvalidOperationException("Steam refused the tunnel listen socket");
@@ -102,8 +107,12 @@ public class SteamNetworkingTunnelTransport : ISteamTunnelTransport
         }
     }
 
-    public bool SendDatagram(uint connection, byte[] data, int length)
+    public bool SendDatagram(uint connection, byte[] data, int length, bool droppable)
     {
+        int sendFlags = droppable
+            ? Constants.k_nSteamNetworkingSend_UnreliableNoNagle
+            : Constants.k_nSteamNetworkingSend_ReliableNoNagle;
+
         // Pinning the caller's buffer avoids a copy and keeps sends off the shared gate,
         // which the game thread's status callback also takes.
         var handle = GCHandle.Alloc(data, GCHandleType.Pinned);
@@ -111,14 +120,39 @@ public class SteamNetworkingTunnelTransport : ISteamTunnelTransport
         {
             var result = SteamNetworkingSockets.SendMessageToConnection(
                 new HSteamNetConnection(connection), handle.AddrOfPinnedObject(), (uint)length,
-                Constants.k_nSteamNetworkingSend_UnreliableNoNagle, out _);
+                sendFlags, out _);
 
-            return result == EResult.k_EResultOK;
+            // Only a full send buffer asks the pump to retry, and only for reliable-class
+            // datagrams (a droppable one is simply lost, per its contract). Any other
+            // failure means the connection is gone, so the datagram is swallowed and the
+            // Closed event that follows tears the peer down.
+            return droppable || result != EResult.k_EResultLimitExceeded;
         }
         finally
         {
             handle.Free();
         }
+    }
+
+    // A full send buffer (k_EResultLimitExceeded) surfaces as false from SendDatagram, and
+    // the pumps hold the datagram until it fits.
+    private static SteamNetworkingConfigValue_t[] TunnelConnectionOptions()
+    {
+        return new[]
+        {
+            Int32Option(ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendBufferSize, SteamTunnel.SendBufferBytes),
+            Int32Option(ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendRateMax, SteamTunnel.SendRateMaxBytesPerSecond),
+        };
+    }
+
+    private static SteamNetworkingConfigValue_t Int32Option(ESteamNetworkingConfigValue key, int value)
+    {
+        return new SteamNetworkingConfigValue_t
+        {
+            m_eValue = key,
+            m_eDataType = ESteamNetworkingConfigDataType.k_ESteamNetworkingConfig_Int32,
+            m_val = new SteamNetworkingConfigValue_t.OptionValue { m_int32 = value },
+        };
     }
 
     public int ReceiveDatagram(uint connection, byte[] buffer)

--- a/source/Coop.Steam/SteamNetworkingTunnelTransport.cs
+++ b/source/Coop.Steam/SteamNetworkingTunnelTransport.cs
@@ -61,9 +61,25 @@ public class SteamNetworkingTunnelTransport : ISteamTunnelTransport
         SetConfigInt32(ESteamNetworkingConfigScope.k_ESteamNetworkingConfig_Global, IntPtr.Zero,
             ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendBufferSize, SteamTunnel.SendBufferBytes);
         SetConfigInt32(ESteamNetworkingConfigScope.k_ESteamNetworkingConfig_Global, IntPtr.Zero,
-            ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendRateMin, SteamTunnel.SendRateMinBytesPerSecond);
-        SetConfigInt32(ESteamNetworkingConfigScope.k_ESteamNetworkingConfig_Global, IntPtr.Zero,
             ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendRateMax, SteamTunnel.SendRateMaxBytesPerSecond);
+    }
+
+    public void SetSendRateFloor(uint connection, int bytesPerSecond)
+    {
+        SetConfigInt32(ESteamNetworkingConfigScope.k_ESteamNetworkingConfig_Connection, (IntPtr)connection,
+            ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendRateMin, bytesPerSecond);
+    }
+
+    public bool TryGetSendHealth(uint connection, out int pendingReliableBytes, out float quality)
+    {
+        var status = default(SteamNetConnectionRealTimeStatus_t);
+        var lanes = default(SteamNetConnectionRealTimeLaneStatus_t);
+        var result = SteamNetworkingSockets.GetConnectionRealTimeStatus(
+            new HSteamNetConnection(connection), ref status, 0, ref lanes);
+
+        pendingReliableBytes = status.m_cbPendingReliable;
+        quality = status.m_flConnectionQualityLocal;
+        return result == EResult.k_EResultOK;
     }
 
     private static void SetConfigInt32(ESteamNetworkingConfigScope scope, IntPtr scopeObj,
@@ -148,8 +164,6 @@ public class SteamNetworkingTunnelTransport : ISteamTunnelTransport
         SetConfigInt32(ESteamNetworkingConfigScope.k_ESteamNetworkingConfig_Connection, (IntPtr)connection,
             ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendBufferSize, SteamTunnel.SendBufferBytes);
         SetConfigInt32(ESteamNetworkingConfigScope.k_ESteamNetworkingConfig_Connection, (IntPtr)connection,
-            ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendRateMin, SteamTunnel.SendRateMinBytesPerSecond);
-        SetConfigInt32(ESteamNetworkingConfigScope.k_ESteamNetworkingConfig_Connection, (IntPtr)connection,
             ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendRateMax, SteamTunnel.SendRateMaxBytesPerSecond);
 
         // Read-back separates "stored but the pacer ignores it" from "never stored".
@@ -230,7 +244,6 @@ public class SteamNetworkingTunnelTransport : ISteamTunnelTransport
         return new[]
         {
             Int32Option(ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendBufferSize, SteamTunnel.SendBufferBytes),
-            Int32Option(ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendRateMin, SteamTunnel.SendRateMinBytesPerSecond),
             Int32Option(ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendRateMax, SteamTunnel.SendRateMaxBytesPerSecond),
         };
     }

--- a/source/Coop.Steam/SteamNetworkingTunnelTransport.cs
+++ b/source/Coop.Steam/SteamNetworkingTunnelTransport.cs
@@ -151,6 +151,35 @@ public class SteamNetworkingTunnelTransport : ISteamTunnelTransport
             ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendRateMin, SteamTunnel.SendRateMinBytesPerSecond);
         SetConfigInt32(ESteamNetworkingConfigScope.k_ESteamNetworkingConfig_Connection, (IntPtr)connection,
             ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendRateMax, SteamTunnel.SendRateMaxBytesPerSecond);
+
+        // Read-back separates "stored but the pacer ignores it" from "never stored".
+        Logger.Information("Tunnel connection {Connection} config: sendRateMin={Min} sendRateMax={Max} sendBuffer={Buffer}",
+            connection,
+            ReadConfigInt32(connection, ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendRateMin),
+            ReadConfigInt32(connection, ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendRateMax),
+            ReadConfigInt32(connection, ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendBufferSize));
+    }
+
+    private static string ReadConfigInt32(uint connection, ESteamNetworkingConfigValue key)
+    {
+        var buffer = new int[1];
+        var handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+        try
+        {
+            ulong size = sizeof(int);
+            var result = SteamNetworkingUtils.GetConfigValue(key,
+                ESteamNetworkingConfigScope.k_ESteamNetworkingConfig_Connection, (IntPtr)connection,
+                out _, handle.AddrOfPinnedObject(), ref size);
+
+            return result == ESteamNetworkingGetConfigValueResult.k_ESteamNetworkingGetConfigValue_OK ||
+                result == ESteamNetworkingGetConfigValueResult.k_ESteamNetworkingGetConfigValue_OKInherited
+                ? buffer[0].ToString()
+                : result.ToString();
+        }
+        finally
+        {
+            handle.Free();
+        }
     }
 
     public void CloseConnection(uint connection)

--- a/source/Coop.Steam/SteamNetworkingTunnelTransport.cs
+++ b/source/Coop.Steam/SteamNetworkingTunnelTransport.cs
@@ -1,0 +1,216 @@
+﻿using Common.Logging;
+using Serilog;
+using Steamworks;
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace Coop.Steam;
+
+/// <inheritdoc cref="ISteamTunnelTransport"/>
+/// <remarks>
+/// User-flavor sockets under the player's own Steam identity, so the game's per-frame
+/// SteamAPI.RunCallbacks pump dispatches the status callback with no pump of our own.
+/// Datagrams are sent unreliable: LiteNetLib runs its own reliability on top.
+/// </remarks>
+public class SteamNetworkingTunnelTransport : ISteamTunnelTransport
+{
+    private static readonly ILogger Logger = LogManager.GetLogger<SteamNetworkingTunnelTransport>();
+
+    private readonly object gate = new object();
+    private readonly HashSet<uint> ownedConnections = new HashSet<uint>();
+    private readonly Callback<SteamNetConnectionStatusChangedCallback_t> statusChangedCallback;
+    private readonly IntPtr[] receivedMessage = new IntPtr[1];
+    private HSteamListenSocket listenSocket = HSteamListenSocket.Invalid;
+
+    public event Action<uint, TunnelConnectionState> ConnectionStateChanged;
+
+    public SteamNetworkingTunnelTransport()
+    {
+        statusChangedCallback = Callback<SteamNetConnectionStatusChangedCallback_t>.Create(OnConnectionStatusChanged);
+    }
+
+    public void EnsureRelayAccess() => SteamNetworkingUtils.InitRelayNetworkAccess();
+
+    public uint ConnectToHost(ulong hostSteamId, int virtualPort)
+    {
+        var identity = new SteamNetworkingIdentity();
+        identity.SetSteamID64(hostSteamId);
+
+        var connection = SteamNetworkingSockets.ConnectP2P(ref identity, virtualPort, 0, null);
+        if (connection == HSteamNetConnection.Invalid)
+        {
+            throw new InvalidOperationException("Steam refused the tunnel connection");
+        }
+
+        lock (gate)
+        {
+            ownedConnections.Add(connection.m_HSteamNetConnection);
+        }
+
+        return connection.m_HSteamNetConnection;
+    }
+
+    public void ListenForClients(int virtualPort)
+    {
+        lock (gate)
+        {
+            if (listenSocket != HSteamListenSocket.Invalid) return;
+
+            var socket = SteamNetworkingSockets.CreateListenSocketP2P(virtualPort, 0, null);
+            if (socket == HSteamListenSocket.Invalid)
+            {
+                throw new InvalidOperationException("Steam refused the tunnel listen socket");
+            }
+
+            listenSocket = socket;
+        }
+    }
+
+    public void StopListening()
+    {
+        lock (gate)
+        {
+            if (listenSocket == HSteamListenSocket.Invalid) return;
+
+            SteamNetworkingSockets.CloseListenSocket(listenSocket);
+            listenSocket = HSteamListenSocket.Invalid;
+        }
+    }
+
+    public void AcceptConnection(uint connection)
+    {
+        var result = SteamNetworkingSockets.AcceptConnection(new HSteamNetConnection(connection));
+        if (result != EResult.k_EResultOK)
+        {
+            Logger.Error("Accepting tunnel connection {Connection} failed: {Result}", connection, result);
+            CloseConnection(connection);
+        }
+    }
+
+    public void CloseConnection(uint connection)
+    {
+        bool owned;
+        lock (gate)
+        {
+            owned = ownedConnections.Remove(connection);
+        }
+
+        if (owned)
+        {
+            SteamNetworkingSockets.CloseConnection(new HSteamNetConnection(connection), 0, string.Empty, false);
+        }
+    }
+
+    public bool SendDatagram(uint connection, byte[] data, int length)
+    {
+        // Pinning the caller's buffer avoids a copy and keeps sends off the shared gate,
+        // which the game thread's status callback also takes.
+        var handle = GCHandle.Alloc(data, GCHandleType.Pinned);
+        try
+        {
+            var result = SteamNetworkingSockets.SendMessageToConnection(
+                new HSteamNetConnection(connection), handle.AddrOfPinnedObject(), (uint)length,
+                Constants.k_nSteamNetworkingSend_UnreliableNoNagle, out _);
+
+            return result == EResult.k_EResultOK;
+        }
+        finally
+        {
+            handle.Free();
+        }
+    }
+
+    public int ReceiveDatagram(uint connection, byte[] buffer)
+    {
+        int count = SteamNetworkingSockets.ReceiveMessagesOnConnection(
+            new HSteamNetConnection(connection), receivedMessage, 1);
+        if (count <= 0) return 0;
+
+        try
+        {
+            var message = SteamNetworkingMessage_t.FromIntPtr(receivedMessage[0]);
+            if (message.m_cbSize > buffer.Length)
+            {
+                Logger.Warning("Dropping oversized tunnel datagram ({Size} bytes)", message.m_cbSize);
+                return 0;
+            }
+
+            Marshal.Copy(message.m_pData, buffer, 0, message.m_cbSize);
+            return message.m_cbSize;
+        }
+        finally
+        {
+            SteamNetworkingMessage_t.Release(receivedMessage[0]);
+        }
+    }
+
+    private void OnConnectionStatusChanged(SteamNetConnectionStatusChangedCallback_t change)
+    {
+        try
+        {
+            uint connection = change.m_hConn.m_HSteamNetConnection;
+
+            bool inbound;
+            lock (gate)
+            {
+                inbound = listenSocket != HSteamListenSocket.Invalid && change.m_info.m_hListenSocket == listenSocket;
+
+                if (inbound)
+                {
+                    ownedConnections.Add(connection);
+                }
+                else if (!ownedConnections.Contains(connection))
+                {
+                    return;
+                }
+            }
+
+            switch (change.m_info.m_eState)
+            {
+                case ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_Connecting:
+                    if (inbound)
+                    {
+                        ConnectionStateChanged?.Invoke(connection, TunnelConnectionState.Connecting);
+                    }
+                    break;
+
+                case ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_Connected:
+                    ConnectionStateChanged?.Invoke(connection, TunnelConnectionState.Connected);
+                    break;
+
+                case ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_ClosedByPeer:
+                case ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_ProblemDetectedLocally:
+                    Logger.Information("Tunnel connection {Connection} closed: {Reason}",
+                        connection, change.m_info.m_szEndDebug);
+                    ConnectionStateChanged?.Invoke(connection, TunnelConnectionState.Closed);
+                    CloseConnection(connection);
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            // The Steam dispatcher swallows handler exceptions into Console, invisible in our logs.
+            Logger.Error(ex, "Tunnel connection status handler failed");
+        }
+    }
+
+    public void Dispose()
+    {
+        StopListening();
+
+        uint[] connections;
+        lock (gate)
+        {
+            connections = new uint[ownedConnections.Count];
+            ownedConnections.CopyTo(connections);
+        }
+
+        foreach (var connection in connections)
+        {
+            CloseConnection(connection);
+        }
+
+        statusChangedCallback?.Dispose();
+    }
+}

--- a/source/Coop.Steam/SteamNetworkingTunnelTransport.cs
+++ b/source/Coop.Steam/SteamNetworkingTunnelTransport.cs
@@ -33,7 +33,52 @@ public class SteamNetworkingTunnelTransport : ISteamTunnelTransport
         statusChangedCallback = Callback<SteamNetConnectionStatusChangedCallback_t>.Create(OnConnectionStatusChanged);
     }
 
-    public void EnsureRelayAccess() => SteamNetworkingUtils.InitRelayNetworkAccess();
+    public void EnsureRelayAccess()
+    {
+        ApplyGlobalTunnelConfig();
+        SteamNetworkingUtils.InitRelayNetworkAccess();
+    }
+
+    public string DescribeConnection(uint connection)
+    {
+        var status = default(SteamNetConnectionRealTimeStatus_t);
+        var lanes = default(SteamNetConnectionRealTimeLaneStatus_t);
+        var result = SteamNetworkingSockets.GetConnectionRealTimeStatus(
+            new HSteamNetConnection(connection), ref status, 0, ref lanes);
+        if (result != EResult.k_EResultOK) return $"status unavailable ({result})";
+
+        return $"sendRate={status.m_nSendRateBytesPerSecond}B/s out={status.m_flOutBytesPerSec:F0}B/s " +
+            $"in={status.m_flInBytesPerSec:F0}B/s pendingReliable={status.m_cbPendingReliable} " +
+            $"unacked={status.m_cbSentUnackedReliable} ping={status.m_nPing}ms " +
+            $"quality={status.m_flConnectionQualityLocal:F2}";
+    }
+
+    // The per-call options on ConnectP2P/CreateListenSocketP2P should already cover this,
+    // but whether an accepted connection inherits listen-socket options is the one link we
+    // cannot observe locally, so the same values are also set globally.
+    private static void ApplyGlobalTunnelConfig()
+    {
+        SetGlobalInt32(ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendBufferSize, SteamTunnel.SendBufferBytes);
+        SetGlobalInt32(ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendRateMax, SteamTunnel.SendRateMaxBytesPerSecond);
+    }
+
+    private static void SetGlobalInt32(ESteamNetworkingConfigValue key, int value)
+    {
+        var handle = GCHandle.Alloc(value, GCHandleType.Pinned);
+        try
+        {
+            if (!SteamNetworkingUtils.SetConfigValue(key,
+                ESteamNetworkingConfigScope.k_ESteamNetworkingConfig_Global, IntPtr.Zero,
+                ESteamNetworkingConfigDataType.k_ESteamNetworkingConfig_Int32, handle.AddrOfPinnedObject()))
+            {
+                Logger.Warning("Steam refused global tunnel config {Key}", key);
+            }
+        }
+        finally
+        {
+            handle.Free();
+        }
+    }
 
     public uint ConnectToHost(ulong hostSteamId, int virtualPort)
     {

--- a/source/Coop.Steam/SteamNetworkingTunnelTransport.cs
+++ b/source/Coop.Steam/SteamNetworkingTunnelTransport.cs
@@ -61,6 +61,8 @@ public class SteamNetworkingTunnelTransport : ISteamTunnelTransport
         SetConfigInt32(ESteamNetworkingConfigScope.k_ESteamNetworkingConfig_Global, IntPtr.Zero,
             ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendBufferSize, SteamTunnel.SendBufferBytes);
         SetConfigInt32(ESteamNetworkingConfigScope.k_ESteamNetworkingConfig_Global, IntPtr.Zero,
+            ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendRateMin, SteamTunnel.SendRateMinBytesPerSecond);
+        SetConfigInt32(ESteamNetworkingConfigScope.k_ESteamNetworkingConfig_Global, IntPtr.Zero,
             ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendRateMax, SteamTunnel.SendRateMaxBytesPerSecond);
     }
 
@@ -146,6 +148,8 @@ public class SteamNetworkingTunnelTransport : ISteamTunnelTransport
         SetConfigInt32(ESteamNetworkingConfigScope.k_ESteamNetworkingConfig_Connection, (IntPtr)connection,
             ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendBufferSize, SteamTunnel.SendBufferBytes);
         SetConfigInt32(ESteamNetworkingConfigScope.k_ESteamNetworkingConfig_Connection, (IntPtr)connection,
+            ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendRateMin, SteamTunnel.SendRateMinBytesPerSecond);
+        SetConfigInt32(ESteamNetworkingConfigScope.k_ESteamNetworkingConfig_Connection, (IntPtr)connection,
             ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendRateMax, SteamTunnel.SendRateMaxBytesPerSecond);
     }
 
@@ -197,6 +201,7 @@ public class SteamNetworkingTunnelTransport : ISteamTunnelTransport
         return new[]
         {
             Int32Option(ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendBufferSize, SteamTunnel.SendBufferBytes),
+            Int32Option(ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendRateMin, SteamTunnel.SendRateMinBytesPerSecond),
             Int32Option(ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_SendRateMax, SteamTunnel.SendRateMaxBytesPerSecond),
         };
     }

--- a/source/Coop.Steam/SteamTunnelClient.cs
+++ b/source/Coop.Steam/SteamTunnelClient.cs
@@ -1,0 +1,100 @@
+﻿using Common.Logging;
+using Common.Util;
+using Serilog;
+using System;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Coop.Steam;
+
+/// <summary>
+/// Joiner-side tunnel pump: a loopback UDP socket the local LiteNetLib client dials, with
+/// every datagram forwarded over a Steam P2P connection to the hosting player and back.
+/// </summary>
+public class SteamTunnelClient : IDisposable
+{
+    private static readonly ILogger Logger = LogManager.GetLogger<SteamTunnelClient>();
+
+    private readonly ISteamTunnelTransport transport;
+    private readonly byte[] udpBuffer = new byte[SteamTunnel.MaxDatagramBytes];
+    private readonly byte[] steamBuffer = new byte[SteamTunnel.MaxDatagramBytes];
+
+    private Socket socket;
+    private Poller poller;
+    private uint connection;
+    // Both endpoints are only touched on the poller thread; clientEndpoint is learned from
+    // the first datagram.
+    private EndPoint receiveSender = TunnelSocket.AnyEndpoint();
+    private EndPoint clientEndpoint;
+
+    public SteamTunnelClient(ISteamTunnelTransport transport)
+    {
+        this.transport = transport;
+        transport.ConnectionStateChanged += OnConnectionStateChanged;
+    }
+
+    public int LocalPort { get; private set; }
+
+    public void Start(ulong hostSteamId)
+    {
+        transport.EnsureRelayAccess();
+
+        socket = TunnelSocket.CreateLoopbackDatagramSocket();
+        LocalPort = ((IPEndPoint)socket.LocalEndPoint).Port;
+
+        connection = transport.ConnectToHost(hostSteamId, SteamTunnel.VirtualPort);
+
+        poller = new Poller(Update, SteamTunnel.PumpInterval);
+        poller.Start();
+
+        Logger.Information("Steam tunnel pump on 127.0.0.1:{Port} connecting to host {HostSteamId}",
+            LocalPort, hostSteamId.ToString());
+    }
+
+    private void Update(TimeSpan deltaTime)
+    {
+        while (true)
+        {
+            int length = TunnelSocket.TryReceiveFrom(socket, udpBuffer, ref receiveSender);
+            if (length < 0) break;
+            if (length == 0) continue;
+
+            clientEndpoint = receiveSender;
+            transport.SendDatagram(connection, udpBuffer, length);
+        }
+
+        int size;
+        while ((size = transport.ReceiveDatagram(connection, steamBuffer)) > 0)
+        {
+            // Nothing has dialed the pump yet; the server never sends first, so drop.
+            if (clientEndpoint == null) continue;
+
+            socket.SendTo(steamBuffer, size, SocketFlags.None, clientEndpoint);
+        }
+    }
+
+    private void OnConnectionStateChanged(uint changedConnection, TunnelConnectionState state)
+    {
+        if (changedConnection != connection) return;
+
+        switch (state)
+        {
+            case TunnelConnectionState.Connected:
+                Logger.Information("Steam tunnel to the host established");
+                break;
+            case TunnelConnectionState.Closed:
+                Logger.Warning("Steam tunnel to the host closed");
+                break;
+        }
+    }
+
+    public void Dispose()
+    {
+        // Wait out any in-flight pump tick so the teardown below can't race it.
+        poller?.StopAndWait(TimeSpan.FromSeconds(1));
+        transport.ConnectionStateChanged -= OnConnectionStateChanged;
+        transport.CloseConnection(connection);
+        transport.Dispose();
+        socket?.Close();
+    }
+}

--- a/source/Coop.Steam/SteamTunnelClient.cs
+++ b/source/Coop.Steam/SteamTunnelClient.cs
@@ -110,10 +110,12 @@ public class SteamTunnelClient : IDisposable
         switch (state)
         {
             case TunnelConnectionState.Connected:
-                Logger.Information("Steam tunnel to the host established");
+                Logger.Information("Steam tunnel to the host established; {Status}",
+                    transport.DescribeConnection(connection));
                 break;
             case TunnelConnectionState.Closed:
-                Logger.Warning("Steam tunnel to the host closed");
+                Logger.Warning("Steam tunnel to the host closed; {Status}",
+                    transport.DescribeConnection(connection));
                 break;
         }
     }

--- a/source/Coop.Steam/SteamTunnelClient.cs
+++ b/source/Coop.Steam/SteamTunnelClient.cs
@@ -26,6 +26,9 @@ public class SteamTunnelClient : IDisposable
     // the first datagram.
     private EndPoint receiveSender = TunnelSocket.AnyEndpoint();
     private EndPoint clientEndpoint;
+    // Length of a held-back datagram for when the Steam send buffer is full. It stays in
+    // udpBuffer, which nothing overwrites until the retry succeeds.
+    private int pendingLength;
 
     public SteamTunnelClient(ISteamTunnelTransport transport)
     {
@@ -53,6 +56,37 @@ public class SteamTunnelClient : IDisposable
 
     private void Update(TimeSpan deltaTime)
     {
+        PumpToSteam();
+
+        try
+        {
+            int size;
+            while ((size = transport.ReceiveDatagram(connection, steamBuffer)) > 0)
+            {
+                // Nothing has dialed the pump yet; the server never sends first, so drop.
+                if (clientEndpoint == null) continue;
+
+                socket.SendTo(steamBuffer, size, SocketFlags.None, clientEndpoint);
+            }
+        }
+        catch (SocketException)
+        {
+            // A refused loopback send loses one datagram; LiteNetLib retransmits what matters.
+        }
+    }
+
+    // A refused send parks the datagram and stops draining, so the OS socket buffer queues
+    // the rest instead of anything being dropped while the Steam send buffer is full.
+    private void PumpToSteam()
+    {
+        // Only reliable-class datagrams ever park, so the retry is never droppable.
+        if (pendingLength > 0)
+        {
+            if (!transport.SendDatagram(connection, udpBuffer, pendingLength, droppable: false)) return;
+
+            pendingLength = 0;
+        }
+
         while (true)
         {
             int length = TunnelSocket.TryReceiveFrom(socket, udpBuffer, ref receiveSender);
@@ -60,16 +94,12 @@ public class SteamTunnelClient : IDisposable
             if (length == 0) continue;
 
             clientEndpoint = receiveSender;
-            transport.SendDatagram(connection, udpBuffer, length);
-        }
-
-        int size;
-        while ((size = transport.ReceiveDatagram(connection, steamBuffer)) > 0)
-        {
-            // Nothing has dialed the pump yet; the server never sends first, so drop.
-            if (clientEndpoint == null) continue;
-
-            socket.SendTo(steamBuffer, size, SocketFlags.None, clientEndpoint);
+            bool droppable = SteamTunnel.IsDroppableDatagram(udpBuffer, length);
+            if (!transport.SendDatagram(connection, udpBuffer, length, droppable))
+            {
+                pendingLength = length;
+                return;
+            }
         }
     }
 

--- a/source/Coop.Steam/SteamTunnelHost.cs
+++ b/source/Coop.Steam/SteamTunnelHost.cs
@@ -28,6 +28,8 @@ public class SteamTunnelHost : ISessionTunnelHost
         public Socket Socket;
         public byte[] PendingDatagram = new byte[SteamTunnel.MaxDatagramBytes];
         public int PendingLength;
+        // 0 = untouched: the connection runs on Steam's default pacing.
+        public int FloorBytesPerSecond;
     }
 
     private readonly ISteamTunnelTransport transport;
@@ -48,6 +50,20 @@ public class SteamTunnelHost : ISessionTunnelHost
     // ~10s of 2ms pump ticks between connection-stats log lines.
     private const int StatsLogTicks = 5000;
     private int ticksSinceStatsLog;
+
+    // Send-rate governor: Steam's pacing estimate never rises on its own in the game's
+    // build, so a floor forces the join transfer through — but only while a join-sized
+    // reliable backlog waits, halved when delivery quality sags (a weak uplink degrades to
+    // a slower transfer instead of a loss spiral), and restored to default once drained.
+    // The quality band is hysteresis so the floor doesn't flap around one threshold.
+    private const int GovernorTicks = 500;
+    private const int RaiseBacklogBytes = 256 * 1024;
+    private const int DrainBacklogBytes = 64 * 1024;
+    private const float BackOffQuality = 0.95f;
+    private const float RaiseQuality = 0.98f;
+    // Matches the default pacing rate observed on this Steam build.
+    private const int DefaultFloorBytesPerSecond = 256 * 1024;
+    private int ticksSinceGovernor;
 
     public SteamTunnelHost(ISteamTunnelTransport transport)
     {
@@ -155,6 +171,15 @@ public class SteamTunnelHost : ISessionTunnelHost
             }
         }
 
+        if (peerSnapshot.Length > 0 && ++ticksSinceGovernor >= GovernorTicks)
+        {
+            ticksSinceGovernor = 0;
+            foreach (var peer in peerSnapshot)
+            {
+                GovernSendRate(peer.Key, peer.Value);
+            }
+        }
+
         foreach (var peer in peerSnapshot)
         {
             try
@@ -177,6 +202,45 @@ public class SteamTunnelHost : ISessionTunnelHost
                 // A refused loopback send loses one datagram; LiteNetLib retransmits what matters.
             }
         }
+    }
+
+    private void GovernSendRate(uint connection, TunnelPeer peer)
+    {
+        if (!transport.TryGetSendHealth(connection, out int pendingReliable, out float quality)) return;
+
+        int floor = peer.FloorBytesPerSecond;
+        bool qualityKnown = quality >= 0;
+
+        if (floor > DefaultFloorBytesPerSecond && qualityKnown && quality < BackOffQuality)
+        {
+            SetFloor(connection, peer, Math.Max(DefaultFloorBytesPerSecond, floor / 2), "delivery quality sagged");
+            return;
+        }
+
+        if (pendingReliable > RaiseBacklogBytes && (!qualityKnown || quality >= RaiseQuality))
+        {
+            int target = floor <= DefaultFloorBytesPerSecond
+                ? SteamTunnel.TransferFloorBytesPerSecond
+                : Math.Min(SteamTunnel.TransferFloorBytesPerSecond, floor * 2);
+            if (target > floor)
+            {
+                SetFloor(connection, peer, target, "reliable backlog waiting");
+            }
+            return;
+        }
+
+        if (floor > DefaultFloorBytesPerSecond && pendingReliable < DrainBacklogBytes)
+        {
+            SetFloor(connection, peer, DefaultFloorBytesPerSecond, "backlog drained");
+        }
+    }
+
+    private void SetFloor(uint connection, TunnelPeer peer, int bytesPerSecond, string reason)
+    {
+        peer.FloorBytesPerSecond = bytesPerSecond;
+        transport.SetSendRateFloor(connection, bytesPerSecond);
+        Logger.Information("Tunnel peer {Connection} send floor {Floor}B/s ({Reason})",
+            connection, bytesPerSecond, reason);
     }
 
     // A refused send parks the datagram and stops draining, so the OS socket buffer queues

--- a/source/Coop.Steam/SteamTunnelHost.cs
+++ b/source/Coop.Steam/SteamTunnelHost.cs
@@ -1,0 +1,165 @@
+﻿using Common.Logging;
+using Common.Network.Session;
+using Common.Util;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Coop.Steam;
+
+/// <inheritdoc cref="ISessionTunnelHost"/>
+/// <remarks>
+/// Runs in the hosting player's client. Each accepted Steam peer gets its own loopback UDP
+/// socket toward the local server, because LiteNetLib keys peers by endpoint: a shared
+/// socket would merge every tunneled client into one peer, and the per-peer port must stay
+/// stable for the session (AllowPeerAddressChange is off).
+/// </remarks>
+public class SteamTunnelHost : ISessionTunnelHost
+{
+    private static readonly ILogger Logger = LogManager.GetLogger<SteamTunnelHost>();
+
+    private readonly ISteamTunnelTransport transport;
+    private readonly object gate = new object();
+    private readonly Dictionary<uint, Socket> peerSockets = new Dictionary<uint, Socket>();
+    private readonly byte[] serverBuffer = new byte[SteamTunnel.MaxDatagramBytes];
+    private readonly byte[] steamBuffer = new byte[SteamTunnel.MaxDatagramBytes];
+
+    // Rebuilt under the gate whenever the peer set changes, so the 2ms pump tick reads a
+    // stable array without taking the lock.
+    private volatile KeyValuePair<uint, Socket>[] peerSnapshot = Array.Empty<KeyValuePair<uint, Socket>>();
+    // Only touched on the poller thread.
+    private EndPoint receiveSender = TunnelSocket.AnyEndpoint();
+
+    private IPEndPoint serverEndpoint;
+    private Poller poller;
+    private volatile bool listening;
+
+    public SteamTunnelHost(ISteamTunnelTransport transport)
+    {
+        this.transport = transport;
+        transport.ConnectionStateChanged += OnConnectionStateChanged;
+    }
+
+    public bool IsListening => listening;
+
+    public int PeerCount => peerSnapshot.Length;
+
+    public void Start(int serverPort)
+    {
+        if (listening) return;
+
+        serverEndpoint = new IPEndPoint(IPAddress.Loopback, serverPort);
+        transport.EnsureRelayAccess();
+        transport.ListenForClients(SteamTunnel.VirtualPort);
+
+        poller = new Poller(Update, SteamTunnel.PumpInterval);
+        poller.Start();
+        listening = true;
+
+        Logger.Information("Steam tunnel host listening; forwarding peers to {ServerEndpoint}", serverEndpoint);
+    }
+
+    public void Stop()
+    {
+        if (!listening) return;
+        listening = false;
+
+        transport.StopListening();
+        // Wait out any in-flight pump tick so the socket teardown below can't race it.
+        poller?.StopAndWait(TimeSpan.FromSeconds(1));
+
+        KeyValuePair<uint, Socket>[] peers;
+        lock (gate)
+        {
+            peers = peerSockets.ToArray();
+            peerSockets.Clear();
+            peerSnapshot = Array.Empty<KeyValuePair<uint, Socket>>();
+        }
+
+        foreach (var peer in peers)
+        {
+            transport.CloseConnection(peer.Key);
+            peer.Value.Close();
+        }
+
+        Logger.Information("Steam tunnel host stopped");
+    }
+
+    private void OnConnectionStateChanged(uint connection, TunnelConnectionState state)
+    {
+        switch (state)
+        {
+            case TunnelConnectionState.Connecting:
+                if (!listening) return;
+
+                transport.AcceptConnection(connection);
+                break;
+
+            case TunnelConnectionState.Connected:
+                lock (gate)
+                {
+                    if (!listening || peerSockets.ContainsKey(connection)) return;
+
+                    var socket = TunnelSocket.CreateLoopbackDatagramSocket();
+                    socket.Connect(serverEndpoint);
+                    peerSockets[connection] = socket;
+                    peerSnapshot = peerSockets.ToArray();
+
+                    Logger.Information("Tunnel peer {Connection} connected; local relay port {Port}",
+                        connection, ((IPEndPoint)socket.LocalEndPoint).Port);
+                }
+                break;
+
+            case TunnelConnectionState.Closed:
+                Socket peerSocket;
+                lock (gate)
+                {
+                    if (!peerSockets.TryGetValue(connection, out peerSocket)) return;
+
+                    peerSockets.Remove(connection);
+                    peerSnapshot = peerSockets.ToArray();
+                }
+
+                peerSocket.Close();
+                Logger.Information("Tunnel peer {Connection} disconnected", connection);
+                break;
+        }
+    }
+
+    private void Update(TimeSpan deltaTime)
+    {
+        foreach (var peer in peerSnapshot)
+        {
+            try
+            {
+                int length;
+                while ((length = TunnelSocket.TryReceiveFrom(peer.Value, serverBuffer, ref receiveSender)) >= 0)
+                {
+                    if (length == 0) continue;
+
+                    transport.SendDatagram(peer.Key, serverBuffer, length);
+                }
+
+                int size;
+                while ((size = transport.ReceiveDatagram(peer.Key, steamBuffer)) > 0)
+                {
+                    peer.Value.Send(steamBuffer, size, SocketFlags.None);
+                }
+            }
+            catch (ObjectDisposedException)
+            {
+                // The Closed handler disposed this peer's socket mid-tick; the next tick's
+                // snapshot no longer contains it.
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        Stop();
+        transport.ConnectionStateChanged -= OnConnectionStateChanged;
+    }
+}

--- a/source/Coop.Steam/SteamTunnelHost.cs
+++ b/source/Coop.Steam/SteamTunnelHost.cs
@@ -21,15 +21,24 @@ public class SteamTunnelHost : ISessionTunnelHost
 {
     private static readonly ILogger Logger = LogManager.GetLogger<SteamTunnelHost>();
 
+    // A peer's loopback socket toward the server, plus one held-back datagram for when the
+    // Steam send buffer is full: the pump retries it before draining the socket further.
+    private sealed class TunnelPeer
+    {
+        public Socket Socket;
+        public byte[] PendingDatagram = new byte[SteamTunnel.MaxDatagramBytes];
+        public int PendingLength;
+    }
+
     private readonly ISteamTunnelTransport transport;
     private readonly object gate = new object();
-    private readonly Dictionary<uint, Socket> peerSockets = new Dictionary<uint, Socket>();
+    private readonly Dictionary<uint, TunnelPeer> peers = new Dictionary<uint, TunnelPeer>();
     private readonly byte[] serverBuffer = new byte[SteamTunnel.MaxDatagramBytes];
     private readonly byte[] steamBuffer = new byte[SteamTunnel.MaxDatagramBytes];
 
     // Rebuilt under the gate whenever the peer set changes, so the 2ms pump tick reads a
     // stable array without taking the lock.
-    private volatile KeyValuePair<uint, Socket>[] peerSnapshot = Array.Empty<KeyValuePair<uint, Socket>>();
+    private volatile KeyValuePair<uint, TunnelPeer>[] peerSnapshot = Array.Empty<KeyValuePair<uint, TunnelPeer>>();
     // Only touched on the poller thread.
     private EndPoint receiveSender = TunnelSocket.AnyEndpoint();
 
@@ -71,18 +80,18 @@ public class SteamTunnelHost : ISessionTunnelHost
         // Wait out any in-flight pump tick so the socket teardown below can't race it.
         poller?.StopAndWait(TimeSpan.FromSeconds(1));
 
-        KeyValuePair<uint, Socket>[] peers;
+        KeyValuePair<uint, TunnelPeer>[] remaining;
         lock (gate)
         {
-            peers = peerSockets.ToArray();
-            peerSockets.Clear();
-            peerSnapshot = Array.Empty<KeyValuePair<uint, Socket>>();
+            remaining = peers.ToArray();
+            peers.Clear();
+            peerSnapshot = Array.Empty<KeyValuePair<uint, TunnelPeer>>();
         }
 
-        foreach (var peer in peers)
+        foreach (var peer in remaining)
         {
             transport.CloseConnection(peer.Key);
-            peer.Value.Close();
+            peer.Value.Socket.Close();
         }
 
         Logger.Information("Steam tunnel host stopped");
@@ -101,12 +110,12 @@ public class SteamTunnelHost : ISessionTunnelHost
             case TunnelConnectionState.Connected:
                 lock (gate)
                 {
-                    if (!listening || peerSockets.ContainsKey(connection)) return;
+                    if (!listening || peers.ContainsKey(connection)) return;
 
                     var socket = TunnelSocket.CreateLoopbackDatagramSocket();
                     socket.Connect(serverEndpoint);
-                    peerSockets[connection] = socket;
-                    peerSnapshot = peerSockets.ToArray();
+                    peers[connection] = new TunnelPeer { Socket = socket };
+                    peerSnapshot = peers.ToArray();
 
                     Logger.Information("Tunnel peer {Connection} connected; local relay port {Port}",
                         connection, ((IPEndPoint)socket.LocalEndPoint).Port);
@@ -114,16 +123,16 @@ public class SteamTunnelHost : ISessionTunnelHost
                 break;
 
             case TunnelConnectionState.Closed:
-                Socket peerSocket;
+                TunnelPeer closedPeer;
                 lock (gate)
                 {
-                    if (!peerSockets.TryGetValue(connection, out peerSocket)) return;
+                    if (!peers.TryGetValue(connection, out closedPeer)) return;
 
-                    peerSockets.Remove(connection);
-                    peerSnapshot = peerSockets.ToArray();
+                    peers.Remove(connection);
+                    peerSnapshot = peers.ToArray();
                 }
 
-                peerSocket.Close();
+                closedPeer.Socket.Close();
                 Logger.Information("Tunnel peer {Connection} disconnected", connection);
                 break;
         }
@@ -135,24 +144,49 @@ public class SteamTunnelHost : ISessionTunnelHost
         {
             try
             {
-                int length;
-                while ((length = TunnelSocket.TryReceiveFrom(peer.Value, serverBuffer, ref receiveSender)) >= 0)
-                {
-                    if (length == 0) continue;
-
-                    transport.SendDatagram(peer.Key, serverBuffer, length);
-                }
+                PumpToSteam(peer.Key, peer.Value);
 
                 int size;
                 while ((size = transport.ReceiveDatagram(peer.Key, steamBuffer)) > 0)
                 {
-                    peer.Value.Send(steamBuffer, size, SocketFlags.None);
+                    peer.Value.Socket.Send(steamBuffer, size, SocketFlags.None);
                 }
             }
             catch (ObjectDisposedException)
             {
                 // The Closed handler disposed this peer's socket mid-tick; the next tick's
                 // snapshot no longer contains it.
+            }
+            catch (SocketException)
+            {
+                // A refused loopback send loses one datagram; LiteNetLib retransmits what matters.
+            }
+        }
+    }
+
+    // A refused send parks the datagram and stops draining, so the OS socket buffer queues
+    // the rest instead of anything reliable being dropped while the Steam send buffer is full.
+    private void PumpToSteam(uint connection, TunnelPeer peer)
+    {
+        // Only reliable-class datagrams ever park, so the retry is never droppable.
+        if (peer.PendingLength > 0)
+        {
+            if (!transport.SendDatagram(connection, peer.PendingDatagram, peer.PendingLength, droppable: false)) return;
+
+            peer.PendingLength = 0;
+        }
+
+        int length;
+        while ((length = TunnelSocket.TryReceiveFrom(peer.Socket, serverBuffer, ref receiveSender)) >= 0)
+        {
+            if (length == 0) continue;
+
+            bool droppable = SteamTunnel.IsDroppableDatagram(serverBuffer, length);
+            if (!transport.SendDatagram(connection, serverBuffer, length, droppable))
+            {
+                Array.Copy(serverBuffer, peer.PendingDatagram, length);
+                peer.PendingLength = length;
+                return;
             }
         }
     }

--- a/source/Coop.Steam/SteamTunnelHost.cs
+++ b/source/Coop.Steam/SteamTunnelHost.cs
@@ -45,6 +45,9 @@ public class SteamTunnelHost : ISessionTunnelHost
     private IPEndPoint serverEndpoint;
     private Poller poller;
     private volatile bool listening;
+    // ~10s of 2ms pump ticks between connection-stats log lines.
+    private const int StatsLogTicks = 5000;
+    private int ticksSinceStatsLog;
 
     public SteamTunnelHost(ISteamTunnelTransport transport)
     {
@@ -117,8 +120,10 @@ public class SteamTunnelHost : ISessionTunnelHost
                     peers[connection] = new TunnelPeer { Socket = socket };
                     peerSnapshot = peers.ToArray();
 
-                    Logger.Information("Tunnel peer {Connection} connected; local relay port {Port}",
-                        connection, ((IPEndPoint)socket.LocalEndPoint).Port);
+                    // The effective sendRate/buffer here also proves whether the listen
+                    // socket's config options reached the accepted connection.
+                    Logger.Information("Tunnel peer {Connection} connected; local relay port {Port}; {Status}",
+                        connection, ((IPEndPoint)socket.LocalEndPoint).Port, transport.DescribeConnection(connection));
                 }
                 break;
 
@@ -140,6 +145,16 @@ public class SteamTunnelHost : ISessionTunnelHost
 
     private void Update(TimeSpan deltaTime)
     {
+        if (peerSnapshot.Length > 0 && ++ticksSinceStatsLog >= StatsLogTicks)
+        {
+            ticksSinceStatsLog = 0;
+            foreach (var peer in peerSnapshot)
+            {
+                Logger.Information("Tunnel peer {Connection}: {Status}",
+                    peer.Key, transport.DescribeConnection(peer.Key));
+            }
+        }
+
         foreach (var peer in peerSnapshot)
         {
             try

--- a/source/Coop.Steam/SteamTunnelHost.cs
+++ b/source/Coop.Steam/SteamTunnelHost.cs
@@ -56,7 +56,9 @@ public class SteamTunnelHost : ISessionTunnelHost
     // reliable backlog waits, halved when delivery quality sags (a weak uplink degrades to
     // a slower transfer instead of a loss spiral), and restored to default once drained.
     // The quality band is hysteresis so the floor doesn't flap around one threshold.
-    private const int GovernorTicks = 500;
+    // Nominally ~100ms of pump ticks; degraded Task.Delay timer resolution stretches a
+    // tick toward 15ms, so the real cadence can be several times longer.
+    private const int GovernorTicks = 50;
     private const int RaiseBacklogBytes = 256 * 1024;
     private const int DrainBacklogBytes = 64 * 1024;
     private const float BackOffQuality = 0.95f;

--- a/source/Coop.Steam/SteamTunnelJoinEndpointPreparer.cs
+++ b/source/Coop.Steam/SteamTunnelJoinEndpointPreparer.cs
@@ -1,0 +1,68 @@
+﻿using Common.Logging;
+using Common.Network.Session;
+using Serilog;
+using System;
+using System.Threading.Tasks;
+
+namespace Coop.Steam;
+
+/// <summary>
+/// Prepares a tunneled join: stands up the local pump connecting to the host's Steam
+/// identity and returns its loopback endpoint for the client to dial. Returns immediately;
+/// the Steam link finishes connecting in the background while the client's connect retries
+/// and the join watchdog bound the wait.
+/// </summary>
+public class SteamTunnelJoinEndpointPreparer : IJoinEndpointPreparer
+{
+    private static readonly ILogger Logger = LogManager.GetLogger<SteamTunnelJoinEndpointPreparer>();
+
+    private readonly object gate = new object();
+    private SteamTunnelClient tunnel;
+
+    public Task<SessionJoinInfo> PrepareAsync(SessionJoinInfo info)
+    {
+        lock (gate)
+        {
+            TearDownLocked();
+
+            SteamTunnelClient client = null;
+            try
+            {
+                client = new SteamTunnelClient(new SteamNetworkingTunnelTransport());
+                client.Start(info.HostSteamId);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Steam tunnel setup failed; falling back to the advertised address");
+                client?.Dispose();
+                return Task.FromResult(info);
+            }
+
+            tunnel = client;
+
+            return Task.FromResult(new SessionJoinInfo
+            {
+                Version = info.Version,
+                Address = "127.0.0.1",
+                Port = client.LocalPort,
+                HostSteamId = info.HostSteamId,
+                Tunneled = true,
+            });
+        }
+    }
+
+    /// <summary>Closes the active tunnel; called when the session ends or the join fails.</summary>
+    public void TearDown()
+    {
+        lock (gate)
+        {
+            TearDownLocked();
+        }
+    }
+
+    private void TearDownLocked()
+    {
+        tunnel?.Dispose();
+        tunnel = null;
+    }
+}

--- a/source/Coop.Steam/TunnelSocket.cs
+++ b/source/Coop.Steam/TunnelSocket.cs
@@ -19,6 +19,8 @@ internal static class TunnelSocket
         var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp)
         {
             Blocking = false,
+            ReceiveBufferSize = SteamTunnel.LoopbackBufferBytes,
+            SendBufferSize = SteamTunnel.LoopbackBufferBytes,
         };
 
         // Best effort: the control code is Windows-only, and the receive helpers tolerate

--- a/source/Coop.Steam/TunnelSocket.cs
+++ b/source/Coop.Steam/TunnelSocket.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Coop.Steam;
+
+/// <summary>
+/// Loopback UDP socket helpers shared by the tunnel pumps: non-blocking sockets with
+/// Windows' ICMP port-unreachable reset suppressed, and drain-style receives.
+/// </summary>
+internal static class TunnelSocket
+{
+    // SIO_UDP_CONNRESET: without this, a send to a not-yet-open loopback port makes the
+    // next receive throw ConnectionReset instead of just dropping the datagram.
+    private const int SioUdpConnReset = -1744830452;
+
+    public static Socket CreateLoopbackDatagramSocket()
+    {
+        var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp)
+        {
+            Blocking = false,
+        };
+
+        // Best effort: the control code is Windows-only, and the receive helpers tolerate
+        // the resets anyway.
+        try
+        {
+            socket.IOControl(SioUdpConnReset, new byte[] { 0 }, null);
+        }
+        catch (SocketException)
+        {
+        }
+        catch (PlatformNotSupportedException)
+        {
+        }
+
+        socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        return socket;
+    }
+
+    public static EndPoint AnyEndpoint() => new IPEndPoint(IPAddress.Any, 0);
+
+    /// <summary>Returns the datagram length, 0 for a transient error worth skipping, -1 when drained.</summary>
+    public static int TryReceiveFrom(Socket socket, byte[] buffer, ref EndPoint sender)
+    {
+        try
+        {
+            if (socket.Available == 0) return -1;
+
+            return socket.ReceiveFrom(buffer, ref sender);
+        }
+        catch (SocketException ex)
+        {
+            return ex.SocketErrorCode == SocketError.WouldBlock ? -1 : 0;
+        }
+    }
+
+}

--- a/source/Coop.Tests/Steam/FakeSteamLobbyApi.cs
+++ b/source/Coop.Tests/Steam/FakeSteamLobbyApi.cs
@@ -12,6 +12,7 @@ namespace Coop.Tests.Steam
     {
         public bool OverlayEnabled = true;
         public ulong NextCreatedLobbyId = 1001;
+        public ulong LobbyOwner = 76561198000000001;
         public bool CreateSucceeds = true;
         public bool JoinSucceeds = true;
         public bool SetLobbyDataSucceeds = true;
@@ -84,6 +85,12 @@ namespace Coop.Tests.Steam
             if (LobbyData.TryGetValue(lobbyId, out var data) && data.TryGetValue(key, out var value)) return value;
 
             return string.Empty;
+        }
+
+        // Only valid while a member, like the real API; reading after leaving yields nothing.
+        public ulong GetLobbyOwner(ulong lobbyId)
+        {
+            return LeftLobbies.Contains(lobbyId) ? 0 : LobbyOwner;
         }
 
         public void OpenInviteDialog(ulong lobbyId) => InviteDialogsOpened.Add(lobbyId);

--- a/source/Coop.Tests/Steam/FakeSteamTunnelTransport.cs
+++ b/source/Coop.Tests/Steam/FakeSteamTunnelTransport.cs
@@ -104,6 +104,40 @@ namespace Coop.Tests.Steam
 
         public string DescribeConnection(uint connection) => "fake";
 
+        // Health the governor reads; volatile because the pump polls from its own thread.
+        public volatile int PendingReliableBytes;
+        public volatile float Quality = -1f;
+
+        private readonly List<(uint Connection, int Floor)> floorSets = new List<(uint, int)>();
+
+        public void SetSendRateFloor(uint connection, int bytesPerSecond)
+        {
+            lock (gate)
+            {
+                floorSets.Add((connection, bytesPerSecond));
+            }
+        }
+
+        public int LastFloorFor(uint connection)
+        {
+            lock (gate)
+            {
+                for (int i = floorSets.Count - 1; i >= 0; i--)
+                {
+                    if (floorSets[i].Connection == connection) return floorSets[i].Floor;
+                }
+            }
+
+            return -1;
+        }
+
+        public bool TryGetSendHealth(uint connection, out int pendingReliableBytes, out float quality)
+        {
+            pendingReliableBytes = PendingReliableBytes;
+            quality = Quality;
+            return true;
+        }
+
         public void Dispose() => Disposed = true;
     }
 }

--- a/source/Coop.Tests/Steam/FakeSteamTunnelTransport.cs
+++ b/source/Coop.Tests/Steam/FakeSteamTunnelTransport.cs
@@ -21,6 +21,8 @@ namespace Coop.Tests.Steam
         public bool Listening;
         public bool Disposed;
         public int RelayAccessCalls;
+        public int FailSendsRemaining;
+        public int RejectedSends;
         public readonly List<uint> AcceptedConnections = new List<uint>();
         public readonly List<uint> ClosedConnections = new List<uint>();
 
@@ -70,10 +72,18 @@ namespace Coop.Tests.Steam
 
         public void CloseConnection(uint connection) => ClosedConnections.Add(connection);
 
-        public bool SendDatagram(uint connection, byte[] data, int length)
+        public bool SendDatagram(uint connection, byte[] data, int length, bool droppable)
         {
             lock (gate)
             {
+                if (FailSendsRemaining > 0)
+                {
+                    FailSendsRemaining--;
+                    RejectedSends++;
+                    // Mirrors the real transport: a droppable datagram is lost, not retried.
+                    return droppable;
+                }
+
                 sentDatagrams.Add((connection, data.Take(length).ToArray()));
             }
 

--- a/source/Coop.Tests/Steam/FakeSteamTunnelTransport.cs
+++ b/source/Coop.Tests/Steam/FakeSteamTunnelTransport.cs
@@ -102,6 +102,8 @@ namespace Coop.Tests.Steam
             }
         }
 
+        public string DescribeConnection(uint connection) => "fake";
+
         public void Dispose() => Disposed = true;
     }
 }

--- a/source/Coop.Tests/Steam/FakeSteamTunnelTransport.cs
+++ b/source/Coop.Tests/Steam/FakeSteamTunnelTransport.cs
@@ -1,0 +1,97 @@
+﻿using Coop.Steam;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Coop.Tests.Steam
+{
+    /// <summary>
+    /// Scriptable <see cref="ISteamTunnelTransport"/>: records calls, queues inbound
+    /// datagrams, and lets tests raise connection-state events. The pumps poll from a
+    /// background thread, so all state is lock-protected.
+    /// </summary>
+    public class FakeSteamTunnelTransport : ISteamTunnelTransport
+    {
+        private readonly object gate = new object();
+        private readonly List<(uint Connection, byte[] Data)> sentDatagrams = new List<(uint, byte[])>();
+        private readonly Dictionary<uint, Queue<byte[]>> pendingReceives = new Dictionary<uint, Queue<byte[]>>();
+
+        public uint NextConnection = 501;
+        public ulong ConnectedHost;
+        public bool Listening;
+        public bool Disposed;
+        public int RelayAccessCalls;
+        public readonly List<uint> AcceptedConnections = new List<uint>();
+        public readonly List<uint> ClosedConnections = new List<uint>();
+
+        public event Action<uint, TunnelConnectionState> ConnectionStateChanged;
+
+        public void RaiseConnectionState(uint connection, TunnelConnectionState state) =>
+            ConnectionStateChanged?.Invoke(connection, state);
+
+        public (uint Connection, byte[] Data)[] SentDatagrams
+        {
+            get
+            {
+                lock (gate)
+                {
+                    return sentDatagrams.ToArray();
+                }
+            }
+        }
+
+        public void EnqueueReceive(uint connection, byte[] data)
+        {
+            lock (gate)
+            {
+                if (!pendingReceives.TryGetValue(connection, out var queue))
+                {
+                    queue = new Queue<byte[]>();
+                    pendingReceives[connection] = queue;
+                }
+
+                queue.Enqueue(data);
+            }
+        }
+
+        public void EnsureRelayAccess() => RelayAccessCalls++;
+
+        public uint ConnectToHost(ulong hostSteamId, int virtualPort)
+        {
+            ConnectedHost = hostSteamId;
+            return NextConnection;
+        }
+
+        public void ListenForClients(int virtualPort) => Listening = true;
+
+        public void StopListening() => Listening = false;
+
+        public void AcceptConnection(uint connection) => AcceptedConnections.Add(connection);
+
+        public void CloseConnection(uint connection) => ClosedConnections.Add(connection);
+
+        public bool SendDatagram(uint connection, byte[] data, int length)
+        {
+            lock (gate)
+            {
+                sentDatagrams.Add((connection, data.Take(length).ToArray()));
+            }
+
+            return true;
+        }
+
+        public int ReceiveDatagram(uint connection, byte[] buffer)
+        {
+            lock (gate)
+            {
+                if (!pendingReceives.TryGetValue(connection, out var queue) || queue.Count == 0) return 0;
+
+                var data = queue.Dequeue();
+                Array.Copy(data, buffer, data.Length);
+                return data.Length;
+            }
+        }
+
+        public void Dispose() => Disposed = true;
+    }
+}

--- a/source/Coop.Tests/Steam/LobbyDataCodecTests.cs
+++ b/source/Coop.Tests/Steam/LobbyDataCodecTests.cs
@@ -48,6 +48,22 @@ namespace Coop.Tests.Steam
         }
 
         [Fact]
+        public void Decode_AcceptsOlderVersion()
+        {
+            var data = new Dictionary<string, string>
+            {
+                [LobbyDataCodec.VersionKey] = "1",
+                [LobbyDataCodec.AddressKey] = "203.0.113.7",
+                [LobbyDataCodec.PortKey] = "4200",
+            };
+
+            Assert.True(LobbyDataCodec.TryDecode(key => Read(data, key), out var decoded, out _));
+
+            Assert.Equal(1, decoded.Version);
+            Assert.True(decoded.Version < SessionJoinInfo.MinTunnelVersion);
+        }
+
+        [Fact]
         public void Decode_FailsOnNewerVersion()
         {
             var data = new Dictionary<string, string>

--- a/source/Coop.Tests/Steam/SteamJoinListenerTests.cs
+++ b/source/Coop.Tests/Steam/SteamJoinListenerTests.cs
@@ -28,9 +28,10 @@ namespace Coop.Tests.Steam
         private void Handle_Resolved(MessagePayload<SessionJoinInfoResolved> payload) => resolved.Add(payload.What);
         private void Handle_Failed(MessagePayload<SessionJoinFailed> payload) => failed.Add(payload.What);
 
-        private void SetupLobby(ulong lobbyId, string address = "203.0.113.7", int port = 4200)
+        private void SetupLobby(ulong lobbyId, string address = "203.0.113.7", int port = 4200,
+            int version = SessionJoinInfo.CurrentVersion)
         {
-            foreach (var pair in LobbyDataCodec.Encode(new SessionJoinInfo { Address = address, Port = port }))
+            foreach (var pair in LobbyDataCodec.Encode(new SessionJoinInfo { Address = address, Port = port, Version = version }))
             {
                 api.SetLobbyData(lobbyId, pair.Key, pair.Value);
             }
@@ -123,15 +124,42 @@ namespace Coop.Tests.Steam
         }
 
         [Fact]
-        public void LobbyWithoutAddress_PublishesFailureAndLeaves()
+        public void DirectOnlyLobbyWithoutAddress_PublishesFailureAndLeaves()
         {
-            SetupLobby(42, address: null);
+            SetupLobby(42, address: null, version: SessionJoinInfo.MinTunnelVersion - 1);
 
             api.RaiseLobbyJoinRequested(42);
 
             Assert.Empty(resolved);
             Assert.Contains("public address", Assert.Single(failed).Reason);
             Assert.Contains(42UL, api.LeftLobbies);
+        }
+
+        [Fact]
+        public void TunnelCapableLobby_ResolvesHostSteamIdWithoutAddress()
+        {
+            SetupLobby(42, address: null);
+
+            api.RaiseLobbyJoinRequested(42);
+
+            var info = Assert.Single(resolved).JoinInfo;
+            Assert.Equal(api.LobbyOwner, info.HostSteamId);
+            Assert.False(info.HasAddress);
+            Assert.Empty(failed);
+            // The owner is only readable while a member, so the leave must come after the read.
+            Assert.Contains(42UL, api.LeftLobbies);
+        }
+
+        [Fact]
+        public void DirectOnlyLobby_ResolvesWithoutHostSteamId()
+        {
+            SetupLobby(42, version: SessionJoinInfo.MinTunnelVersion - 1);
+
+            api.RaiseLobbyJoinRequested(42);
+
+            var info = Assert.Single(resolved).JoinInfo;
+            Assert.False(info.HasHostSteamId);
+            Assert.Equal("203.0.113.7", info.Address);
         }
 
         [Theory]

--- a/source/Coop.Tests/Steam/SteamTunnelClientTests.cs
+++ b/source/Coop.Tests/Steam/SteamTunnelClientTests.cs
@@ -66,6 +66,45 @@ namespace Coop.Tests.Steam
         }
 
         [Fact]
+        public void BackpressuredSend_IsRetriedInOrderWithoutLoss()
+        {
+            client.Start(76561198000000042);
+
+            using var liteNetSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            liteNetSocket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            var pumpEndpoint = new IPEndPoint(IPAddress.Loopback, client.LocalPort);
+
+            transport.FailSendsRemaining = 2;
+            liteNetSocket.SendTo(new byte[] { 1 }, pumpEndpoint);
+            WaitUntil(() => transport.RejectedSends >= 1);
+            liteNetSocket.SendTo(new byte[] { 2 }, pumpEndpoint);
+
+            WaitUntil(() => transport.SentDatagrams.Length == 2);
+            Assert.Equal(new byte[] { 1 }, transport.SentDatagrams[0].Data);
+            Assert.Equal(new byte[] { 2 }, transport.SentDatagrams[1].Data);
+        }
+
+        [Fact]
+        public void DroppableDatagram_IsDroppedNotParkedUnderBackpressure()
+        {
+            client.Start(76561198000000042);
+
+            using var liteNetSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            liteNetSocket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            var pumpEndpoint = new IPEndPoint(IPAddress.Loopback, client.LocalPort);
+
+            transport.FailSendsRemaining = 1;
+            // First byte 0 = LiteNetLib Unreliable: refused under pressure means dropped.
+            liteNetSocket.SendTo(new byte[] { 0, 9 }, pumpEndpoint);
+            WaitUntil(() => transport.RejectedSends >= 1);
+
+            // First byte 1 = Channeled (reliable class): must still get through.
+            liteNetSocket.SendTo(new byte[] { 1, 7 }, pumpEndpoint);
+            WaitUntil(() => transport.SentDatagrams.Length == 1);
+            Assert.Equal(new byte[] { 1, 7 }, transport.SentDatagrams[0].Data);
+        }
+
+        [Fact]
         public void InboundBeforeAnyOutbound_IsDroppedNotMisdelivered()
         {
             client.Start(76561198000000042);

--- a/source/Coop.Tests/Steam/SteamTunnelClientTests.cs
+++ b/source/Coop.Tests/Steam/SteamTunnelClientTests.cs
@@ -1,0 +1,90 @@
+﻿using Coop.Steam;
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using Xunit;
+
+namespace Coop.Tests.Steam
+{
+    public class SteamTunnelClientTests : IDisposable
+    {
+        private readonly FakeSteamTunnelTransport transport = new FakeSteamTunnelTransport();
+        private readonly SteamTunnelClient client;
+
+        public SteamTunnelClientTests()
+        {
+            client = new SteamTunnelClient(transport);
+        }
+
+        public void Dispose() => client.Dispose();
+
+        // The pump drains on a background poller, so data-path assertions wait for it.
+        internal static void WaitUntil(Func<bool> condition)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            while (!condition())
+            {
+                Assert.True(stopwatch.ElapsedMilliseconds < 5000, "Pump did not forward within 5s");
+                Thread.Sleep(10);
+            }
+        }
+
+        [Fact]
+        public void Start_BindsLoopbackPortAndConnectsToHost()
+        {
+            client.Start(76561198000000042);
+
+            Assert.NotEqual(0, client.LocalPort);
+            Assert.Equal(76561198000000042ul, transport.ConnectedHost);
+            Assert.Equal(1, transport.RelayAccessCalls);
+        }
+
+        [Fact]
+        public void Datagrams_FlowBothWaysThroughThePump()
+        {
+            client.Start(76561198000000042);
+
+            using var liteNetSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            liteNetSocket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            var pumpEndpoint = new IPEndPoint(IPAddress.Loopback, client.LocalPort);
+
+            var outbound = new byte[] { 1, 2, 3, 4 };
+            liteNetSocket.SendTo(outbound, pumpEndpoint);
+            WaitUntil(() => transport.SentDatagrams.Length == 1);
+            Assert.Equal(outbound, transport.SentDatagrams[0].Data);
+            Assert.Equal(transport.NextConnection, transport.SentDatagrams[0].Connection);
+
+            var inbound = new byte[] { 9, 8, 7 };
+            transport.EnqueueReceive(transport.NextConnection, inbound);
+            liteNetSocket.ReceiveTimeout = 5000;
+            var buffer = new byte[SteamTunnel.MaxDatagramBytes];
+            int received = liteNetSocket.Receive(buffer);
+            Assert.Equal(inbound, buffer.Take(received).ToArray());
+        }
+
+        [Fact]
+        public void InboundBeforeAnyOutbound_IsDroppedNotMisdelivered()
+        {
+            client.Start(76561198000000042);
+
+            transport.EnqueueReceive(transport.NextConnection, new byte[] { 5 });
+
+            // Drained without a destination: the pump has not learned the client endpoint yet.
+            WaitUntil(() => transport.ReceiveDatagram(transport.NextConnection, new byte[16]) == 0);
+        }
+
+        [Fact]
+        public void Dispose_ClosesConnectionAndTransport()
+        {
+            client.Start(76561198000000042);
+
+            client.Dispose();
+
+            Assert.Contains(transport.NextConnection, transport.ClosedConnections);
+            Assert.True(transport.Disposed);
+        }
+    }
+}

--- a/source/Coop.Tests/Steam/SteamTunnelHostTests.cs
+++ b/source/Coop.Tests/Steam/SteamTunnelHostTests.cs
@@ -97,6 +97,60 @@ namespace Coop.Tests.Steam
         }
 
         [Fact]
+        public void BackpressuredSend_IsRetriedInOrderWithoutLoss()
+        {
+            using var serverSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            serverSocket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            serverSocket.ReceiveTimeout = 5000;
+            int serverPort = ((IPEndPoint)serverSocket.LocalEndPoint).Port;
+
+            host.Start(serverPort);
+            transport.RaiseConnectionState(7, TunnelConnectionState.Connected);
+
+            // Learn the peer's relay endpoint from one steam->server datagram.
+            transport.EnqueueReceive(7, new byte[] { 0 });
+            var buffer = new byte[SteamTunnel.MaxDatagramBytes];
+            EndPoint peerRelayEndpoint = new IPEndPoint(IPAddress.Any, 0);
+            serverSocket.ReceiveFrom(buffer, ref peerRelayEndpoint);
+
+            transport.FailSendsRemaining = 2;
+            serverSocket.SendTo(new byte[] { 1 }, peerRelayEndpoint);
+            SteamTunnelClientTests.WaitUntil(() => transport.RejectedSends >= 1);
+            serverSocket.SendTo(new byte[] { 2 }, peerRelayEndpoint);
+
+            SteamTunnelClientTests.WaitUntil(() => transport.SentDatagrams.Length == 2);
+            Assert.Equal(new byte[] { 1 }, transport.SentDatagrams[0].Data);
+            Assert.Equal(new byte[] { 2 }, transport.SentDatagrams[1].Data);
+        }
+
+        [Fact]
+        public void DroppableDatagram_IsDroppedNotParkedUnderBackpressure()
+        {
+            using var serverSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            serverSocket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            serverSocket.ReceiveTimeout = 5000;
+            int serverPort = ((IPEndPoint)serverSocket.LocalEndPoint).Port;
+
+            host.Start(serverPort);
+            transport.RaiseConnectionState(7, TunnelConnectionState.Connected);
+
+            transport.EnqueueReceive(7, new byte[] { 0 });
+            var buffer = new byte[SteamTunnel.MaxDatagramBytes];
+            EndPoint peerRelayEndpoint = new IPEndPoint(IPAddress.Any, 0);
+            serverSocket.ReceiveFrom(buffer, ref peerRelayEndpoint);
+
+            transport.FailSendsRemaining = 1;
+            // First byte 0 = LiteNetLib Unreliable: refused under pressure means dropped.
+            serverSocket.SendTo(new byte[] { 0, 9 }, peerRelayEndpoint);
+            SteamTunnelClientTests.WaitUntil(() => transport.RejectedSends >= 1);
+
+            // First byte 1 = Channeled (reliable class): must still get through.
+            serverSocket.SendTo(new byte[] { 1, 7 }, peerRelayEndpoint);
+            SteamTunnelClientTests.WaitUntil(() => transport.SentDatagrams.Length == 1);
+            Assert.Equal(new byte[] { 1, 7 }, transport.SentDatagrams[0].Data);
+        }
+
+        [Fact]
         public void TwoPeers_GetDistinctRelayPorts()
         {
             using var serverSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);

--- a/source/Coop.Tests/Steam/SteamTunnelHostTests.cs
+++ b/source/Coop.Tests/Steam/SteamTunnelHostTests.cs
@@ -1,0 +1,125 @@
+﻿using Coop.Steam;
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using Xunit;
+
+namespace Coop.Tests.Steam
+{
+    public class SteamTunnelHostTests : IDisposable
+    {
+        private readonly FakeSteamTunnelTransport transport = new FakeSteamTunnelTransport();
+        private readonly SteamTunnelHost host;
+
+        public SteamTunnelHostTests()
+        {
+            host = new SteamTunnelHost(transport);
+        }
+
+        public void Dispose() => host.Dispose();
+
+        [Fact]
+        public void Start_ListensOnce()
+        {
+            host.Start(4200);
+            host.Start(4200);
+
+            Assert.True(host.IsListening);
+            Assert.True(transport.Listening);
+            Assert.Equal(1, transport.RelayAccessCalls);
+        }
+
+        [Fact]
+        public void ConnectingPeer_IsAcceptedOnlyWhileListening()
+        {
+            transport.RaiseConnectionState(7, TunnelConnectionState.Connecting);
+            Assert.Empty(transport.AcceptedConnections);
+
+            host.Start(4200);
+            transport.RaiseConnectionState(7, TunnelConnectionState.Connecting);
+            Assert.Contains(7u, transport.AcceptedConnections);
+        }
+
+        [Fact]
+        public void PeerLifecycle_TracksConnectedPeers()
+        {
+            host.Start(4200);
+
+            transport.RaiseConnectionState(7, TunnelConnectionState.Connected);
+            Assert.Equal(1, host.PeerCount);
+
+            transport.RaiseConnectionState(8, TunnelConnectionState.Connected);
+            Assert.Equal(2, host.PeerCount);
+
+            transport.RaiseConnectionState(7, TunnelConnectionState.Closed);
+            Assert.Equal(1, host.PeerCount);
+        }
+
+        [Fact]
+        public void Stop_ClosesEveryPeer()
+        {
+            host.Start(4200);
+            transport.RaiseConnectionState(7, TunnelConnectionState.Connected);
+
+            host.Stop();
+
+            Assert.False(host.IsListening);
+            Assert.False(transport.Listening);
+            Assert.Equal(0, host.PeerCount);
+            Assert.Contains(7u, transport.ClosedConnections);
+        }
+
+        [Fact]
+        public void Datagrams_FlowBothWaysBetweenPeerAndServer()
+        {
+            using var serverSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            serverSocket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            serverSocket.ReceiveTimeout = 5000;
+            int serverPort = ((IPEndPoint)serverSocket.LocalEndPoint).Port;
+
+            host.Start(serverPort);
+            transport.RaiseConnectionState(7, TunnelConnectionState.Connected);
+
+            var fromPeer = new byte[] { 1, 2, 3 };
+            transport.EnqueueReceive(7, fromPeer);
+
+            var buffer = new byte[SteamTunnel.MaxDatagramBytes];
+            EndPoint peerRelayEndpoint = new IPEndPoint(IPAddress.Any, 0);
+            int received = serverSocket.ReceiveFrom(buffer, ref peerRelayEndpoint);
+            Assert.Equal(fromPeer, buffer.Take(received).ToArray());
+
+            var reply = new byte[] { 4, 5 };
+            serverSocket.SendTo(reply, peerRelayEndpoint);
+            SteamTunnelClientTests.WaitUntil(() => transport.SentDatagrams.Length == 1);
+            Assert.Equal(reply, transport.SentDatagrams[0].Data);
+            Assert.Equal(7u, transport.SentDatagrams[0].Connection);
+        }
+
+        [Fact]
+        public void TwoPeers_GetDistinctRelayPorts()
+        {
+            using var serverSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            serverSocket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            serverSocket.ReceiveTimeout = 5000;
+            int serverPort = ((IPEndPoint)serverSocket.LocalEndPoint).Port;
+
+            host.Start(serverPort);
+            transport.RaiseConnectionState(7, TunnelConnectionState.Connected);
+            transport.RaiseConnectionState(8, TunnelConnectionState.Connected);
+
+            transport.EnqueueReceive(7, new byte[] { 7 });
+            transport.EnqueueReceive(8, new byte[] { 8 });
+
+            var buffer = new byte[SteamTunnel.MaxDatagramBytes];
+            EndPoint firstSender = new IPEndPoint(IPAddress.Any, 0);
+            EndPoint secondSender = new IPEndPoint(IPAddress.Any, 0);
+            serverSocket.ReceiveFrom(buffer, ref firstSender);
+            serverSocket.ReceiveFrom(buffer, ref secondSender);
+
+            // LiteNetLib keys peers by endpoint, so each tunneled client must arrive
+            // from its own local port.
+            Assert.NotEqual(((IPEndPoint)firstSender).Port, ((IPEndPoint)secondSender).Port);
+        }
+    }
+}

--- a/source/Coop.Tests/Steam/SteamTunnelHostTests.cs
+++ b/source/Coop.Tests/Steam/SteamTunnelHostTests.cs
@@ -151,6 +151,35 @@ namespace Coop.Tests.Steam
         }
 
         [Fact]
+        public void Governor_RaisesFloorOnlyWhileBacklogWaits()
+        {
+            host.Start(4200);
+            transport.RaiseConnectionState(7, TunnelConnectionState.Connected);
+
+            transport.PendingReliableBytes = 1024 * 1024;
+            SteamTunnelClientTests.WaitUntil(() =>
+                transport.LastFloorFor(7) == SteamTunnel.TransferFloorBytesPerSecond);
+
+            transport.PendingReliableBytes = 0;
+            SteamTunnelClientTests.WaitUntil(() => transport.LastFloorFor(7) == 256 * 1024);
+        }
+
+        [Fact]
+        public void Governor_BacksOffWhenDeliveryQualitySags()
+        {
+            host.Start(4200);
+            transport.RaiseConnectionState(7, TunnelConnectionState.Connected);
+
+            transport.PendingReliableBytes = 1024 * 1024;
+            SteamTunnelClientTests.WaitUntil(() =>
+                transport.LastFloorFor(7) == SteamTunnel.TransferFloorBytesPerSecond);
+
+            transport.Quality = 0.5f;
+            SteamTunnelClientTests.WaitUntil(() =>
+                transport.LastFloorFor(7) == SteamTunnel.TransferFloorBytesPerSecond / 2);
+        }
+
+        [Fact]
         public void TwoPeers_GetDistinctRelayPorts()
         {
             using var serverSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);

--- a/source/GameInterface/Services/UI/Commands/SteamDebugCommand.cs
+++ b/source/GameInterface/Services/UI/Commands/SteamDebugCommand.cs
@@ -3,7 +3,6 @@ using Common.Network;
 using Common.Network.Session;
 using Common.Network.Session.Messages;
 using System.Collections.Generic;
-using System.Net;
 using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.UI.Commands;
@@ -24,6 +23,12 @@ public class SteamDebugCommand
         if (!ContainerProvider.TryGetContainer(out _)) return "Steam integration active; no co-op session running";
         if (!ContainerProvider.TryResolve<ISessionAdvertiser>(out var advertiser)) return "Steam integration active; this process has no session advertiser (server process?)";
 
+        if (ContainerProvider.TryResolve<ISessionTunnelHost>(out var tunnelHost))
+        {
+            return $"Steam integration active; advertising={advertiser.IsAdvertising}; " +
+                $"tunnelListening={tunnelHost.IsListening}; tunnelPeers={tunnelHost.PeerCount}";
+        }
+
         return $"Steam integration active; advertising={advertiser.IsAdvertising}";
     }
 
@@ -34,15 +39,18 @@ public class SteamDebugCommand
         if (!ContainerProvider.TryResolve<ISessionAdvertiser>(out var advertiser)) return "No session advertiser; join a session first";
         if (!ContainerProvider.TryResolve<ISessionJoinInfoSource>(out var joinInfoSource)) return "No join info source; join a session first";
         if (!ContainerProvider.TryResolve<INetworkConfig>(out var networkConfig)) return "No network config; join a session first";
+        if (!ContainerProvider.TryResolve<ISessionTunnelHost>(out var tunnelHost)) return "No session tunnel host; join a session first";
 
-        // Only the host's own client (connected over loopback) may advertise the session.
-        bool loopback = networkConfig.Address == "localhost" ||
-            (IPAddress.TryParse(networkConfig.Address, out var address) && IPAddress.IsLoopback(address));
-        if (!loopback) return "Run coop.debug.steam.host_lobby on the host's own client (connected to localhost)";
+        // Only the host's own client (connected over loopback) may advertise the session; a
+        // tunneled joiner's loopback address is its own join pump, not a local server.
+        if (networkConfig.IsTunneled || !TunnelAdvertisement.IsLoopbackAddress(networkConfig.Address))
+            return "Run coop.debug.steam.host_lobby on the host's own client (connected to localhost)";
 
         var info = joinInfoSource.Get();
+        TunnelAdvertisement.StartAndStamp(tunnelHost, networkConfig, info);
+
         advertiser.Advertise(info);
-        return $"Advertising session (address='{info.Address}', port={info.Port})";
+        return $"Advertising session (address='{info.Address}', port={info.Port}, version={info.Version})";
     }
 
     [CommandLineArgumentFunction("invite", "coop.debug.steam")]

--- a/source/IntroServer/Config/NetworkConfiguration.cs
+++ b/source/IntroServer/Config/NetworkConfiguration.cs
@@ -81,6 +81,8 @@ namespace IntroServer.Config
 
         public string Token => P2PToken;
 
+        public bool IsTunneled => false;
+
         public TimeSpan ConnectionTimeout => DisconnectTimeout;
 
         public int MaxPacketsInQueue => 10000;

--- a/source/Missions/Services/Network/LiteNetP2PClient.cs
+++ b/source/Missions/Services/Network/LiteNetP2PClient.cs
@@ -171,13 +171,19 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
 
     public void ConnectToInstance(string instanceId)
     {
+        // The relay send and the connection-accept check both read this, so it is set even
+        // when the punch below is skipped.
+        this.instanceId = instanceId;
+
+        // A tunneled session cannot punch: the rendezvous only observes loopback pump
+        // endpoints, so mission traffic stays on the per-send server relay fallback.
+        if (Config.IsTunneled) return;
+
         Logger.Verbose("Attempting NAT Punch");
 
         ConnectionToken token = new ConnectionToken(ControllerId, instanceId);
 
         netManager.NatPunchModule.SendNatIntroduceRequest(relayNetwork.ServerEndpoint, token);
-
-        this.instanceId = instanceId;
     }
 
     public void OnNatIntroductionRequest(IPEndPoint localEndPoint, IPEndPoint remoteEndPoint, string token)


### PR DESCRIPTION
### 
**This is a stacked PR**

## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] New feature (non-breaking change that adds functionality)

## What is the current behavior?

The user must port forward 4200/4201.

## What is the new behavior?

Resolves #1668

Steam lobbies now connect players through Steam's P2P networking with a Valve relay fallback, so the host doesn't need to port forward.
