### PR TITLE
Enable DesertionCampaignBehavior

### DIFF
--- a/source/GameInterface/Services/MobileParties/Patches/Disable/DisableDesertionCampaignBehavior.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/Disable/DisableDesertionCampaignBehavior.cs
@@ -1,11 +1,12 @@
-﻿using HarmonyLib;
+﻿using Common;
+using HarmonyLib;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
 
-namespace GameInterface.Services.MobileParties.Patches;
+namespace GameInterface.Services.MobileParties.Patches.Disable;
 
 [HarmonyPatch(typeof(DesertionCampaignBehavior))]
 internal class DisableDesertionCampaignBehavior
 {
     [HarmonyPatch(nameof(DesertionCampaignBehavior.RegisterEvents))]
-    static bool Prefix() => false;
+    static bool Prefix() => ModInformation.IsServer;
 }


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
DesertionCampaignBehavior is disabled.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Enable DesertionCampaignBehavior's daily tick on the server. `TroopRoster` change and `DestroyPartyAction` are already managed.

Notifying players of deserting troops from their parties is enabled by #1695.

## Other information
