### PR TITLE
[1771] Increase Steam tunnel pump test timeout

### DIFF
--- a/source/Coop.Tests/Steam/SteamTunnelClientTests.cs
+++ b/source/Coop.Tests/Steam/SteamTunnelClientTests.cs
@@ -27,7 +27,7 @@ namespace Coop.Tests.Steam
             var stopwatch = Stopwatch.StartNew();
             while (!condition())
             {
-                Assert.True(stopwatch.ElapsedMilliseconds < 5000, "Pump did not forward within 5s");
+                Assert.True(stopwatch.ElapsedMilliseconds < 10000, "Pump did not forward within 10s");
                 Thread.Sleep(10);
             }
         }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

`SteamTunnelClientTests.DroppableDatagram_IsDroppedNotParkedUnderBackpressure` can fail in CI when the background pump does not forward within the 5 second test timeout.

## What is the new behavior?

Resolves #1771

The test now waits up to 10 seconds before failing, giving loaded CI runs more time for the pump to forward the datagram.