### PR TITLE
[1805] Fix client party movement rubberbanding on midspec computers

### DIFF
--- a/source/Coop.Core/Client/Services/Time/Handlers/CampaignTimeSyncHandler.cs
+++ b/source/Coop.Core/Client/Services/Time/Handlers/CampaignTimeSyncHandler.cs
@@ -1,8 +1,6 @@
-﻿using Common.Logging;
-using Common.Messaging;
+﻿using Common.Messaging;
 using Coop.Core.Server.Services.Time.Messages;
 using GameInterface.Services.Time.Interfaces;
-using Serilog;
 
 namespace Coop.Core.Client.Services.Time.Handlers;
 
@@ -12,8 +10,6 @@ namespace Coop.Core.Client.Services.Time.Handlers;
 /// </summary>
 public class CampaignTimeSyncHandler : IHandler
 {
-    private static readonly ILogger Logger = LogManager.GetLogger<CampaignTimeSyncHandler>();
-
     private readonly IMessageBroker messageBroker;
     private readonly IMapTimeTrackerInterface mapTimeTrackerInterface;
 
@@ -33,8 +29,6 @@ public class CampaignTimeSyncHandler : IHandler
     internal void Handle_CampaignTimeUpdated(MessagePayload<CampaignTimeUpdated> obj)
     {
         var serverTicks = obj.What.ServerTicks;
-
-        Logger.Verbose("Client correcting campaign time toward server tick {ticks}", serverTicks);
 
         mapTimeTrackerInterface.SyncCampaignTime(serverTicks);
     }

--- a/source/Coop.Core/Client/Services/Time/Handlers/CampaignTimeSyncHandler.cs
+++ b/source/Coop.Core/Client/Services/Time/Handlers/CampaignTimeSyncHandler.cs
@@ -1,4 +1,4 @@
-using Common.Logging;
+﻿using Common.Logging;
 using Common.Messaging;
 using Coop.Core.Server.Services.Time.Messages;
 using GameInterface.Services.Time.Interfaces;
@@ -7,8 +7,8 @@ using Serilog;
 namespace Coop.Core.Client.Services.Time.Handlers;
 
 /// <summary>
-/// Receives authoritative campaign time from the server and smoothly corrects
-/// the client's local campaign time toward it.
+/// Receives authoritative campaign time from the server and paces the client's
+/// campaign simulation toward it.
 /// </summary>
 public class CampaignTimeSyncHandler : IHandler
 {

--- a/source/Coop.Core/Server/Services/MobileParties/PacketHandlers/PartyAIBehaviorPacketHandler.cs
+++ b/source/Coop.Core/Server/Services/MobileParties/PacketHandlers/PartyAIBehaviorPacketHandler.cs
@@ -3,8 +3,12 @@ using Common.Network.Coalescing;
 using Common.PacketHandlers;
 using Coop.Core.Server.Services.MobileParties.Messages;
 using Coop.Core.Server.Services.MobileParties.Packets;
+using GameInterface.Services.MobileParties.Data;
 using GameInterface.Services.MobileParties.Messages.Behavior;
+using static GameInterface.Services.ObjectManager.ObjectManager;
 using LiteNetLib;
+using System;
+using TaleWorlds.CampaignSystem.Party;
 
 namespace Coop.Core.Server.Services.MobileParties.PacketHandlers;
 
@@ -56,7 +60,39 @@ internal class RequestMobilePartyBehaviorPacketHandler : IPacketHandler
         var data = payload.What.BehaviorUpdateData;
 
         // Coalesce per party: repeated behavior changes to one party collapse into a single latest-wins send per tick.
-        var key = new CoalesceKey(PartyBehaviorUpdateChannel, data.MobilePartyId);
-        coalescer.Enqueue(key, new LatestWinsPayload(new NetworkUpdatePartyBehavior(data)));
+        var key = new CoalesceKey(PartyBehaviorUpdateChannel, Compact(data.MobilePartyId, typeof(MobileParty)));
+        coalescer.Enqueue(key, new PartyBehaviorCoalescedPayload(data));
+    }
+
+    /// <summary>
+    /// Keeps the latest behavior while retaining server authority across a merged tick.
+    /// </summary>
+    private sealed class PartyBehaviorCoalescedPayload : ICoalescedPayload
+    {
+        private readonly PartyBehaviorUpdateData data;
+
+        public PartyBehaviorCoalescedPayload(PartyBehaviorUpdateData data)
+        {
+            this.data = data;
+        }
+
+        public ICoalescedPayload Merge(ICoalescedPayload incoming)
+        {
+            if (incoming is not PartyBehaviorCoalescedPayload latest)
+            {
+                throw new ArgumentException(
+                    $"Cannot merge {incoming?.GetType().Name ?? "null"} into {nameof(PartyBehaviorCoalescedPayload)}; " +
+                    "a coalesce key must use a single payload type.",
+                    nameof(incoming));
+            }
+
+            var latestData = latest.data;
+            if (string.IsNullOrEmpty(data.OriginControllerId))
+                latestData.OriginControllerId = null;
+
+            return new PartyBehaviorCoalescedPayload(latestData);
+        }
+
+        public IMessage ToMessage() => new NetworkUpdatePartyBehavior(data);
     }
 }

--- a/source/Coop.Core/Server/Services/MobileParties/PacketHandlers/PartyAIBehaviorPacketHandler.cs
+++ b/source/Coop.Core/Server/Services/MobileParties/PacketHandlers/PartyAIBehaviorPacketHandler.cs
@@ -1,13 +1,12 @@
 ﻿using Common.Messaging;
+using Common.Network;
 using Common.Network.Coalescing;
 using Common.PacketHandlers;
 using Coop.Core.Server.Services.MobileParties.Messages;
 using Coop.Core.Server.Services.MobileParties.Packets;
-using GameInterface.Services.MobileParties.Data;
 using GameInterface.Services.MobileParties.Messages.Behavior;
 using static GameInterface.Services.ObjectManager.ObjectManager;
 using LiteNetLib;
-using System;
 using TaleWorlds.CampaignSystem.Party;
 
 namespace Coop.Core.Server.Services.MobileParties.PacketHandlers;
@@ -25,15 +24,18 @@ internal class RequestMobilePartyBehaviorPacketHandler : IPacketHandler
     private readonly IPacketManager packetManager;
     private readonly ISendCoalescer coalescer;
     private readonly IMessageBroker messageBroker;
+    private readonly INetwork network;
 
     public RequestMobilePartyBehaviorPacketHandler(
         IPacketManager packetManager,
         ISendCoalescer coalescer,
-        IMessageBroker messageBroker)
+        IMessageBroker messageBroker,
+        INetwork network)
     {
         this.packetManager = packetManager;
         this.coalescer = coalescer;
         this.messageBroker = messageBroker;
+        this.network = network;
         packetManager.RegisterPacketHandler(this);
 
         messageBroker.Subscribe<PartyBehaviorUpdated>(Handle_PartyBehaviorUpdated);
@@ -61,44 +63,9 @@ internal class RequestMobilePartyBehaviorPacketHandler : IPacketHandler
 
         // Coalesce per party: repeated behavior changes to one party collapse into a single latest-wins send per tick.
         var key = new CoalesceKey(PartyBehaviorUpdateChannel, Compact(data.MobilePartyId, typeof(MobileParty)));
-        coalescer.Enqueue(key, new PartyBehaviorCoalescedPayload(data));
-    }
+        coalescer.Enqueue(key, new LatestWinsPayload(new NetworkUpdatePartyBehavior(data)));
 
-    /// <summary>
-    /// Keeps the latest behavior while retaining server authority across a merged tick.
-    /// </summary>
-    private sealed class PartyBehaviorCoalescedPayload : ICoalescedPayload
-    {
-        private readonly PartyBehaviorUpdateData data;
-
-        public PartyBehaviorCoalescedPayload(PartyBehaviorUpdateData data)
-        {
-            if (string.IsNullOrEmpty(data.OriginControllerId))
-                data.OriginRequestSequence = 0;
-
-            this.data = data;
-        }
-
-        public ICoalescedPayload Merge(ICoalescedPayload incoming)
-        {
-            if (incoming is not PartyBehaviorCoalescedPayload latest)
-            {
-                throw new ArgumentException(
-                    $"Cannot merge {incoming?.GetType().Name ?? "null"} into {nameof(PartyBehaviorCoalescedPayload)}; " +
-                    "a coalesce key must use a single payload type.",
-                    nameof(incoming));
-            }
-
-            var latestData = latest.data;
-            if (string.IsNullOrEmpty(data.OriginControllerId))
-            {
-                latestData.OriginControllerId = null;
-                latestData.OriginRequestSequence = 0;
-            }
-
-            return new PartyBehaviorCoalescedPayload(latestData);
-        }
-
-        public IMessage ToMessage() => new NetworkUpdatePartyBehavior(data);
+        if (data.ForcePosition)
+            coalescer.FlushInstance(key.InstanceId, network);
     }
 }

--- a/source/Coop.Core/Server/Services/MobileParties/PacketHandlers/PartyAIBehaviorPacketHandler.cs
+++ b/source/Coop.Core/Server/Services/MobileParties/PacketHandlers/PartyAIBehaviorPacketHandler.cs
@@ -73,6 +73,9 @@ internal class RequestMobilePartyBehaviorPacketHandler : IPacketHandler
 
         public PartyBehaviorCoalescedPayload(PartyBehaviorUpdateData data)
         {
+            if (string.IsNullOrEmpty(data.OriginControllerId))
+                data.OriginRequestSequence = 0;
+
             this.data = data;
         }
 
@@ -88,7 +91,10 @@ internal class RequestMobilePartyBehaviorPacketHandler : IPacketHandler
 
             var latestData = latest.data;
             if (string.IsNullOrEmpty(data.OriginControllerId))
+            {
                 latestData.OriginControllerId = null;
+                latestData.OriginRequestSequence = 0;
+            }
 
             return new PartyBehaviorCoalescedPayload(latestData);
         }

