### PR TITLE
Fix client campaign time pacing

### DIFF
--- a/source/GameInterface.Tests/Services/Time/MapTimeTrackerInterfaceTests.cs
+++ b/source/GameInterface.Tests/Services/Time/MapTimeTrackerInterfaceTests.cs
@@ -16,60 +16,77 @@ public class MapTimeTrackerInterfaceTests
     }
 
     [Fact]
-    public void BeginCorrection_OrdinaryHeartbeatStartsBoundedCorrection()
+    public void PrepareCorrection_ClientWithinLeadBandKeepsVanillaFastForwardRate()
     {
-        var tracker = CreateSynchronizedTracker();
+        var tracker = CreateTrackerWithServerRate();
 
-        Assert.False(tracker.BeginCorrection(150L, 1000L));
-        tracker.PrepareCorrection(200L);
-        Assert.Equal(-5L, tracker.GetTickCorrection(10L, 0.025f));
+        tracker.PrepareCorrection(190L, 40L);
+
+        Assert.Equal(0L, tracker.GetTickCorrection(40L, 0.05f));
     }
 
     [Fact]
-    public void GetTickCorrection_AheadClientNeverRunsBackward()
+    public void PrepareCorrection_HealthyFourHertzHeartbeatsDoNotPaceClient()
     {
         var tracker = CreateSynchronizedTracker();
-        tracker.BeginCorrection(100L, 1000L);
-        tracker.PrepareCorrection(10000L);
+        long localTicks = 100L;
+
+        for (int heartbeat = 0; heartbeat < 8; heartbeat++)
+        {
+            for (int frame = 0; frame < 5; frame++)
+            {
+                const long vanillaDeltaTicks = 10L;
+                localTicks += vanillaDeltaTicks;
+                tracker.PrepareCorrection(localTicks, vanillaDeltaTicks);
+                localTicks += tracker.GetTickCorrection(vanillaDeltaTicks, 0.05f);
+            }
+
+            Assert.False(tracker.BeginCorrection(localTicks, 1000L));
+        }
+    }
+
+    [Fact]
+    public void PrepareCorrection_ClientAheadOfLeadBandSlowsWithoutPausing()
+    {
+        var tracker = CreateTrackerWithServerRate();
+
+        tracker.PrepareCorrection(220L, 10L);
+
+        Assert.Equal(-1L, tracker.GetTickCorrection(10L, 0.05f));
+    }
+
+    [Fact]
+    public void PrepareCorrection_ClientFarAheadPausesUntilItReentersResumeBand()
+    {
+        var tracker = CreateTrackerWithServerRate();
+
+        tracker.PrepareCorrection(260L, 10L);
+        Assert.Equal(-10L, tracker.GetTickCorrection(10L, 0.05f));
 
         Assert.Equal(-10L, tracker.GetTickCorrection(10L, 0.25f));
+        tracker.BeginCorrection(230L, 1000L);
+        tracker.PrepareCorrection(250L, 10L);
+
+        Assert.Equal(0L, tracker.GetTickCorrection(10L, 0.05f));
     }
 
     [Fact]
-    public void GetTickCorrection_BehindClientNeverExceedsDoubleSpeed()
+    public void PrepareCorrection_BehindClientNeverExceedsDoubleSpeed()
     {
-        var tracker = CreateSynchronizedTracker();
-        tracker.BeginCorrection(10000L, 10000L);
-        tracker.PrepareCorrection(100L);
+        var tracker = CreateTrackerWithServerRate();
 
-        Assert.Equal(10L, tracker.GetTickCorrection(10L, 0.25f));
-    }
+        tracker.PrepareCorrection(0L, 10L);
 
-    [Fact]
-    public void GetTickCorrection_AccumulatesFractionalTicks()
-    {
-        var tracker = CreateSynchronizedTracker();
-        tracker.BeginCorrection(101L, 1000L);
-        tracker.PrepareCorrection(100L);
-
-        Assert.Equal(0L, tracker.GetTickCorrection(10L, 0.1f));
-        Assert.Equal(0L, tracker.GetTickCorrection(10L, 0.1f));
-        Assert.Equal(1L, tracker.GetTickCorrection(10L, 0.1f));
+        Assert.Equal(5L, tracker.GetTickCorrection(10L, 0.05f));
     }
 
     [Fact]
     public void GetTickCorrection_StaleHeartbeatStopsSimulation()
     {
-        var tracker = CreateSynchronizedTracker();
-        tracker.BeginCorrection(100L, 1000L);
-        tracker.PrepareCorrection(100L);
+        var tracker = CreateTrackerWithServerRate();
 
         Assert.Equal(0L, tracker.GetTickCorrection(10L, 0.8f));
         Assert.Equal(-10L, tracker.GetTickCorrection(10L, 0.8f));
-
-        tracker.BeginCorrection(110L, 1000L);
-        tracker.PrepareCorrection(110L);
-        Assert.Equal(0L, tracker.GetTickCorrection(10L, 0.01f));
     }
 
     [Fact]
