### PR TITLE
[1692] Distinguish players and their parties in the kill feed

### DIFF
--- a/source/GameInterface.Tests/Services/UI/PlayerColorAssignerTests.cs
+++ b/source/GameInterface.Tests/Services/UI/PlayerColorAssignerTests.cs
@@ -1,0 +1,49 @@
+﻿using GameInterface.Services.UI;
+using System.Collections.Generic;
+using TaleWorlds.Library;
+using Xunit;
+
+namespace GameInterface.Tests.Services.UI;
+
+public class PlayerColorAssignerTests
+{
+    [Fact]
+    public void GetColor_SamePlayer_ReturnsSameColorEveryTime()
+    {
+        var first = PlayerColorAssigner.GetColor("PlayerOne");
+        var second = PlayerColorAssigner.GetColor("PlayerOne");
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void GetColor_DifferentPlayers_ReturnsDifferentColors()
+    {
+        var colorOne = PlayerColorAssigner.GetColor("PlayerOne");
+        var colorTwo = PlayerColorAssigner.GetColor("PlayerTwo");
+
+        Assert.NotEqual(colorOne, colorTwo);
+    }
+
+    [Fact]
+    public void GetColor_MorePlayersThanPaletteEntries_RepeatsRatherThanThrowing()
+    {
+        var seen = new HashSet<Color>();
+
+        for (var i = 0; i < 100; i++)
+        {
+            seen.Add(PlayerColorAssigner.GetColor($"Player{i}"));
+        }
+
+        Assert.True(seen.Count > 1);
+    }
+
+    [Fact]
+    public void GetColor_NullOrEmptyControllerId_ReturnsFallbackInsteadOfThrowing()
+    {
+        var nullColor = PlayerColorAssigner.GetColor(null);
+        var emptyColor = PlayerColorAssigner.GetColor(string.Empty);
+
+        Assert.Equal(nullColor, emptyColor);
+    }
+}

--- a/source/GameInterface/Services/UI/Patches/KillFeedPlayerColorPatch.cs
+++ b/source/GameInterface/Services/UI/Patches/KillFeedPlayerColorPatch.cs
@@ -1,4 +1,4 @@
-﻿﻿using GameInterface.Services.MapEvents.TroopSupply;
+﻿using GameInterface.Services.MapEvents.TroopSupply;
 using GameInterface.Services.Players;
 using HarmonyLib;
 using System;
@@ -16,7 +16,7 @@ namespace GameInterface.Services.UI.Patches;
 /// regardless of who did it.
 /// </summary>
 [HarmonyPatch(typeof(SPGeneralKillNotificationItemVM), MethodType.Constructor,
-    new[] { typeof(Agent), typeof(Agent), typeof(bool), typeof(bool), typeof(bool), typeof(Action<SPGeneralKillNotificationItemVM>) })]
+    typeof(Agent), typeof(Agent), typeof(bool), typeof(bool), typeof(bool), typeof(Action<SPGeneralKillNotificationItemVM>))]
 internal class KillFeedPlayerColorPatch
 {
     [HarmonyPostfix]

--- a/source/GameInterface/Services/UI/Patches/KillFeedPlayerColorPatch.cs
+++ b/source/GameInterface/Services/UI/Patches/KillFeedPlayerColorPatch.cs
@@ -1,0 +1,52 @@
+﻿﻿using GameInterface.Services.MapEvents.TroopSupply;
+using GameInterface.Services.Players;
+using HarmonyLib;
+using System;
+using TaleWorlds.CampaignSystem.AgentOrigins;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.MountAndBlade.ViewModelCollection.HUD.KillFeed.General;
+
+namespace GameInterface.Services.UI.Patches;
+
+/// <summary>
+/// Gives each ally player a distinct, stable kill-feed color instead of vanilla's single shared "an ally
+/// scored a kill" green, so a client can tell which of their allies (or their allies' troops) got the kill.
+/// The "an ally was killed" branch is left untouched, so the enemy side still reads as vanilla red
+/// regardless of who did it.
+/// </summary>
+[HarmonyPatch(typeof(SPGeneralKillNotificationItemVM), MethodType.Constructor,
+    new[] { typeof(Agent), typeof(Agent), typeof(bool), typeof(bool), typeof(bool), typeof(Action<SPGeneralKillNotificationItemVM>) })]
+internal class KillFeedPlayerColorPatch
+{
+    [HarmonyPostfix]
+    private static void Postfix(SPGeneralKillNotificationItemVM __instance, Agent affectedAgent, Agent affectorAgent)
+    {
+        // Only the "ally scored a kill" branch (victim's team is not player-allied) is ours to recolor.
+        var victimTeam = affectedAgent?.Team;
+        if (victimTeam == null || !victimTeam.IsValid || victimTeam.IsPlayerAlly) return;
+
+        // Players can PvP each other, so an enemy player killing a non-allied troop (their own side, a
+        // rebellion, etc.) would otherwise also match the guard above — require the killer to actually be
+        // on the client's allied side before crediting the kill to one of "our" players.
+        var affectorTeam = affectorAgent?.Team;
+        if (affectorTeam == null || !affectorTeam.IsValid || !affectorTeam.IsPlayerAlly) return;
+
+        var party = GetOwningParty(affectorAgent);
+        if (party == null) return;
+
+        if (!PlayerManager.TryGetControlledObjectInfo(party, out var info)) return;
+
+        __instance.BackgroundColor = PlayerColorAssigner.GetColor(info.ObjectControllerId);
+    }
+
+    // Agent has no Party property of its own; every concrete IAgentOriginBase that carries one names it
+    // independently. PartyAgentOrigin covers vanilla troops (and, via its own IsHero special-case, a
+    // player's own hero agent too); CoopAgentOrigin covers this mod's server-supplied field-battle troops,
+    // whose vanilla origin type (SimpleAgentOrigin) leaves Party null for non-heroes.
+    private static MobileParty GetOwningParty(Agent agent)
+    {
+        var party = (agent?.Origin as PartyAgentOrigin)?.Party ?? (agent?.Origin as CoopAgentOrigin)?.Party;
+        return party?.MobileParty;
+    }
+}

--- a/source/GameInterface/Services/UI/PlayerColorAssigner.cs
+++ b/source/GameInterface/Services/UI/PlayerColorAssigner.cs
@@ -1,0 +1,56 @@
+﻿using TaleWorlds.Library;
+
+namespace GameInterface.Services.UI;
+
+/// <summary>
+/// Maps each player to a stable, visually distinct color for UI that needs to tell ally players apart
+/// (e.g. the kill feed). The mapping is a deterministic hash of the player's controller id, not session
+/// state, so the same controller id always gets the same color — across battles, reconnects, and restarts.
+/// </summary>
+public static class PlayerColorAssigner
+{
+    // Categorical palette tuned to stay clear of the vanilla kill-feed team colors (friendly green
+    // ~(0.54,0.78,0.42), enemy red ~(0.95,0.49,0.43)) so a per-player color is never confused with them.
+    private static readonly Color[] Palette =
+    {
+        new Color(0.231f, 0.510f, 0.965f), // blue
+        new Color(0.545f, 0.361f, 0.965f), // violet
+        new Color(0.961f, 0.620f, 0.043f), // amber
+        new Color(0.024f, 0.714f, 0.831f), // cyan
+        new Color(0.925f, 0.282f, 0.600f), // pink
+        new Color(0.980f, 0.800f, 0.082f), // yellow
+        new Color(0.388f, 0.400f, 0.945f), // indigo
+        new Color(0.078f, 0.722f, 0.651f), // teal
+        new Color(0.851f, 0.275f, 0.937f), // fuchsia
+        new Color(0.055f, 0.647f, 0.914f), // sky blue
+        new Color(0.659f, 0.333f, 0.969f), // purple
+        new Color(0.918f, 0.702f, 0.031f), // gold
+        new Color(0.957f, 0.447f, 0.714f), // light pink
+        new Color(0.220f, 0.741f, 0.973f), // light blue
+        new Color(0.753f, 0.518f, 0.988f), // light purple
+        new Color(0.988f, 0.827f, 0.302f), // light yellow
+    };
+
+    private static readonly Color FallbackColor = Palette[0];
+
+    public static Color GetColor(string controllerId)
+    {
+        if (string.IsNullOrEmpty(controllerId)) return FallbackColor;
+
+        return Palette[HashToIndex(controllerId)];
+    }
+
+    // FNV-1a: string.GetHashCode() is randomized per process in .NET, so it can't be used here — every
+    // client must derive the same index for the same controllerId, including across reconnects and restarts.
+    private static int HashToIndex(string controllerId)
+    {
+        var hash = 2166136261u;
+        foreach (var c in controllerId)
+        {
+            hash ^= c;
+            hash *= 16777619;
+        }
+
+        return (int)(hash % (uint)Palette.Length);
+    }
+}

--- a/source/GameInterface/Services/UI/PlayerColorAssigner.cs
+++ b/source/GameInterface/Services/UI/PlayerColorAssigner.cs
@@ -17,7 +17,6 @@ public static class PlayerColorAssigner
         new Color(0.545f, 0.361f, 0.965f), // violet
         new Color(0.961f, 0.620f, 0.043f), // amber
         new Color(0.024f, 0.714f, 0.831f), // cyan
-        new Color(0.925f, 0.282f, 0.600f), // pink
         new Color(0.980f, 0.800f, 0.082f), // yellow
         new Color(0.388f, 0.400f, 0.945f), // indigo
         new Color(0.078f, 0.722f, 0.651f), // teal
@@ -25,7 +24,6 @@ public static class PlayerColorAssigner
         new Color(0.055f, 0.647f, 0.914f), // sky blue
         new Color(0.659f, 0.333f, 0.969f), // purple
         new Color(0.918f, 0.702f, 0.031f), // gold
-        new Color(0.957f, 0.447f, 0.714f), // light pink
         new Color(0.220f, 0.741f, 0.973f), // light blue
         new Color(0.753f, 0.518f, 0.988f), // light purple
         new Color(0.988f, 0.827f, 0.302f), // light yellow
@@ -40,8 +38,7 @@ public static class PlayerColorAssigner
         return Palette[HashToIndex(controllerId)];
     }
 
