### PR TITLE
Fix for #1724

### DIFF
--- a/source/GameInterface/Services/Inventory/Handlers/TradeHandler.cs
+++ b/source/GameInterface/Services/Inventory/Handlers/TradeHandler.cs
@@ -8,13 +8,11 @@ using GameInterface.Services.Inventory.Interfaces;
 using GameInterface.Services.Inventory.Messages;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.TroopRosters.Interfaces;
-using GameInterface.Services.UI.Notifications.Messages;
 using GameInterface.Services.Workshops.Messages;
 using HarmonyLib;
 using Helpers;
 using LiteNetLib;
 using Serilog;
-using System;
 using System.Collections.Generic;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
@@ -74,11 +72,12 @@ internal class TradeHandler : IHandler
 
         if (!objectManager.TryGetIdWithLogging(what.ToRoster, out var toRosterId)) return;
         if (!objectManager.TryGetIdWithLogging(what.Hero, out var heroId)) return;
+        if (!objectManager.TryGetIdWithLogging(what.OwnerParty, out var ownerPartyId)) return;
         if (!objectManager.TryGetIdWithLogging(what.TroopRoster, out var troopRosterId)) return;
         if (!objectManager.TryGetIdWithLogging(what.InitialCharacterEquipment.HeroObject, out var initialHeroId)) return;
 