@@ -111,39 +128,11 @@ public class MapTimeTrackerInterfaceTests
     }
 
     [Fact]
-    public void GetTickCorrection_RepeatedUnchangedHeartbeatsDoNotAccumulateDrift()
-    {
-        var tracker = CreateSynchronizedTracker();
-        long localTicks = 100L;
-        long firstCycleTicks = 0L;
-
-        for (int heartbeat = 0; heartbeat < 8; heartbeat++)
-        {
-            tracker.BeginCorrection(100L, 1000L);
-
-            for (int frame = 0; frame < 5; frame++)
-            {
-                const long vanillaDeltaTicks = 10L;
-                localTicks += vanillaDeltaTicks;
-                tracker.PrepareCorrection(localTicks);
-                localTicks += tracker.GetTickCorrection(vanillaDeltaTicks, 0.05f);
-            }
-
-            if (heartbeat == 0)
-            {
-                firstCycleTicks = localTicks;
-            }
-        }
-
-        Assert.Equal(firstCycleTicks, localTicks);
-    }
-
-    [Fact]
     public void GetTickCorrection_PausedClientDoesNotCatchUpOrRunBackward()
     {
-        var tracker = CreateSynchronizedTracker();
-        tracker.BeginCorrection(200L, 1000L);
-        tracker.PrepareCorrection(100L);
+        var tracker = CreateTrackerWithServerRate();
+
+        tracker.PrepareCorrection(100L, 0L);
 
         Assert.Equal(0L, tracker.GetTickCorrection(0L, 1f));
         Assert.Equal(0L, tracker.GetTickCorrection(0L, 1f));
@@ -152,23 +141,11 @@ public class MapTimeTrackerInterfaceTests
     [Fact]
     public void PrepareCorrection_PostHitchVanillaProgressIsNotAppliedTwice()
     {
-        var tracker = CreateSynchronizedTracker();
-        tracker.BeginCorrection(200L, 1000L);
+        var tracker = CreateTrackerWithServerRate();
 
-        tracker.PrepareCorrection(200L);
+        tracker.PrepareCorrection(150L, 100L);
 
         Assert.Equal(0L, tracker.GetTickCorrection(100L, 1f));
-    }
-
-    [Fact]
-    public void PrepareCorrection_PostHitchCorrectsOnlyUnconsumedProgress()
-    {
-        var tracker = CreateSynchronizedTracker();
-        tracker.BeginCorrection(200L, 1000L);
-
-        tracker.PrepareCorrection(150L);
-
-        Assert.Equal(50L, tracker.GetTickCorrection(50L, 1f));
     }
 
     private static MapTimeTrackerInterface CreateSynchronizedTracker()
@@ -176,6 +153,19 @@ public class MapTimeTrackerInterfaceTests
         var tracker = new MapTimeTrackerInterface();
         tracker.BeginCorrection(100L, 1000L);
         tracker.TryConsumeHardSync(out _);
+        return tracker;
+    }
+
+    private static MapTimeTrackerInterface CreateTrackerWithServerRate()
+    {
+        var tracker = CreateSynchronizedTracker();
+
+        for (int frame = 0; frame < 5; frame++)
+        {
+            tracker.GetTickCorrection(10L, 0.05f);
+        }
+
+        tracker.BeginCorrection(150L, 1000L);
         return tracker;
     }
 }

--- a/source/GameInterface/Services/Time/Interaces/MapTimeTrackerInterface.cs
+++ b/source/GameInterface/Services/Time/Interaces/MapTimeTrackerInterface.cs
@@ -54,21 +54,28 @@ internal class MapTimeTrackerInterface : IMapTimeTrackerInterface
 
     private static ILogger Logger => LogManager.GetLogger<MapTimeTrackerInterface>();
 
-    internal const float CorrectionWindowSeconds = 0.25f;
+    internal const float MaximumClientLeadSeconds = 0.25f;
     internal const float HeartbeatTimeoutSeconds = 0.75f;
-    private const float PacingLogDebounceSeconds = CorrectionWindowSeconds * 2f;
+    private const float ResumeClientLeadRatio = 0.5f;
+    private const float PauseClientLeadMultiplier = 2f;
+    private const float CorrectionSettleSeconds = 1f;
+    private const float MaximumSlowdownRatio = 0.25f;
+    private const float PacingLogDebounceSeconds = MaximumClientLeadSeconds * 2f;
     private const float MapSecondsPerCampaignDelta = 4320f;
 
     private bool hasServerTime;
     private bool hasPendingHardSync;