--- a/source/Coop.Core/Server/Services/MobileParties/Packets/RequestMobilePartyBehaviorPacket.cs
+++ b/source/Coop.Core/Server/Services/MobileParties/Packets/RequestMobilePartyBehaviorPacket.cs
@@ -12,7 +12,7 @@ namespace Coop.Core.Server.Services.MobileParties.Packets;
 public struct RequestMobilePartyBehaviorPacket : IPacket
 {
     public PacketType PacketType => PacketType.RequestUpdatePartyBehavior;
-    public DeliveryMethod DeliveryMethod => DeliveryMethod.ReliableUnordered;
+    public DeliveryMethod DeliveryMethod => DeliveryMethod.ReliableOrdered;
     [ProtoMember(1)]
     public PartyBehaviorUpdateData BehaviorUpdateData { get; }
 

--- a/source/Coop.Core/Server/Services/Time/Handlers/CampaignTimeSyncHandler.cs
+++ b/source/Coop.Core/Server/Services/Time/Handlers/CampaignTimeSyncHandler.cs
@@ -1,4 +1,4 @@
-using Common.Logging;
+﻿using Common.Logging;
 using Common.Messaging;
 using Common.Network;
 using Coop.Core.Server.Services.Time.Messages;
@@ -13,14 +13,14 @@ namespace Coop.Core.Server.Services.Time.Handlers;
 /// Periodically broadcasts the authoritative campaign time to all clients.
 /// </summary>
 /// <remarks>
-/// Once per second the server reads the current <c>MapTimeTracker</c> tick value and
+/// Four times per second the server reads the current <c>MapTimeTracker</c> tick value and
 /// sends a <see cref="CampaignTimeUpdated"/> message to every connected client.
 /// </remarks>
 public class CampaignTimeSyncHandler : IHandler
 {
     private static readonly ILogger Logger = LogManager.GetLogger<CampaignTimeSyncHandler>();
 
-    private const double PublishIntervalMs = 1000d;
+    private const double PublishIntervalMs = 250d;
 
     private readonly INetwork network;
     private readonly IMapTimeTrackerInterface mapTimeTrackerInterface;

--- a/source/Coop.Core/Server/Services/Time/Messages/CampaignTimeUpdated.cs
+++ b/source/Coop.Core/Server/Services/Time/Messages/CampaignTimeUpdated.cs
@@ -1,4 +1,4 @@
-using Common.Messaging;
+﻿using Common.Messaging;
 using ProtoBuf;
 
 namespace Coop.Core.Server.Services.Time.Messages;
@@ -7,8 +7,8 @@ namespace Coop.Core.Server.Services.Time.Messages;
 /// Authoritative campaign time broadcast from the server to all clients.
 /// </summary>
 /// <remarks>
-/// Sent once per second by the server. Clients smoothly interpolate their
-/// local <c>MapTimeTracker</c> tick value toward <see cref="ServerTicks"/>.
+/// Sent four times per second by the server. Clients use it to keep their
+/// campaign simulation paced with the authoritative server.
 /// </remarks>
 [ProtoContract(SkipConstructor = true)]
 public sealed class CampaignTimeUpdated : IEvent

--- a/source/Coop.IntegrationTests/MobileParties/PartyBehaviorTest.cs
+++ b/source/Coop.IntegrationTests/MobileParties/PartyBehaviorTest.cs
@@ -1,11 +1,17 @@
 ﻿using Common.Network;
 using Common.Network.Coalescing;
-using Common.Util;
 using Coop.Core.Server.Services.MobileParties.Messages;
+using Coop.Core.Server.Services.MobileParties.Packets;
 using Coop.IntegrationTests.Environment;
 using Coop.IntegrationTests.Environment.Instance;
+using Coop.IntegrationTests.Environment.Mock;
 using GameInterface.Services.MobileParties.Data;
+using GameInterface.Services.MobileParties.Handlers;
 using GameInterface.Services.MobileParties.Messages.Behavior;
+using LiteNetLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.Library;
 
 namespace Coop.IntegrationTests.MobileParties;
 
@@ -27,7 +33,12 @@ public class PartyBehaviorTest
     public void ControlledPartyBehaviorUpdated_Publishes_Server()
     {
         // Arrange
-        var message = ObjectHelper.SkipConstructor<ControlledPartyBehaviorUpdated>();
+        const string originControllerId = "Controller_1";
+        var data = new PartyBehaviorUpdateData("Test_Party", default, default, default, default, default, default, default, default)
+        {
+            OriginControllerId = originControllerId,
+        };
+        var message = new ControlledPartyBehaviorUpdated(data);
 
         var client1 = TestEnvironment.Clients.First();
         var server = TestEnvironment.Server;
@@ -36,7 +47,12 @@ public class PartyBehaviorTest
         client1.SimulateMessage(this, message);
 
         // Assert
-        Assert.Equal(1, server.InternalMessages.GetMessageCount<UpdatePartyBehavior>());
+        var update = Assert.Single(server.InternalMessages.GetMessages<UpdatePartyBehavior>());
+        Assert.Equal(originControllerId, update.BehaviorUpdateData.OriginControllerId);
+
+        var packet = Assert.Single(client1.Resolve<MockClient>().NetworkSentPackets.GetPackets<RequestMobilePartyBehaviorPacket>());
+        Assert.Equal(DeliveryMethod.ReliableOrdered, packet.DeliveryMethod);
+        Assert.Equal(originControllerId, packet.BehaviorUpdateData.OriginControllerId);
 
         // Only publishes on the server
         foreach (var client in TestEnvironment.Clients)
@@ -78,9 +94,16 @@ public class PartyBehaviorTest
     [Fact]
     public void ServerCoalescesPartyBehaviorUpdates_SendsLatestOnly()
     {
-        // Arrange: two updates for the same party, distinguished by HasTarget so the latest is identifiable.
-        var first = new PartyBehaviorUpdateData("Test_Party", default, default, default, false, default, default, default, default);
-        var latest = new PartyBehaviorUpdateData("Test_Party", default, default, default, true, default, default, default, default);
+        // Arrange
+        const string originControllerId = "Controller_1";
+        var first = new PartyBehaviorUpdateData("Test_Party", AiBehavior.EngageParty, "Test_Target", default, true, default, default, default, default)
+        {
+            OriginControllerId = originControllerId,
+        };
+        var latest = new PartyBehaviorUpdateData("Test_Party", AiBehavior.GoToPoint, null, default, false, default, default, default, default)
+        {
+            OriginControllerId = originControllerId,
+        };
 
         var server = TestEnvironment.Server;
 
@@ -93,15 +116,97 @@ public class PartyBehaviorTest
 
         FlushCoalescer(server);
 
-        // Assert: the two updates for the same party collapse into one send carrying the latest behavior.
+        // Assert
         var sent = Assert.Single(server.NetworkSentMessages.GetMessages<NetworkUpdatePartyBehavior>());
-        Assert.True(sent.BehaviorUpdateData.HasTarget);
+        Assert.Equal(AiBehavior.GoToPoint, sent.BehaviorUpdateData.NewAiBehavior);
+        Assert.Equal(originControllerId, sent.BehaviorUpdateData.OriginControllerId);
+
+        var serialized = server.EnsureSerializable(sent);
+        Assert.Equal(originControllerId, serialized.BehaviorUpdateData.OriginControllerId);
 
         foreach (var client in TestEnvironment.Clients)
         {
             var update = Assert.Single(client.InternalMessages.GetMessages<UpdatePartyBehavior>());
-            Assert.True(update.BehaviorUpdateData.HasTarget);
+            Assert.Equal(AiBehavior.GoToPoint, update.BehaviorUpdateData.NewAiBehavior);
+            Assert.Equal(originControllerId, update.BehaviorUpdateData.OriginControllerId);
         }
+    }
+
+    /// <summary>
+    /// Compact client ids and full server ids share one authoritative latest-wins slot.
+    /// </summary>
+    [Fact]
+    public void ServerCoalescesMixedPartyIds_PreservesLatestAuthoritativeState()
+    {
+        // Arrange
+        const string originControllerId = "Controller_1";
+        const string compactPartyId = "Test_Party";
+        const string fullPartyId = "MobileParty_Test_Party";
+        var gatePosition = new CampaignVec2(new Vec2(42f, 24f), true);
+        var first = new PartyBehaviorUpdateData(compactPartyId, AiBehavior.EngageParty, null, gatePosition, false, gatePosition, default, gatePosition, default)
+        {
+            OriginControllerId = originControllerId,
+        };
+        var authoritative = new PartyBehaviorUpdateData(fullPartyId, AiBehavior.None, null, gatePosition, false, gatePosition, default, gatePosition, default);
+        var latest = new PartyBehaviorUpdateData(compactPartyId, AiBehavior.GoToPoint, null, gatePosition, false, gatePosition, default, gatePosition, default)
+        {
+            OriginControllerId = originControllerId,
+        };
+
+        var server = TestEnvironment.Server;
+
+        // Act
+        server.SimulateMessage(this, new PartyBehaviorUpdated(ref first));
+        server.SimulateMessage(this, new PartyBehaviorUpdated(ref authoritative));
+        server.SimulateMessage(this, new PartyBehaviorUpdated(ref latest));
+        FlushCoalescer(server);
+
+        // Assert
+        var sent = Assert.Single(server.NetworkSentMessages.GetMessages<NetworkUpdatePartyBehavior>());
+        Assert.Equal(AiBehavior.GoToPoint, sent.BehaviorUpdateData.NewAiBehavior);
+        Assert.Null(sent.BehaviorUpdateData.OriginControllerId);
+        AssertPosition(gatePosition, sent.BehaviorUpdateData.PartyPosition);
+
+        var serialized = server.EnsureSerializable(sent);
+        Assert.Null(serialized.BehaviorUpdateData.OriginControllerId);
+        AssertPosition(gatePosition, serialized.BehaviorUpdateData.PartyPosition);
+
+        foreach (var client in TestEnvironment.Clients)
+        {
+            var update = Assert.Single(client.InternalMessages.GetMessages<UpdatePartyBehavior>());
+            Assert.Equal(AiBehavior.GoToPoint, update.BehaviorUpdateData.NewAiBehavior);
+            Assert.Null(update.BehaviorUpdateData.OriginControllerId);
+            AssertPosition(gatePosition, update.BehaviorUpdateData.PartyPosition);
+        }
+    }
+
+    [Fact]
+    public void MatchesPrediction_DistinguishesMapTargets()
+    {
+        var predictedPoint = new CampaignVec2(new Vec2(42f, 24f), true);
+        var stalePoint = new CampaignVec2(new Vec2(12f, 8f), true);
+        var prediction = new PartyBehaviorUpdateData("Test_Party", AiBehavior.GoToPoint, null, predictedPoint, false, default, default, default, default);
+        var matchingEcho = new PartyBehaviorUpdateData("Test_Party", AiBehavior.GoToPoint, null, predictedPoint, false, default, default, default, default);
+        var staleEcho = new PartyBehaviorUpdateData("Test_Party", AiBehavior.GoToPoint, null, stalePoint, false, default, default, default, default);
+
+        Assert.True(MobilePartyBehaviorHandler.MatchesPrediction(matchingEcho, prediction));
+        Assert.False(MobilePartyBehaviorHandler.MatchesPrediction(staleEcho, prediction));
+    }
+
+    [Fact]
+    public void MatchesPrediction_TreatsInvalidTargetsAsEquivalent()
+    {
+        var prediction = new PartyBehaviorUpdateData("Test_Party", AiBehavior.None, null, CampaignVec2.Invalid, false, default, default, default, default);
+        var echo = new PartyBehaviorUpdateData("Test_Party", AiBehavior.None, null, CampaignVec2.Invalid, false, default, default, default, default);
+
+        Assert.True(MobilePartyBehaviorHandler.MatchesPrediction(echo, prediction));
+    }
+
+    private static void AssertPosition(CampaignVec2 expected, CampaignVec2 actual)
+    {
+        Assert.Equal(expected.X, actual.X);
+        Assert.Equal(expected.Y, actual.Y);
+        Assert.Equal(expected.IsOnLand, actual.IsOnLand);
     }
 
     // Drains the server's per-tick coalescer the way CoopServer.Update does, inside the server's

--- a/source/Coop.IntegrationTests/MobileParties/PartyBehaviorTest.cs
+++ b/source/Coop.IntegrationTests/MobileParties/PartyBehaviorTest.cs
@@ -37,7 +37,6 @@ public class PartyBehaviorTest
         var data = new PartyBehaviorUpdateData("Test_Party", default, default, default, default, default, default, default, default)
         {
             OriginControllerId = originControllerId,
-            OriginRequestSequence = 7,
         };
         var message = new ControlledPartyBehaviorUpdated(data);
 
@@ -50,12 +49,10 @@ public class PartyBehaviorTest
         // Assert
         var update = Assert.Single(server.InternalMessages.GetMessages<UpdatePartyBehavior>());
         Assert.Equal(originControllerId, update.BehaviorUpdateData.OriginControllerId);
-        Assert.Equal(7, update.BehaviorUpdateData.OriginRequestSequence);
 
         var packet = Assert.Single(client1.Resolve<MockClient>().NetworkSentPackets.GetPackets<RequestMobilePartyBehaviorPacket>());
         Assert.Equal(DeliveryMethod.ReliableOrdered, packet.DeliveryMethod);
         Assert.Equal(originControllerId, packet.BehaviorUpdateData.OriginControllerId);
-        Assert.Equal(7, packet.BehaviorUpdateData.OriginRequestSequence);
 
         // Only publishes on the server
         foreach (var client in TestEnvironment.Clients)
@@ -97,18 +94,9 @@ public class PartyBehaviorTest
     [Fact]
     public void ServerCoalescesPartyBehaviorUpdates_SendsLatestOnly()
     {
-        // Arrange
-        const string originControllerId = "Controller_1";
-        var first = new PartyBehaviorUpdateData("Test_Party", AiBehavior.EngageParty, "Test_Target", default, true, default, default, default, default)
-        {
-            OriginControllerId = originControllerId,
-            OriginRequestSequence = 1,
-        };
-        var latest = new PartyBehaviorUpdateData("Test_Party", AiBehavior.GoToPoint, null, default, false, default, default, default, default)
-        {
-            OriginControllerId = originControllerId,
-            OriginRequestSequence = 2,
-        };
+        // Arrange: two updates for the same party, distinguished by HasTarget so the latest is identifiable.
+        var first = new PartyBehaviorUpdateData("Test_Party", default, default, default, false, default, default, default, default);
+        var latest = new PartyBehaviorUpdateData("Test_Party", default, default, default, true, default, default, default, default);
 
         var server = TestEnvironment.Server;
 
@@ -121,135 +109,122 @@ public class PartyBehaviorTest
 
         FlushCoalescer(server);
 
-        // Assert
+        // Assert: the two updates for the same party collapse into one send carrying the latest behavior.
         var sent = Assert.Single(server.NetworkSentMessages.GetMessages<NetworkUpdatePartyBehavior>());
-        Assert.Equal(AiBehavior.GoToPoint, sent.BehaviorUpdateData.NewAiBehavior);
-        Assert.Equal(originControllerId, sent.BehaviorUpdateData.OriginControllerId);
-        Assert.Equal(2, sent.BehaviorUpdateData.OriginRequestSequence);
-
-        var serialized = server.EnsureSerializable(sent);
-        Assert.Equal(originControllerId, serialized.BehaviorUpdateData.OriginControllerId);
-        Assert.Equal(2, serialized.BehaviorUpdateData.OriginRequestSequence);
+        Assert.True(sent.BehaviorUpdateData.HasTarget);
 
         foreach (var client in TestEnvironment.Clients)
         {
             var update = Assert.Single(client.InternalMessages.GetMessages<UpdatePartyBehavior>());
-            Assert.Equal(AiBehavior.GoToPoint, update.BehaviorUpdateData.NewAiBehavior);
-            Assert.Equal(originControllerId, update.BehaviorUpdateData.OriginControllerId);
-            Assert.Equal(2, update.BehaviorUpdateData.OriginRequestSequence);
+            Assert.True(update.BehaviorUpdateData.HasTarget);
         }
     }
 
     /// <summary>
-    /// Compact client ids and full server ids share one authoritative latest-wins slot.
+    /// Compact client ids and full server ids share one latest-wins slot.
     /// </summary>
     [Fact]
-    public void ServerCoalescesMixedPartyIds_PreservesLatestAuthoritativeState()
+    public void ServerFlushesImmediateMixedPartyUpdate()
     {
         // Arrange
-        const string originControllerId = "Controller_1";
         const string compactPartyId = "Test_Party";
         const string fullPartyId = "MobileParty_Test_Party";
-        var firstPosition = new CampaignVec2(new Vec2(4f, 2f), true);
-        var gatePosition = new CampaignVec2(new Vec2(42f, 24f), true);
-        var first = new PartyBehaviorUpdateData(compactPartyId, AiBehavior.EngageParty, null, gatePosition, false, firstPosition, default, gatePosition, default)
+        var pending = new PartyBehaviorUpdateData(compactPartyId, default, default, default, true, default, default, default, default);
+        var immediate = new PartyBehaviorUpdateData(fullPartyId, default, default, default, false, default, default, default, default)
         {
-            OriginControllerId = originControllerId,
-            OriginRequestSequence = 1,
-        };
-        var authoritative = new PartyBehaviorUpdateData(fullPartyId, AiBehavior.None, null, gatePosition, false, gatePosition, default, gatePosition, default);
-        var latest = new PartyBehaviorUpdateData(compactPartyId, AiBehavior.GoToPoint, null, gatePosition, false, gatePosition, default, gatePosition, default)
-        {
-            OriginControllerId = originControllerId,
-            OriginRequestSequence = 3,
+            ForcePosition = true,
         };
 
         var server = TestEnvironment.Server;
 
         // Act
-        server.SimulateMessage(this, new PartyBehaviorUpdated(ref first));
-        server.SimulateMessage(this, new PartyBehaviorUpdated(ref authoritative));
-        server.SimulateMessage(this, new PartyBehaviorUpdated(ref latest));
-        FlushCoalescer(server);
+        server.SimulateMessage(this, new PartyBehaviorUpdated(ref pending));
+        Assert.Equal(0, server.NetworkSentMessages.GetMessageCount<NetworkUpdatePartyBehavior>());
+
+        server.SimulateMessage(this, new PartyBehaviorUpdated(ref immediate));
 
         // Assert
         var sent = Assert.Single(server.NetworkSentMessages.GetMessages<NetworkUpdatePartyBehavior>());
-        Assert.Equal(AiBehavior.GoToPoint, sent.BehaviorUpdateData.NewAiBehavior);
-        Assert.Null(sent.BehaviorUpdateData.OriginControllerId);
-        Assert.Equal(0, sent.BehaviorUpdateData.OriginRequestSequence);
-        AssertPosition(gatePosition, sent.BehaviorUpdateData.PartyPosition);
+        Assert.False(sent.BehaviorUpdateData.HasTarget);
+        Assert.True(sent.BehaviorUpdateData.ForcePosition);
 
         var serialized = server.EnsureSerializable(sent);
-        Assert.Null(serialized.BehaviorUpdateData.OriginControllerId);
-        Assert.Equal(0, serialized.BehaviorUpdateData.OriginRequestSequence);
-        AssertPosition(gatePosition, serialized.BehaviorUpdateData.PartyPosition);
+        Assert.True(serialized.BehaviorUpdateData.ForcePosition);
 
         foreach (var client in TestEnvironment.Clients)
         {
             var update = Assert.Single(client.InternalMessages.GetMessages<UpdatePartyBehavior>());
-            Assert.Equal(AiBehavior.GoToPoint, update.BehaviorUpdateData.NewAiBehavior);
-            Assert.Null(update.BehaviorUpdateData.OriginControllerId);
-            Assert.Equal(0, update.BehaviorUpdateData.OriginRequestSequence);
-            AssertPosition(gatePosition, update.BehaviorUpdateData.PartyPosition);
+            Assert.False(update.BehaviorUpdateData.HasTarget);
+            Assert.True(update.BehaviorUpdateData.ForcePosition);
         }
     }
 
+    [Fact]
+    public void TrySelectBehaviorUpdate_SelfEchoUsesLatestPrediction()
+    {
+        var stalePoint = new CampaignVec2(new Vec2(12f, 8f), true);
+        var latestPoint = new CampaignVec2(new Vec2(42f, 24f), true);
+        var staleEcho = new PartyBehaviorUpdateData(
+            "MobileParty_Test_Party",
+            AiBehavior.EscortParty,
+            "Old_Target",
+            stalePoint,
+            true,
+            stalePoint,
+            default,
+            stalePoint,
+            default);
+        var latestPrediction = new PartyBehaviorUpdateData(
+            "Test_Party",
+            AiBehavior.GoToPoint,
+            null,
+            latestPoint,
+            false,
+            latestPoint,
+            default,
+            latestPoint,
+            default);
+        var latestPredictions = new Dictionary<string, PartyBehaviorUpdateData>
+        {
+            ["Test_Party"] = latestPrediction,
+        };
+
+        Assert.True(MobilePartyBehaviorHandler.TrySelectBehaviorUpdate(
+            true,
+            latestPredictions,
+            ref staleEcho));
+        Assert.Equal(AiBehavior.GoToPoint, staleEcho.NewAiBehavior);
+        Assert.False(staleEcho.HasTarget);
+        Assert.Equal(latestPoint.X, staleEcho.BestTargetPoint.X);
+        Assert.Equal(latestPoint.Y, staleEcho.BestTargetPoint.Y);
+        Assert.Equal(latestPoint.IsOnLand, staleEcho.BestTargetPoint.IsOnLand);
+    }
+
     [Theory]
-    [InlineData(1, 3, false)]
-    [InlineData(2, 3, false)]
-    [InlineData(3, 3, true)]
-    [InlineData(4, 3, false)]
-    [InlineData(0, 0, false)]
-    public void IsLatestPredictionAcknowledgement_RequiresExactPositiveSequence(
-        long acknowledgementSequence,
-        long latestIssuedSequence,
+    [InlineData(false, false, false, true, true, false)]
+    [InlineData(false, false, true, true, true, true)]
+    [InlineData(false, false, false, true, false, true)]
+    [InlineData(false, true, false, true, true, true)]
+    [InlineData(true, true, true, true, false, false)]
+    public void ShouldApplyAuthoritativePosition_ReturnsExpected(
+        bool isSelfEcho,
+        bool forcePosition,
+        bool isHolding,
+        bool currentIsOnLand,
+        bool authoritativeIsOnLand,
         bool expected)
     {
+        var currentPosition = new CampaignVec2(new Vec2(42f, 24f), currentIsOnLand);
+        var authoritativePosition = new CampaignVec2(new Vec2(12f, 8f), authoritativeIsOnLand);
+
         Assert.Equal(
             expected,
-            MobilePartyBehaviorHandler.IsLatestPredictionAcknowledgement(acknowledgementSequence, latestIssuedSequence));
-    }
-
-    [Fact]
-    public void ShouldApplyOwnerPosition_LatestAcknowledgementKeepsSmallPredictionLead()
-    {
-        var ownerPosition = new CampaignVec2(new Vec2(42f, 24f), true);
-        var serverPosition = new CampaignVec2(new Vec2(41.75f, 24f), true);
-
-        Assert.False(MobilePartyBehaviorHandler.ShouldApplyOwnerPosition(true, ownerPosition, serverPosition));
-    }
-
-    [Fact]
-    public void ShouldApplyOwnerPosition_LatestAcknowledgementCorrectsLargeDrift()
-    {
-        var ownerPosition = new CampaignVec2(new Vec2(42f, 24f), true);
-        var serverPosition = new CampaignVec2(new Vec2(40f, 24f), true);
-
-        Assert.True(MobilePartyBehaviorHandler.ShouldApplyOwnerPosition(true, ownerPosition, serverPosition));
-    }
-
-    [Fact]
-    public void ShouldApplyOwnerPosition_LatestAcknowledgementCorrectsNavigationLayer()
-    {
-        var ownerPosition = new CampaignVec2(new Vec2(42f, 24f), true);
-        var serverPosition = new CampaignVec2(new Vec2(42f, 24f), false);
-
-        Assert.True(MobilePartyBehaviorHandler.ShouldApplyOwnerPosition(true, ownerPosition, serverPosition));
-    }
-
-    [Fact]
-    public void ShouldApplyOwnerPosition_AuthoritativeUpdateAlwaysApplies()
-    {
-        var position = new CampaignVec2(new Vec2(42f, 24f), true);
-
-        Assert.True(MobilePartyBehaviorHandler.ShouldApplyOwnerPosition(false, position, position));
-    }
-
-    private static void AssertPosition(CampaignVec2 expected, CampaignVec2 actual)
-    {
-        Assert.Equal(expected.X, actual.X);
-        Assert.Equal(expected.Y, actual.Y);
-        Assert.Equal(expected.IsOnLand, actual.IsOnLand);
+            MobilePartyBehaviorHandler.ShouldApplyAuthoritativePosition(
+                isSelfEcho,
+                forcePosition,
+                isHolding,
+                currentPosition,
+                authoritativePosition));
     }
 
     // Drains the server's per-tick coalescer the way CoopServer.Update does, inside the server's

--- a/source/Coop.IntegrationTests/MobileParties/PartyBehaviorTest.cs
+++ b/source/Coop.IntegrationTests/MobileParties/PartyBehaviorTest.cs
@@ -37,6 +37,7 @@ public class PartyBehaviorTest
         var data = new PartyBehaviorUpdateData("Test_Party", default, default, default, default, default, default, default, default)
         {
             OriginControllerId = originControllerId,
+            OriginRequestSequence = 7,
         };
         var message = new ControlledPartyBehaviorUpdated(data);
 
@@ -49,10 +50,12 @@ public class PartyBehaviorTest
         // Assert
         var update = Assert.Single(server.InternalMessages.GetMessages<UpdatePartyBehavior>());
         Assert.Equal(originControllerId, update.BehaviorUpdateData.OriginControllerId);
+        Assert.Equal(7, update.BehaviorUpdateData.OriginRequestSequence);
 
         var packet = Assert.Single(client1.Resolve<MockClient>().NetworkSentPackets.GetPackets<RequestMobilePartyBehaviorPacket>());
         Assert.Equal(DeliveryMethod.ReliableOrdered, packet.DeliveryMethod);
         Assert.Equal(originControllerId, packet.BehaviorUpdateData.OriginControllerId);
+        Assert.Equal(7, packet.BehaviorUpdateData.OriginRequestSequence);
 
         // Only publishes on the server
         foreach (var client in TestEnvironment.Clients)
@@ -99,10 +102,12 @@ public class PartyBehaviorTest
         var first = new PartyBehaviorUpdateData("Test_Party", AiBehavior.EngageParty, "Test_Target", default, true, default, default, default, default)
         {
             OriginControllerId = originControllerId,
+            OriginRequestSequence = 1,
         };
         var latest = new PartyBehaviorUpdateData("Test_Party", AiBehavior.GoToPoint, null, default, false, default, default, default, default)
         {
             OriginControllerId = originControllerId,
+            OriginRequestSequence = 2,
         };
 
         var server = TestEnvironment.Server;
@@ -120,15 +125,18 @@ public class PartyBehaviorTest
         var sent = Assert.Single(server.NetworkSentMessages.GetMessages<NetworkUpdatePartyBehavior>());
         Assert.Equal(AiBehavior.GoToPoint, sent.BehaviorUpdateData.NewAiBehavior);
         Assert.Equal(originControllerId, sent.BehaviorUpdateData.OriginControllerId);
+        Assert.Equal(2, sent.BehaviorUpdateData.OriginRequestSequence);
 
         var serialized = server.EnsureSerializable(sent);
         Assert.Equal(originControllerId, serialized.BehaviorUpdateData.OriginControllerId);
+        Assert.Equal(2, serialized.BehaviorUpdateData.OriginRequestSequence);
 
         foreach (var client in TestEnvironment.Clients)
         {
             var update = Assert.Single(client.InternalMessages.GetMessages<UpdatePartyBehavior>());
             Assert.Equal(AiBehavior.GoToPoint, update.BehaviorUpdateData.NewAiBehavior);
             Assert.Equal(originControllerId, update.BehaviorUpdateData.OriginControllerId);
+            Assert.Equal(2, update.BehaviorUpdateData.OriginRequestSequence);
         }
     }
 
@@ -142,15 +150,18 @@ public class PartyBehaviorTest
         const string originControllerId = "Controller_1";
         const string compactPartyId = "Test_Party";
         const string fullPartyId = "MobileParty_Test_Party";
+        var firstPosition = new CampaignVec2(new Vec2(4f, 2f), true);
         var gatePosition = new CampaignVec2(new Vec2(42f, 24f), true);
-        var first = new PartyBehaviorUpdateData(compactPartyId, AiBehavior.EngageParty, null, gatePosition, false, gatePosition, default, gatePosition, default)
+        var first = new PartyBehaviorUpdateData(compactPartyId, AiBehavior.EngageParty, null, gatePosition, false, firstPosition, default, gatePosition, default)
         {
             OriginControllerId = originControllerId,
+            OriginRequestSequence = 1,
         };
         var authoritative = new PartyBehaviorUpdateData(fullPartyId, AiBehavior.None, null, gatePosition, false, gatePosition, default, gatePosition, default);
         var latest = new PartyBehaviorUpdateData(compactPartyId, AiBehavior.GoToPoint, null, gatePosition, false, gatePosition, default, gatePosition, default)
         {
             OriginControllerId = originControllerId,
+            OriginRequestSequence = 3,
         };
 
         var server = TestEnvironment.Server;
@@ -165,10 +176,12 @@ public class PartyBehaviorTest
         var sent = Assert.Single(server.NetworkSentMessages.GetMessages<NetworkUpdatePartyBehavior>());
         Assert.Equal(AiBehavior.GoToPoint, sent.BehaviorUpdateData.NewAiBehavior);
         Assert.Null(sent.BehaviorUpdateData.OriginControllerId);
+        Assert.Equal(0, sent.BehaviorUpdateData.OriginRequestSequence);
         AssertPosition(gatePosition, sent.BehaviorUpdateData.PartyPosition);
 
         var serialized = server.EnsureSerializable(sent);
         Assert.Null(serialized.BehaviorUpdateData.OriginControllerId);
+        Assert.Equal(0, serialized.BehaviorUpdateData.OriginRequestSequence);
         AssertPosition(gatePosition, serialized.BehaviorUpdateData.PartyPosition);
 
         foreach (var client in TestEnvironment.Clients)
@@ -176,30 +189,60 @@ public class PartyBehaviorTest
             var update = Assert.Single(client.InternalMessages.GetMessages<UpdatePartyBehavior>());
             Assert.Equal(AiBehavior.GoToPoint, update.BehaviorUpdateData.NewAiBehavior);
             Assert.Null(update.BehaviorUpdateData.OriginControllerId);
+            Assert.Equal(0, update.BehaviorUpdateData.OriginRequestSequence);
             AssertPosition(gatePosition, update.BehaviorUpdateData.PartyPosition);
         }
     }
 
