### PR TITLE
[1734] Allow auto-resolve after all players retreat

### DIFF
--- a/source/Coop.Core/Server/Services/Instances/Handlers/ServerMissionMembershipHandler.cs
+++ b/source/Coop.Core/Server/Services/Instances/Handlers/ServerMissionMembershipHandler.cs
@@ -71,7 +71,11 @@ public class ServerMissionMembershipHandler : IHandler
 
         // Local signal for battle host migration / successor cleanup (no-op for non-battle instances). A
         // graceful leave is a retreat — the battle reserve forgets the party so a rejoin re-spawns.
-        messageBroker.Publish(this, new MissionMemberDeparted(message.ControllerId, message.InstanceId, wasRetreat: true));
+        messageBroker.Publish(this, new MissionMemberDeparted(
+            message.ControllerId,
+            message.InstanceId,
+            wasRetreat: true,
+            isInstanceEmpty: remaining.Count == 0));
     }
 
     private void Handle_PlayerDisconnected(MessagePayload<PlayerDisconnected> payload)
@@ -87,6 +91,10 @@ public class ServerMissionMembershipHandler : IHandler
 
         // Local signal for battle host migration / successor cleanup (no-op for non-battle instances). A drop
         // is NOT a retreat — the host adopts the dropped player's troops, so the reserve pointer is kept.
-        messageBroker.Publish(this, new MissionMemberDeparted(controllerId, instanceId, wasRetreat: false));
+        messageBroker.Publish(this, new MissionMemberDeparted(
+            controllerId,
+            instanceId,
+            wasRetreat: false,
+            isInstanceEmpty: remaining.Count == 0));
     }
 }

--- a/source/Coop.IntegrationTests/Missions/MissionMembershipTests.cs
+++ b/source/Coop.IntegrationTests/Missions/MissionMembershipTests.cs
@@ -1,3 +1,4 @@
+using Common.Messaging;
 using Coop.Core.Server.Services.Instances;
 using Coop.IntegrationTests.Environment;
 using Coop.IntegrationTests.Environment.Instance;
@@ -58,6 +59,35 @@ public class MissionMembershipTests
         Leave(members[2]);
 
         AssertControllersEquivalent(members.Take(2).ToList());
+    }
+
+    [Fact]
+    public void ClientLeaves_DepartureMarksWhetherInstanceIsEmpty()
+    {
+        var members = SetupClients().Take(2).ToArray();
+        var departures = new List<MissionMemberDeparted>();
+        var messageBroker = TestEnvironment.Server.Resolve<IMessageBroker>();
+        messageBroker.Subscribe<MissionMemberDeparted>(payload => departures.Add(payload.What));
+
+        Join(members[0]);
+        Join(members[1]);
+
+        Leave(members[1]);
+
+        var firstDeparture = Assert.Single(departures);
+        Assert.Equal(members[1].ControllerId, firstDeparture.ControllerId);
+        Assert.Equal(InstanceId, firstDeparture.InstanceId);
+        Assert.True(firstDeparture.WasRetreat);
+        Assert.False(firstDeparture.IsInstanceEmpty);
+
+        departures.Clear();
+        Leave(members[0]);
+
+        var lastDeparture = Assert.Single(departures);
+        Assert.Equal(members[0].ControllerId, lastDeparture.ControllerId);
+        Assert.Equal(InstanceId, lastDeparture.InstanceId);
+        Assert.True(lastDeparture.WasRetreat);
+        Assert.True(lastDeparture.IsInstanceEmpty);
     }
 
     private record Member(EnvironmentInstance Instance, string ControllerId);

