### PR TITLE
Sometimes player parties somehow get taken over by AI on the server

### DIFF
--- a/source/GameInterface/Services/MobilePartyAIs/Patches/DefaultMobilePartyAIModelPatches.cs
+++ b/source/GameInterface/Services/MobilePartyAIs/Patches/DefaultMobilePartyAIModelPatches.cs
@@ -1,5 +1,6 @@
 ﻿using Common;
 using GameInterface.Services.MapEvents;
+using GameInterface.Services.MobileParties.Extensions;
 using HarmonyLib;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
@@ -35,6 +36,18 @@ internal class DefaultMobilePartyAIModelPatches
         // would block the attack anyway, and this keeps the AI from chasing an unattackable target.
         if (ConversationPartyHold.IsInPlayerConversation(targetParty))
             __result = false;
+    }
+    [HarmonyPatch(nameof(DefaultMobilePartyAIModel.ShouldPartyCheckInitiativeBehavior))]
+    [HarmonyPrefix]
+    private static bool ShouldPartyCheckInitiativeBehaviorPrefix(MobileParty mobileParty, ref bool __result)
+    {
+        if (mobileParty.IsPlayerParty())
+        {
+            __result = false;
+            return false;
+        }
+
+        return true;
     }
     [HarmonyPatch(typeof(DefaultMobilePartyAIModel))]
     internal class FixGarrisonFleePatch


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ x ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ x ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Sometimes player parties somehow get taken over by AI on the server
## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #1727
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Added a check for `DefaultMobilePartyAIModel.ShouldPartyCheckInitiativeBehavior` to check if the mobileparty is a player. 
Normally vanilla checks `mobileparty.mainparty` but server has a different hero than the client, meaning that the server would let `getbehaviors()` compute and apply a new ai behavior