-    [Fact]
-    public void MatchesPrediction_DistinguishesMapTargets()
+    [Theory]
+    [InlineData(1, 3, false)]
+    [InlineData(2, 3, false)]
+    [InlineData(3, 3, true)]
+    [InlineData(4, 3, false)]
+    [InlineData(0, 0, false)]
+    public void IsLatestPredictionAcknowledgement_RequiresExactPositiveSequence(
+        long acknowledgementSequence,
+        long latestIssuedSequence,
+        bool expected)
     {
-        var predictedPoint = new CampaignVec2(new Vec2(42f, 24f), true);
-        var stalePoint = new CampaignVec2(new Vec2(12f, 8f), true);
-        var prediction = new PartyBehaviorUpdateData("Test_Party", AiBehavior.GoToPoint, null, predictedPoint, false, default, default, default, default);
-        var matchingEcho = new PartyBehaviorUpdateData("Test_Party", AiBehavior.GoToPoint, null, predictedPoint, false, default, default, default, default);
-        var staleEcho = new PartyBehaviorUpdateData("Test_Party", AiBehavior.GoToPoint, null, stalePoint, false, default, default, default, default);
-
-        Assert.True(MobilePartyBehaviorHandler.MatchesPrediction(matchingEcho, prediction));
-        Assert.False(MobilePartyBehaviorHandler.MatchesPrediction(staleEcho, prediction));
+        Assert.Equal(
+            expected,
+            MobilePartyBehaviorHandler.IsLatestPredictionAcknowledgement(acknowledgementSequence, latestIssuedSequence));
     }
 
     [Fact]
