### PR TITLE
Fix caravans without leaders initialisation

### DIFF
--- a/source/GameInterface/Services/PartyComponents/Handlers/CaravanPartyComponentHandler.cs
+++ b/source/GameInterface/Services/PartyComponents/Handlers/CaravanPartyComponentHandler.cs
@@ -69,24 +69,17 @@ internal class CaravanPartyComponentHandler : IHandler
     {
         var message = payload.What;
 
-        GameThread.Run(() =>
+        GameThread.RunSafe(() =>
         {
-            try
-            {
-                if (!objectManager.TryGetObjectWithLogging<CaravanPartyComponent>(message.CaravanPartyComponentId, out var instance)) return;
+            if (!objectManager.TryGetObjectWithLogging<CaravanPartyComponent>(message.CaravanPartyComponentId, out var instance)) return;
 
-                Hero owner = null;
-                if (message.OwnerId != null &&
-                    !objectManager.TryGetObjectWithLogging(message.OwnerId, out owner)) return;
+            Hero owner = null;
+            if (message.OwnerId != null &&
+                !objectManager.TryGetObjectWithLogging(message.OwnerId, out owner)) return;
 
-                using (new AllowedThread())
-                {
-                    instance.Owner = owner;
-                }
-            }
-            catch (Exception e)
+            using (new AllowedThread())
             {
-                Logger.Error(e, "Failed to apply NetworkCaravanPartyOwnerChanged");
+                instance.Owner = owner;
             }
         });
     }
@@ -106,21 +99,14 @@ internal class CaravanPartyComponentHandler : IHandler
     {
         var message = payload.What;
 
-        GameThread.Run(() =>
+        GameThread.RunSafe(() =>
         {
-            try
-            {
-                if (!objectManager.TryGetObjectWithLogging<CaravanPartyComponent>(message.CaravanPartyComponentId, out var instance)) return;
-                if (!objectManager.TryGetObjectWithLogging<Settlement>(message.SettlementId, out var settlement)) return;
+            if (!objectManager.TryGetObjectWithLogging<CaravanPartyComponent>(message.CaravanPartyComponentId, out var instance)) return;
+            if (!objectManager.TryGetObjectWithLogging<Settlement>(message.SettlementId, out var settlement)) return;
 
-                using (new AllowedThread())
-                {
-                    instance.Settlement = settlement;
-                }
-            }
-            catch (Exception e)
+            using (new AllowedThread())
             {
-                Logger.Error(e, "Failed to apply NetworkCaravanPartySettlementChanged");
+                instance.Settlement = settlement;
             }
         });
     }
@@ -131,12 +117,14 @@ internal class CaravanPartyComponentHandler : IHandler
         var initArgs = payload.What.InitArgs;
 
         if (!objectManager.TryGetIdWithLogging(instance, out var caravanPartyComponentId)) return;
-        if (!objectManager.TryGetIdWithLogging(initArgs.CaravanLeader, out var caravanLeaderId)) return;
+
+        // caravanLeader may legitimately be null
+        string caravanLeaderId = null;
+        if (initArgs.CaravanLeader != null && !objectManager.TryGetIdWithLogging(initArgs.CaravanLeader, out caravanLeaderId)) return;
 
         string caravanItemRosterId = null;
         if (initArgs.CaravanItems != null && !objectManager.TryGetIdWithLogging(initArgs.CaravanItems, out caravanItemRosterId)) return;
         if (!objectManager.TryGetIdWithLogging(initArgs.PartyTemplateObject, out var partyTemplateObjectId)) return;
-
 
         network.SendAll(new NetworkUpdateCaravanPartyComponentInitArgs(
             caravanPartyComponentId,
@@ -150,27 +138,22 @@ internal class CaravanPartyComponentHandler : IHandler
     {
         var message = payload.What;
 
-        GameThread.Run(() =>
+        GameThread.RunSafe(() =>
         {
-            try
+            if (!objectManager.TryGetObjectWithLogging<CaravanPartyComponent>(message.CaravanPartyComponentId, out var instance)) return;
+
+            Hero caravanLeader = null;
+            if (message.CaravanLeaderId != null && !objectManager.TryGetObjectWithLogging<Hero>(message.CaravanLeaderId, out caravanLeader)) return;
+
+            ItemRoster caravanItems = null;
+            if (message.CaravanItemRosterId != null && !objectManager.TryGetObjectWithLogging<ItemRoster>(message.CaravanItemRosterId, out caravanItems)) return;
+            if (!objectManager.TryGetObjectWithLogging<PartyTemplateObject>(message.PartyTemplateObjectId, out var partyTemplateObject)) return;
+
+            using (new AllowedThread())
             {
-                if (!objectManager.TryGetObjectWithLogging<CaravanPartyComponent>(message.CaravanPartyComponentId, out var instance)) return;
-                if (!objectManager.TryGetObjectWithLogging<Hero>(message.CaravanLeaderId, out var caravanLeader)) return;
+                var initArgs = new CaravanPartyComponent.InitializationArgs(partyTemplateObject, caravanLeader, caravanItems);
 
-                ItemRoster caravanItems = null;
-                if (message.CaravanItemRosterId != null && !objectManager.TryGetObjectWithLogging<ItemRoster>(message.CaravanItemRosterId, out caravanItems)) return;
-                if (!objectManager.TryGetObjectWithLogging<PartyTemplateObject>(message.PartyTemplateObjectId, out var partyTemplateObject)) return;
-
-                using (new AllowedThread())
-                {
-                    var initArgs = new CaravanPartyComponent.InitializationArgs(partyTemplateObject, caravanLeader, caravanItems);
-
-                    instance._initializationArgs = initArgs;
-                }
-            }
-            catch (Exception e)
-            {
-                Logger.Error(e, "Failed to apply NetworkUpdateCaravanPartyComponentInitArgs");
+                instance._initializationArgs = initArgs;
             }
         });
     }


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`CaravanPartyComponentHandler` assumes there is always a caravan leader. Caravan leaders can be legitimately null and when they are it leads to a failed object resolve which blocks the rest of the caravan initialisation for clients.

<img width="2058" height="648" alt="image" src="https://github.com/user-attachments/assets/40b9d71d-5e91-4d22-a310-6f66a79e96af" />


## What is the new behavior?
<!-- Insert issue id after hashtag. -->
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Added check to allow caravans to initialise correctly for clients if the leader is null.

## Other information