--- a/source/E2E.Tests/Services/Missions/HostMigrationTests.cs
+++ b/source/E2E.Tests/Services/Missions/HostMigrationTests.cs
@@ -71,7 +71,12 @@ public class HostMigrationTests : MissionTestEnvironment
     public void LastPlayerDeparts_ReleasesMissionModeForSimulation()
     {
         var (mapEventId, _) = SetupCoopBattle("ctrl-A", "ctrl-B");
-        EnterBattle(Clients.First(), mapEventId);
+        var client = Clients.First();
+        EnterBattle(client, mapEventId);
+
+        // Model the retreat transition: the mission mode is still recorded, but this harness's main party and
+        // PlayerEncounter do not point at the event while the unclaimed update arrives.
+        client.Call(() => BattleModeRegistry.Begin(mapEventId, BattleStartMode.Mission));
 
         Server.Call(() => Assert.True(ServerBattleModeArbiter.TryClaimMission(mapEventId)));
         Server.NetworkSentMessages.Clear();
@@ -81,6 +86,7 @@ public class HostMigrationTests : MissionTestEnvironment
         var modeChange = Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkBattleModeSet>());
         Assert.Equal(mapEventId, modeChange.MapEventId);
         Assert.Equal((int)BattleStartMode.Unclaimed, modeChange.Mode);
+        client.Call(() => Assert.False(BattleModeRegistry.IsMission(mapEventId)));
 
         Server.Call(() =>
         {

--- a/source/E2E.Tests/Services/Missions/HostMigrationTests.cs
+++ b/source/E2E.Tests/Services/Missions/HostMigrationTests.cs
@@ -1,3 +1,6 @@
+using GameInterface.Services.MapEvents;
+using GameInterface.Services.MapEvents.Handlers;
+using GameInterface.Services.MapEvents.Messages.Start;
 using Xunit.Abstractions;
 
 namespace E2E.Tests.Services.Missions;
@@ -62,5 +65,27 @@ public class HostMigrationTests : MissionTestEnvironment
         AssertHost(Server, mapEventId, "ctrl-C");
         foreach (var client in Clients)
             AssertHost(client, mapEventId, "ctrl-C");
+    }
+
+    [Fact]
+    public void LastPlayerDeparts_ReleasesMissionModeForSimulation()
+    {
+        var (mapEventId, _) = SetupCoopBattle("ctrl-A", "ctrl-B");
+        EnterBattle(Clients.First(), mapEventId);
+
+        Server.Call(() => Assert.True(ServerBattleModeArbiter.TryClaimMission(mapEventId)));
+        Server.NetworkSentMessages.Clear();
+
+        DepartBattle("ctrl-A", mapEventId, wasRetreat: true, isInstanceEmpty: true);
+
+        var modeChange = Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkBattleModeSet>());
+        Assert.Equal(mapEventId, modeChange.MapEventId);
+        Assert.Equal((int)BattleStartMode.Unclaimed, modeChange.Mode);
+
+        Server.Call(() =>
+        {
+            Assert.True(ServerBattleModeArbiter.TryClaimSimulation(mapEventId));
+            ServerBattleModeArbiter.Release(mapEventId);
+        });
     }
 }

--- a/source/E2E.Tests/Services/Missions/MissionTestEnvironment.cs
+++ b/source/E2E.Tests/Services/Missions/MissionTestEnvironment.cs
@@ -133,11 +133,12 @@ public class MissionTestEnvironment : E2ETestEnvironment
     /// publishes <see cref="MissionMemberDeparted"/> on the server, which drives host migration (promote the
     /// next successor) or successor-line cleanup. The promotion broadcast travels the mock campaign network.
     /// </summary>
-    protected void DepartBattle(string controllerId, string mapEventId, bool wasRetreat = false)
+    protected void DepartBattle(string controllerId, string mapEventId, bool wasRetreat = false, bool isInstanceEmpty = false)
     {
         Server.Call(() =>
         {
-            Server.Resolve<IMessageBroker>().Publish(this, new MissionMemberDeparted(controllerId, mapEventId, wasRetreat));
+            Server.Resolve<IMessageBroker>().Publish(this,
+                new MissionMemberDeparted(controllerId, mapEventId, wasRetreat, isInstanceEmpty));
         });
     }
 

--- a/source/GameInterface.Tests/Serialization/NetworkBattleModeSetSerializationTest.cs
+++ b/source/GameInterface.Tests/Serialization/NetworkBattleModeSetSerializationTest.cs
@@ -7,10 +7,12 @@ namespace GameInterface.Tests.Serialization;
 
 public class NetworkBattleModeSetSerializationTest
 {
-    [Fact]
-    public void RoundTrip_PreservesFields()
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void RoundTrip_PreservesFields(int mode)
     {
-        var original = new NetworkBattleModeSet("mapEvent-7", 1);
+        var original = new NetworkBattleModeSet("mapEvent-7", mode);
 
         byte[] bytes;
         using (var ms = new MemoryStream())
@@ -28,6 +30,6 @@ public class NetworkBattleModeSetSerializationTest
         }
 
         Assert.Equal("mapEvent-7", result.MapEventId);
-        Assert.Equal(1, result.Mode);
+        Assert.Equal(mode, result.Mode);
     }
 }

