### PR TITLE
[1727] Stop server AI from controlling player parties

### DIFF
--- a/source/GameInterface.Tests/Services/MobileParties/MobilePartyAIDisablePatchesTests.cs
+++ b/source/GameInterface.Tests/Services/MobileParties/MobilePartyAIDisablePatchesTests.cs
@@ -1,0 +1,101 @@
+﻿using Common;
+using Common.Util;
+using GameInterface.Services.Entity;
+using GameInterface.Services.MobilePartyAIs.Patches;
+using GameInterface.Services.Players;
+using HarmonyLib;
+using System;
+using System.Runtime.CompilerServices;
+using TaleWorlds.CampaignSystem.Party;
+using Xunit;
+
+namespace GameInterface.Tests.Services.MobileParties;
+
+/// <summary>
+/// Prevents tests that mutate global role and player-control state from running concurrently.
+/// </summary>
+[CollectionDefinition(nameof(MobilePartyAiAuthorityCollection), DisableParallelization = true)]
+public class MobilePartyAiAuthorityCollection
+{
+}
+
+/// <summary>
+/// Tests the authority boundary for campaign-map AI decisions.
+/// </summary>
+[Collection(nameof(MobilePartyAiAuthorityCollection))]
+public class MobilePartyAIDisablePatchesTests : IDisposable
+{
+    private readonly bool wasServer = ModInformation.IsServer;
+    private readonly ConditionalWeakTable<object, ControlledObjectInfo> playerObjects =
+        (ConditionalWeakTable<object, ControlledObjectInfo>)AccessTools
+            .Field(typeof(PlayerManager), "PlayerObjects")
+            .GetValue(null)!;
+    private MobileParty? registeredParty;
+
+    public void Dispose()
+    {
+        ModInformation.IsServer = wasServer;
+
+        if (registeredParty != null)
+        {
+            playerObjects.Remove(registeredParty);
+        }
+    }
+
+    [Fact]
+    public void IsTickAuthority_ServerPlayerParty_ReturnsFalse()
+    {
+        var party = RegisterPlayerParty("PlayerOne", "Server");
+        ModInformation.IsServer = true;
+
+        bool result = MobilePartyAIDisablePatches.IsTickAuthority(party);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsTickAuthority_ServerAiParty_ReturnsTrue()
+    {
+        var party = ObjectHelper.SkipConstructor<MobileParty>();
+        ModInformation.IsServer = true;
+
+        bool result = MobilePartyAIDisablePatches.IsTickAuthority(party);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsTickAuthority_OwningClientParty_ReturnsTrue()
+    {
+        var party = RegisterPlayerParty("PlayerOne", "PlayerOne");
+        ModInformation.IsServer = false;
+
+        bool result = MobilePartyAIDisablePatches.IsTickAuthority(party);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsTickAuthority_RemoteClientParty_ReturnsFalse()
+    {
+        var party = RegisterPlayerParty("PlayerOne", "PlayerTwo");
+        ModInformation.IsServer = false;
+
+        bool result = MobilePartyAIDisablePatches.IsTickAuthority(party);
+
+        Assert.False(result);
+    }
+
+    private MobileParty RegisterPlayerParty(string ownerControllerId, string localControllerId)
+    {
+        var controllerIdProvider = new ControllerIdProvider();
+        controllerIdProvider.SetControllerId(localControllerId);
+
+        registeredParty = ObjectHelper.SkipConstructor<MobileParty>();
+        playerObjects.Add(
+            registeredParty,
+            new ControlledObjectInfo(ownerControllerId, controllerIdProvider));
+
+        return registeredParty;
+    }
+}

--- a/source/GameInterface/Services/MobileParties/Commands/MobilePartyDebugCommand.cs
+++ b/source/GameInterface/Services/MobileParties/Commands/MobilePartyDebugCommand.cs
@@ -3,6 +3,7 @@ using Common;
 using Common.Logging;
 using GameInterface.Services.MobileParties.Audit;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Players;
 using Helpers;
 using Serilog;
 using System;
@@ -121,6 +122,63 @@ internal class MobilePartyDebugCommand
         var result = sb.ToString();
         Logger.Debug("{AttachmentIds}", result);
         return result;
+    }
+
+    [CommandLineArgumentFunction("verify_ai_authority", "coop.debug.mobileparty")]
+    public static string VerifyAiAuthority(List<string> args)
+    {
+        if (ModInformation.IsClient)
+        {
+            return "verify_ai_authority is server-only";
+        }
+
+        if (args.Count != 1)
+        {
+            return "Usage: coop.debug.mobileparty.verify_ai_authority <MobilePartyId>";
+        }
+
+        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
+        {
+            return $"Unable to get {nameof(IObjectManager)}";
+        }
+
+        if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager))
+        {
+            return $"Unable to get {nameof(IPlayerManager)}";
+        }
+
+        if (!objectManager.TryGetObjectWithLogging<MobileParty>(args[0], out var mobileParty))
+        {
+            return $"Unable to get {nameof(MobileParty)} with id: {args[0]}";
+        }
+
+        if (!playerManager.Contains(mobileParty))
+        {
+            return $"Party {args[0]} is not registered as a player party";
+        }
+
+        var partyAi = mobileParty.Ai;
+        if (partyAi == null)
+        {
+            return $"Party {args[0]} has no {nameof(MobilePartyAi)}";
+        }
+
+        bool previousNeedsUpdate = partyAi.DefaultBehaviorNeedsUpdate;
+        bool tickWasBlocked;
+        try
+        {
+            partyAi.DefaultBehaviorNeedsUpdate = true;
+            partyAi.Tick(0f);
+            tickWasBlocked = partyAi.DefaultBehaviorNeedsUpdate;
+        }
+        finally
+        {
+            partyAi.DefaultBehaviorNeedsUpdate = previousNeedsUpdate;
+        }
+
+        return tickWasBlocked
+            ? $"Server AI tick blocked for player party {args[0]}"
+            : $"Server AI tick ran for player party {args[0]}";
     }
 
     private static void AppendAttachmentId(StringBuilder sb, IObjectManager objectManager, string label, object obj)

--- a/source/GameInterface/Services/MobilePartyAIs/Patches/MobilePartyAIDisablePatches.cs
+++ b/source/GameInterface/Services/MobilePartyAIs/Patches/MobilePartyAIDisablePatches.cs
@@ -1,5 +1,4 @@
-﻿using Common;
-using GameInterface.Policies;
+﻿using GameInterface.Policies;
 using GameInterface.Services.MobileParties.Extensions;
 using HarmonyLib;
 using TaleWorlds.CampaignSystem.Party;
@@ -11,11 +10,13 @@ internal class MobilePartyAIDisablePatches
 {
     [HarmonyPatch(nameof(MobilePartyAi.Tick))]
     [HarmonyPrefix]
-    private static bool ClientDisableTickPrefix(MobilePartyAi __instance)
+    private static bool TickPrefix(MobilePartyAi __instance)
     {
         // Run original if we called it
         if (CallOriginalPolicy.IsOriginalAllowed()) return true;
 
-        return ModInformation.IsServer || __instance._mobileParty.IsControlledByThisInstance();
+        return IsTickAuthority(__instance._mobileParty);
     }
+
+    internal static bool IsTickAuthority(MobileParty party) => party.IsControlledByThisInstance();
 }


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

A player party can start following an AI behavior on the server while its client continues toward the selected destination, causing their positions to diverge.

## What is the new behavior?

Player parties stay controlled by their clients on the campaign map, so the server follows their selected movement instead of replacing it with an AI behavior.

Resolves #1727
