### PR TITLE
Enable MobilePartyTrainingBehavior

### DIFF
--- a/source/GameInterface/Services/MobileParties/Patches/Disable/DisableMobilePartyTrainingBehavior.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/Disable/DisableMobilePartyTrainingBehavior.cs
@@ -1,11 +1,77 @@
-﻿using HarmonyLib;
+﻿using Common;
+using GameInterface.Services.MobileParties.Extensions;
+using HarmonyLib;
+using System.Collections.Generic;
+using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
+using TaleWorlds.CampaignSystem.CharacterDevelopment;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Roster;
+using TaleWorlds.Core;
 
-namespace GameInterface.Services.MobileParties.Patches;
+namespace GameInterface.Services.MobileParties.Patches.Disable;
 
 [HarmonyPatch(typeof(MobilePartyTrainingBehavior))]
 internal class DisableMobilePartyTrainingBehavior
 {
     [HarmonyPatch(nameof(MobilePartyTrainingBehavior.RegisterEvents))]
-    static bool Prefix() => false;
+    static bool Prefix() => ModInformation.IsServer;
+}
+
+// OnPlayerUpgradedTroops already replaced in PartyDoneLogicHandler.ApplyUpgradedTroopHistory
+[HarmonyPatch(typeof(MobilePartyTrainingBehavior))]
+internal class MobilePartyTrainingBehaviorPatches
+{
+    [HarmonyPatch(nameof(MobilePartyTrainingBehavior.CheckScouting))]
+    [HarmonyPrefix]
+    public static bool CheckScoutingPrefix(MobileParty mobileParty)
+    {
+        if (mobileParty.EffectiveScout != null && !mobileParty.IsCurrentlyAtSea)
+        {
+            TerrainType faceTerrainType = Campaign.Current.MapSceneWrapper.GetFaceTerrainType(mobileParty.CurrentNavigationFace);
+            if (!mobileParty.IsPlayerParty()) // Replace MainParty check
+            {
+                SkillLevelingManager.OnAIPartiesTravel(mobileParty.EffectiveScout, mobileParty.IsCaravan, faceTerrainType);
+            }
+            SkillLevelingManager.OnTraverseTerrain(mobileParty, faceTerrainType);
+        }
+
+        return false;
+    }
+
+    [HarmonyPatch(nameof(MobilePartyTrainingBehavior.CheckMovementSkills))]
+    [HarmonyPrefix]
+    public static bool CheckMovementSkillsPrefix(MobileParty mobileParty)
+    {
+        // Only need to patch first block as mobileParty == MobileParty.MainParty won't be true on the server
+        if (mobileParty.IsPlayerParty())
+        {
+            if (mobileParty.IsCurrentlyAtSea)
+            {
+                SkillLevelingManager.OnTravelOnWater(mobileParty, mobileParty._lastCalculatedSpeed);
+                return false;
+            }
+            using (List<TroopRosterElement>.Enumerator enumerator = mobileParty.MemberRoster.GetTroopRoster().GetEnumerator())
+            {
+                while (enumerator.MoveNext())
+                {
+                    TroopRosterElement troopRosterElement = enumerator.Current;
+                    if (troopRosterElement.Character.IsHero)
+                    {
+                        if (troopRosterElement.Character.Equipment.Horse.IsEmpty)
+                        {
+                            SkillLevelingManager.OnTravelOnFoot(troopRosterElement.Character.HeroObject, mobileParty._lastCalculatedSpeed);
+                        }
+                        else
+                        {
+                            SkillLevelingManager.OnTravelOnHorse(troopRosterElement.Character.HeroObject, mobileParty._lastCalculatedSpeed);
+                        }
+                    }
+                }
+                return false;
+            }
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`MobilePartyTrainingBehavior` is disabled. This behavior passively gives xp to troops in a party based on perks etc. as well as levelling up used skills for heroes while moving on the campaign map.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
`MobilePartyTrainingBehavior` enabled and patched.