-        string mobilePartyId = null;
-        if (what.Party is not null && !objectManager.TryGetIdWithLogging(what.Party, out mobilePartyId)) return;
+        string currentMobilePartyId = null;
+        if (what.CurrentMobileParty is not null && !objectManager.TryGetIdWithLogging(what.CurrentMobileParty, out currentMobilePartyId)) return;
 
         string currentSettlementComponentId = null;
         if (what.CurrentSettlementComponent is not null && 
@@ -87,7 +86,7 @@ internal class TradeHandler : IHandler
         var boughtItems = ResolveTradeItemIds(what.BoughtItems);
         var soldItems = ResolveTradeItemIds(what.SoldItems);
 
-        var characterIdEquipmentsData = ResolveCharacterIdEquipmentsData(what.Party, what.InitialCharacterEquipment);
+        var characterIdEquipmentsData = ResolveCharacterIdEquipmentsData(what.OwnerParty, what.InitialCharacterEquipment);
 
         var troopRosterData = troopRosterInterface.PackTroopRosterData(what.TroopRoster);
 
@@ -105,7 +104,8 @@ internal class TradeHandler : IHandler
             initialHeroId,
             what.TotalAmount,
             what.MerchantGold,
-            mobilePartyId,
+            ownerPartyId,
+            currentMobilePartyId,
             currentSettlementComponentId is null,
             currentSettlementComponentId,
             boughtItems,
@@ -122,88 +122,84 @@ internal class TradeHandler : IHandler
         var message = payload.What;
         var peer = payload.Who as NetPeer;
 
-        GameThread.Run(() =>
+        GameThread.RunSafe(() =>
         {
-            try
+            ItemRoster fromRoster = null;
+            if (!message.IsFromItemRosterNull && !objectManager.TryGetObjectWithLogging<ItemRoster>(message.FromItemRosterId, out fromRoster)) return;
+
+            if (!objectManager.TryGetObjectWithLogging<ItemRoster>(message.ToItemRosterId, out var toRoster)) return;
+            if (!objectManager.TryGetObjectWithLogging<Hero>(message.HeroId, out var hero)) return;
+            if (!objectManager.TryGetObjectWithLogging<MobileParty>(message.OwnerPartyId, out var ownerParty)) return;
+            if (!objectManager.TryGetObjectWithLogging<TroopRoster>(message.TroopRosterId, out var troopRoster)) return;
+            if (!objectManager.TryGetObjectWithLogging<Hero>(message.InitialHeroId, out var initialHero)) return;
+
+            SettlementComponent currentSettlementComponent = null;
+            if (!message.IsSettlementComponentNull &&
+                !objectManager.TryGetObjectWithLogging<SettlementComponent>(message.CurrentSettlementComponentId, out currentSettlementComponent)) return;
+
+            MobileParty currentMobileParty = null;
+            if (message.CurrentMobilePartyId != null && !objectManager.TryGetObjectWithLogging<MobileParty>(message.CurrentMobilePartyId, out currentMobileParty)) return;
+
+            var boughtItems = ResolveTradeItems(message.BoughtItems);
+            var soldItems = ResolveTradeItems(message.SoldItems);
+            ResolveCharacterEquipmentsData(message.CharacterIdEquipmentsData, out var characterEquipmentsData);
+
+            var fromItemRosterData = message.FromItemRosterData;
+            var toItemRosterData = message.ToItemRosterData;
+            var totalAmount = message.TotalAmount;
+
+            // Undo any purchases that are no longer present in the roster
+            // When looting, taken items are treated as bought items. Don't need to manage changed rosters in these cases
+            if (fromRoster != null)
             {
-                ItemRoster fromRoster = null;
-                if (!message.IsFromItemRosterNull && !objectManager.TryGetObjectWithLogging<ItemRoster>(message.FromItemRosterId, out fromRoster)) return;
-
-                if (!objectManager.TryGetObjectWithLogging<ItemRoster>(message.ToItemRosterId, out var toRoster)) return;
-                if (!objectManager.TryGetObjectWithLogging<Hero>(message.HeroId, out var hero)) return;
-                if (!objectManager.TryGetObjectWithLogging<MobileParty>(message.PartyId, out var mobileParty)) return;
-                if (!objectManager.TryGetObjectWithLogging<TroopRoster>(message.TroopRosterId, out var troopRoster)) return;
-                if (!objectManager.TryGetObjectWithLogging<Hero>(message.InitialHeroId, out var initialHero)) return;
-
-                SettlementComponent currentSettlementComponent = null;
-                if (!message.IsSettlementComponentNull &&
-                    !objectManager.TryGetObjectWithLogging<SettlementComponent>(message.CurrentSettlementComponentId, out currentSettlementComponent)) return;
-
-                var boughtItems = ResolveTradeItems(message.BoughtItems);
-                var soldItems = ResolveTradeItems(message.SoldItems);
-                ResolveCharacterEquipmentsData(message.CharacterIdEquipmentsData, out var characterEquipmentsData);
-
-                var fromItemRosterData = message.FromItemRosterData;
-                var toItemRosterData = message.ToItemRosterData;
-                var totalAmount = message.TotalAmount;
-
-                // Undo any purchases that are no longer present in the roster
-                // When looting, taken items are treated as bought items. Don't need to manage changed rosters in these cases
-                if (fromRoster != null)
+                foreach (var boughtItem in boughtItems)
                 {
-                    foreach (var boughtItem in boughtItems)
+                    int difference = fromRoster.GetItemNumber(boughtItem.Item1.EquipmentElement.Item) - boughtItem.Item1.Amount;
+
+                    if (difference < 0)
                     {
-                        int difference = fromRoster.GetItemNumber(boughtItem.Item1.EquipmentElement.Item) - boughtItem.Item1.Amount;
+                        int fromRosterDataIndex = fromItemRosterData.FindIndex(rosterElement => rosterElement.EquipmentElement.Equals(boughtItem.Item1));
+                        if (fromRosterDataIndex >= 0) fromItemRosterData[fromRosterDataIndex].Amount -= difference;
+                        else fromItemRosterData.AddItem(new ItemRosterElement(boughtItem.Item1.EquipmentElement, -difference));
 
-                        if (difference < 0)
-                        {
-                            int fromRosterDataIndex = fromItemRosterData.FindIndex(rosterElement => rosterElement.EquipmentElement.Equals(boughtItem.Item1));
-                            if (fromRosterDataIndex >= 0) fromItemRosterData[fromRosterDataIndex].Amount -= difference;
-                            else fromItemRosterData.AddItem(new ItemRosterElement(boughtItem.Item1.EquipmentElement, -difference));
+                        int toRosterDataIndex = toItemRosterData.FindIndex(rosterElement => rosterElement.EquipmentElement.Equals(boughtItem.Item1));
+                        if (toRosterDataIndex >= 0) toItemRosterData[toRosterDataIndex].Amount += difference;
+                        else toItemRosterData.AddItem(new ItemRosterElement(boughtItem.Item1.EquipmentElement, difference));
 
-                            int toRosterDataIndex = toItemRosterData.FindIndex(rosterElement => rosterElement.EquipmentElement.Equals(boughtItem.Item1));
-                            if (toRosterDataIndex >= 0) toItemRosterData[toRosterDataIndex].Amount += difference;
-                            else toItemRosterData.AddItem(new ItemRosterElement(boughtItem.Item1.EquipmentElement, difference));
-
-                            totalAmount -= boughtItem.Item2;
-                        }
+                        totalAmount -= boughtItem.Item2;
                     }
                 }
-
-                // Update rosters with new data
-                if (toRoster != null) inventoryLogicInterface.UpdateRosterWithData(toRoster, toItemRosterData);
-                if (fromRoster != null) inventoryLogicInterface.UpdateRosterWithData(fromRoster, fromItemRosterData);
-                else if (message.IsManagingWarehouse)
-                {
-                    // Manage warehouse rosters separately as they involve more complicated logic
-                    MessageBroker.Instance.Publish(this, new WarehouseRosterManaged(payload.Who as NetPeer, hero, currentSettlementComponent.Settlement, fromItemRosterData));
-                }
-        
-                // Update hero equipment with new data
-                inventoryLogicInterface.UpdateEquipmentWithData(mobileParty, characterEquipmentsData, initialHero);
-                network.SendAll(new UpdateEquipmentClients(message.CharacterIdEquipmentsData, message.PartyId, message.InitialHeroId));
-
-                // Update troop roster for if items were donated
-                troopRosterInterface.UpdateWithData(troopRoster, message.TroopRosterData, hero);
-
-                inventoryLogicInterface.ApplyDoneLogic(
-                    fromRoster,
-                    toRoster,
-                    message.IsTrading,
-                    message.CanGainXpFromDiscarding,
-                    hero,
-                    totalAmount,
-                    message.MerchantGold,
-                    mobileParty,
-                    currentSettlementComponent,
-                    boughtItems,
-                    soldItems
-                );
             }
-            catch (Exception e)
+
+            // Update rosters with new data
+            if (toRoster != null) inventoryLogicInterface.UpdateRosterWithData(toRoster, toItemRosterData);
+            if (fromRoster != null) inventoryLogicInterface.UpdateRosterWithData(fromRoster, fromItemRosterData);
+            else if (message.IsManagingWarehouse)
             {
-                logger.Error(e, "Failed to apply {Message}", nameof(CompleteTrade));
+                // Manage warehouse rosters separately as they involve more complicated logic
+                MessageBroker.Instance.Publish(this, new WarehouseRosterManaged(payload.Who as NetPeer, hero, currentSettlementComponent.Settlement, fromItemRosterData));
             }
+
+            // Update hero equipment with new data
+            inventoryLogicInterface.UpdateEquipmentWithData(ownerParty, characterEquipmentsData, initialHero);
+            network.SendAll(new UpdateEquipmentClients(message.CharacterIdEquipmentsData, message.OwnerPartyId, message.InitialHeroId));
+
+            // Update troop roster for if items were donated
+            troopRosterInterface.UpdateWithData(troopRoster, message.TroopRosterData, hero);
+
+            inventoryLogicInterface.ApplyDoneLogic(
+                fromRoster,
+                toRoster,
+                message.IsTrading,
+                message.CanGainXpFromDiscarding,
+                hero,
+                totalAmount,
+                message.MerchantGold,
+                currentMobileParty,
+                currentSettlementComponent,
+                boughtItems,
+                soldItems
+            );
         });
     }
 
@@ -213,18 +209,11 @@ internal class TradeHandler : IHandler
         {
             using (new AllowedThread())
             {
-                try
-                {
-                    if (!objectManager.TryGetObjectWithLogging<MobileParty>(obj.What.MobilePartyId, out var mobileParty)) return;
-                    if (!objectManager.TryGetObjectWithLogging<Hero>(obj.What.InitialHeroId, out var initialHero)) return;
+                if (!objectManager.TryGetObjectWithLogging<MobileParty>(obj.What.MobilePartyId, out var mobileParty)) return;
+                if (!objectManager.TryGetObjectWithLogging<Hero>(obj.What.InitialHeroId, out var initialHero)) return;
 
-                    ResolveCharacterEquipmentsData(obj.What.CharacterIdEquipmentsData, out var characterEquipmentsData);
-                    inventoryLogicInterface.UpdateEquipmentWithData(mobileParty, characterEquipmentsData, initialHero);
-                }
-                catch (Exception e)
-                {
-                    logger.Error(e, "Failed to apply {Message}", nameof(UpdateEquipmentClients));
-                }
+                ResolveCharacterEquipmentsData(obj.What.CharacterIdEquipmentsData, out var characterEquipmentsData);
+                inventoryLogicInterface.UpdateEquipmentWithData(mobileParty, characterEquipmentsData, initialHero);
             }
         });
     }

