### PR TITLE
fixed unpaidwages morale

### DIFF
--- a/source/GameInterface/Services/Clans/Patches/ClanDefaultClanFinanceModelPatches.cs
+++ b/source/GameInterface/Services/Clans/Patches/ClanDefaultClanFinanceModelPatches.cs
@@ -1,0 +1,33 @@
+﻿using GameInterface.Services.Clans.Extensions;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.GameComponents;
+using TaleWorlds.CampaignSystem.Party;
+
+namespace GameInterface.Services.Clans.Patches;
+
+[HarmonyPatch(typeof(DefaultClanFinanceModel))]
+internal class ClanDefaultClanFinanceModelPatches
+{
+    [HarmonyPatch(nameof(DefaultClanFinanceModel.AddExpenseFromLeaderParty))]
+    [HarmonyPrefix]
+    private static bool AddExpenseFromLeaderPartyPrefix(DefaultClanFinanceModel __instance, Clan clan, ExplainedNumber goldChange, bool applyWithdrawals, ref int __result)
+    {
+        Hero leader = clan.Leader;
+        MobileParty mobileParty = (leader != null) ? leader.PartyBelongedTo : null;
+        if (mobileParty != null)
+        {
+            int num = clan.Gold + (int)goldChange.ResultNumber;
+            if (num < 2000 && applyWithdrawals && !clan.IsPlayerClan()) // Vanilla runs clan != Clan.PlayerClan, which is always true on server
+            {
+                num = 0;
+            }
+            __result = -__instance.CalculatePartyWage(mobileParty, num, applyWithdrawals);
+        }
+        else
+        {
+            __result = 0;
+        }
+        return false;
+    }
+}

--- a/source/GameInterface/Services/MobileParties/Commands/MobilePartyDebugCommand.cs
+++ b/source/GameInterface/Services/MobileParties/Commands/MobilePartyDebugCommand.cs
@@ -42,9 +42,9 @@ internal class MobilePartyDebugCommand
         stringBuilder.AppendLine($"MobileParty info for: {SafeToString(mobileParty)}");
         stringBuilder.AppendLine($"StringID: {SafeToString(mobileParty.StringId)}");
         stringBuilder.AppendLine($"Name: {SafeToString(mobileParty.Name)}");
-        stringBuilder.AppendLine($"morale : {mobileParty.Morale}");
-        stringBuilder.AppendLine($"recentmorale : {mobileParty.RecentEventsMorale}");
-        stringBuilder.AppendLine($"unpaidwage : {mobileParty.HasUnpaidWages}");
+        stringBuilder.AppendLine($"Morale: {mobileParty.Morale}");
+        stringBuilder.AppendLine($"RecentEventsMorale: {mobileParty.RecentEventsMorale}");
+        stringBuilder.AppendLine($"HasUnpaidWages: {mobileParty.HasUnpaidWages}");
         stringBuilder.AppendLine();
 
         stringBuilder.AppendLine("Fields:");

--- a/source/GameInterface/Services/MobileParties/Commands/MobilePartyDebugCommand.cs
+++ b/source/GameInterface/Services/MobileParties/Commands/MobilePartyDebugCommand.cs
@@ -42,6 +42,9 @@ internal class MobilePartyDebugCommand
         stringBuilder.AppendLine($"MobileParty info for: {SafeToString(mobileParty)}");
         stringBuilder.AppendLine($"StringID: {SafeToString(mobileParty.StringId)}");
         stringBuilder.AppendLine($"Name: {SafeToString(mobileParty.Name)}");
+        stringBuilder.AppendLine($"morale : {mobileParty.Morale}");
+        stringBuilder.AppendLine($"recentmorale : {mobileParty.RecentEventsMorale}");
+        stringBuilder.AppendLine($"unpaidwage : {mobileParty.HasUnpaidWages}");
         stringBuilder.AppendLine();
 
         stringBuilder.AppendLine("Fields:");


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ x ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ x ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Playerparty keeps losing morale for unpaidwages, while they have been paying and have enough gold

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #1742 
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
PlayerParty doesnt lose morale for unpaidwages when they have enough money

## Other information
This happened because in `AddExpenseFromLeaderParty` gets called which checks `if (num < 2000 && applyWithdrawals && clan != Clan.PlayerClan)`, which sets the budget to 0 when an ai party has less than 2000 gold. Unfortunately, ` clan != Clan.PlayerClan` is always true on the server, setting the playerparty's budget to 0.
Unable to replicate losing morale after battle. Tried fighting over 10 parties, and never lost morale when winning.