### PR TITLE
[1718] Fix race where client's own party doesn't attach to its map-event side

### DIFF
--- a/source/GameInterface/Services/MapEvents/Handlers/MapEventCreationCoordinator.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/MapEventCreationCoordinator.cs
@@ -9,6 +9,7 @@ using LiteNetLib;
 using Serilog;
 using System;
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Threading;
 using TaleWorlds.CampaignSystem.MapEvents;
 using TaleWorlds.CampaignSystem.Party;
@@ -125,14 +126,24 @@ internal class MapEventCreationCoordinator : IHandler
             }
 
             // The MapEvent object is materialized on this client by the AutoRegistry create broadcast, which is
-            // sent just before the reply; keep pumping in case the reply is processed first.
+            // sent just before the reply; keep pumping in case the reply is processed first. Resolving the bare
+            // MapEvent isn't enough: the parties' side attachment lands via separate, GameThread-deferred
+            // messages sent right after, so wait for those on the same deadline too.
             MapEvent mapEvent = null;
+            bool BothSidesAttached() =>
+                attacker.MapEventSide != null && defender.MapEventSide != null
+                && attacker.MapEventSide.Parties.Any(p => p.Party == attacker)
+                && defender.MapEventSide.Parties.Any(p => p.Party == defender)
+                && (mapEvent.AttackerSide == attacker.MapEventSide || mapEvent.DefenderSide == attacker.MapEventSide)
+                && (mapEvent.AttackerSide == defender.MapEventSide || mapEvent.DefenderSide == defender.MapEventSide);
+
             if (!GameThread.WaitWhilePumping(
-                    () => objectManager.TryGetObject(pending.MapEventId, out mapEvent) && mapEvent != null,
+                    () => objectManager.TryGetObject(pending.MapEventId, out mapEvent) && mapEvent != null
+                        && BothSidesAttached(),
                     deadline))
             {
                 Logger.Error(
-                    "Server created map event {MapEventId} but it was not resolvable on this client before timeout. RequestId={RequestId}",
+                    "Server created map event {MapEventId} but it (or the attacker/defender side attachment) was not resolvable on this client before timeout. RequestId={RequestId}",
                     pending.MapEventId, requestId);
                 return null;
             }


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Starting a fight can leave your own party missing from the encounter: the battle screen shows the enemy's troop count against 0 on your side, your party doesn't appear in the parties list at the top, and the only option available is "Try to get away." You can't fight, surrender, or recruit.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #1718
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Your party is reliably attached to its side before the encounter screen opens, so the normal fight/surrender/recruit options are available every time.

## Other information
