### PR TITLE
[1728] Route mount hits through the rider's owner

### DIFF
--- a/source/GameInterface/Services/MapEvents/Messages/BattlePuppetHit.cs
+++ b/source/GameInterface/Services/MapEvents/Messages/BattlePuppetHit.cs
@@ -13,18 +13,22 @@ namespace GameInterface.Services.MapEvents.Messages;
 /// </summary>
 public record BattlePuppetHit : IEvent
 {
-    /// <summary>The puppet that was hit (owned by another client).</summary>
+    /// <summary>The puppet that was hit, or (for a mount hit) the puppet riding it — mounts are never
+    /// registered/puppet-gated themselves, so ownership is always resolved through a rider.</summary>
     public Agent Victim { get; }
     /// <summary>The local attacker, resolved from <c>blow.OwnerId</c>; null if it couldn't be resolved.</summary>
     public Agent Attacker { get; }
     public Blow Blow { get; }
     public AttackCollisionData CollisionData { get; }
+    /// <summary>True when the actual target of the blow is <see cref="Victim"/>'s mount, not the rider itself.</summary>
+    public bool IsMount { get; }
 
-    public BattlePuppetHit(Agent victim, Agent attacker, Blow blow, AttackCollisionData collisionData)
+    public BattlePuppetHit(Agent victim, Agent attacker, Blow blow, AttackCollisionData collisionData, bool isMount = false)
     {
         Victim = victim;
         Attacker = attacker;
         Blow = blow;
         CollisionData = collisionData;
+        IsMount = isMount;
     }
 }

--- a/source/GameInterface/Services/MapEvents/Patches/BattleBlowInterceptPatch.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/BattleBlowInterceptPatch.cs
@@ -18,6 +18,10 @@ namespace GameInterface.Services.MapEvents.Patches;
 /// Puppets are inert (never attack), so every blow originates from a locally-controlled agent — only the
 /// VICTIM's ownership matters here.
 /// </para>
+/// <para>
+/// Mounts are never registered/puppet-gated themselves, so a blow against a horse is keyed off its rider's
+/// ownership instead.
+/// </para>
 /// </summary>
 [HarmonyPatch(typeof(Agent), nameof(Agent.RegisterBlow))]
 internal class BattleBlowInterceptPatch
@@ -28,10 +32,16 @@ internal class BattleBlowInterceptPatch
         if (!BattleSpawnConfig.Enabled) return true;
         if (!BattleSpawnGate.IsCoopBattleActive) return true;
 
+        if (__instance == null) return true;
+
         // A puppet is an agent this client does not own: own troops are AI-controlled and the own hero is
-        // Player; every replicated puppet is spawned with AgentControllerType.None. Non-puppet victims take
-        // the blow locally as usual.
-        if (__instance == null || !__instance.IsHuman || __instance.Controller != AgentControllerType.None)
+        // Player; every replicated puppet is spawned with AgentControllerType.None. A mount is never itself
+        // registered/puppet-gated, so route it off its rider's ownership instead.
+        bool isMount = !__instance.IsHuman;
+        Agent puppet = isMount ? __instance.RiderAgent : __instance;
+
+        // A masterless horse, or one carrying our own rider, has no ownership conflict — take the blow locally.
+        if (puppet == null || puppet.Controller != AgentControllerType.None)
             return true;
 
         // Suppress locally and route the WHOLE blow (+ collision data) to the puppet's owner, which re-applies
@@ -40,7 +50,7 @@ internal class BattleBlowInterceptPatch
         if (blow.InflictedDamage > 0)
         {
             var attacker = Mission.Current?.FindAgentWithIndex(blow.OwnerId);
-            MessageBroker.Instance.Publish(__instance, new BattlePuppetHit(__instance, attacker, blow, collisionData));
+            MessageBroker.Instance.Publish(__instance, new BattlePuppetHit(puppet, attacker, blow, collisionData, isMount));
         }
         return false;
     }

--- a/source/Missions/Battles/BattleDamageRouter.cs
+++ b/source/Missions/Battles/BattleDamageRouter.cs
@@ -70,14 +70,15 @@ public class BattleDamageRouter : IBattleDamageRouter
             if (payload.What.Attacker != null && registry.TryGetAgentInfo(payload.What.Attacker, out var attackerInfo))
                 attackerId = attackerInfo.AgentId;
 
