### PR TITLE
[1699] Assign puppets to their formation so hostile formation icons and orders work for every client

### DIFF
--- a/source/Missions/Battles/AgentFormationAssigner.cs
+++ b/source/Missions/Battles/AgentFormationAssigner.cs
@@ -1,0 +1,28 @@
+using TaleWorlds.MountAndBlade;
+
+namespace Missions.Battles;
+
+/// <summary>
+/// The one copy of "slot this agent into its team's formation for its troop class" every spawn path needs.
+/// Vanilla's Alt-hold/order-screen formation marker VM (and order-targeting) key off
+/// <c>Formation.CountOfUnits</c>, which only counts members actually assigned via <c>Agent.Formation</c> — an
+/// agent left off its formation is invisible to both even though it's a real, fighting member of the side.
+/// </summary>
+public static class AgentFormationAssigner
+{
+    /// <summary>
+    /// Assign <paramref name="agent"/> to its team's formation for its character's troop class. Returns the
+    /// formation (for a caller that needs it, e.g. to also call <c>SetControlledByAI</c>), or null if the
+    /// agent has no character/team yet or its team has no matching formation.
+    /// </summary>
+    public static Formation Assign(Agent agent)
+    {
+        if (agent.Character == null || agent.Team == null) return null;
+
+        var formation = agent.Team.GetFormation(agent.Character.GetFormationClass());
+        if (formation != null)
+            agent.Formation = formation;
+
+        return formation;
+    }
+}

--- a/source/Missions/Battles/AgentFormationAssigner.cs
+++ b/source/Missions/Battles/AgentFormationAssigner.cs
@@ -8,14 +8,20 @@ namespace Missions.Battles;
 /// assigned via <c>Agent.Formation</c> — an agent left off its formation is invisible to both even though
 /// it's a real, fighting member of the side.
 /// </summary>
