### PR TITLE
[1816] Hide loading screen after module validation fails

### DIFF
--- a/source/Coop.Core/Client/ClientLogic.cs
+++ b/source/Coop.Core/Client/ClientLogic.cs
@@ -76,7 +76,7 @@ public class ClientLogic : IClientLogic
         new Dictionary<Type, Func<IClientState>>
         {
             [typeof(MainMenuState)] = () => new MainMenuState(this, context.MessageBroker, context.Network, context.GameInterface, context.GameStateInterface, context.LoadingInterface),
-            [typeof(ValidateModuleState)] = () => new ValidateModuleState(this, context.MessageBroker, context.Network, context.ControllerIdProvider, context.CoopFinalizer, context.GameStateInterface, context.ModuleInfoProvider),
+            [typeof(ValidateModuleState)] = () => new ValidateModuleState(this, context.MessageBroker, context.Network, context.ControllerIdProvider, context.CoopFinalizer, context.LoadingInterface, context.ModuleInfoProvider),
             [typeof(CharacterCreationState)] = () => new CharacterCreationState(this, context.MessageBroker, context.Network, context.HeroInterface, context.RegistryManager, context.ControllerIdProvider, context.LoadingInterface, context.PlayerManager, context.GameStateInterface, context.CoopFinalizer),
             [typeof(ReceivingSavedDataState)] = () => new ReceivingSavedDataState(this, context.MessageBroker, context.LoadingInterface, context.GameStateInterface),
             [typeof(LoadingState)] = () => new LoadingState(this, context.MessageBroker, context.RegistryManager, context.HeroInterface, context.ControllerIdProvider, context.PlayerManager, context.GameStateInterface, context.LoadingInterface),

--- a/source/Coop.Core/Client/States/ValidateModuleState.cs
+++ b/source/Coop.Core/Client/States/ValidateModuleState.cs
@@ -63,8 +63,7 @@ public class ValidateModuleState : ClientStateBase
         }
         else
         {
-            messageBroker.Publish(this, new SendInformationMessage("Module validation failed!\nReason: " + obj.What.Reason));
-            Logic.Disconnect();
+            FinalizeDisconnect("Module validation failed!\n\n" + obj.What.Reason);
         }
     }
 
@@ -101,12 +100,17 @@ public class ValidateModuleState : ClientStateBase
 
     public override void Disconnect()
     {
+        FinalizeDisconnect("Client has been stopped");
+    }
+
+    private void FinalizeDisconnect(string closeText)
+    {
         loadingInterface.HideLoadingScreen();
 
         // Finalize tears down coop (EndCoopMode -> DestroyContainer), which disposes the container the
         // state machine resolves from — so do NOT SetState afterwards (it would resolve from a disposed
         // container and throw). This matches the teardown in the other states (e.g. CampaignState).
-        coopFinalizer.Finalize("Client has been stopped");
+        coopFinalizer.Finalize(closeText);
     }
 
     public override void EnterCampaignState()

--- a/source/Coop.Core/Client/States/ValidateModuleState.cs
+++ b/source/Coop.Core/Client/States/ValidateModuleState.cs
@@ -5,8 +5,8 @@ using Coop.Core.Server.Connections.Messages;
 using GameInterface.Services.CharacterCreation.Messages;
 using GameInterface.Services.Entity;
 using GameInterface.Services.GameDebug.Messages;
-using GameInterface.Services.GameState.Interfaces;
 using GameInterface.Services.Modules;
+using GameInterface.Services.UI.Interfaces;
 
 namespace Coop.Core.Client.States;
 
@@ -19,7 +19,7 @@ public class ValidateModuleState : ClientStateBase
     private readonly INetwork network;
     private readonly IControllerIdProvider controllerIdProvider;
     private readonly ICoopFinalizer coopFinalizer;
-    private readonly IGameStateInterface gameStateInterface;
+    private readonly ILoadingInterface loadingInterface;
 
     public ValidateModuleState(
         IClientLogic logic,
@@ -27,14 +27,14 @@ public class ValidateModuleState : ClientStateBase
         INetwork network,
         IControllerIdProvider controllerIdProvider,
         ICoopFinalizer coopFinalizer,
-        IGameStateInterface gameStateInterface,
+        ILoadingInterface loadingInterface,
         IModuleInfoProvider moduleInfoProvider) : base(logic)
     {
         this.messageBroker = messageBroker;
         this.network = network;
         this.controllerIdProvider = controllerIdProvider;
         this.coopFinalizer = coopFinalizer;
-        this.gameStateInterface = gameStateInterface;
+        this.loadingInterface = loadingInterface;
         messageBroker.Subscribe<NetworkModuleVersionsValidated>(Handle_NetworkModuleVersionsValidated);
         messageBroker.Subscribe<NetworkClientValidated>(Handle_NetworkClientValidated);
         messageBroker.Subscribe<CharacterCreationStarted>(Handle_CharacterCreationStarted);
@@ -101,6 +101,8 @@ public class ValidateModuleState : ClientStateBase
 
     public override void Disconnect()
     {
+        loadingInterface.HideLoadingScreen();
+
         // Finalize tears down coop (EndCoopMode -> DestroyContainer), which disposes the container the
         // state machine resolves from — so do NOT SetState afterwards (it would resolve from a disposed
         // container and throw). This matches the teardown in the other states (e.g. CampaignState).

--- a/source/Coop.Tests/Client/States/ValidateModuleStateTests.cs
+++ b/source/Coop.Tests/Client/States/ValidateModuleStateTests.cs
@@ -58,6 +58,24 @@ namespace Coop.Tests.Client.States
         }
 
         [Fact]
+        public void NetworkModuleVersionsValidated_Failure_FinalizesWithReason()
+        {
+            // Arrange
+            var validateState = clientLogic.SetState<ValidateModuleState>();
+            const string reason = "Wrong game version detected.";
+            var payload = new MessagePayload<NetworkModuleVersionsValidated>(
+                this, new NetworkModuleVersionsValidated(false, reason));
+
+            // Act
+            validateState.Handle_NetworkModuleVersionsValidated(payload);
+
+            // Assert
+            var popup = Assert.Single(clientComponent.TestMessageBroker.GetMessagesFromType<SendPopupMessage>());
+            Assert.Equal("Module validation failed!\n\n" + reason, popup.Text);
+            Assert.Single(clientComponent.TestMessageBroker.GetMessagesFromType<EndCoopMode>());
+        }
+
+        [Fact]
         public void NetworkClientValidated_Transitions_ReceivingSavedDataState()
         {
             // Arrange


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

After a server rejects the client's module selection, the client remains trapped behind the `Validating modules...` loading screen. The rejection reason and stop notice are hidden and the main menu cannot be used.

## What is the new behavior?

Resolves #1816

The loading screen now closes as soon as module validation fails, so the rejection reason and stop notice are visible and the client can use the main menu or try joining again.

<img width="359" height="220" alt="image" src="https://github.com/user-attachments/assets/afccf17c-aca9-4148-8cf6-3479283f2146" />

