### PR TITLE
[Movement Stop] when entering party menu

### DIFF
--- a/source/GameInterface/Services/MobileParties/Patches/SetMoveModeHoldPatches.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/SetMoveModeHoldPatches.cs
@@ -1,0 +1,19 @@
+﻿using GameInterface.Services.Party.Patches;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem.Party;
+
+namespace GameInterface.Services.MobileParties.Patches;
+
+[HarmonyPatch]
+internal class SetMoveModeHoldPatches
+{
+    [HarmonyPatch(typeof(MobileParty), nameof(MobileParty.SetMoveModeHold))]
+    [HarmonyPrefix]
+    static bool BlockHoldDuringCommit()
+    {
+        if (PartyScreenLogicPatches.InCommit)
+            return false;
+
+        return true;
+    }
+}

--- a/source/GameInterface/Services/Party/Patches/PartyScreenLogicPatches.cs
+++ b/source/GameInterface/Services/Party/Patches/PartyScreenLogicPatches.cs
@@ -19,7 +19,8 @@ namespace GameInterface.Services.Party.Patches;
 internal class PartyScreenLogicPatches
 {
     private static readonly ILogger Logger = LogManager.GetLogger<PartyScreenLogic>();
-
+    [ThreadStatic]
+    public static bool InCommit;
     [HarmonyPatch(nameof(PartyScreenLogic.DoneLogic))]
     [HarmonyPrefix]
     public static bool DoneLogicPrefix(PartyScreenLogic __instance, ref bool __result, bool isForced)
@@ -84,27 +85,34 @@ internal class PartyScreenLogicPatches
                 TroopRoster duplicateLeftMemberRoster = __instance.MemberRosters[0].CloneRosterData();
                 TroopRoster duplicateLeftPrisonerRoster = __instance.PrisonerRosters[0].CloneRosterData();
 
-                __instance.Reset(true);
-            
-                //__instance.FireCampaignRelatedEvents(); // Managed on server
-                __instance.SetPartyGoldChangeAmount(0);
-                __instance.SetHorseChangeAmount(0);
-                __instance.SetInfluenceChangeAmount(0, 0, 0);
-                __instance.SetMoraleChangeAmount(0);
-                __instance.CurrentData.UpgradedTroopsHistory = new List<Tuple<CharacterObject, CharacterObject, int>>();
-                __instance.CurrentData.TransferredPrisonersHistory = new List<Tuple<CharacterObject, int>>();
-                __instance.CurrentData.RecruitedPrisonersHistory = new List<Tuple<CharacterObject, int>>();
-                __instance.CurrentData.UsedUpgradeHorsesHistory = new List<Tuple<EquipmentElement, int>>();
-                __instance._initialData.CopyFromScreenData(__instance.CurrentData);
+                InCommit = true;
+                try
+                {
+                    __instance.Reset(true);
 
-                // In vanilla, the rosters would already be updated but with this patch the rosters are reset on the client to be managed by the server.
-                // This assigns a duplicate version of the left rosters needed in extra logic handled by the PartyScreenHelper when closing the party screen.
-                // For example, the left member roster when creating a new clan party is not managed on the server but the server does need this data.
-                __instance.MemberRosters[0] = duplicateLeftMemberRoster;
-                __instance.PrisonerRosters[1] = duplicateLeftPrisonerRoster;
+                    //__instance.FireCampaignRelatedEvents(); // Managed on server
+                    __instance.SetPartyGoldChangeAmount(0);
+                    __instance.SetHorseChangeAmount(0);
+                    __instance.SetInfluenceChangeAmount(0, 0, 0);
+                    __instance.SetMoraleChangeAmount(0);
+                    __instance.CurrentData.UpgradedTroopsHistory = new List<Tuple<CharacterObject, CharacterObject, int>>();
+                    __instance.CurrentData.TransferredPrisonersHistory = new List<Tuple<CharacterObject, int>>();
+                    __instance.CurrentData.RecruitedPrisonersHistory = new List<Tuple<CharacterObject, int>>();
+                    __instance.CurrentData.UsedUpgradeHorsesHistory = new List<Tuple<EquipmentElement, int>>();
+                    __instance._initialData.CopyFromScreenData(__instance.CurrentData);
+
+                    // In vanilla, the rosters would already be updated but with this patch the rosters are reset on the client to be managed by the server.
+                    // This assigns a duplicate version of the left rosters needed in extra logic handled by the PartyScreenHelper when closing the party screen.
+                    // For example, the left member roster when creating a new clan party is not managed on the server but the server does need this data.
+                    __instance.MemberRosters[0] = duplicateLeftMemberRoster;
+                    __instance.PrisonerRosters[1] = duplicateLeftPrisonerRoster;
+                }
+                finally
+                {
+                    InCommit = false;
+                }
             }
         }
-
         __result = flag;
         return false;
     }

--- a/source/GameInterface/Services/Party/Patches/PartyScreenLogicPatches.cs
+++ b/source/GameInterface/Services/Party/Patches/PartyScreenLogicPatches.cs
@@ -20,7 +20,12 @@ internal class PartyScreenLogicPatches
 {
     private static readonly ILogger Logger = LogManager.GetLogger<PartyScreenLogic>();
     [ThreadStatic]
-    public static bool InCommit;
+    private static bool _inCommit;
+    internal static bool InCommit
+    {
+        get => _inCommit;
+        private set => _inCommit = value;
+    }
     [HarmonyPatch(nameof(PartyScreenLogic.DoneLogic))]
     [HarmonyPrefix]
     public static bool DoneLogicPrefix(PartyScreenLogic __instance, ref bool __result, bool isForced)


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ x ] All new classes have class-level documentation comments, if there are any at all
- [ x ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ x ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Player would stop moving after closing partyscreen.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #1710
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Player continues moving after closing partyscreen.
This happened because the patch for `PartyScreenLogic.DoneLogic` calls `__instance.reset(true)`, which doesnt normally happen in vanilla. This spirals into `this.PartyBelongedTo = null;`, momentarily setting the hero's partybelongedto to null, which eventually does `if (newLeader == null && this.MobileParty.MapEvent == null)` then `this.MobileParty.SetMoveModeHold();`
Added a static boolean that checks if theyre being called within `donelogic`, which is used in the `MobileParty.SetMoveModeHold` patch to know if it should let the patch follow through.   Note: clicking on cancel or reset in the partyscreen makes your party stop. This is vanilla behavior. Clicking on done does not stop