-    public void MatchesPrediction_TreatsInvalidTargetsAsEquivalent()
+    public void ShouldApplyOwnerPosition_LatestAcknowledgementKeepsSmallPredictionLead()
     {
-        var prediction = new PartyBehaviorUpdateData("Test_Party", AiBehavior.None, null, CampaignVec2.Invalid, false, default, default, default, default);
-        var echo = new PartyBehaviorUpdateData("Test_Party", AiBehavior.None, null, CampaignVec2.Invalid, false, default, default, default, default);
+        var ownerPosition = new CampaignVec2(new Vec2(42f, 24f), true);
+        var serverPosition = new CampaignVec2(new Vec2(41.75f, 24f), true);
 
-        Assert.True(MobilePartyBehaviorHandler.MatchesPrediction(echo, prediction));
+        Assert.False(MobilePartyBehaviorHandler.ShouldApplyOwnerPosition(true, ownerPosition, serverPosition));
+    }
+
+    [Fact]
+    public void ShouldApplyOwnerPosition_LatestAcknowledgementCorrectsLargeDrift()
+    {
+        var ownerPosition = new CampaignVec2(new Vec2(42f, 24f), true);
+        var serverPosition = new CampaignVec2(new Vec2(40f, 24f), true);
+
+        Assert.True(MobilePartyBehaviorHandler.ShouldApplyOwnerPosition(true, ownerPosition, serverPosition));
+    }
+
+    [Fact]
+    public void ShouldApplyOwnerPosition_LatestAcknowledgementCorrectsNavigationLayer()
+    {
+        var ownerPosition = new CampaignVec2(new Vec2(42f, 24f), true);
+        var serverPosition = new CampaignVec2(new Vec2(42f, 24f), false);
+
+        Assert.True(MobilePartyBehaviorHandler.ShouldApplyOwnerPosition(true, ownerPosition, serverPosition));
+    }
+
+    [Fact]
+    public void ShouldApplyOwnerPosition_AuthoritativeUpdateAlwaysApplies()
+    {
+        var position = new CampaignVec2(new Vec2(42f, 24f), true);
+
+        Assert.True(MobilePartyBehaviorHandler.ShouldApplyOwnerPosition(false, position, position));
     }
 
     private static void AssertPosition(CampaignVec2 expected, CampaignVec2 actual)

--- a/source/E2E.Tests/Services/Villages/VillageHostileActionTests.cs
+++ b/source/E2E.Tests/Services/Villages/VillageHostileActionTests.cs
@@ -1,7 +1,6 @@
-using Common;
+﻿using Common;
 using Common.Messaging;
 using Common.Network;
-using Common.Network.Coalescing;
 using Coop.Core.Client.Services.MobileParties.Messages;
 using System.Collections.Generic;
 using Coop.Core.Server.Services.ItemRosters.Messages;
@@ -912,8 +911,6 @@ public class VillageHostileActionTests : MapEventTestBase
             .ToList();
 
         client.Call(() => client.Resolve<INetwork>().SendAll(new NetworkMapEventFinalizeAttempted(mapEventId!)), disabledMethods);