--- a/source/GameInterface/Services/Inventory/Interfaces/InventoryLogicInterface.cs
+++ b/source/GameInterface/Services/Inventory/Interfaces/InventoryLogicInterface.cs
@@ -56,27 +56,20 @@ namespace GameInterface.Services.Inventory.Interfaces
             List<ValueTuple<ItemRosterElement, int>> boughtItems,
             List<ValueTuple<ItemRosterElement, int>> soldItems)
         {
-            GameThread.Run(() =>
+            GameThread.RunSafe(() =>
             {
-                try
-                {
-                    ApplyDoneLogicInternal(
+                ApplyDoneLogicInternal(
                         fromRoster,
                         toRoster,
-                        isTrading, 
+                        isTrading,
                         isDiscardDonating,
-                        ownerHero, 
-                        totalAmount, 
+                        ownerHero,
+                        totalAmount,
                         merchantGold,
                         currentMobileParty,
                         currentSettlementComponent,
                         boughtItems,
                         soldItems);
-                }
-                catch (Exception ex)
-                {
-                    logger.Error(ex, "Failed to {method}", nameof(ApplyDoneLogic));
-                }
             });
         }
 
@@ -105,7 +98,7 @@ namespace GameInterface.Services.Inventory.Interfaces
 
             if (ownerHero.CharacterObject != null && ownerHero != null && isTrading)
             {
-                // Trasnfers gold between player and other party (if party does not have enough gold, sends all gold)
+                // Transfers gold between player and other party (if party does not have enough gold, sends all gold)
                 // Note: Total amount = transactional debt which is negative
                 GiveGoldAction.ApplyBetweenCharacters(null, ownerHero, MathF.Min(-totalAmount, merchantGold), false);
                 if (currentSettlementComponent != null && currentSettlementComponent.IsTown && ownerHero.CharacterObject.GetPerkValue(DefaultPerks.Trade.TrickleDown))
@@ -157,7 +150,6 @@ namespace GameInterface.Services.Inventory.Interfaces
             }
             else if (((currentMobileParty != null) ? currentMobileParty.Party.LeaderHero : null) != null && isTrading)
             {
-                // TODO
                 GiveGoldAction.ApplyBetweenCharacters(null, currentMobileParty.Party.LeaderHero, totalAmount, false);
                 if (currentMobileParty.Party.LeaderHero.CompanionOf != null)
                 {
@@ -166,7 +158,6 @@ namespace GameInterface.Services.Inventory.Interfaces
             }
             else if (partyBase != null && partyBase.LeaderHero == null && isTrading)
             {
-                // TODO
                 GiveGoldAction.ApplyForCharacterToParty(null, partyBase, totalAmount, false);
             }
         }

--- a/source/GameInterface/Services/Inventory/Messages/CompleteTrade.cs
+++ b/source/GameInterface/Services/Inventory/Messages/CompleteTrade.cs
@@ -37,20 +37,22 @@ internal readonly struct CompleteTrade : ICommand
     [ProtoMember(13)]
     public readonly int MerchantGold;
     [ProtoMember(14)]
-    public readonly string PartyId;
+    public readonly string OwnerPartyId;
     [ProtoMember(15)]
-    public readonly bool IsSettlementComponentNull;
+    public readonly string CurrentMobilePartyId;
     [ProtoMember(16)]
+    public readonly bool IsSettlementComponentNull;
+    [ProtoMember(17)]
     public readonly string CurrentSettlementComponentId;
 
-    [ProtoMember(17)]
-    public readonly (ItemRosterElementData, int)[] BoughtItems;
     [ProtoMember(18)]
+    public readonly (ItemRosterElementData, int)[] BoughtItems;
+    [ProtoMember(19)]
     public readonly (ItemRosterElementData, int)[] SoldItems;
 
-    [ProtoMember(19)]
-    public readonly string TroopRosterId;
     [ProtoMember(20)]
+    public readonly string TroopRosterId;
+    [ProtoMember(21)]
     public readonly TroopRosterData TroopRosterData;
 
     public CompleteTrade(
@@ -67,7 +69,8 @@ internal readonly struct CompleteTrade : ICommand
         string initialHeroId,
         int totalAmount,
         int merchantGold,
-        string partyId,
+        string ownerPartyId,
+        string currentMobilePartyId,
         bool isSettlementComponentNull,
         string currentSettlementComponentId,
         (ItemRosterElementData, int)[] boughtItems,
@@ -88,7 +91,8 @@ internal readonly struct CompleteTrade : ICommand
         InitialHeroId = initialHeroId;
         TotalAmount = totalAmount;
         MerchantGold = merchantGold;
-        PartyId = partyId;
+        OwnerPartyId = ownerPartyId;
+        CurrentMobilePartyId = currentMobilePartyId;
         IsSettlementComponentNull = isSettlementComponentNull;
         CurrentSettlementComponentId = currentSettlementComponentId;
         BoughtItems = boughtItems;

--- a/source/GameInterface/Services/Inventory/Messages/TradeAttempted.cs
+++ b/source/GameInterface/Services/Inventory/Messages/TradeAttempted.cs
@@ -20,7 +20,7 @@ public readonly struct TradeAttempted : IEvent
     public readonly CharacterObject InitialCharacterEquipment;
     public readonly int TotalAmount;
     public readonly int MerchantGold;
-    public readonly MobileParty Party;
+    public readonly MobileParty OwnerParty;
     public readonly MobileParty CurrentMobileParty;
     public readonly SettlementComponent CurrentSettlementComponent;
     public readonly List<(ItemRosterElement, int)> BoughtItems;
@@ -37,7 +37,7 @@ public readonly struct TradeAttempted : IEvent
         CharacterObject initialCharacterEquipment,
     int totalAmount,
         int merchantGold,
-        MobileParty party,
+        MobileParty ownerParty,
         MobileParty currentMobileParty,
         SettlementComponent currentSettlementComponent,
         List<(ItemRosterElement, int)> boughtItems,
@@ -53,7 +53,7 @@ public readonly struct TradeAttempted : IEvent
         InitialCharacterEquipment = initialCharacterEquipment;
         TotalAmount = totalAmount;
         MerchantGold = merchantGold;
-        Party = party;
+        OwnerParty = ownerParty;
         CurrentMobileParty = currentMobileParty;
         CurrentSettlementComponent = currentSettlementComponent;
         BoughtItems = boughtItems;


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The trading done logic isn't handling the current mobile party correctly as it uses the player's party instead of the conversation party. As a result, the following check in `InventoryLogicInterface.ApplyDoneLogicInternal()` allows `GiveGoldAction` to run again for the player, reversing the gold transaction.

`else if (((currentMobileParty != null) ? currentMobileParty.Party.LeaderHero : null) != null && isTrading)`

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #1724
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Fixed the problem and also replaced uses of `GameThread.Run()` with `GameThread.RunSafe()`.

## Other information
