### PR TITLE
Update SetAiBehavior

### DIFF
--- a/source/GameInterface/Services/MobilePartyAIs/Patches/PartyBehaviorPatch.cs
+++ b/source/GameInterface/Services/MobilePartyAIs/Patches/PartyBehaviorPatch.cs
@@ -103,32 +103,14 @@ public static class PartyBehaviorPatch
 
             var mobileParty = partyAi._mobileParty;
 
-            mobileParty.DefaultBehavior = newBehavior;
-
-
-            if (interactablePoint is null)
-            {
-                mobileParty._targetSettlement = null;
-                mobileParty._targetParty = null;
-                partyAi.AiBehaviorPartyBase = null;
-            }
-
             if (interactablePoint is PartyBase partyBase)
             {
-                if (partyBase.IsSettlement)
-                {
-                    mobileParty._targetSettlement = partyBase.Settlement;
-                    mobileParty._targetParty = null;
-                    partyAi.AiBehaviorPartyBase = partyBase;
-                }
-                else if (partyBase.IsMobile)
-                {
-                    mobileParty._targetSettlement = null;
-                    mobileParty._targetParty = partyBase.MobileParty;
-                    partyAi.AiBehaviorPartyBase = partyBase;
-                }
+                partyAi.AiBehaviorPartyBase = partyBase;
             }
-
+            else
+            {
+                partyAi.AiBehaviorPartyBase = null;
+            }
 
             try
             {
@@ -138,7 +120,6 @@ public static class PartyBehaviorPatch
                 partyAi.AiBehaviorInteractable = interactablePoint;
                 partyAi.BehaviorTarget = targetPoint;
 
-                mobileParty.RecalculateShortTermBehavior();
                 partyAi.UpdateBehavior();
             }
             catch(Exception ex)


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x  ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`PartyBehaviorPatch.SetAiBehavior` was writing DefaultBehavior = newBehavior, where newBehavior is the resolved short-term value produced by GetBehaviors on a tactical tick. In vanilla, DefaultBehavior is only ever set by the hourly strategic think (PartyHourlyAiTick), and GetBehaviors reads DefaultBehavior as its starting input, resolving it into a separate value ShortTermBehavior each tick without writing it back.
By writing that resolved value into DefaultBehavior, the next tactical tick's GetBehaviors call read back the previous tick's resolved output as if it were the strategic decision, feeding a tactical result into itself as strategic input. Result: incorrect UI state ("Running from" instead of "Following") and weird behaviors.

## What is the new behavior?
SetAiBehavior now only touches fields it owns: ShortTermBehavior, TargetPosition, AiBehaviorInteractable, AiBehaviorPartyBase. Removed the DefaultBehavior write, the redundant RecalculateShortTermBehavior() call, and the _targetParty/_targetSettlement null/set branches.
<!-- Insert issue id after hashtag. -->
Resolves #1897
This also resolves unable to follow players with alt+click.