-        Server.Call(() => Server.Resolve<ISendCoalescer>().Flush(Server.Resolve<INetwork>()));
-
         AssertRaidPartyMovedToVillageGate(Server, mobilePartyId, target.SettlementId);
         foreach (var syncedClient in Clients)
         {

--- a/source/GameInterface.Tests/Services/GameDebug/GameThreadDebugCommandTests.cs
+++ b/source/GameInterface.Tests/Services/GameDebug/GameThreadDebugCommandTests.cs
@@ -1,0 +1,56 @@
+﻿using Common;
+using GameInterface.Services.GameDebug.Commands;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace GameInterface.Tests.Services.GameDebug;
+
+[CollectionDefinition(nameof(GameThreadDebugCommandCollection), DisableParallelization = true)]
+public class GameThreadDebugCommandCollection
+{
+}
+
+[Collection(nameof(GameThreadDebugCommandCollection))]
+public class GameThreadDebugCommandTests : IDisposable
+{
+    private readonly bool wasServer = ModInformation.IsServer;
+
+    public void Dispose()
+    {
+        ModInformation.IsServer = wasServer;
+    }
+
+    [Fact]
+    public void Stall_WhenClient_ReturnsServerOnlyError()
+    {
+        ModInformation.IsServer = false;
+
+        Assert.Equal(
+            "gamethread.stall must be run on the server",
+            GameThreadDebugCommand.Stall(new List<string> { "1" }));
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("5001")]
+    [InlineData("invalid")]
+    public void Stall_WhenDurationIsInvalid_ReturnsUsage(string duration)
+    {
+        ModInformation.IsServer = true;
+
+        Assert.StartsWith(
+            "Usage:",
+            GameThreadDebugCommand.Stall(new List<string> { duration }));
+    }
+
+    [Fact]
+    public void Stall_WhenServerAndDurationIsValid_StallsGameThread()
+    {
+        ModInformation.IsServer = true;
+
+        Assert.Equal(
+            "Stalled the server game thread for 1 ms",
+            GameThreadDebugCommand.Stall(new List<string> { "1" }));
+    }
+}

--- a/source/GameInterface.Tests/Services/Time/MapTimeTrackerInterfaceTests.cs
+++ b/source/GameInterface.Tests/Services/Time/MapTimeTrackerInterfaceTests.cs
@@ -1,0 +1,181 @@
+﻿using GameInterface.Services.Time.Interfaces;
+using Xunit;
+
+namespace GameInterface.Tests.Services.Time;
+
+public class MapTimeTrackerInterfaceTests
+{
+    [Fact]
+    public void BeginCorrection_FirstHeartbeatRequestsHardSync()
+    {
+        var tracker = new MapTimeTrackerInterface();
+
+        Assert.True(tracker.BeginCorrection(100L, 1000L));
+        Assert.True(tracker.TryConsumeHardSync(out long serverTicks));
+        Assert.Equal(100L, serverTicks);
+    }
+
+    [Fact]
+    public void BeginCorrection_OrdinaryHeartbeatStartsBoundedCorrection()
+    {
+        var tracker = CreateSynchronizedTracker();
+
+        Assert.False(tracker.BeginCorrection(150L, 1000L));
+        tracker.PrepareCorrection(200L);
+        Assert.Equal(-5L, tracker.GetTickCorrection(10L, 0.025f));
+    }
+
+    [Fact]
+    public void GetTickCorrection_AheadClientNeverRunsBackward()
+    {
+        var tracker = CreateSynchronizedTracker();
+        tracker.BeginCorrection(100L, 1000L);
+        tracker.PrepareCorrection(10000L);
+
+        Assert.Equal(-10L, tracker.GetTickCorrection(10L, 0.25f));
+    }
+
+    [Fact]
+    public void GetTickCorrection_BehindClientNeverExceedsDoubleSpeed()
+    {
+        var tracker = CreateSynchronizedTracker();
+        tracker.BeginCorrection(10000L, 10000L);
+        tracker.PrepareCorrection(100L);
+
+        Assert.Equal(10L, tracker.GetTickCorrection(10L, 0.25f));
+    }
+
+    [Fact]
+    public void GetTickCorrection_AccumulatesFractionalTicks()
+    {
+        var tracker = CreateSynchronizedTracker();
+        tracker.BeginCorrection(101L, 1000L);
+        tracker.PrepareCorrection(100L);
+
+        Assert.Equal(0L, tracker.GetTickCorrection(10L, 0.1f));
+        Assert.Equal(0L, tracker.GetTickCorrection(10L, 0.1f));
+        Assert.Equal(1L, tracker.GetTickCorrection(10L, 0.1f));
+    }
+
+    [Fact]
+    public void GetTickCorrection_StaleHeartbeatStopsSimulation()
+    {
+        var tracker = CreateSynchronizedTracker();
+        tracker.BeginCorrection(100L, 1000L);
+        tracker.PrepareCorrection(100L);
+
+        Assert.Equal(0L, tracker.GetTickCorrection(10L, 0.8f));
+        Assert.Equal(-10L, tracker.GetTickCorrection(10L, 0.8f));
+
+        tracker.BeginCorrection(110L, 1000L);
+        tracker.PrepareCorrection(110L);
+        Assert.Equal(0L, tracker.GetTickCorrection(10L, 0.01f));
+    }
+
+    [Fact]
+    public void BeginCorrection_LargeServerJumpRequestsHardSync()
+    {
+        var tracker = CreateSynchronizedTracker();
+
+        Assert.True(tracker.BeginCorrection(1000L, 100L));
+    }
+
+    [Fact]
+    public void BeginCorrection_QueuedHeartbeatPreservesPendingHardSyncAndUsesLatestTicks()
+    {
+        var tracker = new MapTimeTrackerInterface();
+        tracker.BeginCorrection(100L, 1000L);
+
+        Assert.True(tracker.BeginCorrection(110L, 1000L));
+        Assert.True(tracker.TryConsumeHardSync(out long serverTicks));
+        Assert.Equal(110L, serverTicks);
+    }
+
+    [Fact]
+    public void BeginCorrection_QueuedHeartbeatPreservesPendingDiscontinuity()
+    {
+        var tracker = CreateSynchronizedTracker();
+        tracker.BeginCorrection(1000L, 100L);
+
+        Assert.True(tracker.BeginCorrection(1010L, 100L));
+        Assert.True(tracker.TryConsumeHardSync(out long serverTicks));
+        Assert.Equal(1010L, serverTicks);
+    }
+
+    [Fact]
+    public void GetTickCorrection_BeforeFirstHeartbeatLeavesSimulationUnchanged()
+    {
+        var tracker = new MapTimeTrackerInterface();
+
+        Assert.Equal(0L, tracker.GetTickCorrection(10L, 1f));
+    }
+
+    [Fact]
+    public void GetTickCorrection_RepeatedUnchangedHeartbeatsDoNotAccumulateDrift()
+    {
+        var tracker = CreateSynchronizedTracker();
+        long localTicks = 100L;
+        long firstCycleTicks = 0L;
+
+        for (int heartbeat = 0; heartbeat < 8; heartbeat++)
+        {
+            tracker.BeginCorrection(100L, 1000L);
+
+            for (int frame = 0; frame < 5; frame++)
+            {
+                const long vanillaDeltaTicks = 10L;
+                localTicks += vanillaDeltaTicks;
+                tracker.PrepareCorrection(localTicks);
+                localTicks += tracker.GetTickCorrection(vanillaDeltaTicks, 0.05f);
+            }
+
+            if (heartbeat == 0)
+            {
+                firstCycleTicks = localTicks;
+            }
+        }
+
+        Assert.Equal(firstCycleTicks, localTicks);
+    }
+
+    [Fact]
+    public void GetTickCorrection_PausedClientDoesNotCatchUpOrRunBackward()
+    {
+        var tracker = CreateSynchronizedTracker();
+        tracker.BeginCorrection(200L, 1000L);
+        tracker.PrepareCorrection(100L);
+
+        Assert.Equal(0L, tracker.GetTickCorrection(0L, 1f));
+        Assert.Equal(0L, tracker.GetTickCorrection(0L, 1f));
+    }
+
+    [Fact]
+    public void PrepareCorrection_PostHitchVanillaProgressIsNotAppliedTwice()
+    {
+        var tracker = CreateSynchronizedTracker();
+        tracker.BeginCorrection(200L, 1000L);
+
+        tracker.PrepareCorrection(200L);
+
+        Assert.Equal(0L, tracker.GetTickCorrection(100L, 1f));
+    }
+
+    [Fact]
+    public void PrepareCorrection_PostHitchCorrectsOnlyUnconsumedProgress()
+    {
+        var tracker = CreateSynchronizedTracker();
+        tracker.BeginCorrection(200L, 1000L);
+
+        tracker.PrepareCorrection(150L);
+
+        Assert.Equal(50L, tracker.GetTickCorrection(50L, 1f));
+    }
+
+    private static MapTimeTrackerInterface CreateSynchronizedTracker()
+    {
+        var tracker = new MapTimeTrackerInterface();
+        tracker.BeginCorrection(100L, 1000L);
+        tracker.TryConsumeHardSync(out _);
+        return tracker;
+    }
+}

--- a/source/GameInterface/Services/GameDebug/Commands/GameThreadDebugCommand.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/GameThreadDebugCommand.cs
@@ -1,16 +1,14 @@
-using Common;
+﻿using Common;
 using System.Collections.Generic;
+using System.Threading;
 using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.GameDebug.Commands;
 
 /// <summary>
-/// Console commands for the <see cref="GameThread"/> drain instrumentation. The instrumentation times
-/// how long the game thread spends applying marshaled network actions each frame and logs a per-second
-/// summary (drain time, worst single-frame hitch, backlog depth, and the handlers that dominate the
-/// cost), which attributes game-thread/render lag to the handlers that cause it. It is off by default
-/// and purely local — run the command on the process you want to profile (the client, to diagnose
-/// client-side lag).
+/// Console commands for <see cref="GameThread"/> diagnostics. The optional instrumentation attributes
+/// game-thread lag to marshaled handlers, while the server-only stall reproduces an authoritative
+/// simulation hitch for synchronization testing.
 /// </summary>
 public class GameThreadDebugCommand
 {
@@ -47,5 +45,25 @@ public class GameThreadDebugCommand
 
         return $"GameThread drain instrumentation is {(GameThread.Instrument ? "ON" : "OFF")}. " +
                "When ON, a per-second [GameThread] summary (drain ms, worst frame, backlog, top handlers) is written to the log.";
+    }
+
+    [CommandLineArgumentFunction("stall", "coop.debug.gamethread")]
+    public static string Stall(List<string> args)
+    {
+        if (ModInformation.IsClient)
+        {
+            return "gamethread.stall must be run on the server";
+        }
+
+        if (args.Count != 1 ||
+            int.TryParse(args[0], out int milliseconds) == false ||
+            milliseconds < 1 ||
+            milliseconds > 5000)
+        {
+            return "Usage: coop.debug.gamethread.stall <milliseconds from 1 to 5000>";
+        }
+
+        Thread.Sleep(milliseconds);
+        return $"Stalled the server game thread for {milliseconds} ms";
     }
 }

--- a/source/GameInterface/Services/MapEvents/Handlers/BattleFinalizeHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/BattleFinalizeHandler.cs
@@ -1,4 +1,4 @@
-using Common;
+﻿using Common;
 using Common.Logging;
 using Common.Messaging;
 using Common.Network;
@@ -455,7 +455,12 @@ internal class BattleFinalizeHandler : IHandler
             mobileParty.Position,
             mobileParty.DefaultBehavior,
             mobileParty.TargetPosition,
-            mobileParty.DesiredAiNavigationType);
+            mobileParty.DesiredAiNavigationType)
+        {
+            ForcePosition = true,
+        };
+
+        // The gate reset must reach clients before the encounter close allows another map command.
         messageBroker.Publish(this, new PartyBehaviorUpdated(ref data));
     }
 

--- a/source/GameInterface/Services/MobileParties/Data/PartyBehaviorUpdateData.cs
+++ b/source/GameInterface/Services/MobileParties/Data/PartyBehaviorUpdateData.cs
@@ -43,6 +43,9 @@ public struct PartyBehaviorUpdateData
     [ProtoMember(12)]
     public string OriginControllerId { get; set; }
 
+    [ProtoMember(13)]
+    public long OriginRequestSequence { get; set; }
+
     public PartyBehaviorUpdateData(
         string mobilePartyId,
         AiBehavior newAiBehavior,
@@ -64,5 +67,6 @@ public struct PartyBehaviorUpdateData
         TargetPosition = targetPosition;
         DesiredAiNavigationType = desiredAiNavigationType;
         OriginControllerId = null;
+        OriginRequestSequence = 0;
     }
 }

--- a/source/GameInterface/Services/MobileParties/Data/PartyBehaviorUpdateData.cs
+++ b/source/GameInterface/Services/MobileParties/Data/PartyBehaviorUpdateData.cs
@@ -39,6 +39,10 @@ public struct PartyBehaviorUpdateData
     [ProtoMember(11)]
     public readonly MobileParty.NavigationType DesiredAiNavigationType;
 
+    // Server-authored updates leave the origin null.
+    [ProtoMember(12)]
+    public string OriginControllerId { get; set; }
+
     public PartyBehaviorUpdateData(
         string mobilePartyId,
         AiBehavior newAiBehavior,
@@ -59,5 +63,6 @@ public struct PartyBehaviorUpdateData
         DefaultBehavior = defaultBehavior;
         TargetPosition = targetPosition;
         DesiredAiNavigationType = desiredAiNavigationType;
+        OriginControllerId = null;
     }
 }

--- a/source/GameInterface/Services/MobileParties/Data/PartyBehaviorUpdateData.cs
+++ b/source/GameInterface/Services/MobileParties/Data/PartyBehaviorUpdateData.cs
@@ -43,8 +43,9 @@ public struct PartyBehaviorUpdateData
     [ProtoMember(12)]
     public string OriginControllerId { get; set; }
 
-    [ProtoMember(13)]
-    public long OriginRequestSequence { get; set; }
+    // Field 13 was OriginRequestSequence in an earlier development build.
+    [ProtoMember(14)]
+    public bool ForcePosition { get; set; }
 
     public PartyBehaviorUpdateData(
         string mobilePartyId,
@@ -67,6 +68,6 @@ public struct PartyBehaviorUpdateData
         TargetPosition = targetPosition;
         DesiredAiNavigationType = desiredAiNavigationType;
         OriginControllerId = null;
-        OriginRequestSequence = 0;
+        ForcePosition = false;
     }
 }

--- a/source/GameInterface/Services/MobileParties/Handlers/MobilePartyBehaviorHandler.cs
+++ b/source/GameInterface/Services/MobileParties/Handlers/MobilePartyBehaviorHandler.cs
@@ -13,6 +13,7 @@ using GameInterface.Services.ObjectManager;
 using static GameInterface.Services.ObjectManager.ObjectManager;
 using Serilog;
 using System;
+using System.Collections.Generic;
 using TaleWorlds.CampaignSystem.Party;
 
 namespace GameInterface.Services.MobileParties.Handlers;
