### PR TITLE
[1732] Prevent provisional client party targets

### DIFF
--- a/source/GameInterface.Tests/Services/MobilePartyAIs/PartyBehaviorPatchTests.cs
+++ b/source/GameInterface.Tests/Services/MobilePartyAIs/PartyBehaviorPatchTests.cs
@@ -1,0 +1,128 @@
+﻿using Autofac;
+using Common;
+using Common.Util;
+using GameInterface.Policies;
+using GameInterface.Services.MobilePartyAIs.Patches;
+using Moq;
+using System;
+using Xunit;
+
+namespace GameInterface.Tests.Services.MobilePartyAIs;
+
+/// <summary>
+/// Prevents tests that mutate shared role and dependency-container state from running in parallel.
+/// </summary>
+[CollectionDefinition(nameof(PartyBehaviorPatchCollection), DisableParallelization = true)]
+public class PartyBehaviorPatchCollection
+{
+}
+
+/// <summary>
+/// Tests that client AI calculation does not apply provisional short-term behavior locally.
+/// </summary>
+[Collection(nameof(PartyBehaviorPatchCollection))]
+public class PartyBehaviorPatchTests : IDisposable
+{
+    private readonly bool wasServer = ModInformation.IsServer;
+    private readonly bool hadPreviousContainer;
+    private readonly ILifetimeScope previousContainer;
+    private readonly IContainer testContainer;
+
+    public PartyBehaviorPatchTests()
+    {
+        hadPreviousContainer = ContainerProvider.TryGetContainer(out previousContainer);
+
+        var syncPolicy = new Mock<ISyncPolicy>();
+        syncPolicy.Setup(policy => policy.AllowOriginal()).Returns(false);
+
+        var builder = new ContainerBuilder();
+        builder.RegisterInstance(syncPolicy.Object).As<ISyncPolicy>();
+        testContainer = builder.Build();
+        ContainerProvider.SetContainer(testContainer);
+    }
+
+    public void Dispose()
+    {
+        ModInformation.IsServer = wasServer;
+        if (hadPreviousContainer)
+        {
+            ContainerProvider.SetContainer(previousContainer);
+        }
+        else
+        {
+            ContainerProvider.Clear();
+        }
+
+        testContainer.Dispose();
+    }
+
+    [Fact]
+    public void SetShortTermBehavior_ClientCalculation_BlocksProvisionalApply()
+    {
+        ModInformation.IsServer = false;
+        PartyBehaviorPatch.GetBehaviorsPrefix(out var state);
+
+        try
+        {
+            Assert.False(MobilePartyShortTermBehaviorPatches.SetShortTermBehaviorPrefix());
+        }
+        finally
+        {
+            PartyBehaviorPatch.GetBehaviorsFinalizer(state);
+        }
+    }
+
+    [Fact]
+    public void SetShortTermBehavior_ClientOutsideCalculation_AllowsApply()
+    {
+        ModInformation.IsServer = false;
+
+        Assert.True(MobilePartyShortTermBehaviorPatches.SetShortTermBehaviorPrefix());
+    }
+
+    [Fact]
+    public void SetShortTermBehavior_ServerCalculation_AllowsApply()
+    {
+        ModInformation.IsServer = true;
+        PartyBehaviorPatch.GetBehaviorsPrefix(out var state);
+
+        try
+        {
+            Assert.True(MobilePartyShortTermBehaviorPatches.SetShortTermBehaviorPrefix());
+        }
+        finally
+        {
+            PartyBehaviorPatch.GetBehaviorsFinalizer(state);
+        }
+    }
+
+    [Fact]
+    public void SetShortTermBehavior_AllowedClientCalculation_AllowsApply()
+    {
+        ModInformation.IsServer = false;
+        PartyBehaviorPatch.GetBehaviorsPrefix(out var state);
+
+        try
+        {
+            using (new AllowedThread())
+            {
+                Assert.True(MobilePartyShortTermBehaviorPatches.SetShortTermBehaviorPrefix());
+            }
+        }
+        finally
+        {
+            PartyBehaviorPatch.GetBehaviorsFinalizer(state);
+        }
+    }
+
+    [Fact]
+    public void GetBehaviorsFinalizer_ClearsCalculationScope()
+    {
+        ModInformation.IsServer = false;
+        PartyBehaviorPatch.GetBehaviorsPrefix(out var state);
+
+        PartyBehaviorPatch.GetBehaviorsFinalizer(state);
+
+        Assert.True(MobilePartyShortTermBehaviorPatches.SetShortTermBehaviorPrefix());
+    }
+}

--- a/source/GameInterface/Services/MobilePartyAIs/Patches/PartyBehaviorPatch.cs
+++ b/source/GameInterface/Services/MobilePartyAIs/Patches/PartyBehaviorPatch.cs
@@ -24,6 +24,11 @@ public static class PartyBehaviorPatch
 {
     static readonly ILogger Logger = LogManager.GetLogger<MobilePartyAi>();
 
+    [ThreadStatic]
+    private static int clientBehaviorCalculationDepth;
+
+    internal static bool IsClientBehaviorCalculation => clientBehaviorCalculationDepth > 0;
+
     /// <summary>
     /// This prevents the tick method being called without the need for an update
     /// Likely speeds the game up quite a bit lmao
@@ -36,6 +41,27 @@ public static class PartyBehaviorPatch
             
         // This disables AI
         return __instance._mobileParty == MobileParty.MainParty;
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch("GetBehaviors")]
+    internal static void GetBehaviorsPrefix(out bool __state)
+    {
+        __state = ModInformation.IsClient;
+        if (__state)
+        {
+            clientBehaviorCalculationDepth++;
+        }
+    }
+
+    [HarmonyFinalizer]
+    [HarmonyPatch("GetBehaviors")]
+    internal static void GetBehaviorsFinalizer(bool __state)
+    {
+        if (__state)
+        {
+            clientBehaviorCalculationDepth--;
+        }
     }
 
     [HarmonyPrefix]
@@ -145,5 +171,20 @@ public static class PartyBehaviorPatch
                 Logger.Error(ex, "Failed to update party behavior for {StringId}", mobileParty.StringId);
             }
         }
+    }
+}
+
+/// <summary>
+/// Keeps client AI calculation from applying provisional behavior before the server accepts it.
+/// </summary>
+[HarmonyPatch(typeof(MobileParty), "SetShortTermBehavior")]
+internal static class MobilePartyShortTermBehaviorPatches
+{
+    [HarmonyPrefix]
+    internal static bool SetShortTermBehaviorPrefix()
+    {
+        if (!PartyBehaviorPatch.IsClientBehaviorCalculation) return true;
+
+        return CallOriginalPolicy.IsOriginalAllowed();
     }
 }


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

A player's party can switch its movement target locally during recalculation before the server accepts the change. This can leave the client showing a different target and produce repeated managed-property errors.

## What is the new behavior?

A player's recalculated movement target is applied only after the server accepts it. Player movement commands continue to work normally.

Resolves #1732
