### PR TITLE
[1719] Stop client AiBehaviorPartyBase log spam

### DIFF
--- a/source/GameInterface/Services/MobilePartyAIs/MobilePartyAiSync.cs
+++ b/source/GameInterface/Services/MobilePartyAIs/MobilePartyAiSync.cs
@@ -7,8 +7,6 @@ internal class MobilePartyAiSync : IAutoSync
 {
     public MobilePartyAiSync(AutoSyncRegistry autoSyncBuilder)
     {
-        autoSyncBuilder.AddProperty(AccessTools.Property(typeof(MobilePartyAi), nameof(MobilePartyAi.AiBehaviorPartyBase)));
-
         // This is readonly (now done in the lifetime handler)
         autoSyncBuilder.AddField(AccessTools.Field(typeof(MobilePartyAi), nameof(MobilePartyAi._mobileParty)));
         autoSyncBuilder.AddField(AccessTools.Field(typeof(MobilePartyAi), nameof(MobilePartyAi._isDisabled)));


### PR DESCRIPTION
### What is the current behavior?
The server tries to sync AiBehaviorPartyBase and clients repeatedly log an error, `Client updated managed MobilePartyAi.AiBehaviorPartyBase`.

Resolves #1719

### What is the new behavior?
Server no longer attempts to sync it and the client derives it from `AiBehaviorInteractable`