### PR TITLE
Enable InfluenceGainCampaignBehavior

### DIFF
--- a/source/GameInterface/Services/Kingdoms/Patches/DisableInfluenceGainCampaignBehavior.cs
+++ b/source/GameInterface/Services/Kingdoms/Patches/DisableInfluenceGainCampaignBehavior.cs
@@ -1,5 +1,11 @@
-﻿using HarmonyLib;
+﻿using Common;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Roster;
+using TaleWorlds.CampaignSystem.Settlements;
 
 namespace GameInterface.Services.Kingdoms.Patches;
 
@@ -7,5 +13,26 @@ namespace GameInterface.Services.Kingdoms.Patches;
 internal class DisableInfluenceGainCampaignBehavior
 {
     [HarmonyPatch(nameof(InfluenceGainCampaignBehavior.RegisterEvents))]
-    static bool Prefix() => false;
+    static bool Prefix() => ModInformation.IsServer;
+}
+
+[HarmonyPatch(typeof(InfluenceGainCampaignBehavior))]
+internal class InfluenceGainCampaignBehaviorPatches
+{
+    [HarmonyPatch(nameof(InfluenceGainCampaignBehavior.OnPrisonerDonatedToSettlement))]
+    [HarmonyPrefix]
+    public static bool OnPrisonerDonatedToSettlementPrefix(MobileParty donatingParty, FlattenedTroopRoster donatedPrisoners, Settlement donatedSettlement)
+    {
+        // Donating party is part of the same clan as the settlement, don't give influence
+        if (donatedSettlement.OwnerClan == donatingParty.ActualClan) return false;
+
+        float gainedInfluence = 0f;
+        foreach (FlattenedTroopRosterElement flattenedTroopRosterElement in donatedPrisoners)
+        {
+            gainedInfluence += Campaign.Current.Models.PrisonerDonationModel.CalculateInfluenceGainAfterPrisonerDonation(donatingParty.Party, flattenedTroopRosterElement.Troop, donatedSettlement);
+        }
+        GainKingdomInfluenceAction.ApplyForDonatePrisoners(donatingParty, gainedInfluence);
+
+        return false;
+    }
 }

--- a/source/GameInterface/Services/UI/Notifications/Handlers/OtherNotificationsHandler.cs
+++ b/source/GameInterface/Services/UI/Notifications/Handlers/OtherNotificationsHandler.cs
@@ -5,10 +5,13 @@ using Common.Network;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.UI.Notifications.Messages;
 using Serilog;
+using System;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.Extensions;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.Core;
+using TaleWorlds.Engine;
 using TaleWorlds.Library;
 using TaleWorlds.Localization;
 
@@ -43,6 +46,9 @@ internal class OtherNotificationsHandler : IHandler
         messageBroker.Subscribe<NotifyFoundItemOnMap>(Handle_NotifyFoundItemOnMap);
         messageBroker.Subscribe<NetworkNotifyFoundItemOnMap>(Handle_NetworkNotifyFoundItemOnMap);
 
+        messageBroker.Subscribe<NotifyKingdomInfluenceChanged>(Handle_NotifyKingdomInfluenceChanged);
+        messageBroker.Subscribe<NetworkNotifyKingdomInfluenceChanged>(Handle_NetworkNotifyKingdomInfluenceChanged);
+
         messageBroker.Subscribe<NetworkNotifyRemovedSupporter>(Handle_NetworkNotifyRemovedSupporter);
     }
 
@@ -59,6 +65,9 @@ internal class OtherNotificationsHandler : IHandler
 
         messageBroker.Unsubscribe<NotifyFoundItemOnMap>(Handle_NotifyFoundItemOnMap);
         messageBroker.Unsubscribe<NetworkNotifyFoundItemOnMap>(Handle_NetworkNotifyFoundItemOnMap);
+
+        messageBroker.Unsubscribe<NotifyKingdomInfluenceChanged>(Handle_NotifyKingdomInfluenceChanged);
+        messageBroker.Unsubscribe<NetworkNotifyKingdomInfluenceChanged>(Handle_NetworkNotifyKingdomInfluenceChanged);
 
         messageBroker.Unsubscribe<NetworkNotifyRemovedSupporter>(Handle_NetworkNotifyRemovedSupporter);
     }
