### PR TITLE
[1901] Fix grey hero portrait on join

### DIFF
--- a/source/GameInterface/Services/UI/Patches/PartyPlayerNameplateVisualPatch.cs
+++ b/source/GameInterface/Services/UI/Patches/PartyPlayerNameplateVisualPatch.cs
@@ -1,0 +1,21 @@
+﻿using Common;
+using HarmonyLib;
+using SandBox.ViewModelCollection.Nameplate;
+
+namespace GameInterface.Services.UI.Patches;
+
+/// <summary>
+/// Applies the refreshed main-hero portrait that vanilla stores without rebinding to the nameplate.
+/// </summary>
+[HarmonyPatch(typeof(PartyPlayerNameplateVM), nameof(PartyPlayerNameplateVM.RefreshBinding))]
+internal class PartyPlayerNameplateVisualPatch
+{
+    [HarmonyPostfix]
+    private static void ApplyRefreshedPortrait(PartyPlayerNameplateVM __instance)
+    {
+        if (ModInformation.IsClient && __instance._mainHeroVisualBind != null)
+        {
+            __instance.MainHeroVisual = __instance._mainHeroVisualBind;
+        }
+    }
+}

--- a/source/GameInterface/Services/UI/Patches/PartyPlayerNameplateVisualPatch.cs
+++ b/source/GameInterface/Services/UI/Patches/PartyPlayerNameplateVisualPatch.cs
@@ -15,6 +15,8 @@ internal class PartyPlayerNameplateVisualPatch
     {
         if (ModInformation.IsClient && __instance._mainHeroVisualBind != null)
         {
+            // The nameplate can initialize before a joining client switches to its hero. Vanilla refreshes
+            // this value afterward but never rebinds it, leaving the initial gray portrait visible.
             __instance.MainHeroVisual = __instance._mainHeroVisualBind;
         }
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

The first client joining a fresh save can see an empty gray portrait when the campaign-map tracker initializes before the client finishes switching to their own hero. The stale portrait remains until the client reconnects.

## What is the new behavior?

Resolves #1901

The tracker displays the first client's current character portrait immediately after their initial join and continues to show it after reconnecting.
