### PR TITLE
Enable PartyUpgraderCampaignBehavior

### DIFF
--- a/source/GameInterface/Services/MobileParties/Patches/Disable/DisablePartyUpgraderCampaignBehavior.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/Disable/DisablePartyUpgraderCampaignBehavior.cs
@@ -1,11 +1,46 @@
-﻿using HarmonyLib;
+﻿using Common;
+using GameInterface.Services.MobileParties.Extensions;
+using HarmonyLib;
+using System.Collections.Generic;
+using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
+using TaleWorlds.CampaignSystem.ComponentInterfaces;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Roster;
 
-namespace GameInterface.Services.MobileParties.Patches;
+namespace GameInterface.Services.MobileParties.Patches.Disable;
 
 [HarmonyPatch(typeof(PartyUpgraderCampaignBehavior))]
 internal class DisablePartyUpgraderCampaignBehavior
 {
     [HarmonyPatch(nameof(PartyUpgraderCampaignBehavior.RegisterEvents))]
-    static bool Prefix() => false;
+    static bool Prefix() => ModInformation.IsServer;
+}
+
+[HarmonyPatch(typeof(PartyUpgraderCampaignBehavior))]
+internal class PartyUpgraderCampaignBehaviorPatches
+{
+    [HarmonyPatch(nameof(PartyUpgraderCampaignBehavior.UpgradeReadyTroops))]
+    [HarmonyPrefix]
+    public static bool UpgradeReadyTroopsPrefix(PartyUpgraderCampaignBehavior __instance, PartyBase party)
+    {
+        // Replace MainParty check
+        if ((party.IsMobile && party.MobileParty.IsPlayerParty()) || !party.IsActive) return false;
+
+        TroopRoster memberRoster = party.MemberRoster;
+        PartyTroopUpgradeModel partyTroopUpgradeModel = Campaign.Current.Models.PartyTroopUpgradeModel;
+        for (int i = 0; i < memberRoster.Count; i++)
+        {
+            TroopRosterElement elementCopyAtIndex = memberRoster.GetElementCopyAtIndex(i);
+            if (!partyTroopUpgradeModel.IsTroopUpgradeable(party, elementCopyAtIndex.Character)) continue;
+
+            List<PartyUpgraderCampaignBehavior.TroopUpgradeArgs> possibleUpgradeTargets = __instance.GetPossibleUpgradeTargets(party, elementCopyAtIndex);
+            if (possibleUpgradeTargets.Count <= 0) continue;
+
+            PartyUpgraderCampaignBehavior.TroopUpgradeArgs upgradeArgs = __instance.SelectPossibleUpgrade(possibleUpgradeTargets);
+            __instance.UpgradeTroop(party, i, upgradeArgs);
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
AI parties do not upgrade their troops because `PartyUpgraderCampaignBehavior` is disabled.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
`PartyUpgraderCampaignBehavior` enabled with a patch added to prevent automatically upgrading player parties.

## Other information