@@ -155,6 +164,43 @@ internal class OtherNotificationsHandler : IHandler
             textObject.SetTextVariable("COUNT", obj.What.Count);
             textObject.SetTextVariable("ANIMAL_NAME", obj.What.ItemName);
             InformationManager.DisplayMessage(new InformationMessage(textObject.ToString()));
+        });
+    }
+
+    private void Handle_NotifyKingdomInfluenceChanged(MessagePayload<NotifyKingdomInfluenceChanged> obj)
+    {
+        GameThread.RunSafe(() =>
+        {
+            if (!objectManager.TryGetIdWithLogging(obj.What.Hero, out var heroId)) return;
+            if (!objectManager.TryGetIdWithLogging(obj.What.MobileParty, out var mobilePartyId)) return;
+            if (!objectManager.TryGetIdWithLogging(obj.What.Clan, out var clanId)) return;
+
+            network.SendAll(new NetworkNotifyKingdomInfluenceChanged(heroId, mobilePartyId, clanId, obj.What.GainedInfluence, obj.What.Detail));
+        });
+    }
+
+    private void Handle_NetworkNotifyKingdomInfluenceChanged(MessagePayload<NetworkNotifyKingdomInfluenceChanged> obj)
+    {
+        GameThread.RunSafe(() =>
+        {
+            if (!objectManager.TryGetObjectWithLogging<Hero>(obj.What.HeroId, out var hero)) return;
+            if (!objectManager.TryGetObjectWithLogging<MobileParty>(obj.What.MobilePartyId, out var mobileParty)) return;
+            if (!objectManager.TryGetObjectWithLogging<Clan>(obj.What.ClanId, out var clan)) return;
+
+            if ((obj.What.Detail == GainKingdomInfluenceAction.InfluenceGainingReason.DonatePrisoners && mobileParty == MobileParty.MainParty) 
+            || (obj.What.Detail == GainKingdomInfluenceAction.InfluenceGainingReason.Battle && hero == Hero.MainHero))
+            {
+                TextObject textObject = GameTexts.FindText("str_influence_gain_message", null);
+                textObject.SetTextVariable("INFLUENCE", obj.What.GainedInfluence);
+                textObject.SetTextVariable("NEW_INFLUENCE", (int)clan.Influence);
+                InformationManager.DisplayMessage(new InformationMessage(textObject.ToString()));
+            }
+            if (obj.What.Detail == GainKingdomInfluenceAction.InfluenceGainingReason.SiegeSafePassage && hero == Hero.MainHero)
+            {
+                TextObject textObject2 = GameTexts.FindText("str_leave_siege_lose_influence_message", null);
+                textObject2.SetTextVariable("INFLUENCE", -obj.What.GainedInfluence);
+                InformationManager.DisplayMessage(new InformationMessage(textObject2.ToString()));
+            }
         });
     }
 

--- a/source/GameInterface/Services/UI/Notifications/Messages/NetworkNotifyKingdomInfluenceChanged.cs
+++ b/source/GameInterface/Services/UI/Notifications/Messages/NetworkNotifyKingdomInfluenceChanged.cs
@@ -1,0 +1,29 @@
+﻿using Common.Messaging;
+using ProtoBuf;
+using TaleWorlds.CampaignSystem.Actions;
+
+namespace GameInterface.Services.UI.Notifications.Messages;
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkNotifyKingdomInfluenceChanged : ICommand
+{
+    public readonly string HeroId;
+    public readonly string MobilePartyId;
+    public readonly string ClanId;
+    public readonly int GainedInfluence;
+    public readonly GainKingdomInfluenceAction.InfluenceGainingReason Detail;
+
+    public NetworkNotifyKingdomInfluenceChanged(
+        string heroId,
+        string mobilePartyId,
+        string clanId,
+        int gainedInfluence,
+        GainKingdomInfluenceAction.InfluenceGainingReason detail)
+    {
+        HeroId = heroId;
+        MobilePartyId = mobilePartyId;
+        ClanId = clanId;
+        GainedInfluence = gainedInfluence;
+        Detail = detail;
+    }
+}

