### PR TITLE
[1815] Prevent militia starvation wounds

### DIFF
--- a/source/GameInterface.Tests/Services/MobileParties/MobilePartyFoodConsumptionModelPatchesTests.cs
+++ b/source/GameInterface.Tests/Services/MobileParties/MobilePartyFoodConsumptionModelPatchesTests.cs
@@ -1,0 +1,220 @@
+﻿using Common.Util;
+using GameInterface.Services.Entity;
+using GameInterface.Services.MobileParties.Interfaces;
+using GameInterface.Services.MobileParties.Patches;
+using GameInterface.Services.Players;
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.GameComponents;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Party.PartyComponents;
+using TaleWorlds.Core;
+using Xunit;
+
+namespace GameInterface.Tests.Services.MobileParties;
+
+/// <summary>
+/// Regression coverage for co-op food-consumption eligibility and legacy starvation repair.
+/// </summary>
+[Collection(nameof(MobilePartyAiAuthorityCollection))]
+public class MobilePartyFoodConsumptionModelPatchesTests : IDisposable
+{
+    private readonly ConditionalWeakTable<object, ControlledObjectInfo> playerObjects =
+        (ConditionalWeakTable<object, ControlledObjectInfo>)AccessTools
+            .Field(typeof(PlayerManager), "PlayerObjects")
+            .GetValue(null)!;
+    private readonly List<object> registeredPlayerObjects = new();
+
+    public void Dispose()
+    {
+        foreach (var playerObject in registeredPlayerObjects)
+        {
+            playerObjects.Remove(playerObject);
+        }
+    }
+
+    [Fact]
+    public void DoesPartyConsumeFood_ActiveLeaderlessParty_ReturnsTrue()
+    {
+        var party = CreateActiveParty();
+
+        Assert.True(DoesPartyConsumeFood(party));
+    }
+
+    [Fact]
+    public void DoesPartyConsumeFood_InactiveParty_ReturnsFalse()
+    {
+        var party = CreateActiveParty();
+        party.IsActive = false;
+
+        Assert.False(DoesPartyConsumeFood(party));
+    }
+
+    [Fact]
+    public void DoesPartyConsumeFood_VanillaExcludedParties_ReturnFalse()
+    {
+        var excludedParties = new (string Name, Action<MobileParty> Configure)[]
+        {
+            (nameof(MobileParty.IsGarrison), party => party.IsGarrison = true),
+            (nameof(MobileParty.IsCaravan), party => party.IsCaravan = true),
+            (nameof(MobileParty.IsBandit), party => party.IsBandit = true),
+            (nameof(MobileParty.IsMilitia), party => party.IsMilitia = true),
+            (nameof(MobileParty.IsPatrolParty), party => party.IsPatrolParty = true),
+            (nameof(MobileParty.IsVillager), party => party.IsVillager = true),
+        };
+
+        foreach (var excludedParty in excludedParties)
+        {
+            var party = CreateActiveParty();
+            excludedParty.Configure(party);
+
+            Assert.False(DoesPartyConsumeFood(party), excludedParty.Name);
+        }
+    }
+
+    [Fact]
+    public void DoesPartyConsumeFood_CoopPlayerClanParty_ReturnsTrue()
+    {
+        var party = CreatePlayerClanParty();
+
+        Assert.True(DoesPartyConsumeFood(party));
+    }
+
+    [Fact]
+    public void DoesPartyConsumeFood_CoopPlayerClanMilitia_ReturnsFalse()
+    {
+        var party = CreatePlayerClanParty();
+        party.IsMilitia = true;
+
+        Assert.False(DoesPartyConsumeFood(party));
+    }
+
+    [Fact]
+    public void DoesPartyConsumeFood_UnqualifiedLeader_ReturnsFalse()
+    {
+        var leader = CreateLeader(Occupation.NotAssigned, isMinorFactionHero: false);
+        var party = CreatePartyWithLeader(leader);
+
+        Assert.False(DoesPartyConsumeFood(party));
+    }
+
+    [Fact]
+    public void DoesPartyConsumeFood_LordAndMinorFactionLeaders_ReturnTrue()
+    {
+        var lordParty = CreatePartyWithLeader(CreateLeader(Occupation.Lord, isMinorFactionHero: false));
+        var minorFactionParty = CreatePartyWithLeader(CreateLeader(Occupation.NotAssigned, isMinorFactionHero: true));
+
+        Assert.True(DoesPartyConsumeFood(lordParty));
+        Assert.True(DoesPartyConsumeFood(minorFactionParty));
+    }
+
+    [Fact]
+    public void RepairNonConsumingPartyFoodState_NonConsumerClearsPersistedStarvation()
+    {
+        var party = CreatePartyWithFoodDebt(isActive: true);
+
+        bool repaired = FoodConsumptionBehaviorInterface.RepairNonConsumingPartyFoodState(party, doesPartyConsumeFood: false);
+
+        Assert.True(repaired);
+        Assert.Equal(0, party.Party.RemainingFoodPercentage);
+        Assert.False(party.Party.IsStarving);
+    }
+
+    [Fact]
+    public void RepairNonConsumingPartyFoodState_ConsumerLeavesFoodDebtUntouched()
+    {
+        var party = CreatePartyWithFoodDebt(isActive: true);
+
+        bool repaired = FoodConsumptionBehaviorInterface.RepairNonConsumingPartyFoodState(party, doesPartyConsumeFood: true);
+
+        Assert.False(repaired);
+        Assert.Equal(-100, party.Party.RemainingFoodPercentage);
+        Assert.True(party.Party.IsStarving);
+    }
+
+    [Fact]
+    public void RepairNonConsumingPartyFoodState_InactivePartyLeavesFoodDebtUntouched()
+    {
+        var party = CreatePartyWithFoodDebt(isActive: false);
+
+        bool repaired = FoodConsumptionBehaviorInterface.RepairNonConsumingPartyFoodState(party, doesPartyConsumeFood: false);
+
+        Assert.False(repaired);
+        Assert.Equal(-100, party.Party.RemainingFoodPercentage);
+    }
+
+    [Fact]
+    public void RepairNonConsumingPartyFoodState_PositiveFoodStateRemainsUntouched()
+    {
+        var party = CreatePartyWithFoodDebt(isActive: true);
+        party.Party.RemainingFoodPercentage = 25;
+
+        bool repaired = FoodConsumptionBehaviorInterface.RepairNonConsumingPartyFoodState(party, doesPartyConsumeFood: false);
+
+        Assert.False(repaired);
+        Assert.Equal(25, party.Party.RemainingFoodPercentage);
+    }
+
+    private static MobileParty CreateActiveParty()
+    {
+        var party = ObjectHelper.SkipConstructor<MobileParty>();
+        party.IsActive = true;
+        return party;
+    }
+
+    private MobileParty CreatePlayerClanParty()
+    {
+        var clan = ObjectHelper.SkipConstructor<Clan>();
+        var controllerIdProvider = new ControllerIdProvider();
+        controllerIdProvider.SetControllerId("PlayerOne");
+        playerObjects.Add(clan, new ControlledObjectInfo("PlayerOne", controllerIdProvider));
+        registeredPlayerObjects.Add(clan);
+
+        var leader = CreateLeader(Occupation.NotAssigned, isMinorFactionHero: false);
+        leader._clan = clan;
+        return CreatePartyWithLeader(leader);
+    }
+
+    private static Hero CreateLeader(Occupation occupation, bool isMinorFactionHero)
+    {
+        var leader = ObjectHelper.SkipConstructor<Hero>();
+        leader.Occupation = occupation;
+        leader.IsMinorFactionHero = isMinorFactionHero;
+        return leader;
+    }
+
+    private static MobileParty CreatePartyWithLeader(Hero leader)
+    {
+        var component = ObjectHelper.SkipConstructor<CustomPartyComponent>();
+        component._leader = leader;
+
+        var party = CreateActiveParty();
+        party._partyComponent = component;
+        return party;
+    }
+
+    private static MobileParty CreatePartyWithFoodDebt(bool isActive)
+    {
+        var party = ObjectHelper.SkipConstructor<MobileParty>();
+        party.IsActive = isActive;
+        party.Party = ObjectHelper.SkipConstructor<PartyBase>();
+        party.Party.MobileParty = party;
+        party.Party.RemainingFoodPercentage = -100;
+        return party;
+    }
+
+    private static bool DoesPartyConsumeFood(MobileParty party)
+    {
+        bool result = false;
+        bool runOriginal = MobilePartyFoodConsumptionModelPatches.DoesPartyConsumeFoodPrefix(
+            new DefaultMobilePartyFoodConsumptionModel(),
+            ref result,
+            party);
+
+        Assert.False(runOriginal);
+        return result;
+    }
+}

