### PR TITLE
Enable PartyRolesCampaignBehavior

### DIFF
--- a/source/GameInterface/Extentions/CampaignObjectManagerExtentions.cs
+++ b/source/GameInterface/Extentions/CampaignObjectManagerExtentions.cs
@@ -1,4 +1,5 @@
-﻿using GameInterface.Services.MobileParties.Extensions;
+﻿using GameInterface.Services.Clans.Extensions;
+using GameInterface.Services.MobileParties.Extensions;
 using System.Collections.Generic;
 using System.Linq;
 using TaleWorlds.CampaignSystem;
@@ -11,6 +12,11 @@ namespace GameInterface.Extentions
         public static List<MobileParty> GetPlayerMobileParties(this CampaignObjectManager campaignObjectManager)
         {
             return campaignObjectManager._mobileParties.Where(party => party.IsPlayerParty()).ToList();
+        }
+
+        public static List<Clan> GetPlayerClans(this CampaignObjectManager campaignObjectManager)
+        {
+            return campaignObjectManager._clans.Where(clan => clan.IsPlayerClan()).ToList();
         }
     }
 }

--- a/source/GameInterface/Services/MobileParties/MobilePartySync.cs
+++ b/source/GameInterface/Services/MobileParties/MobilePartySync.cs
@@ -53,6 +53,8 @@ internal class MobilePartySync : IAutoSync
         autoSyncBuilder.AddProperty(AccessTools.Property(typeof(MobileParty), nameof(MobileParty.Engineer)));
         autoSyncBuilder.AddProperty(AccessTools.Property(typeof(MobileParty), nameof(MobileParty.Quartermaster)));
         autoSyncBuilder.AddProperty(AccessTools.Property(typeof(MobileParty), nameof(MobileParty.Surgeon)));
+        autoSyncBuilder.AddProperty(AccessTools.Property(typeof(MobileParty), nameof(MobileParty.FirstMate)));
+        autoSyncBuilder.AddProperty(AccessTools.Property(typeof(MobileParty), nameof(MobileParty.Navigator)));
         autoSyncBuilder.AddProperty(AccessTools.Property(typeof(MobileParty), nameof(MobileParty.PartyTradeTaxGold)));
         autoSyncBuilder.AddProperty(AccessTools.Property(typeof(MobileParty), nameof(MobileParty.RecentEventsMorale)));
         autoSyncBuilder.AddProperty(AccessTools.Property(typeof(MobileParty), nameof(MobileParty.EventPositionAdder)));

--- a/source/GameInterface/Services/MobileParties/Patches/Disable/DisablePartyRolesCampaignBehavior.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/Disable/DisablePartyRolesCampaignBehavior.cs
@@ -1,11 +1,121 @@
-﻿using HarmonyLib;
+﻿using Common;
+using GameInterface.Extentions;
+using GameInterface.Services.Clans.Extensions;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Party.PartyComponents;
+using TaleWorlds.CampaignSystem.Roster;
+using TaleWorlds.CampaignSystem.Settlements;
 