--- a/source/GameInterface.Tests/Services/MapEvents/BattleModeRegistryTests.cs
+++ b/source/GameInterface.Tests/Services/MapEvents/BattleModeRegistryTests.cs
@@ -14,7 +14,7 @@ public class BattleModeRegistryTests
 
         try
         {
-            BattleModeRegistry.End("old-map-event");
+            Assert.False(BattleModeRegistry.End("old-map-event"));
 
             Assert.True(BattleModeRegistry.IsMission("current-map-event"));
         }
@@ -22,5 +22,14 @@ public class BattleModeRegistryTests
         {
             BattleModeRegistry.End();
         }
+    }
+
+    [Fact]
+    public void End_CurrentMapEvent_ClearsModeAndReportsChange()
+    {
+        BattleModeRegistry.Begin("current-map-event", BattleStartMode.Mission);
+
+        Assert.True(BattleModeRegistry.End("current-map-event"));
+        Assert.False(BattleModeRegistry.IsMission("current-map-event"));
     }
 }

--- a/source/GameInterface.Tests/Services/MapEvents/BattleModeRegistryTests.cs
+++ b/source/GameInterface.Tests/Services/MapEvents/BattleModeRegistryTests.cs
@@ -1,0 +1,26 @@
+﻿using GameInterface.Services.MapEvents;
+using GameInterface.Services.MapEvents.Handlers;
+using Xunit;
+
+namespace GameInterface.Tests.Services.MapEvents;
+
+/// <summary>Tests map-event-scoped client battle mode tracking.</summary>
+public class BattleModeRegistryTests
+{
+    [Fact]
+    public void End_DifferentMapEvent_DoesNotClearCurrentMode()
+    {
+        BattleModeRegistry.Begin("current-map-event", BattleStartMode.Mission);
+
+        try
+        {
+            BattleModeRegistry.End("old-map-event");
+
+            Assert.True(BattleModeRegistry.IsMission("current-map-event"));
+        }
+        finally
+        {
+            BattleModeRegistry.End();
+        }
+    }
+}

--- a/source/GameInterface.Tests/Services/MapEvents/ServerBattleModeArbiterTests.cs
+++ b/source/GameInterface.Tests/Services/MapEvents/ServerBattleModeArbiterTests.cs
@@ -1,0 +1,44 @@
+﻿using GameInterface.Services.MapEvents;
+using Xunit;
+
+namespace GameInterface.Tests.Services.MapEvents;
+
+/// <summary>Tests conditional release of server-authoritative battle mode claims.</summary>
+public class ServerBattleModeArbiterTests
+{
+    [Fact]
+    public void ReleaseMission_MissionClaim_AllowsSimulationClaim()
+    {
+        const string mapEventId = "release-mission-claim";
+
+        try
+        {
+            Assert.True(ServerBattleModeArbiter.TryClaimMission(mapEventId));
+
+            Assert.True(ServerBattleModeArbiter.ReleaseMission(mapEventId));
+            Assert.True(ServerBattleModeArbiter.TryClaimSimulation(mapEventId));
+        }
+        finally
+        {
+            ServerBattleModeArbiter.Release(mapEventId);
+        }
+    }
+
+    [Fact]
+    public void ReleaseMission_SimulationClaim_DoesNotReleaseClaim()
+    {
+        const string mapEventId = "preserve-simulation-claim";
+
+        try
+        {
+            Assert.True(ServerBattleModeArbiter.TryClaimSimulation(mapEventId));
+
+            Assert.False(ServerBattleModeArbiter.ReleaseMission(mapEventId));
+            Assert.False(ServerBattleModeArbiter.TryClaimMission(mapEventId));
+        }
+        finally
+        {
+            ServerBattleModeArbiter.Release(mapEventId);
+        }
+    }
+}

