### PR TITLE
Enable CampaignBattleRecoveryBehavior

### DIFF
--- a/source/GameInterface/Services/MapEvents/Patches/Disable/DisableCampaignBattleRecoveryBehavior.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/Disable/DisableCampaignBattleRecoveryBehavior.cs
@@ -1,11 +1,12 @@
-﻿using HarmonyLib;
+﻿using Common;
+using HarmonyLib;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
 
-namespace GameInterface.Services.Battles.Patches.Disable;
+namespace GameInterface.Services.MapEvents.Patches.Disable;
 
 [HarmonyPatch(typeof(CampaignBattleRecoveryBehavior))]
 internal class DisableCampaignBattleRecoveryBehavior
 {
     [HarmonyPatch(nameof(CampaignBattleRecoveryBehavior.RegisterEvents))]
-    static bool Prefix() => false;
+    static bool Prefix() => ModInformation.IsServer;
 }


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`CampaignBattleRecoveryBehavior` is disabled. It has logic for healing lame horses and post battle recovery after map events.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Enable `CampaignBattleRecoveryBehavior`.

## Other information
