### PR TITLE
[1715] Fix missing HUD for clients joining a host saved inside a settlement

### DIFF
--- a/source/GameInterface/Services/GameState/Patches/HostSettlementMenuLoadPatch.cs
+++ b/source/GameInterface/Services/GameState/Patches/HostSettlementMenuLoadPatch.cs
@@ -1,0 +1,28 @@
+﻿using Common;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.GameState;
+
+namespace GameInterface.Services.GameState.Patches;
+
+[HarmonyPatch]
+internal class HostSettlementMenuLoadPatch
+{
+    [HarmonyPatch(typeof(MapState), nameof(MapState.OnLoadingFinished))]
+    [HarmonyPostfix]
+    static void ExitStaleSettlementMenu(MapState __instance)
+    {
+        // The host must never sit in a settlement/game menu. A save made while the hero was inside
+        // one restores that menu here on load; leaving it now, before anything can transfer the
+        // host's live state to a joining client, keeps the stale menu from being baked into that snapshot.
+        // RemoveMainParty has already run by this point (it fires earlier in the same load, from
+        // CampaignReady), so MobileParty.MainParty is gone; PlayerEncounter.Finish() assumes a live
+        // main party and would NRE, so the encounter is cleared directly instead.
+        if (!ModInformation.IsServer || !__instance.AtMenu)
+            return;
+
+        __instance.ExitMenuMode();
+        Campaign.Current.PlayerEncounter = null;
+        Campaign.Current.LocationEncounter = null;
+    }
+}

--- a/source/GameInterface/Services/GameState/Patches/HostSettlementMenuLoadPatch.cs
+++ b/source/GameInterface/Services/GameState/Patches/HostSettlementMenuLoadPatch.cs
@@ -18,7 +18,7 @@ internal class HostSettlementMenuLoadPatch
         // RemoveMainParty has already run by this point (it fires earlier in the same load, from
         // CampaignReady), so MobileParty.MainParty is gone; PlayerEncounter.Finish() assumes a live
         // main party and would NRE, so the encounter is cleared directly instead.
-        if (!ModInformation.IsServer || !__instance.AtMenu)
+        if (ModInformation.IsClient || !__instance.AtMenu)
             return;
 
         __instance.ExitMenuMode();


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
If the host's save was made while the hero was standing inside a village or town, the host boots straight back into that settlement's menu with dead buttons that do nothing. Any client that then joins gets no HUD and no cursor at all instead of the normal campaign map.

## What is the new behavior?
Resolves #1715
The host always leaves that stale menu on load, so it boots straight to the normal campaign map like any other host save, and clients joining afterward get the usual HUD and cursor right away.

## Other information
