### PR TITLE
Do not include disconnected peers in occupancy check

### DIFF
--- a/source/GameInterface/Services/MapEvents/Handlers/PlayerOccupancyPauseHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/PlayerOccupancyPauseHandler.cs
@@ -59,10 +59,8 @@ internal class PlayerOccupancyPauseHandler : IHandler
     private bool AllPlayersOccupied()
     {
         var players = playerManager.Players;
-        return players.Any() && players.All(player =>
+        return players.Any() && players.Where(playerManager.IsConnected).All(player =>
         {
-            // TODO skip disconnected players
-
             if (!objectManager.TryGetObject<MobileParty>(player.MobilePartyId, out var playerParty))
                 return false;
 

--- a/source/GameInterface/Services/Players/PlayerManager.cs
+++ b/source/GameInterface/Services/Players/PlayerManager.cs
@@ -52,6 +52,11 @@ public interface IPlayerManager
     /// Resolves the Player currently controlled by a connected peer.
     /// </summary>
     bool TryGetPlayer(NetPeer peer, out Player player);
+
+    /// <summary>
+    /// Checks whether the given player has a connected peer.
+    /// </summary>
+    bool IsConnected(Player player);
 }
 
 /// <inheritdoc cref="IPlayerManager"/>
@@ -155,6 +160,10 @@ public class PlayerManager : IPlayerManager
     public bool TryGetPlayer(NetPeer peer, out Player player)
     {
         return peerToPlayer.TryGetValue(peer, out player);
+    }
+    public bool IsConnected(Player player)
+    {
+        return peerToPlayer.Values.Contains(player);
     }
 }
 

--- a/source/GameInterface/Services/Players/PlayerManager.cs
+++ b/source/GameInterface/Services/Players/PlayerManager.cs
@@ -163,7 +163,8 @@ public class PlayerManager : IPlayerManager
     }
     public bool IsConnected(Player player)
     {
-        return peerToPlayer.Values.Contains(player);
+        return peerToPlayer.Any(kvp =>
+         kvp.Value == player && kvp.Key.ConnectionState == ConnectionState.Connected);
     }
 }
 


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ x ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ x  ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Included disconnected peers in occupancy check.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #1657 
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Made a method to check whether a player has a connected peer. Used this method to only check connected peers for occupancy check