-namespace GameInterface.Services.MobileParties.Patches;
+namespace GameInterface.Services.MobileParties.Patches.Disable;
 
 [HarmonyPatch(typeof(PartyRolesCampaignBehavior))]
 internal class DisablePartyRolesCampaignBehavior
 {
     [HarmonyPatch(nameof(PartyRolesCampaignBehavior.RegisterEvents))]
-    static bool Prefix() => false;
+    static bool Prefix() => ModInformation.IsServer;
+}
+
+[HarmonyPatch(typeof(PartyRolesCampaignBehavior))]
+internal class PartyRolesCampaignBehaviorPatches
+{
+    [HarmonyPatch(nameof(PartyRolesCampaignBehavior.OnHeroKilled))]
+    [HarmonyPrefix]
+    public static bool OnHeroKilledPrefix(PartyRolesCampaignBehavior __instance, Hero victim)
+    {
+        if (victim.Clan == null || !victim.Clan.IsPlayerClan()) return false;
+
+        __instance.RemoveAllPartyRolesOfHeroIfExist(victim);
+
+        return false;
+    }
+
+    [HarmonyPatch(nameof(PartyRolesCampaignBehavior.OnHeroPrisonerTaken))]
+    [HarmonyPrefix]
+    public static bool OnHeroPrisonerTakenPrefix(PartyRolesCampaignBehavior __instance, PartyBase party, Hero prisoner)
+    {
+        if (prisoner.Clan == null || !prisoner.Clan.IsPlayerClan()) return false;
+
+        __instance.RemoveAllPartyRolesOfHeroIfExist(prisoner);
+
+        return false;
+    }
+
+    [HarmonyPatch(nameof(PartyRolesCampaignBehavior.OnGovernorChanged))]
+    [HarmonyPrefix]
+    public static bool OnGovernorChangedPrefix(PartyRolesCampaignBehavior __instance, Town fortification, Hero oldGovernor, Hero newGovernor)
+    {
+        if (newGovernor == null || newGovernor.Clan == null || !newGovernor.Clan.IsPlayerClan()) return false;
+
+        __instance.RemoveAllPartyRolesOfHeroIfExist(newGovernor);
+
+        return false;
+    }
+
+    [HarmonyPatch(nameof(PartyRolesCampaignBehavior.OnPartySpawned))]
+    [HarmonyPrefix]
+    public static bool OnPartySpawnedPrefix(PartyRolesCampaignBehavior __instance, MobileParty spawnedParty)
+    {
+        if (spawnedParty.IsLordParty && spawnedParty.ActualClan != null && spawnedParty.ActualClan.IsPlayerClan())
+        {
+            foreach (TroopRosterElement troopRosterElement in spawnedParty.MemberRoster.GetTroopRoster())
+            {
+                if (troopRosterElement.Character.IsHero)
+                {
+                    __instance.RemoveAllPartyRolesOfHeroIfExist(troopRosterElement.Character.HeroObject);
+                }
+            }
+        }
+
+        return false;
+    }
+
+    [HarmonyPatch(nameof(PartyRolesCampaignBehavior.OnCompanionRemoved))]
+    [HarmonyPrefix]
+    public static bool OnCompanionRemovedPrefix(PartyRolesCampaignBehavior __instance, Hero companion)
+    {
+        __instance.RemoveAllPartyRolesOfHeroIfExist(companion);
+
+        return false;
+    }
+
+    [HarmonyPatch(nameof(PartyRolesCampaignBehavior.OnHeroGetsBusy))]
+    [HarmonyPrefix]
+    public static bool OnHeroGetsBusyPrefix(PartyRolesCampaignBehavior __instance, Hero hero)
+    {
+        if (hero.Clan == null || !hero.Clan.IsPlayerClan()) return false;
+
+        __instance.RemoveAllPartyRolesOfHeroIfExist(hero);
+
+        return false;
+    }
+
+    [HarmonyPatch(nameof(PartyRolesCampaignBehavior.OnHeroChangedClan))]
+    [HarmonyPrefix]
+    public static bool OnHeroChangedClanPrefix(PartyRolesCampaignBehavior __instance, Hero hero, Clan oldClan)
+    {
+        if (oldClan == null || !oldClan.IsPlayerClan()) return false;
+
+        __instance.RemoveAllPartyRolesOfHeroIfExist(hero);
+
+        return false;
+    }
+
+    [HarmonyPatch(nameof(PartyRolesCampaignBehavior.RemoveAllPartyRolesOfHeroIfExist))]
+    [HarmonyPrefix]
+    public static bool RemoveAllPartyRolesOfHeroIfExistPrefix(PartyRolesCampaignBehavior __instance, Hero hero)
+    {
+        // Update for all player clans. Can't use hero.Clan as it could have changed already when this runs
+        foreach (var clan in Campaign.Current.CampaignObjectManager.GetPlayerClans())
+        {
+            foreach (WarPartyComponent warPartyComponent in clan.WarPartyComponents)
+            {
+                warPartyComponent.MobileParty.RemoveAllPartyRolesOfHero(hero);
+            }
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
PartyRolesCampaignBehavior is disabled. This behavior removes existing party roles for heroes when their role in a clan changes such as becoming a governor or leaving a clan.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Behavior enabled and patched to work with all player clans.

## Other information