--- a/source/GameInterface/Services/MapEvents/BattleModeRegistry.cs
+++ b/source/GameInterface/Services/MapEvents/BattleModeRegistry.cs
@@ -1,4 +1,4 @@
-using GameInterface.Services.MapEvents.Handlers;
+﻿using GameInterface.Services.MapEvents.Handlers;
 
 namespace GameInterface.Services.MapEvents;
 
@@ -29,10 +29,12 @@ internal static class BattleModeRegistry
     public static void End() => mapEventId = null;
 
     /// <summary>Clear the record only if it still belongs to the given map event.</summary>
-    public static void End(string id)
+    public static bool End(string id)
     {
-        if (mapEventId == id)
-            mapEventId = null;
+        if (mapEventId != id) return false;
+
+        mapEventId = null;
+        return true;
     }
 
     /// <summary>True if a live mission owns the given map event.</summary>

--- a/source/GameInterface/Services/MapEvents/BattleModeRegistry.cs
+++ b/source/GameInterface/Services/MapEvents/BattleModeRegistry.cs
@@ -5,10 +5,10 @@ namespace GameInterface.Services.MapEvents;
 /// <summary>
 /// [Client] The single, server-authoritative record of how the local player's current battle is being resolved — a
 /// live mission or an auto-resolve simulation. Set from the server's <see cref="Messages.Start.NetworkBattleModeSet"/>
-/// broadcast (sent when <c>ServerBattleModeArbiter</c> claims the event for a mode) and cleared when the event
-/// finalizes. The encounter-menu gate (<c>BattleModeEncounterOptionsPatch</c>) reads it to grey out the wrong-mode
-/// options. Replaces the former pair of mission/simulation client flags; <see cref="BattleSimulationReplay"/> keeps
-/// only its playback state now.
+/// broadcast (sent when <c>ServerBattleModeArbiter</c> claims or releases the event) and cleared when the mission is
+/// abandoned or the event finalizes. The encounter-menu gate (<c>BattleModeEncounterOptionsPatch</c>) reads it to
+/// grey out the wrong-mode options. Replaces the former pair of mission/simulation client flags;
+/// <see cref="BattleSimulationReplay"/> keeps only its playback state now.
 /// </summary>
 /// <remarks>
 /// The local player is in at most one battle at a time, so a single id suffices. Touched only on the game main thread.
@@ -27,6 +27,13 @@ internal static class BattleModeRegistry
 
     /// <summary>Clear the record (the battle has ended / the event finalized).</summary>
     public static void End() => mapEventId = null;
+
+    /// <summary>Clear the record only if it still belongs to the given map event.</summary>
+    public static void End(string id)
+    {
+        if (mapEventId == id)
+            mapEventId = null;
+    }
 
     /// <summary>True if a live mission owns the given map event.</summary>
     public static bool IsMission(string id) => mapEventId != null && mapEventId == id && mode == BattleStartMode.Mission;

--- a/source/GameInterface/Services/MapEvents/Handlers/BattleHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/BattleHandler.cs
@@ -106,16 +106,21 @@ internal class BattleHandler : IHandler
 
         GameThread.RunSafe(() =>
         {
+            // A retreat briefly tears down the local encounter before reopening its menu. Apply an id-scoped clear
+            // even while neither local encounter reference points at the event, otherwise the mission mode sticks.
+            if (mode == BattleStartMode.Unclaimed)
+            {
+                BattleModeRegistry.End(mapEventId);
+                return;
+            }
+
             if (!objectManager.TryGetObject(mapEventId, out MapEvent mapEvent) || mapEvent == null)
                 return;
 
             if (MobileParty.MainParty?.MapEvent != mapEvent && PlayerEncounter.Battle != mapEvent)
                 return;
 
-            if (mode == BattleStartMode.Unclaimed)
-                BattleModeRegistry.End(mapEventId);
-            else
-                BattleModeRegistry.Begin(mapEventId, mode);
+            BattleModeRegistry.Begin(mapEventId, mode);
         });
     }
 

--- a/source/GameInterface/Services/MapEvents/Handlers/BattleHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/BattleHandler.cs
@@ -112,7 +112,10 @@ internal class BattleHandler : IHandler
             if (MobileParty.MainParty?.MapEvent != mapEvent && PlayerEncounter.Battle != mapEvent)
                 return;
 
