### PR TITLE
Skill xp properly assigned from focus points after character creation

### DIFF
--- a/source/GameInterface/Services/GameState/Patches/AllowCharacterCreationContentPatches.cs
+++ b/source/GameInterface/Services/GameState/Patches/AllowCharacterCreationContentPatches.cs
@@ -1,0 +1,32 @@
+﻿using Common.Util;
+using HarmonyLib;
+using System.Collections.Generic;
+using System.Reflection;
+using TaleWorlds.CampaignSystem.CharacterCreationContent;
+
+namespace GameInterface.Services.GameState.Patches;
+
+/// <summary>
+/// Need to run these methods within AllowedThreads for local modifications to Hero.MainHero.HeroDeveloper
+/// </summary>
+[HarmonyPatch(typeof(CharacterCreationContent))]
+internal class AllowCharacterCreationContentPatches
+{
+    private static IEnumerable<MethodBase> TargetMethods() => new MethodBase[]
+    {
+        AccessTools.Method(typeof(CharacterCreationContent), nameof(CharacterCreationContent.ApplySkillAndAttributeEffects)),
+        AccessTools.Method(typeof(CharacterCreationContent), nameof(CharacterCreationContent.SetMainHeroInitialStats))
+    };
+
+    [HarmonyPrefix]
+    private static void Prefix()
+    {
+        AllowedThread.AllowThisThread();
+    }
+
+    [HarmonyFinalizer]
+    private static void Finalizer()
+    {
+        AllowedThread.RevokeThisThread();
+    }
+}

--- a/source/GameInterface/Services/HeroDevelopers/Patches/ChangeSkillLevelPatch.cs
+++ b/source/GameInterface/Services/HeroDevelopers/Patches/ChangeSkillLevelPatch.cs
@@ -1,5 +1,6 @@
 ﻿using Common.Logging;
 using Common.Messaging;
+using GameInterface.Policies;
 using GameInterface.Services.HeroDevelopers.Messages;
 using HarmonyLib;
 using Serilog;
@@ -17,6 +18,9 @@ namespace GameInterface.Services.HeroDevelopers.Patches
         [HarmonyPrefix]
         public static bool ChangeSkillLevelFromXpChange(ref HeroDeveloper __instance, SkillObject skill, int changeAmount, bool shouldNotify = false)
         {
+            // Call original if we call this function
+            if (CallOriginalPolicy.IsOriginalAllowed()) return true;
+
             // Publish message with data
             var message = new SkillLevelChange(__instance, skill, changeAmount, shouldNotify);
             MessageBroker.Instance.Publish(__instance, message);

--- a/source/GameInterface/Services/HeroDevelopers/Patches/GainRawXpPatch.cs
+++ b/source/GameInterface/Services/HeroDevelopers/Patches/GainRawXpPatch.cs
@@ -1,5 +1,6 @@
 ﻿using Common.Logging;
 using Common.Messaging;
+using GameInterface.Policies;
 using GameInterface.Services.HeroDevelopers.Messages;
 using HarmonyLib;
 using Serilog;
@@ -16,6 +17,9 @@ namespace GameInterface.Services.HeroDevelopers.Patches
         [HarmonyPrefix]
         public static bool GainRawXp(ref HeroDeveloper __instance, float rawXp, bool shouldNotify)
         {
+            // Call original if we call this function
+            if (CallOriginalPolicy.IsOriginalAllowed()) return true;
+
             // Publish message with data
             var message = new RawXpGain(__instance, rawXp, shouldNotify);
             MessageBroker.Instance.Publish(__instance, message);

--- a/source/GameInterface/Services/HeroDevelopers/Patches/SetSkillXpPatch.cs
+++ b/source/GameInterface/Services/HeroDevelopers/Patches/SetSkillXpPatch.cs
@@ -1,5 +1,6 @@
 ﻿using Common.Logging;
 using Common.Messaging;
+using GameInterface.Policies;
 using GameInterface.Services.HeroDevelopers.Messages;
 using HarmonyLib;
 using Serilog;
@@ -17,6 +18,9 @@ namespace GameInterface.Services.HeroDevelopers.Patches
         [HarmonyPrefix]
         public static bool SetSkillXp(ref HeroDeveloper __instance, PropertyObject skill, float value)
         {
+            // Call original if we call this function
+            if (CallOriginalPolicy.IsOriginalAllowed()) return true;
+
             SkillObject skillObject = (SkillObject) skill;
 
             // Publish message with data


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Post character creation is calling patched `HeroDeveloper` methods, resulting in errors because objects can't be resolved on the network at this stage of a client connecting.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #1769 
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Clients now get their starting skill levels and perk points correctly.

Fixed by putting post character creation methods that use `Hero.MainHero.HeroDeveloper` into `AllowedThreads` so local modifications are allowed before sending the created hero data to the server.

## Other information