@@ -30,11 +31,7 @@ internal class MobilePartyBehaviorHandler : IHandler
 {
     private static readonly ILogger Logger = LogManager.GetLogger<MobilePartyBehaviorHandler>();
 
-    // Owner-party position resync threshold, in campaign-map units. The per-click prediction lead is
-    // a small fraction of a unit while map features sit tens of units apart, so 1 unit stays above
-    // normal prediction drift but still catches a genuine desync.
-    private const float OwnerPositionResyncThreshold = 1f;
-
+    private readonly Dictionary<string, PartyBehaviorUpdateData> latestPredictions = new Dictionary<string, PartyBehaviorUpdateData>();
     private readonly IMessageBroker messageBroker;
     private readonly IControllerIdProvider controllerIdProvider;
     private readonly IMobilePartyInterface mobilePartyInterface;
@@ -94,7 +91,13 @@ internal class MobilePartyBehaviorHandler : IHandler
             party.DefaultBehavior,
             party.TargetPosition,
             party.DesiredAiNavigationType
-         );
+        );
+
+        if (ModInformation.IsClient)
+        {
+            data.OriginControllerId = controllerId;
+            latestPredictions[partyId] = data;
+        }
 
         messageBroker.Publish(this, new ControlledPartyBehaviorUpdated(data));
     }
@@ -107,11 +110,25 @@ internal class MobilePartyBehaviorHandler : IHandler
         {
             try
             {
-                PartyBase partyBase = null;
-                if (data.HasTarget && !objectManager.TryGetObject(data.InteractablePointId, out partyBase))
+                if (!objectManager.TryGetObjectWithLogging(data.MobilePartyId, out MobileParty party))
                     return;
 
-                if (!objectManager.TryGetObject(data.MobilePartyId, out MobileParty party))
+                bool isSelfEcho = ModInformation.IsClient &&
+                    party.IsControlledByThisInstance() &&
+                    !string.IsNullOrEmpty(data.OriginControllerId) &&
+                    string.Equals(data.OriginControllerId, controllerIdProvider.ControllerId, StringComparison.Ordinal);
+
+                bool isPredictionAcknowledgement = false;
+                if (isSelfEcho && latestPredictions.TryGetValue(data.MobilePartyId, out var latestPrediction))
+                {
+                    if (!MatchesPrediction(data, latestPrediction))
+                        return;
+
+                    isPredictionAcknowledgement = true;
+                }
+
+                PartyBase partyBase = null;
+                if (data.HasTarget && !objectManager.TryGetObjectWithLogging(data.InteractablePointId, out partyBase))
                     return;
 
                 // The apply drives the Harmony-patched SetAiBehavior path; the AutoSync
@@ -133,16 +150,9 @@ internal class MobilePartyBehaviorHandler : IHandler
 
                     if (ModInformation.IsClient)
                     {
-                        // The local player's own party is client-predicted and runs slightly ahead of the
-                        // server's relayed position; snapping it mid-move is the jitter. Snap when it's at rest,
-                        // on a nav-layer (land/sea) change, or once it's drifted far enough to be a real desync.
-                        if (!party.IsControlledByThisInstance() ||
-                            !party.IsMoving ||
-                            party.Position.IsOnLand != data.PartyPosition.IsOnLand ||
-                            party.Position.Distance(data.PartyPosition) > OwnerPositionResyncThreshold)
-                        {
+                        // A matching prediction echo restores behavior without rewinding movement.
+                        if (!isPredictionAcknowledgement)
                             party.Position = data.PartyPosition;
-                        }
                     }
                     else
                     {
@@ -156,5 +166,15 @@ internal class MobilePartyBehaviorHandler : IHandler
                 Logger.Error(e, "Failed to apply {Message}", nameof(UpdatePartyBehavior));
             }
         });
+    }
+
+    internal static bool MatchesPrediction(PartyBehaviorUpdateData update, PartyBehaviorUpdateData prediction)
+    {
+        return update.NewAiBehavior == prediction.NewAiBehavior &&
+            update.HasTarget == prediction.HasTarget &&
+            string.Equals(update.InteractablePointId, prediction.InteractablePointId, StringComparison.Ordinal) &&
+            update.BestTargetPoint.IsOnLand == prediction.BestTargetPoint.IsOnLand &&
+            update.BestTargetPoint.X.Equals(prediction.BestTargetPoint.X) &&
+            update.BestTargetPoint.Y.Equals(prediction.BestTargetPoint.Y);
     }
 }

--- a/source/GameInterface/Services/MobileParties/Handlers/MobilePartyBehaviorHandler.cs
+++ b/source/GameInterface/Services/MobileParties/Handlers/MobilePartyBehaviorHandler.cs
@@ -14,6 +14,7 @@ using static GameInterface.Services.ObjectManager.ObjectManager;
 using Serilog;
 using System;
 using System.Collections.Generic;
+using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
 
 namespace GameInterface.Services.MobileParties.Handlers;
@@ -30,8 +31,9 @@ namespace GameInterface.Services.MobileParties.Handlers;
 internal class MobilePartyBehaviorHandler : IHandler
 {
     private static readonly ILogger Logger = LogManager.GetLogger<MobilePartyBehaviorHandler>();
+    private const float OwnerPositionResyncThreshold = 1f;
 
-    private readonly Dictionary<string, PartyBehaviorUpdateData> latestPredictions = new Dictionary<string, PartyBehaviorUpdateData>();
+    private readonly Dictionary<string, long> latestIssuedSequences = new Dictionary<string, long>();
     private readonly IMessageBroker messageBroker;
     private readonly IControllerIdProvider controllerIdProvider;
     private readonly IMobilePartyInterface mobilePartyInterface;
@@ -96,7 +98,11 @@ internal class MobilePartyBehaviorHandler : IHandler
         if (ModInformation.IsClient)
         {
             data.OriginControllerId = controllerId;
-            latestPredictions[partyId] = data;
+            long sequence = latestIssuedSequences.TryGetValue(partyId, out var latestSequence)
+                ? checked(latestSequence + 1)
+                : 1;
+            data.OriginRequestSequence = sequence;
+            latestIssuedSequences[partyId] = sequence;
         }
 
         messageBroker.Publish(this, new ControlledPartyBehaviorUpdated(data));
@@ -118,13 +124,15 @@ internal class MobilePartyBehaviorHandler : IHandler
                     !string.IsNullOrEmpty(data.OriginControllerId) &&
                     string.Equals(data.OriginControllerId, controllerIdProvider.ControllerId, StringComparison.Ordinal);
 
-                bool isPredictionAcknowledgement = false;
-                if (isSelfEcho && latestPredictions.TryGetValue(data.MobilePartyId, out var latestPrediction))
+                bool isLatestPredictionAcknowledgement = false;
+                if (isSelfEcho)
                 {
-                    if (!MatchesPrediction(data, latestPrediction))
+                    var partyId = Compact(data.MobilePartyId, typeof(MobileParty));
+                    if (!latestIssuedSequences.TryGetValue(partyId, out var latestSequence) ||
+                        !IsLatestPredictionAcknowledgement(data.OriginRequestSequence, latestSequence))
                         return;
 
-                    isPredictionAcknowledgement = true;
+                    isLatestPredictionAcknowledgement = true;
                 }
 
                 PartyBase partyBase = null;
@@ -150,8 +158,8 @@ internal class MobilePartyBehaviorHandler : IHandler
 
                     if (ModInformation.IsClient)
                     {
-                        // A matching prediction echo restores behavior without rewinding movement.
-                        if (!isPredictionAcknowledgement)
+                        // Keep normal prediction lead, but reconcile real drift from the latest acknowledgement.
+                        if (ShouldApplyOwnerPosition(isLatestPredictionAcknowledgement, party.Position, data.PartyPosition))
                             party.Position = data.PartyPosition;
                     }
                     else
@@ -168,13 +176,18 @@ internal class MobilePartyBehaviorHandler : IHandler
         });
     }
 
-    internal static bool MatchesPrediction(PartyBehaviorUpdateData update, PartyBehaviorUpdateData prediction)
+    internal static bool IsLatestPredictionAcknowledgement(long acknowledgementSequence, long latestIssuedSequence)
     {
-        return update.NewAiBehavior == prediction.NewAiBehavior &&
-            update.HasTarget == prediction.HasTarget &&
-            string.Equals(update.InteractablePointId, prediction.InteractablePointId, StringComparison.Ordinal) &&
-            update.BestTargetPoint.IsOnLand == prediction.BestTargetPoint.IsOnLand &&
-            update.BestTargetPoint.X.Equals(prediction.BestTargetPoint.X) &&
-            update.BestTargetPoint.Y.Equals(prediction.BestTargetPoint.Y);
+        return acknowledgementSequence > 0 && acknowledgementSequence == latestIssuedSequence;
+    }
+
+    internal static bool ShouldApplyOwnerPosition(
+        bool isLatestPredictionAcknowledgement,
+        CampaignVec2 ownerPosition,
+        CampaignVec2 serverPosition)
+    {
+        return !isLatestPredictionAcknowledgement ||
+            ownerPosition.IsOnLand != serverPosition.IsOnLand ||
+            ownerPosition.Distance(serverPosition) > OwnerPositionResyncThreshold;
     }
 }

--- a/source/GameInterface/Services/MobileParties/Handlers/MobilePartyBehaviorHandler.cs
+++ b/source/GameInterface/Services/MobileParties/Handlers/MobilePartyBehaviorHandler.cs
@@ -31,9 +31,8 @@ namespace GameInterface.Services.MobileParties.Handlers;
 internal class MobilePartyBehaviorHandler : IHandler
 {
     private static readonly ILogger Logger = LogManager.GetLogger<MobilePartyBehaviorHandler>();
-    private const float OwnerPositionResyncThreshold = 1f;
 
-    private readonly Dictionary<string, long> latestIssuedSequences = new Dictionary<string, long>();
+    private readonly Dictionary<string, PartyBehaviorUpdateData> latestPredictions = new Dictionary<string, PartyBehaviorUpdateData>();
     private readonly IMessageBroker messageBroker;
     private readonly IControllerIdProvider controllerIdProvider;
     private readonly IMobilePartyInterface mobilePartyInterface;
@@ -66,8 +65,6 @@ internal class MobilePartyBehaviorHandler : IHandler
         var party = obj.What.PartyAi._mobileParty;
         var interactablePoint = obj.What.InteractablePoint;
 
-        var controllerId = controllerIdProvider.ControllerId;
-
         if (!objectManager.TryGetId(partyAi._mobileParty, out var partyId))
             return;
 
@@ -97,12 +94,8 @@ internal class MobilePartyBehaviorHandler : IHandler
 
         if (ModInformation.IsClient)
         {
-            data.OriginControllerId = controllerId;
-            long sequence = latestIssuedSequences.TryGetValue(partyId, out var latestSequence)
-                ? checked(latestSequence + 1)
-                : 1;
-            data.OriginRequestSequence = sequence;
-            latestIssuedSequences[partyId] = sequence;
+            data.OriginControllerId = controllerIdProvider.ControllerId;
+            latestPredictions[partyId] = data;
         }
 
         messageBroker.Publish(this, new ControlledPartyBehaviorUpdated(data));
@@ -124,16 +117,9 @@ internal class MobilePartyBehaviorHandler : IHandler
                     !string.IsNullOrEmpty(data.OriginControllerId) &&
                     string.Equals(data.OriginControllerId, controllerIdProvider.ControllerId, StringComparison.Ordinal);
 
-                bool isLatestPredictionAcknowledgement = false;
-                if (isSelfEcho)
-                {
-                    var partyId = Compact(data.MobilePartyId, typeof(MobileParty));
-                    if (!latestIssuedSequences.TryGetValue(partyId, out var latestSequence) ||
-                        !IsLatestPredictionAcknowledgement(data.OriginRequestSequence, latestSequence))
-                        return;
-
-                    isLatestPredictionAcknowledgement = true;
-                }
+                // Reapply the newest local command if an authoritative update arrived before its echo.
+                if (!TrySelectBehaviorUpdate(isSelfEcho, latestPredictions, ref data))
+                    return;
 
                 PartyBase partyBase = null;
                 if (data.HasTarget && !objectManager.TryGetObjectWithLogging(data.InteractablePointId, out partyBase))
@@ -158,8 +144,13 @@ internal class MobilePartyBehaviorHandler : IHandler
 
                     if (ModInformation.IsClient)
                     {
-                        // Keep normal prediction lead, but reconcile real drift from the latest acknowledgement.
-                        if (ShouldApplyOwnerPosition(isLatestPredictionAcknowledgement, party.Position, data.PartyPosition))
+                        // Moving parties already simulate the replicated target, so an in-flight snapshot is stale.
+                        if (ShouldApplyAuthoritativePosition(
+                            isSelfEcho,
+                            data.ForcePosition,
+                            party.PartyMoveMode == MoveModeType.Hold,
+                            party.Position,
+                            data.PartyPosition))
                             party.Position = data.PartyPosition;
                     }
                     else
@@ -176,18 +167,26 @@ internal class MobilePartyBehaviorHandler : IHandler
         });
     }
 