-            BattleModeRegistry.Begin(mapEventId, mode);
+            if (mode == BattleStartMode.Unclaimed)
+                BattleModeRegistry.End(mapEventId);
+            else
+                BattleModeRegistry.Begin(mapEventId, mode);
         });
     }
 

--- a/source/GameInterface/Services/MapEvents/Handlers/BattleHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/BattleHandler.cs
@@ -110,7 +110,8 @@ internal class BattleHandler : IHandler
             // even while neither local encounter reference points at the event, otherwise the mission mode sticks.
             if (mode == BattleStartMode.Unclaimed)
             {
-                BattleModeRegistry.End(mapEventId);
+                if (BattleModeRegistry.End(mapEventId))
+                    RefreshCurrentEncounterMenu();
                 return;
             }
 
@@ -121,9 +122,17 @@ internal class BattleHandler : IHandler
                 return;
 
             BattleModeRegistry.Begin(mapEventId, mode);
+            RefreshCurrentEncounterMenu();
         });
     }
 
+    private static void RefreshCurrentEncounterMenu()
+    {
+        var menuContext = Campaign.Current?.CurrentMenuContext;
+        // The menu can activate before this queued update, so rebuild it with the new mode.
+        if (menuContext?.GameMenu?.StringId == "encounter")
+            menuContext.Refresh();
+    }
 
     private void Handle_MapEventInvolvedPartiesAdded(MessagePayload<MapEventInvolvedPartiesAdded> payload)
     {

--- a/source/GameInterface/Services/MapEvents/Handlers/BattleStartCoordinator.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/BattleStartCoordinator.cs
@@ -16,6 +16,7 @@ internal enum BattleStartMode
 {
     Mission = 0,
     Simulation = 1,
+    Unclaimed = 2,
 }
 
 /// <summary>

--- a/source/GameInterface/Services/MapEvents/Messages/Start/NetworkBattleModeSet.cs
+++ b/source/GameInterface/Services/MapEvents/Messages/Start/NetworkBattleModeSet.cs
@@ -5,9 +5,10 @@ namespace GameInterface.Services.MapEvents.Messages.Start;
 
 /// <summary>
 /// [Server -&gt; Clients] The server (via <c>ServerBattleModeArbiter</c>) claimed a map event for a battle-resolution
-/// mode (0 = live mission, 1 = auto-resolve simulation; see <c>BattleStartMode</c>). Every client whose own party is
-/// in that event records it (<c>BattleModeRegistry</c>) so the encounter menu greys out the wrong-mode options — a
-/// map event is fought as a mission XOR an auto-resolve, never both. Cleared locally when the event finalizes.
+/// mode (0 = live mission, 1 = auto-resolve simulation, 2 = unclaimed; see <c>BattleStartMode</c>). Every client whose
+/// own party is in that event records it (<c>BattleModeRegistry</c>) so the encounter menu greys out the wrong-mode
+/// options. The server sends unclaimed when the last player leaves a live mission and the map event can be resolved
+/// another way, while map-event finalization also clears the client state locally.
 /// </summary>
 [ProtoContract(SkipConstructor = true)]
 internal readonly struct NetworkBattleModeSet : ICommand

--- a/source/GameInterface/Services/MapEvents/ServerBattleModeArbiter.cs
+++ b/source/GameInterface/Services/MapEvents/ServerBattleModeArbiter.cs
@@ -4,9 +4,10 @@ namespace GameInterface.Services.MapEvents;
 
 /// <summary>
 /// [Server] Authoritative gate that keeps a map event in a single battle-resolution mode: the first player to start
-/// a live mission OR an auto-resolve simulation claims the event, and the other mode is refused until the event is
-/// released (finalized). The client-side <c>BattleModeEncounterOptionsPatch</c> greys the menu out for UX; this is
-/// the backstop that wins the race when two clients act within the broadcast latency window.
+/// a live mission OR an auto-resolve simulation claims the event, and the other mode is refused until the claim is
+/// released. A mission claim ends when its mission instance becomes empty; either claim ends when the event
+/// finalizes. The client-side <c>BattleModeEncounterOptionsPatch</c> greys the menu out for UX; this is the backstop
+/// that wins the race when two clients act within the broadcast latency window.
 /// </summary>
 /// <remarks>
 /// Server-only state. Keyed by map-event object-manager id, so concurrent battles on different events are
@@ -41,6 +42,24 @@ internal static class ServerBattleModeArbiter
                 return current == mode;
 
             modes[mapEventId] = mode;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Release a live-mission claim after the final mission member leaves. Returns false when the event is unclaimed
+    /// or already belongs to a simulation, so a duplicate mission departure cannot clear a newer simulation claim.
+    /// </summary>
+    public static bool ReleaseMission(string mapEventId)
+    {
+        if (mapEventId == null) return false;
+
+        lock (lockObj)
+        {
+            if (!modes.TryGetValue(mapEventId, out var current) || current != Mode.Mission)
+                return false;
+
+            modes.Remove(mapEventId);
             return true;
         }
     }

--- a/source/Missions/Battles/BattleHostHandler.cs
+++ b/source/Missions/Battles/BattleHostHandler.cs
@@ -4,7 +4,9 @@ using Common.Messaging;
 using Common.Network;
 using GameInterface.Services.Entity;
 using GameInterface.Services.MapEvents;
+using GameInterface.Services.MapEvents.Handlers;
 using GameInterface.Services.MapEvents.Messages;
+using GameInterface.Services.MapEvents.Messages.Start;
 using GameInterface.Services.MapEvents.TroopSupply;
 using GameInterface.Services.MapEvents.TroopSupply.Messages;
 using GameInterface.Services.ObjectManager;
@@ -189,6 +191,11 @@ internal class BattleHostHandler : IHandler
 
         var controllerId = payload.What.ControllerId;
         var mapEventId = payload.What.InstanceId;
+
+        // Release before a later battle-start request can be handled on this poll thread. The reliable ordered
+        // stream guarantees the departure is published first, but the host/reserve cleanup below runs next frame.
+        if (payload.What.IsInstanceEmpty && ServerBattleModeArbiter.ReleaseMission(mapEventId))
+            network.SendAll(new NetworkBattleModeSet(mapEventId, (int)BattleStartMode.Unclaimed));
 
         // Mutates the shared assignment, so run on the main thread (serializes with election).
         GameThread.RunSafe(() =>

--- a/source/Missions/Messages/MissionMemberDeparted.cs
+++ b/source/Missions/Messages/MissionMemberDeparted.cs
@@ -4,9 +4,9 @@ namespace Missions.Messages;
 
 /// <summary>
 /// [Server, local] A controller left or dropped from a mission instance, published once the membership
-/// handler has resolved the controller id and instance id (so it is not a networked message). Battle host
-/// election uses it to promote a successor when the departed controller was the host, or to drop the
-/// controller from the successor line otherwise.
+/// handler has resolved the controller id, instance id, and remaining membership (so it is not a networked
+/// message). Battle host election uses it to promote a successor when the departed controller was the host, or
+/// to drop the controller from the successor line otherwise.
 /// <para>
 /// <see cref="WasRetreat"/> distinguishes a graceful leave (retreat — the player's troops despawned, so the
 /// battle reserve must forget its party for a clean re-spawn on rejoin) from an ungraceful drop (disconnect —
@@ -18,11 +18,13 @@ public readonly struct MissionMemberDeparted : IEvent
     public readonly string ControllerId;
     public readonly string InstanceId;
     public readonly bool WasRetreat;
+    public readonly bool IsInstanceEmpty;
 
-    public MissionMemberDeparted(string controllerId, string instanceId, bool wasRetreat)
+    public MissionMemberDeparted(string controllerId, string instanceId, bool wasRetreat, bool isInstanceEmpty)
     {
         ControllerId = controllerId;
         InstanceId = instanceId;
         WasRetreat = wasRetreat;
+        IsInstanceEmpty = isInstanceEmpty;
     }
 }


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

After the player retreats from a field battle, the "Send Troops" remains disabled button remains disabled and says "A battle is already underway."

## What is the new behavior?

After the last player leaves the field battle, Send Troops becomes available and can start auto-resolve.

Resolves #1734