--- a/source/GameInterface/Services/UI/Notifications/Messages/NotifyKingdomInfluenceChanged.cs
+++ b/source/GameInterface/Services/UI/Notifications/Messages/NotifyKingdomInfluenceChanged.cs
@@ -1,0 +1,29 @@
+﻿using Common.Messaging;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Actions;
+using TaleWorlds.CampaignSystem.Party;
+
+namespace GameInterface.Services.UI.Notifications.Messages;
+
+public readonly struct NotifyKingdomInfluenceChanged : IEvent
+{
+    public readonly Hero Hero;
+    public readonly MobileParty MobileParty;
+    public readonly Clan Clan;
+    public readonly int GainedInfluence;
+    public readonly GainKingdomInfluenceAction.InfluenceGainingReason Detail;
+
+    public NotifyKingdomInfluenceChanged(
+        Hero hero,
+        MobileParty mobileParty,
+        Clan clan,
+        int gainedInfluence,
+        GainKingdomInfluenceAction.InfluenceGainingReason detail)
+    {
+        Hero = hero;
+        MobileParty = mobileParty;
+        Clan = clan;
+        GainedInfluence = gainedInfluence;
+        Detail = detail;
+    }
+}

--- a/source/GameInterface/Services/UI/Notifications/Patches/GainKingdomInfluenceActionPatch.cs
+++ b/source/GameInterface/Services/UI/Notifications/Patches/GainKingdomInfluenceActionPatch.cs
@@ -1,0 +1,60 @@
+﻿using Common;
+using Common.Messaging;
+using GameInterface.Services.Heroes.Extensions;
+using GameInterface.Services.MobileParties.Extensions;
+using GameInterface.Services.UI.Notifications.Messages;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Actions;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.Library;
+
+namespace GameInterface.Services.UI.Notifications.Patches;
+
+[HarmonyPatch(typeof(GainKingdomInfluenceAction))]
+internal class GainKingdomInfluenceActionPatch
+{
+    [HarmonyPatch(nameof(GainKingdomInfluenceAction.ApplyInternal))]
+    [HarmonyPostfix]
+    public static void ApplyInternalPostfix(Hero hero, MobileParty party, float gainedInfluence, GainKingdomInfluenceAction.InfluenceGainingReason detail)
+    {
+        if (ModInformation.IsClient) return;
+
+        int gainedInfluenceInt = MathF.Abs((int)gainedInfluence);
+        var clan = GetClan(hero, party);
+
+        // Don't notify players of influence changes that don't involve players
+        if (gainedInfluenceInt == 0 
+            && (party == null || !party.IsPlayerParty())
+            && (hero == null || !hero.IsPlayerHero())) return;
+
+        var message = new NotifyKingdomInfluenceChanged(hero, party, clan, gainedInfluenceInt, detail);
+        MessageBroker.Instance.Publish(null, message);
+    }
+
+    private static Clan GetClan(Hero hero, MobileParty party)
+    {
+        Clan clan = null;
+        if (hero != null)
+        {
+            if (hero.CompanionOf != null)
+            {
+                clan = hero.CompanionOf;
+            }
+            else if (hero.Clan != null)
+            {
+                clan = hero.Clan;
+            }
+        }
+        else if (party.ActualClan != null)
+        {
+            clan = party.ActualClan;
+        }
+        else if (party.Owner != null)
+        {
+            clan = party.Owner.Clan;
+        }
+
+        return clan;
+    }
+}


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- `InfluenceGainCampaignBehavior` is disabled. This behavior gives a party's clan influence when donating prisoners to settlements.
- No notification on clients when their influence in a kingdom changes.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
- `InfluenceGainCampaignBehavior` enabled and patched to work for multiple players.
- Notification on clients when their clan influence changes matching vanilla's notification.

## Other information