--- a/source/GameInterface/Services/MobileParties/Interfaces/FoodConsumptionBehaviorInterface.cs
+++ b/source/GameInterface/Services/MobileParties/Interfaces/FoodConsumptionBehaviorInterface.cs
@@ -58,12 +58,27 @@ public class FoodConsumptionBehaviorInterface : IFoodConsumptionBehaviorInterfac
         GameThread.RunSafe(() =>
         {
             behavior.CheckAnimalBreeding(mobileParty);
-            if (Campaign.Current.Models.MobilePartyFoodConsumptionModel.DoesPartyConsumeFood(mobileParty))
+            bool doesPartyConsumeFood = Campaign.Current.Models.MobilePartyFoodConsumptionModel.DoesPartyConsumeFood(mobileParty);
+            if (RepairNonConsumingPartyFoodState(mobileParty, doesPartyConsumeFood))
+            {
+                mobileParty.Party.OnConsumedFood();
+            }
+
+            if (doesPartyConsumeFood)
             {
                 // Check for a player party starving here instead of OnTick
                 behavior.PartyConsumeFood(mobileParty, mobileParty.IsPlayerParty() && mobileParty.Party.IsStarving);
             }
         });
+    }
+
+    internal static bool RepairNonConsumingPartyFoodState(MobileParty mobileParty, bool doesPartyConsumeFood)
+    {
+        if (!mobileParty.IsActive || doesPartyConsumeFood || mobileParty.Party.RemainingFoodPercentage >= 0) return false;
+
+        // Repair food debt persisted by the old predicate for parties vanilla excludes from consumption.
+        mobileParty.Party.RemainingFoodPercentage = 0;
+        return true;
     }
 
     public void PartyConsumeFood(FoodConsumptionBehavior behavior, MobileParty mobileParty, bool starvingCheck = false)

