### PR TITLE
[1747] Fix duplicate parties shown when hovering a settlement

### DIFF
--- a/source/GameInterface/Services/Settlements/Patches/MobilePartyCachePatch.cs
+++ b/source/GameInterface/Services/Settlements/Patches/MobilePartyCachePatch.cs
@@ -81,8 +81,13 @@ public class MobilePartyCachePatch
             {
                 if (AddMobileParty)
                 {
-                    settlement._partiesCache.Add(party);
-                } 
+                    // The client also gets this membership through the CurrentSettlement AutoSync, so
+                    // guard the Add like vanilla AddMobileParty does, otherwise the party double-lists.
+                    if (!settlement._partiesCache.Contains(party))
+                    {
+                        settlement._partiesCache.Add(party);
+                    }
+                }
                 else
                 {
                     settlement._partiesCache.Remove(party);


### PR DESCRIPTION
## PR Checklist

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Hovering over a town on the campaign map shows the same visiting party listed twice, two identical markers with the same banner and name. It shows up on every client, including the host player's own window. Going inside the settlement shows the party only once, so the duplicate only appears on the map hover.

## What is the new behavior?

Resolves #1747

Hovering the town now lists each party once.
<img width="200" height="207" alt="image" src="https://github.com/user-attachments/assets/9b48ee83-05e2-41e4-85d5-d4a526f64d95" />

