### PR TITLE
[1648] Dispose remaining per-mission sync handlers at mission teardown

### DIFF
--- a/source/Missions/CoopMissionController.cs
+++ b/source/Missions/CoopMissionController.cs
@@ -98,6 +98,15 @@ public abstract class CoopMissionController : MissionBehavior, IDisposable
         coopMissionComponent.AgentMovementHandler.Dispose();
         coopMissionComponent.AgentActionHandler.Dispose();
 
+        // Detach the remaining per-mission sync handlers too. They only unsubscribe from the broker in Dispose
+        // (no poller), so without this their stale subscriptions from a torn-down mission keep handling messages
+        // alongside the next mission's fresh handlers until the GC finalizer runs.
+        coopMissionComponent.MissileHandler.Dispose();
+        coopMissionComponent.WeaponDropHandler.Dispose();
+        coopMissionComponent.WeaponPickupHandler.Dispose();
+        coopMissionComponent.ShieldDamageHandler.Dispose();
+        coopMissionComponent.AgentDeathHandler.Dispose();
+
         OnLeaving();
 
         base.OnEndMission();

--- a/source/Missions/CoopMissionController.cs
+++ b/source/Missions/CoopMissionController.cs
@@ -98,9 +98,6 @@ public abstract class CoopMissionController : MissionBehavior, IDisposable
         coopMissionComponent.AgentMovementHandler.Dispose();
         coopMissionComponent.AgentActionHandler.Dispose();
 
-        // Detach the remaining per-mission sync handlers too. They only unsubscribe from the broker in Dispose
-        // (no poller), so without this their stale subscriptions from a torn-down mission keep handling messages
-        // alongside the next mission's fresh handlers until the GC finalizer runs.
         coopMissionComponent.MissileHandler.Dispose();
         coopMissionComponent.WeaponDropHandler.Dispose();
         coopMissionComponent.WeaponPickupHandler.Dispose();


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

After entering and leaving a few missions (battles, taverns, other locations), some in-mission events start getting handled more than once on the receiving side. A single fired missile, dropped weapon, weapon pickup, shield hit, or agent death can register repeatedly, because handlers from missions that already ended are still listening in the background alongside the current mission's handlers.

## What is the new behavior?

Resolves #1648

Those handlers are now shut off the moment their mission ends, alongside the movement and action handlers that were already cleaned up. Each in-mission event is handled exactly once no matter how many missions have been entered and left during the session.