--- a/source/GameInterface/Services/MobileParties/Patches/MobilePartyFoodConsumptionModelPatches.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/MobilePartyFoodConsumptionModelPatches.cs
@@ -12,13 +12,21 @@ internal class MobilePartyFoodConsumptionModelPatches
     [HarmonyPrefix]
     public static bool DoesPartyConsumeFoodPrefix(DefaultMobilePartyFoodConsumptionModel __instance, ref bool __result, MobileParty mobileParty)
     {
-        // Override PlayerClan check
-        if (mobileParty.IsActive && (mobileParty.LeaderHero == null || mobileParty.LeaderHero.Clan.IsPlayerClan()))
-        {
-            __result = true;
-            return false;
-        }
+        var leaderHero = mobileParty.LeaderHero;
 
-        return true;
+        // Match vanilla eligibility while recognizing every co-op player clan.
+        __result = mobileParty.IsActive &&
+                   (leaderHero == null ||
+                    leaderHero.IsLord ||
+                    leaderHero.Clan?.IsPlayerClan() == true ||
+                    leaderHero.IsMinorFactionHero) &&
+                   !mobileParty.IsGarrison &&
+                   !mobileParty.IsCaravan &&
+                   !mobileParty.IsBandit &&
+                   !mobileParty.IsMilitia &&
+                   !mobileParty.IsPatrolParty &&
+                   !mobileParty.IsVillager;
+
+        return false;
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Militia gradually become wounded even while their settlement still has food. After several campaign days, the entire militia can remain wounded and stop recovering.

## What is the new behavior?

Resolves #1815

Militia no longer become wounded simply as campaign days pass. Existing saves affected by this issue clear the incorrect starvation state on the next daily tick, after which wounded militia can heal normally.