-public static class AgentFormationAssigner
+public interface IAgentFormationAssigner
 {
     /// <summary>
     /// Assign <paramref name="agent"/> to its team's formation for its character's troop class. Returns the
     /// formation (for a caller that needs it, e.g. to also call <c>SetControlledByAI</c>), or null if the
     /// agent has no character/team yet or its team has no matching formation.
     /// </summary>
-    public static Formation Assign(Agent agent)
+    Formation Assign(Agent agent);
+}
+
+/// <inheritdoc cref="IAgentFormationAssigner"/>
+public class AgentFormationAssigner : IAgentFormationAssigner
+{
+    public Formation Assign(Agent agent)
     {
         if (agent.Character == null || agent.Team == null) return null;
 

--- a/source/Missions/Battles/AgentFormationAssigner.cs
+++ b/source/Missions/Battles/AgentFormationAssigner.cs
@@ -3,10 +3,10 @@ using TaleWorlds.MountAndBlade;
 namespace Missions.Battles;
 
 /// <summary>
-/// The one copy of "slot this agent into its team's formation for its troop class" every spawn path needs.
-/// Vanilla's Alt-hold/order-screen formation marker VM (and order-targeting) key off
-/// <c>Formation.CountOfUnits</c>, which only counts members actually assigned via <c>Agent.Formation</c> — an
-/// agent left off its formation is invisible to both even though it's a real, fighting member of the side.
+/// Slots an agent into its team's formation for its troop class. Vanilla's Alt-hold/order-screen formation
+/// marker VM (and order-targeting) key off <c>Formation.CountOfUnits</c>, which only counts members actually
+/// assigned via <c>Agent.Formation</c> — an agent left off its formation is invisible to both even though
+/// it's a real, fighting member of the side.
 /// </summary>
 public static class AgentFormationAssigner
 {

--- a/source/Missions/Battles/BattleAuthorityMigrator.cs
+++ b/source/Missions/Battles/BattleAuthorityMigrator.cs
@@ -41,6 +41,7 @@ public class BattleAuthorityMigrator : IBattleAuthorityMigrator
     private readonly IBattleSession session;
     private readonly ICasualtyAttributionMap casualties;
     private readonly IBattleDeploymentCoordinator deployment;
+    private readonly IAgentFormationAssigner formationAssigner;
 
     // Hosts that RETREATED (graceful leave) — read when the promotion lands so the adoption knows to leave the
     // retreater's own-party troops to the despawn instead of adopting them. Only touched from broker handlers,
@@ -56,7 +57,8 @@ public class BattleAuthorityMigrator : IBattleAuthorityMigrator
         ICoopMissionComponent coopMissionComponent,
         IBattleSession session,
         ICasualtyAttributionMap casualties,
-        IBattleDeploymentCoordinator deployment)
+        IBattleDeploymentCoordinator deployment,
+        IAgentFormationAssigner formationAssigner)
     {
         this.relayNetwork = relayNetwork;
         this.messageBroker = messageBroker;
@@ -66,6 +68,7 @@ public class BattleAuthorityMigrator : IBattleAuthorityMigrator
         this.session = session;
         this.casualties = casualties;
         this.deployment = deployment;
+        this.formationAssigner = formationAssigner;
 
         messageBroker.Subscribe<NetworkMissionPeerEntered>(Handle_PeerEntered);
         messageBroker.Subscribe<MissionPeerLeft>(Handle_PeerLeft);
@@ -359,9 +362,9 @@ public class BattleAuthorityMigrator : IBattleAuthorityMigrator
     // command: place it in its team's formation for its troop class and hand it to the engine AI so it
     // maneuvers and fights like the host's own AI troops. The formation is set AI-controlled because in a
     // coop battle the host fights as a hero, not a general, so nothing would otherwise order it to engage.
-    private static void ConvertPuppetToHostAi(Agent agent)
+    private void ConvertPuppetToHostAi(Agent agent)
     {
-        AgentFormationAssigner.Assign(agent)?.SetControlledByAI(true);
+        formationAssigner.Assign(agent)?.SetControlledByAI(true);
 
         agent.Controller = AgentControllerType.AI;
 

--- a/source/Missions/Battles/BattleAuthorityMigrator.cs
+++ b/source/Missions/Battles/BattleAuthorityMigrator.cs
@@ -361,15 +361,7 @@ public class BattleAuthorityMigrator : IBattleAuthorityMigrator
     // coop battle the host fights as a hero, not a general, so nothing would otherwise order it to engage.
     private static void ConvertPuppetToHostAi(Agent agent)
     {
-        if (agent.Character != null && agent.Team != null)
-        {
-            var formation = agent.Team.GetFormation(agent.Character.GetFormationClass());
-            if (formation != null)
-            {
-                agent.Formation = formation;
-                formation.SetControlledByAI(true);
-            }
-        }
+        AgentFormationAssigner.Assign(agent)?.SetControlledByAI(true);
 
         agent.Controller = AgentControllerType.AI;
 

--- a/source/Missions/Battles/CoopBattleController.cs
+++ b/source/Missions/Battles/CoopBattleController.cs
@@ -70,7 +70,8 @@ public class CoopBattleController : CoopMissionController
         IObjectManager objectManager,
         IPlayerManager playerManager,
         ICoopMissionComponent coopMissionComponent,
-        IBattleHostRegistry hostRegistry)
+        IBattleHostRegistry hostRegistry,
+        IAgentFormationAssigner formationAssigner)
         : base(network, messageBroker, objectManager, coopMissionComponent)
     {
         var session = new BattleSession(controllerIdProvider, hostRegistry);
@@ -81,11 +82,11 @@ public class CoopBattleController : CoopMissionController
         lifecycle = new BattleInstanceLifecycle(network, relayNetwork, messageBroker, objectManager, coopMissionComponent, session);
         replicator = new OwnedAgentReplicator(network, messageBroker, objectManager, coopMissionComponent, session, casualties, deployment);
         deathReporter = new AgentDeathReporter(network, relayNetwork, messageBroker, objectManager, coopMissionComponent, session, casualties);
-        puppetSpawner = new PuppetSpawner(messageBroker, objectManager, coopMissionComponent, session, casualties, deployment);
+        puppetSpawner = new PuppetSpawner(messageBroker, objectManager, coopMissionComponent, session, casualties, deployment, formationAssigner);
         puppetDeathApplier = new PuppetDeathApplier(messageBroker, coopMissionComponent, casualties);
         damageRouter = new BattleDamageRouter(network, messageBroker, coopMissionComponent, session);
-        authorityMigrator = new BattleAuthorityMigrator(relayNetwork, messageBroker, objectManager, playerManager, coopMissionComponent, session, casualties, deployment);
-        reinforcementFielder = new ReinforcementFielder(messageBroker, objectManager, session, deployment);
+        authorityMigrator = new BattleAuthorityMigrator(relayNetwork, messageBroker, objectManager, playerManager, coopMissionComponent, session, casualties, deployment, formationAssigner);
+        reinforcementFielder = new ReinforcementFielder(messageBroker, objectManager, session, deployment, formationAssigner);
         supplyReporter = new SupplyProgressReporter(relayNetwork, session);
 
         Session = session;

--- a/source/Missions/Battles/PuppetSpawner.cs
+++ b/source/Missions/Battles/PuppetSpawner.cs
@@ -44,6 +44,7 @@ public class PuppetSpawner : IPuppetSpawner
     private readonly IBattleSession session;
     private readonly ICasualtyAttributionMap casualties;
     private readonly IBattleDeploymentCoordinator deployment;
+    private readonly IAgentFormationAssigner formationAssigner;
 
     // Puppet spawns from the host's catch-up burst can arrive while THIS client's mission is still loading
     // (before MissionCombatantsLogic creates the teams). An agent built with a null team later NREs the
@@ -58,7 +59,8 @@ public class PuppetSpawner : IPuppetSpawner
         ICoopMissionComponent coopMissionComponent,
         IBattleSession session,
         ICasualtyAttributionMap casualties,
-        IBattleDeploymentCoordinator deployment)
+        IBattleDeploymentCoordinator deployment,
+        IAgentFormationAssigner formationAssigner)
     {
         this.messageBroker = messageBroker;
         this.objectManager = objectManager;
@@ -66,6 +68,7 @@ public class PuppetSpawner : IPuppetSpawner
         this.session = session;
         this.casualties = casualties;
         this.deployment = deployment;
+        this.formationAssigner = formationAssigner;
 
         messageBroker.Subscribe<NetworkSpawnBattleAgents>(Handle_NetworkSpawnBattleAgents);
     }
@@ -167,7 +170,7 @@ public class PuppetSpawner : IPuppetSpawner
         agent.FadeIn();
         if (data.Health > 0) agent.Health = data.Health;
 
-        AgentFormationAssigner.Assign(agent);
+        formationAssigner.Assign(agent);
 
         // Adopt our own hero as the controllable main agent of this mission.
         if (isOwnAgent)

--- a/source/Missions/Battles/PuppetSpawner.cs
+++ b/source/Missions/Battles/PuppetSpawner.cs
@@ -167,8 +167,6 @@ public class PuppetSpawner : IPuppetSpawner
         agent.FadeIn();
         if (data.Health > 0) agent.Health = data.Health;
 
-        // Without this a puppet's Formation stays null, so its icon and order-targeting never appear on this
-        // client even though the side is fully populated.
         AgentFormationAssigner.Assign(agent);
 
         // Adopt our own hero as the controllable main agent of this mission.

--- a/source/Missions/Battles/PuppetSpawner.cs
+++ b/source/Missions/Battles/PuppetSpawner.cs
@@ -167,6 +167,10 @@ public class PuppetSpawner : IPuppetSpawner
         agent.FadeIn();
         if (data.Health > 0) agent.Health = data.Health;
 
+        // Without this a puppet's Formation stays null, so its icon and order-targeting never appear on this
+        // client even though the side is fully populated.
+        AgentFormationAssigner.Assign(agent);
+
         // Adopt our own hero as the controllable main agent of this mission.
         if (isOwnAgent)
         {

--- a/source/Missions/Battles/ReinforcementFielder.cs
+++ b/source/Missions/Battles/ReinforcementFielder.cs
@@ -36,6 +36,7 @@ public class ReinforcementFielder : IReinforcementFielder
     private readonly IObjectManager objectManager;
     private readonly IBattleSession session;
     private readonly IBattleDeploymentCoordinator deployment;
+    private readonly IAgentFormationAssigner formationAssigner;
 
     // [Host] Map-event party ids we have already fielded as mid-battle reinforcements, so a repeated involved-
     // parties broadcast for the same party doesn't double-spawn it.
@@ -45,12 +46,14 @@ public class ReinforcementFielder : IReinforcementFielder
         IMessageBroker messageBroker,
         IObjectManager objectManager,
         IBattleSession session,
-        IBattleDeploymentCoordinator deployment)
+        IBattleDeploymentCoordinator deployment,
+        IAgentFormationAssigner formationAssigner)
     {
         this.messageBroker = messageBroker;
         this.objectManager = objectManager;
         this.session = session;
         this.deployment = deployment;
+        this.formationAssigner = formationAssigner;
 
         // [Host] A new AI party joining the live battle is fielded through our own spawn path (reinforcements).
         messageBroker.Subscribe<NetworkAddInvolvedParties>(Handle_ReinforcementPartiesAdded);
@@ -159,7 +162,7 @@ public class ReinforcementFielder : IReinforcementFielder
 
     // [Host, game thread] Spawn one reinforcement troop AI-controlled. With no InitialPosition set, the engine
     // positions it at the side's reinforcement spawn frame; we then drop it into its troop-class formation.
-    private static Agent SpawnReinforcementTroop(Mission mission, Team team, CharacterObject character, PartyBase party)
+    private Agent SpawnReinforcementTroop(Mission mission, Team team, CharacterObject character, PartyBase party)
     {
         var origin = new CoopAgentOrigin(character, party, -1, null, new UniqueTroopDescriptor(MBRandom.RandomInt(int.MaxValue)));
         var equipment = character.IsHero ? character.HeroObject.BattleEquipment : character.Equipment;
@@ -177,7 +180,7 @@ public class ReinforcementFielder : IReinforcementFielder
         var agent = mission.SpawnAgent(buildData);
         agent.FadeIn();
 
-        AgentFormationAssigner.Assign(agent);
+        formationAssigner.Assign(agent);
 
         // Wake the AI exactly as the adopt and NPC-release paths do. Without this the reinforcement is
         // AI-controlled but NOT alarmed and holds stale enemy caches, so it ignores its formation's Charge order

--- a/source/Missions/Battles/ReinforcementFielder.cs
+++ b/source/Missions/Battles/ReinforcementFielder.cs
@@ -177,12 +177,7 @@ public class ReinforcementFielder : IReinforcementFielder
         var agent = mission.SpawnAgent(buildData);
         agent.FadeIn();
 
-        if (agent.Character != null && agent.Team != null)
-        {
-            var formation = agent.Team.GetFormation(agent.Character.GetFormationClass());
-            if (formation != null)
-                agent.Formation = formation;
-        }
+        AgentFormationAssigner.Assign(agent);
 
         // Wake the AI exactly as the adopt and NPC-release paths do. Without this the reinforcement is
         // AI-controlled but NOT alarmed and holds stale enemy caches, so it ignores its formation's Charge order

--- a/source/Missions/MissionModule.cs
+++ b/source/Missions/MissionModule.cs
@@ -92,6 +92,10 @@ public class MissionModule : Module
             .InstancePerLifetimeScope()
             .AutoActivate();
 
+        // Slots spawned agents into their team formation so vanilla's formation markers/order-targeting see
+        // them. Injected into the battle spawn sub-services (stateless, so transient lifetime is moot).
+        builder.RegisterType<AgentFormationAssigner>().As<IAgentFormationAssigner>().InstancePerDependency();
+
         builder.RegisterType<NetworkAgentRegistry>().As<INetworkAgentRegistry>().InstancePerLifetimeScope();
         //builder.RegisterType<NetworkMissileRegistry>().As<INetworkMissileRegistry>().InstancePerDependency();
         builder.RegisterType<MissileHandler>().As<IMissileHandler>().InstancePerDependency();


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Players who aren't the one simulating a field battle's enemy/AI side can't see hostile formation icons when holding Alt or opening the command/order screen, and can't select an enemy formation to give it orders, even though the battle is fully populated for them and they can see and fight the individual enemy troops.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #1699
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Hostile formation icons appear and are orderable for every client in the battle, the same as for the client actually simulating that side.

## Other information