-    internal static bool IsLatestPredictionAcknowledgement(long acknowledgementSequence, long latestIssuedSequence)
+    internal static bool TrySelectBehaviorUpdate(
+        bool isSelfEcho,
+        IReadOnlyDictionary<string, PartyBehaviorUpdateData> latestPredictions,
+        ref PartyBehaviorUpdateData data)
     {
-        return acknowledgementSequence > 0 && acknowledgementSequence == latestIssuedSequence;
+        if (!isSelfEcho)
+            return true;
+
+        var partyId = Compact(data.MobilePartyId, typeof(MobileParty));
+        return latestPredictions.TryGetValue(partyId, out data);
     }
 
-    internal static bool ShouldApplyOwnerPosition(
-        bool isLatestPredictionAcknowledgement,
-        CampaignVec2 ownerPosition,
-        CampaignVec2 serverPosition)
+    internal static bool ShouldApplyAuthoritativePosition(
+        bool isSelfEcho,
+        bool forcePosition,
+        bool isHolding,
+        CampaignVec2 currentPosition,
+        CampaignVec2 authoritativePosition)
     {
-        return !isLatestPredictionAcknowledgement ||
-            ownerPosition.IsOnLand != serverPosition.IsOnLand ||
-            ownerPosition.Distance(serverPosition) > OwnerPositionResyncThreshold;
+        return !isSelfEcho &&
+            (forcePosition || isHolding || currentPosition.IsOnLand != authoritativePosition.IsOnLand);
     }
 }

--- a/source/GameInterface/Services/MobileParties/Messages/Behavior/ControlledPartyBehaviorUpdated.cs
+++ b/source/GameInterface/Services/MobileParties/Messages/Behavior/ControlledPartyBehaviorUpdated.cs
@@ -6,7 +6,7 @@ namespace GameInterface.Services.MobileParties.Messages.Behavior;
 
 /// <summary>
 /// The behavior of a controlled party has been updated.
-/// Must be confirmed by the server before the change is applied.
+/// Must be sent to the server for replication.
 /// </summary>
 /// <seealso cref="MobilePartyBehaviorHandler"/>
 public record ControlledPartyBehaviorUpdated : IEvent

--- a/source/GameInterface/Services/MobilePartyAIs/Patches/PartyBehaviorPatch.cs
+++ b/source/GameInterface/Services/MobilePartyAIs/Patches/PartyBehaviorPatch.cs
@@ -69,7 +69,7 @@ public static class PartyBehaviorPatch
             }
         }
 
-        // Clients apply their own behavior immediately; matching server echoes are acknowledgements.
+        // Clients apply their own behavior immediately; the server still replicates it to observers.
         return ModInformation.IsClient;
     }
 

--- a/source/GameInterface/Services/MobilePartyAIs/Patches/PartyBehaviorPatch.cs
+++ b/source/GameInterface/Services/MobilePartyAIs/Patches/PartyBehaviorPatch.cs
@@ -69,7 +69,8 @@ public static class PartyBehaviorPatch
             }
         }
 
-        return false;
+        // Clients apply their own behavior immediately; matching server echoes are acknowledgements.
+        return ModInformation.IsClient;
     }
 
     private static bool BehaviorIsSame(

--- a/source/GameInterface/Services/Time/Commands/TimeCommands.cs
+++ b/source/GameInterface/Services/Time/Commands/TimeCommands.cs
@@ -50,6 +50,6 @@ internal class TimeCommands
         mapTimeTrackerInterface.AdvanceTime(ticks);
 
         return $"Advanced campaign time forward by {days} day(s) ({ticks} ticks). " +
-            $"Connected clients should interpolate to catch up over the next second.";
+            $"Connected clients should apply the jump on the next time update.";
     }
 }

--- a/source/GameInterface/Services/Time/Interaces/MapTimeTrackerInterface.cs
+++ b/source/GameInterface/Services/Time/Interaces/MapTimeTrackerInterface.cs
@@ -1,4 +1,6 @@
 ﻿using Common;
+using Common.Logging;
+using Serilog;
 using System;
 using System.Threading;
 using TaleWorlds.CampaignSystem;
@@ -41,8 +43,20 @@ public interface IMapTimeTrackerInterface : IGameAbstraction
 /// <inheritdoc cref="IMapTimeTrackerInterface"/>
 internal class MapTimeTrackerInterface : IMapTimeTrackerInterface
 {
+    private enum CampaignTimePacingState
+    {
+        Normal,
+        Slowing,
+        PausedForServer,
+        PausedForHeartbeat,
+        CatchingUp,
+    }
+
+    private static ILogger Logger => LogManager.GetLogger<MapTimeTrackerInterface>();
+
     internal const float CorrectionWindowSeconds = 0.25f;
     internal const float HeartbeatTimeoutSeconds = 0.75f;
+    private const float PacingLogDebounceSeconds = CorrectionWindowSeconds * 2f;
     private const float MapSecondsPerCampaignDelta = 4320f;
 
     private bool hasServerTime;
@@ -55,6 +69,9 @@ internal class MapTimeTrackerInterface : IMapTimeTrackerInterface
     private double correctionTicksPerSecond;
     private double correctionAccumulator;
     private float secondsSinceHeartbeat;
+    private float candidatePacingStateSeconds;
+    private CampaignTimePacingState loggedPacingState = CampaignTimePacingState.Normal;
+    private CampaignTimePacingState candidatePacingState = CampaignTimePacingState.Normal;
 
     public bool TryGetCurrentTicks(out long ticks)
     {
@@ -90,6 +107,7 @@ internal class MapTimeTrackerInterface : IMapTimeTrackerInterface
         var tracker = campaign.MapTimeTracker;
         if (TryConsumeHardSync(out long hardSyncTicks))
         {
+            LogHardSync(tracker._numTicks, hardSyncTicks);
             tracker._numTicks = hardSyncTicks;
             tracker._deltaTimeInTicks = 0L;
             campaign._dt = 0f;
@@ -99,9 +117,10 @@ internal class MapTimeTrackerInterface : IMapTimeTrackerInterface
         long originalDeltaTicks = tracker._deltaTimeInTicks;
         PrepareCorrection(tracker._numTicks);
         long correctionTicks = GetTickCorrection(originalDeltaTicks, realDt);
+        long correctedDeltaTicks = originalDeltaTicks + correctionTicks;
+        UpdatePacingDiagnostics(tracker._numTicks + correctionTicks, originalDeltaTicks, correctedDeltaTicks, realDt);
         if (correctionTicks == 0) return;
 
-        long correctedDeltaTicks = originalDeltaTicks + correctionTicks;
         tracker._numTicks += correctionTicks;
         tracker._deltaTimeInTicks = correctedDeltaTicks;
         campaign._dt = correctedDeltaTicks / (MapSecondsPerCampaignDelta * CampaignTime.TimeTicksPerSecond);
@@ -152,6 +171,7 @@ internal class MapTimeTrackerInterface : IMapTimeTrackerInterface
 
         hasPendingHardSync = false;
         skipNextHeartbeatAgeIncrement = false;
+        ResetPacingDiagnostics();
         return true;
     }
 
@@ -222,5 +242,82 @@ internal class MapTimeTrackerInterface : IMapTimeTrackerInterface
         }
 
         return correctionTicks;
+    }
+
+    private static CampaignTimePacingState DeterminePacingState(
+        long originalDeltaTicks,
+        long correctedDeltaTicks,
+        bool heartbeatStale)
+    {
+        if (heartbeatStale) return CampaignTimePacingState.PausedForHeartbeat;
+        if (correctedDeltaTicks == 0L && originalDeltaTicks > 0L) return CampaignTimePacingState.PausedForServer;
+        if (correctedDeltaTicks < originalDeltaTicks) return CampaignTimePacingState.Slowing;
+        if (correctedDeltaTicks > originalDeltaTicks) return CampaignTimePacingState.CatchingUp;
+        return CampaignTimePacingState.Normal;
+    }
+
+    private void UpdatePacingDiagnostics(
+        long clientTicks,
+        long originalDeltaTicks,
+        long correctedDeltaTicks,
+        float realDt)
+    {
+        if (hasServerTime == false || originalDeltaTicks <= 0L || realDt <= 0f) return;
+
+        bool heartbeatStale = secondsSinceHeartbeat > HeartbeatTimeoutSeconds;
+        CampaignTimePacingState pacingState = DeterminePacingState(
+            originalDeltaTicks,
+            correctedDeltaTicks,
+            heartbeatStale);
+
+        if (pacingState == candidatePacingState)
+        {
+            candidatePacingStateSeconds += realDt;
+        }
+        else
+        {
+            candidatePacingState = pacingState;
+            candidatePacingStateSeconds = realDt;
+        }
+
+        bool enteredHeartbeatPause = pacingState == CampaignTimePacingState.PausedForHeartbeat &&
+            loggedPacingState != CampaignTimePacingState.PausedForHeartbeat;
+        bool shouldLog = pacingState != loggedPacingState &&
+            (enteredHeartbeatPause || candidatePacingStateSeconds >= PacingLogDebounceSeconds);
+        if (shouldLog == false) return;
+
+        double speedMultiplier = correctedDeltaTicks / (double)originalDeltaTicks;
+        Logger.Information(
+            "[CampaignPacing] {PreviousPacingState} -> {PacingState}; " +
+            "ServerTicks={ServerTicks}, ClientTicks={ClientTicks}, ServerMinusClientTicks={ServerMinusClientTicks}, " +
+            "HeartbeatAgeSeconds={HeartbeatAgeSeconds:0.000}, VanillaDeltaTicks={VanillaDeltaTicks}, " +
+            "AppliedDeltaTicks={AppliedDeltaTicks}, SpeedMultiplier={SpeedMultiplier:0.00}x",
+            loggedPacingState,
+            pacingState,
+            pendingServerTicks,
+            clientTicks,
+            pendingServerTicks - clientTicks,
+            secondsSinceHeartbeat,
+            originalDeltaTicks,
+            correctedDeltaTicks,
+            speedMultiplier);
+
+        loggedPacingState = pacingState;
+    }
+
+    private static void LogHardSync(long clientTicks, long serverTicks)
+    {
+        Logger.Information(
+            "[CampaignPacing] HardSync; ServerTicks={ServerTicks}, ClientTicksBeforeSync={ClientTicksBeforeSync}, CorrectionTicks={CorrectionTicks}",
+            serverTicks,
+            clientTicks,
+            serverTicks - clientTicks);
+    }
+
+    private void ResetPacingDiagnostics()
+    {
+        candidatePacingStateSeconds = 0f;
+        loggedPacingState = CampaignTimePacingState.Normal;
+        candidatePacingState = CampaignTimePacingState.Normal;
     }
 }

--- a/source/GameInterface/Services/Time/Interaces/MapTimeTrackerInterface.cs
+++ b/source/GameInterface/Services/Time/Interaces/MapTimeTrackerInterface.cs
@@ -1,11 +1,7 @@
-using Common;
-using Common.Logging;
-using Serilog;
+﻿using Common;
 using System;
 using System.Threading;
-using System.Timers;
 using TaleWorlds.CampaignSystem;
-using Timer = System.Timers.Timer;
 
 namespace GameInterface.Services.Time.Interfaces;
 
@@ -22,13 +18,17 @@ public interface IMapTimeTrackerInterface : IGameAbstraction
     bool TryGetCurrentTicks(out long ticks);
 
     /// <summary>