-            Logger.Information("[DeathDiag] Routing puppet hit to owner {Owner}: victim={Victim}, dmg={Dmg}", victimInfo.CurrentAuthority, victimInfo.AgentId, payload.What.Blow.InflictedDamage);
-            network.SendAll(new NetworkApplyBattleDamage(victimInfo.AgentId, attackerId, payload.What.Blow, payload.What.CollisionData));
+            Logger.Information("[DeathDiag] Routing puppet hit to owner {Owner}: victim={Victim}, dmg={Dmg}, mount={IsMount}", victimInfo.CurrentAuthority, victimInfo.AgentId, payload.What.Blow.InflictedDamage, payload.What.IsMount);
+            network.SendAll(new NetworkApplyBattleDamage(victimInfo.AgentId, attackerId, payload.What.Blow, payload.What.CollisionData, payload.What.IsMount));
         });
     }
 
-    // [Owner] Another client's troop hit one of OUR agents. Re-apply the real blow through Agent.RegisterBlow so
-    // the engine resolves damage, hit reaction, ragdoll and (if lethal) death — the death then flows through
-    // Agent.Die -> BattleAgentDiedPatch -> the normal death/casualty sync. Non-owners ignore it. No synthetic blow.
+    // [Owner] Another client's troop hit one of OUR agents (or, for a mount hit, one of our riders' horses — a
+    // mount is never itself registered, so it's addressed via its rider's agent id). Re-apply the real blow
+    // through Agent.RegisterBlow so the engine resolves damage, hit reaction, ragdoll and (if lethal) death,
+    // which BattleAgentDiedPatch picks up for the normal death/casualty sync. Non-owners ignore it. No synthetic blow.
     private void Handle_NetworkApplyBattleDamage(MessagePayload<NetworkApplyBattleDamage> payload)
     {
         var registry = coopMissionComponent.AgentRegistry;
@@ -87,7 +88,7 @@ public class BattleDamageRouter : IBattleDamageRouter
             if (!registry.TryGetAgentInfo(payload.What.VictimAgentId, out var info)) return;
             if (info.CurrentAuthority != session.OwnControllerId) return;
 
-            var victim = info.Agent;
+            var victim = payload.What.IsMount ? info.Agent?.MountAgent : info.Agent;
             var blow = payload.What.Blow;
             var collisionData = payload.What.CollisionData;
             var attackerId = payload.What.AttackerAgentId;

--- a/source/Missions/Messages/NetworkApplyBattleDamage.cs
+++ b/source/Missions/Messages/NetworkApplyBattleDamage.cs
@@ -31,12 +31,17 @@ public class NetworkApplyBattleDamage : IEvent
     public Blow Blow { get; }
     [ProtoMember(4)]
     public AttackCollisionData CollisionData { get; }
+    /// <summary>True when the blow targets <see cref="VictimAgentId"/>'s mount, not the rider itself — mounts
+    /// are never registered/puppet-gated, so a mount hit is routed through its rider's ownership instead.</summary>
+    [ProtoMember(5)]
+    public bool IsMount { get; }
 
-    public NetworkApplyBattleDamage(Guid victimAgentId, Guid attackerAgentId, Blow blow, AttackCollisionData collisionData)
+    public NetworkApplyBattleDamage(Guid victimAgentId, Guid attackerAgentId, Blow blow, AttackCollisionData collisionData, bool isMount = false)
     {
         VictimAgentId = victimAgentId;
         AttackerAgentId = attackerAgentId;
         Blow = blow;
         CollisionData = collisionData;
+        IsMount = isMount;
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

After a client kills the horse under an enemy rider, the horse dies only on that client's own screen. Every other machine — including the rider's real owner — still shows the owner reporting itself mounted, so the rider keeps sliding around at horse speed (or snaps back onto the dead horse) instead of dismounting, on every machine but the killer's.

## What is the new behavior?

Resolves #1728

A hit against a horse is now routed to the horse's rider's real owner the same way a hit against a human puppet already is, so the kill is decided once, by the owner, instead of independently on whichever client's local swing happens to land it. Once the owner's own copy of the rider properly dismounts, every other client's existing movement sync picks that up and dismounts its copy too — the rider now walks at normal foot speed everywhere, not just on the client that struck the blow.

A horse with no rider, or one carrying your own troop, still resolves the same as before (no behavior change there).

## Other information

Filed #1750 to track two known follow-ups from this fix's review, both from the same root cause (mounts have no cross-client identity of their own — routing is keyed off the rider instead): a narrow remount-timing race that could misapply damage to the wrong horse, and lethal mount deaths not being broadcast to peers (so a killed horse can be left standing, riderless, on non-owner clients even though the rider correctly dismounts).