-    private bool hasPendingServerTime;
+    private bool hasEstimatedServerRate;
+    private bool isPausedForServer;
     private bool skipNextHeartbeatAgeIncrement;
     private long previousServerTicks;
     private long pendingServerTicks;
-    private double remainingCorrectionTicks;
+    private double localTicksPerSecond;
+    private double serverTicksPerSecond;
     private double correctionTicksPerSecond;
     private double correctionAccumulator;
     private float secondsSinceHeartbeat;
+    private float secondsSinceServerSample;
     private float candidatePacingStateSeconds;
     private CampaignTimePacingState loggedPacingState = CampaignTimePacingState.Normal;
     private CampaignTimePacingState candidatePacingState = CampaignTimePacingState.Normal;
@@ -115,7 +122,7 @@ internal class MapTimeTrackerInterface : IMapTimeTrackerInterface
         }
 
         long originalDeltaTicks = tracker._deltaTimeInTicks;
-        PrepareCorrection(tracker._numTicks);
+        PrepareCorrection(tracker._numTicks, originalDeltaTicks);
         long correctionTicks = GetTickCorrection(originalDeltaTicks, realDt);
         long correctedDeltaTicks = originalDeltaTicks + correctionTicks;
         UpdatePacingDiagnostics(tracker._numTicks + correctionTicks, originalDeltaTicks, correctedDeltaTicks, realDt);
@@ -139,7 +146,9 @@ internal class MapTimeTrackerInterface : IMapTimeTrackerInterface
 
     internal bool BeginCorrection(long serverTicks, long maxServerProgressTicks)
     {
+        float elapsedSincePreviousHeartbeat = secondsSinceServerSample;
         secondsSinceHeartbeat = 0f;
+        secondsSinceServerSample = 0f;
         skipNextHeartbeatAgeIncrement = true;
 
         bool isDiscontinuity = hasServerTime == false ||
@@ -147,20 +156,24 @@ internal class MapTimeTrackerInterface : IMapTimeTrackerInterface
             serverTicks - previousServerTicks > maxServerProgressTicks;
 
         hasServerTime = true;
+        if (isDiscontinuity == false && elapsedSincePreviousHeartbeat > 0f)
+        {
+            double observedServerTicksPerSecond = (serverTicks - previousServerTicks) / elapsedSincePreviousHeartbeat;
+            serverTicksPerSecond = observedServerTicksPerSecond == 0d || hasEstimatedServerRate == false
+                ? observedServerTicksPerSecond
+                : ((serverTicksPerSecond * 0.75d) + (observedServerTicksPerSecond * 0.25d));
+            hasEstimatedServerRate = true;
+        }
+
         previousServerTicks = serverTicks;
         pendingServerTicks = serverTicks;
         hasPendingHardSync = hasPendingHardSync || isDiscontinuity;
-        hasPendingServerTime = false;
-        remainingCorrectionTicks = 0d;
-        correctionTicksPerSecond = 0d;
-        correctionAccumulator = 0d;
 
         if (hasPendingHardSync)
         {
             return true;
         }
 
-        hasPendingServerTime = true;
         return false;
     }
 
@@ -171,23 +184,64 @@ internal class MapTimeTrackerInterface : IMapTimeTrackerInterface
 
         hasPendingHardSync = false;
         skipNextHeartbeatAgeIncrement = false;
+        hasEstimatedServerRate = false;
+        isPausedForServer = false;
+        localTicksPerSecond = 0d;
+        serverTicksPerSecond = 0d;
+        correctionTicksPerSecond = 0d;
+        correctionAccumulator = 0d;
         ResetPacingDiagnostics();
         return true;
     }
 