-    /// Smoothly corrects the local campaign time toward <paramref name="serverTicks"/>.
-    /// Interpolates <c>_numTicks</c> from its current value to the server value over 1 second,
-    /// updating every 0.25 seconds. A new call cancels any interpolation already in progress
-    /// and restarts from the current local tick value.
+    /// Corrects the client campaign simulation toward <paramref name="serverTicks"/>.
     /// </summary>
     /// <param name="serverTicks">The authoritative server tick value to converge toward.</param>
     void SyncCampaignTime(long serverTicks);
+
+    /// <summary>
+    /// Applies the pending server-time correction to the current client simulation frame.
+    /// </summary>
+    /// <param name="campaign">The campaign whose frame delta and map time are being corrected.</param>
+    /// <param name="realDt">The real-time frame delta passed to the campaign tick.</param>
+    void ApplyClientSimulationTime(Campaign campaign, float realDt);
 
     /// <summary>
     /// Advances the campaign time forward by the given number of ticks.
@@ -39,21 +39,22 @@ public interface IMapTimeTrackerInterface : IGameAbstraction
 }
 
 /// <inheritdoc cref="IMapTimeTrackerInterface"/>
-internal class MapTimeTrackerInterface : IMapTimeTrackerInterface, IDisposable
+internal class MapTimeTrackerInterface : IMapTimeTrackerInterface
 {
-    private static readonly ILogger Logger = LogManager.GetLogger<MapTimeTrackerInterface>();
+    internal const float CorrectionWindowSeconds = 0.25f;
+    internal const float HeartbeatTimeoutSeconds = 0.75f;
+    private const float MapSecondsPerCampaignDelta = 4320f;
 
-    private const double InterpolationDurationMs = 1000d;
-    private const double InterpolationIntervalMs = 250d;
-    private const int TotalSteps = 4;
-
-    private readonly object interpolationLock = new object();
-
-    private Timer interpolationTimer;
-    private long startTicks;
-    private long targetTicks;
-    private long previousTicks;
-    private int currentStep;
+    private bool hasServerTime;
+    private bool hasPendingHardSync;
+    private bool hasPendingServerTime;
+    private bool skipNextHeartbeatAgeIncrement;
+    private long previousServerTicks;
+    private long pendingServerTicks;
+    private double remainingCorrectionTicks;
+    private double correctionTicksPerSecond;
+    private double correctionAccumulator;
+    private float secondsSinceHeartbeat;
 
     public bool TryGetCurrentTicks(out long ticks)
     {
@@ -70,86 +71,156 @@ internal class MapTimeTrackerInterface : IMapTimeTrackerInterface, IDisposable
 
     public void SyncCampaignTime(long serverTicks)
     {
-        var tracker = Campaign.Current?.MapTimeTracker;
-        if (tracker == null) return;
-
-        lock (interpolationLock)
+        GameThread.RunSafe(() =>
         {
-            // A newer server update replaces any currently-running interpolation,
-            // restarting from the current local tick value.
-            StopTimer();
+            var tracker = Campaign.Current?.MapTimeTracker;
+            if (tracker == null) return;
 
-            startTicks = tracker._numTicks;
-            previousTicks = startTicks;
-            targetTicks = serverTicks;
-            currentStep = 0;
+            long maxServerProgressTicks = CampaignTime.Hours(6f).NumTicks;
+            if (maxServerProgressTicks <= 0L) return;
 
-            interpolationTimer = new Timer(InterpolationIntervalMs) { AutoReset = true };
-            interpolationTimer.Elapsed += OnInterpolationStep;
-            interpolationTimer.Start();
-        }
+            BeginCorrection(serverTicks, maxServerProgressTicks);
+        }, context: nameof(MapTimeTrackerInterface));
     }
 
-    private void OnInterpolationStep(object sender, ElapsedEventArgs e)
+    public void ApplyClientSimulationTime(Campaign campaign, float realDt)
     {
-        lock (interpolationLock)
+        if (campaign == null) throw new ArgumentNullException(nameof(campaign));
+
+        var tracker = campaign.MapTimeTracker;
+        if (TryConsumeHardSync(out long hardSyncTicks))
         {
-            // Ignore stale callbacks from a timer that has already been replaced/stopped.
-            if (sender != interpolationTimer) return;
-
-            currentStep++;
-
-            double t = currentStep * InterpolationIntervalMs / InterpolationDurationMs;
-            if (t > 1d) t = 1d;
-
-            long newTicks = (long)(startTicks + (targetTicks - startTicks) * t);
-            long deltaTicks = newTicks - previousTicks;
-            previousTicks = newTicks;
-
-            // Field writes happen on the game thread, the only place MapTimeTracker is ticked.
-            GameThread.Run(() =>
-            {
-                var tracker = Campaign.Current?.MapTimeTracker;
-                if (tracker == null) return;
-
-                tracker._deltaTimeInTicks = deltaTicks;
-                tracker._numTicks = newTicks;
-            });
-
-            if (currentStep >= TotalSteps)
-            {
-                StopTimer();
-            }
+            tracker._numTicks = hardSyncTicks;
+            tracker._deltaTimeInTicks = 0L;
+            campaign._dt = 0f;
+            return;
         }
+
+        long originalDeltaTicks = tracker._deltaTimeInTicks;
+        PrepareCorrection(tracker._numTicks);
+        long correctionTicks = GetTickCorrection(originalDeltaTicks, realDt);
+        if (correctionTicks == 0) return;
+
+        long correctedDeltaTicks = originalDeltaTicks + correctionTicks;
+        tracker._numTicks += correctionTicks;
+        tracker._deltaTimeInTicks = correctedDeltaTicks;
+        campaign._dt = correctedDeltaTicks / (MapSecondsPerCampaignDelta * CampaignTime.TimeTicksPerSecond);
     }
 
     public void AdvanceTime(long ticks)
     {
-        // Field write happens on the game thread, the only place MapTimeTracker is ticked.
-        GameThread.Run(() =>
+        GameThread.RunSafe(() =>
         {
             var tracker = Campaign.Current?.MapTimeTracker;
             if (tracker == null) return;
 
             tracker._numTicks += ticks;
-        });
+        }, context: nameof(MapTimeTrackerInterface));
     }
 
-    private void StopTimer()
+    internal bool BeginCorrection(long serverTicks, long maxServerProgressTicks)
     {
-        if (interpolationTimer == null) return;
+        secondsSinceHeartbeat = 0f;
+        skipNextHeartbeatAgeIncrement = true;
 
-        interpolationTimer.Elapsed -= OnInterpolationStep;
-        interpolationTimer.Stop();
-        interpolationTimer.Dispose();
-        interpolationTimer = null;
-    }
+        bool isDiscontinuity = hasServerTime == false ||
+            serverTicks < previousServerTicks ||
+            serverTicks - previousServerTicks > maxServerProgressTicks;
 
-    public void Dispose()
-    {
-        lock (interpolationLock)
+        hasServerTime = true;
+        previousServerTicks = serverTicks;
+        pendingServerTicks = serverTicks;
+        hasPendingHardSync = hasPendingHardSync || isDiscontinuity;
+        hasPendingServerTime = false;
+        remainingCorrectionTicks = 0d;
+        correctionTicksPerSecond = 0d;
+        correctionAccumulator = 0d;
+
+        if (hasPendingHardSync)
         {
-            StopTimer();
+            return true;
         }
+
+        hasPendingServerTime = true;
+        return false;
+    }
+
+    internal bool TryConsumeHardSync(out long serverTicks)
+    {
+        serverTicks = pendingServerTicks;
+        if (hasPendingHardSync == false) return false;
+
+        hasPendingHardSync = false;
+        skipNextHeartbeatAgeIncrement = false;
+        return true;
+    }
+
+    internal void PrepareCorrection(long localTicks)
+    {
+        if (hasPendingServerTime == false) return;
+
+        hasPendingServerTime = false;
+        remainingCorrectionTicks = pendingServerTicks - localTicks;
+        correctionTicksPerSecond = remainingCorrectionTicks / CorrectionWindowSeconds;
+    }
+
+    internal long GetTickCorrection(long localDeltaTicks, float realDt)
+    {
+        if (hasServerTime == false || realDt <= 0f) return 0L;
+
+        if (skipNextHeartbeatAgeIncrement)
+        {
+            skipNextHeartbeatAgeIncrement = false;
+        }
+        else
+        {
+            secondsSinceHeartbeat += realDt;
+        }
+        if (localDeltaTicks <= 0L) return 0L;
+
+        if (secondsSinceHeartbeat > HeartbeatTimeoutSeconds)
+        {
+            return -localDeltaTicks;
+        }
+
+        if (remainingCorrectionTicks == 0d) return 0L;
+
+        double requestedCorrection = correctionTicksPerSecond * realDt;
+        requestedCorrection = Math.Max(-localDeltaTicks, Math.Min(localDeltaTicks, requestedCorrection));
+
+        if (remainingCorrectionTicks > 0d)
+        {
+            if (requestedCorrection <= 0d) return 0L;
+            requestedCorrection = Math.Min(remainingCorrectionTicks, requestedCorrection);
+        }
+        else
+        {
+            if (requestedCorrection >= 0d) return 0L;
+            requestedCorrection = Math.Max(remainingCorrectionTicks, requestedCorrection);
+        }
+
+        correctionAccumulator += requestedCorrection;
+
+        long correctionTicks = (long)correctionAccumulator;
+        correctionTicks = Math.Max(-localDeltaTicks, Math.Min(localDeltaTicks, correctionTicks));
+
+        if (remainingCorrectionTicks > 0d)
+        {
+            correctionTicks = Math.Min((long)remainingCorrectionTicks, correctionTicks);
+        }
+        else
+        {
+            correctionTicks = Math.Max((long)remainingCorrectionTicks, correctionTicks);
+        }
+
+        correctionAccumulator -= correctionTicks;
+        remainingCorrectionTicks -= correctionTicks;
+
+        if (remainingCorrectionTicks == 0d)
+        {
+            correctionAccumulator = 0d;
+        }
+
+        return correctionTicks;
     }
 }

--- a/source/GameInterface/Services/Time/Patches/TimePatches.cs
+++ b/source/GameInterface/Services/Time/Patches/TimePatches.cs
@@ -1,10 +1,12 @@
-﻿using Common.Messaging;
+﻿using Common;
+using Common.Messaging;
 using Common.Util;
 using GameInterface.Policies;
 using GameInterface.Services.Heroes.Enum;
 using GameInterface.Services.Heroes.Interaces;
 using GameInterface.Services.Heroes.Messages;
 using GameInterface.Services.Time;
+using GameInterface.Services.Time.Interfaces;
 using HarmonyLib;
 using SandBox.View.Map;
 using System.Collections.Generic;
@@ -70,6 +72,20 @@ internal class TimePatches
     internal static void PublishBlockedTimeControlAttempt(object source, TimeControlEnum controlMode)
     {
         MessageBroker.Instance.Publish(source, new TimeSpeedChangedAttempted(controlMode));
+    }
+}
+
+[HarmonyPatch(typeof(Campaign), "TickMapTime")]
+internal class CampaignTimePacingPatches
+{
+    [HarmonyPostfix]
+    private static void TickMapTimePostfix(Campaign __instance, float realDt)
+    {
+        if (ModInformation.IsClient &&
+            ContainerProvider.TryResolve<IMapTimeTrackerInterface>(out var mapTimeTrackerInterface))
+        {
+            mapTimeTrackerInterface.ApplyClientSimulationTime(__instance, realDt);
+        }
     }
 }
 


### PR DESCRIPTION
Basically:

if the server is laggy then the clients will slow down/pause until the server catches up.
if the client is laggy then the client will speed up (up to 2x) until it catches up


new behavior-
1. Clicking moves the client party immediately
2. During normal server performance, movement looks normal
3. If the server slows or freezes, all client-side parties should slow or pause instead of continuing ahead.
4. The client can get at most roughly one heartbeat (~250 ms) ahead before correction begins
5. When the server resumes, it catches up while the client remains slowed/paused; nobody snaps around
6. If the client falls behind, it catches up at no more than 2× speed.
7. If no heartbeat arrives for 750 ms, client campaign simulation pauses until one arrives.
8. Party behavior echoes don't overwrite moving party positions 

<img width="1218" height="168" alt="image" src="https://github.com/user-attachments/assets/0f94b741-1b07-4ba3-9c30-98798b0f85ff" />

https://github.com/user-attachments/assets/d20a35ed-007b-4174-8e4f-3e5a703f6ff1

