### PR TITLE
[1712] Fix duplicate MobilePartyVisual registration causing join log spam

### DIFF
--- a/source/GameInterface/Services/Heroes/Interfaces/HeroInterface.cs
+++ b/source/GameInterface/Services/Heroes/Interfaces/HeroInterface.cs
@@ -6,9 +6,11 @@ using Common.Util;
 using GameInterface.Serialization;
 using GameInterface.Serialization.External;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.PartyBases.Extensions;
 using GameInterface.Services.PlayerCaptivityService.Messages;
 using GameInterface.Services.Players.Data;
 using SandBox.View.Map.Managers;
+using SandBox.View.Map.Visuals;
 using Serilog;
 using System;
 using TaleWorlds.CampaignSystem;
@@ -153,6 +155,13 @@ internal class HeroInterface : IHeroInterface
         // "main_hero" id) and rename afterwards, that cache never learns about the assigned "PlayerN", so the next
         // hero computes — and collides with — the same id.
         assignNetworkIds(hero);
+
+        // The party's visual was created above inside this AllowedThread, which suppressed the patch that
+        // registers it. Register it under the party's derived id, now that the StringId is final, so the host
+        // and already-connected clients (which run this same unpack for a late joiner) resolve it by one id.
+        var partyVisual = party.Party.GetPartyVisual();
+        if (partyVisual != null)
+            objectManager.AddExisting($"{nameof(MobilePartyVisual)}_{party.StringId}", partyVisual);
 
         // The unpacked CharacterObject still carries the sender's MBGUID and IsRegistered flag. The Add* calls
         // below re-mint hero/party/clan ids, but a CharacterObject is owned by MBObjectManager, which only mints

--- a/source/GameInterface/Services/PartyVisuals/PartyVisualRegistry.cs
+++ b/source/GameInterface/Services/PartyVisuals/PartyVisualRegistry.cs
@@ -1,13 +1,11 @@
 ﻿using GameInterface.Registry.Auto;
 using GameInterface.Services.ObjectManager;
-using GameInterface.Services.PartyBases.Extensions;
 using SandBox.View.Map.Managers;
 using SandBox.View.Map.Visuals;
 using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using TaleWorlds.CampaignSystem.Party;
 
 namespace GameInterface.Services.PartyVisuals;
 
@@ -30,15 +28,6 @@ internal class PartyVisualRegistry : AutoRegistryBase<MobilePartyVisual>
         {
             Logger.Error("Unable to register party visuals when PartyVisualManager is null");
             return;
-        }
-
-        foreach (var party in MobileParty.All)
-        {
-            var mobilePartyVisual = party.Party.GetPartyVisual();
-
-            if (mobilePartyVisual == null) continue;
-
-            objectManager.AddExisting(party.StringId, mobilePartyVisual);
         }
 
         foreach (MobilePartyVisual visual in visualManager._visualsFlattened)


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

When a client joins a running server, the server log fills with repeated `Object already registered: SandBox.View.Map.Visuals.MobilePartyVisual` errors, one per active party visual on the map, every time a client joins.

## What is the new behavior?

Resolves #1712

Joining no longer spams the server log with `Object already registered` errors; party visuals are registered once instead of twice.

A disconnected player's party figure is also cleared from the map for everyone still in the session, including players who were already connected when that player joined. Before, it could stay stuck on the map for those players.

## Other information