-    internal void PrepareCorrection(long localTicks)
+    internal void PrepareCorrection(long localTicks, long localDeltaTicks)
     {
-        if (hasPendingServerTime == false) return;
+        if (hasServerTime == false || localDeltaTicks <= 0L) return;
 
-        hasPendingServerTime = false;
-        remainingCorrectionTicks = pendingServerTicks - localTicks;
-        correctionTicksPerSecond = remainingCorrectionTicks / CorrectionWindowSeconds;
+        double projectedTicksPerSecond = hasEstimatedServerRate ? serverTicksPerSecond : localTicksPerSecond;
+        double projectedServerTicks = pendingServerTicks + (projectedTicksPerSecond * secondsSinceServerSample);
+        double maximumClientLeadTicks = Math.Max(localDeltaTicks, projectedTicksPerSecond * MaximumClientLeadSeconds);
+        double resumeClientLeadTicks = maximumClientLeadTicks * ResumeClientLeadRatio;
+        double clientLeadTicks = localTicks - projectedServerTicks;
+
+        if (isPausedForServer)
+        {
+            if (clientLeadTicks > resumeClientLeadTicks)
+            {
+                correctionTicksPerSecond = 0d;
+                return;
+            }
+
+            isPausedForServer = false;
+        }
+
+        if (clientLeadTicks > maximumClientLeadTicks * PauseClientLeadMultiplier)
+        {
+            isPausedForServer = true;
+            correctionTicksPerSecond = 0d;
+            return;
+        }
+
+        if (clientLeadTicks > maximumClientLeadTicks)
+        {
+            correctionTicksPerSecond = -(clientLeadTicks - maximumClientLeadTicks) / CorrectionSettleSeconds;
+            return;
+        }
+
+        if (clientLeadTicks < -maximumClientLeadTicks)
+        {
+            correctionTicksPerSecond = (-clientLeadTicks - maximumClientLeadTicks) / CorrectionSettleSeconds;
+            return;
+        }
+
+        correctionTicksPerSecond = 0d;
     }
 
     internal long GetTickCorrection(long localDeltaTicks, float realDt)
     {
         if (hasServerTime == false || realDt <= 0f) return 0L;
 
+        secondsSinceServerSample += realDt;
         if (skipNextHeartbeatAgeIncrement)
         {
             skipNextHeartbeatAgeIncrement = false;
@@ -196,6 +250,10 @@ internal class MapTimeTrackerInterface : IMapTimeTrackerInterface
         {
             secondsSinceHeartbeat += realDt;
         }
+        if (localDeltaTicks > 0L)
+        {
+            localTicksPerSecond = localDeltaTicks / realDt;
+        }
         if (localDeltaTicks <= 0L) return 0L;
 
         if (secondsSinceHeartbeat > HeartbeatTimeoutSeconds)
@@ -203,43 +261,19 @@ internal class MapTimeTrackerInterface : IMapTimeTrackerInterface
             return -localDeltaTicks;
         }
 
-        if (remainingCorrectionTicks == 0d) return 0L;
+        if (isPausedForServer) return -localDeltaTicks;
+        if (correctionTicksPerSecond == 0d) return 0L;
 
         double requestedCorrection = correctionTicksPerSecond * realDt;
-        requestedCorrection = Math.Max(-localDeltaTicks, Math.Min(localDeltaTicks, requestedCorrection));
-
-        if (remainingCorrectionTicks > 0d)
-        {
-            if (requestedCorrection <= 0d) return 0L;
-            requestedCorrection = Math.Min(remainingCorrectionTicks, requestedCorrection);
-        }
-        else
-        {
-            if (requestedCorrection >= 0d) return 0L;
-            requestedCorrection = Math.Max(remainingCorrectionTicks, requestedCorrection);
-        }
+        double maximumSlowdownTicks = localDeltaTicks * MaximumSlowdownRatio;
+        requestedCorrection = Math.Max(-maximumSlowdownTicks, Math.Min(localDeltaTicks, requestedCorrection));
 
         correctionAccumulator += requestedCorrection;
 
         long correctionTicks = (long)correctionAccumulator;
-        correctionTicks = Math.Max(-localDeltaTicks, Math.Min(localDeltaTicks, correctionTicks));
-
-        if (remainingCorrectionTicks > 0d)
-        {
-            correctionTicks = Math.Min((long)remainingCorrectionTicks, correctionTicks);
-        }
-        else
-        {
-            correctionTicks = Math.Max((long)remainingCorrectionTicks, correctionTicks);
-        }
+        correctionTicks = Math.Max(-(long)maximumSlowdownTicks, Math.Min(localDeltaTicks, correctionTicks));
 
         correctionAccumulator -= correctionTicks;
-        remainingCorrectionTicks -= correctionTicks;
-
-        if (remainingCorrectionTicks == 0d)
-        {
-            correctionAccumulator = 0d;
-        }
 
         return correctionTicks;
     }


### PR DESCRIPTION
## What

Fix client campaign pacing that was continuously slowing, pausing, then catching up even with a healthy server.

Each heartbeat used to reset the client toward the server's sampled tick over the same 250ms interval. A client that was slightly ahead of that sampled time could not finish correcting before the next heartbeat discarded the partial correction. It then alternated between slowdown or pause and catch-up.

The client now projects current server time from consecutive heartbeat progress and permits up to one heartbeat of expected lead. It only changes the vanilla campaign rate outside that band. A larger lead pauses with hysteresis, so the client stays paused until server progress brings it back inside a lower resume threshold. Catch-up remains capped at 2x. Fast-forward keeps its normal vanilla speed while the client is inside the lead band.

## How to test

Ran `MapTimeTrackerInterfaceTests`, 13 passing.
