### PR TITLE
Enable DisorganizedStateCampaignBehavior

### DIFF
--- a/source/GameInterface/Services/MapEvents/Patches/Disable/DisableDisorganizedStateCampaignBehavior.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/Disable/DisableDisorganizedStateCampaignBehavior.cs
@@ -1,9 +1,16 @@
-﻿using HarmonyLib;
+﻿using Common;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem.CampaignBehaviors;
 
-namespace GameInterface.Services.Battles.Patches.Disable;
+namespace GameInterface.Services.MapEvents.Patches.Disable;
 
-[HarmonyPatch("DisorganizedStateCampaignBehavior", "RegisterEvents")]
+[HarmonyPatch(typeof(DisorganizedStateCampaignBehavior))]
 internal class DisableDisorganizedStateCampaignBehavior
 {
-    static bool Prefix() => false;
+    // Shouldn't need to patch the uses of MobileParty.MainParty for this campaign behavior.
+    // Vanilla assumes the campaign map will be paused for the duration of a battle with only one player, 
+    // and makes involved parties disorganized at the start of the player MapEvent/battle.
+    // Leaving it like this instead means any involved player parties become disorganized only when a MapEvent ends.
+    [HarmonyPatch(nameof(DisorganizedStateCampaignBehavior.RegisterEvents))]
+    static bool Prefix() => ModInformation.IsServer;
 }


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] New feature (non-breaking change that adds functionality)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In vanilla Bannerlord parties become disorganised after a MapEvent. This is a simple but useful mechanic as disorganised parties move slower, making them much easier to catch up with.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Enabled `DisorganizedStateCampaignBehavior`. We shouldn't need to patch the uses of `MobileParty.MainParty` as explained in the committed comment.

## Other information