-    // FNV-1a: string.GetHashCode() is randomized per process in .NET, so it can't be used here — every
-    // client must derive the same index for the same controllerId, including across reconnects and restarts.
+    // string.GetHashCode() is randomized per process in .NET, so it can't be used here.
     private static int HashToIndex(string controllerId)
     {
         var hash = 2166136261u;


### PR DESCRIPTION
## What is the current behavior?
Every kill an ally scores in a battle shows the same shared green in the kill feed, so there's no way to tell which of your allies actually got the kill.

## What is the new behavior?
Each connected player gets their own distinct, stable color for kills credited to them or their troops, so allies can tell each other's kills apart in the feed. The color is derived from the player's own persistent id, so the same player keeps the same color across battles and reconnects. Kills where an ally gets killed, or where the killer isn't on the client's allied side, are untouched and still show vanilla's plain red.

When multiple players are on the same side:
<img width="270" height="108" alt="image" src="https://github.com/user-attachments/assets/981666e4-7dcd-4b96-8b86-cf4c22120cf4" />

Allies being wounded is still just red even if its enemy players doing it

Created a separate issue to allow players to choose their own colors https://github.com/Bannerlord-Coop-Team/BannerlordCoop/issues/1740
Resolves #1692

## PR Type
- [x] Feature

## Checklist
- [x] Class level comments exist for all new classes.
- [x] XUnit tests exist for every method that does not require the game to be ran.