### PR TITLE
Drop queued mobile party updates on destruction

### DIFF
--- a/source/GameInterface.Tests/Services/MobileParties/MobilePartyRegistryCoalescingTests.cs
+++ b/source/GameInterface.Tests/Services/MobileParties/MobilePartyRegistryCoalescingTests.cs
@@ -1,0 +1,82 @@
+﻿using Common;
+using Common.Messaging;
+using Common.Network;
+using Common.Network.Coalescing;
+using Common.Util;
+using GameInterface.Registry.Auto;
+using GameInterface.Services.Entity;
+using GameInterface.Services.MobileParties;
+using GameInterface.Services.MobileParties.Messages;
+using Moq;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Roster;
+using Xunit;
+using ObjectManagerService = GameInterface.Services.ObjectManager.ObjectManager;
+
+namespace GameInterface.Tests.Services.MobileParties;
+
+public sealed class MobilePartyRegistryCoalescingTests
+{
+    [Fact]
+    public void Destroy_DropsPendingBehaviorBeforeNetworkDestroy_AndFlushHasNoLateUpdate()
+    {
+        const string fullPartyId = "MobileParty_destroy-me";
+        const string compactPartyId = "destroy-me";
+
+        var party = ObjectHelper.SkipConstructor<MobileParty>();
+        party.Party = ObjectHelper.SkipConstructor<PartyBase>();
+        party.Party.MobileParty = party;
+        party.Party.MemberRoster = new TroopRoster();
+        party.Party.PrisonRoster = new TroopRoster();
+
+        var objectManager = new ObjectManagerService(Mock.Of<ILogger>());
+        Assert.True(objectManager.AddExisting(fullPartyId, party));
+
+        var coalescer = new SendCoalescer();
+        coalescer.Enqueue(
+            new CoalesceKey("party-behavior", compactPartyId),
+            new LatestWinsPayload(new PendingBehaviorUpdate()));
+
+        var sent = new List<IMessage>();
+        var network = new Mock<INetwork>();
+        network
+            .Setup(instance => instance.SendAll(It.IsAny<IMessage>()))
+            .Callback<IMessage>(sent.Add);
+
+        var broker = new MessageBroker();
+        bool mobilePartyDestroyedPublished = false;
+        Action<MessagePayload<MobilePartyDestroyed>> destroyedSubscription =
+            _ => mobilePartyDestroyedPublished = true;
+        broker.Subscribe(destroyedSubscription);
+
+        var registry = new MobilePartyRegistry(
+            Mock.Of<IControllerIdProvider>(),
+            broker,
+            Mock.Of<ILogger>(),
+            Mock.Of<IAutoRegistryFactory>(),
+            objectManager,
+            coalescer);
+        using var handler = new AutoRegistryHandler<MobileParty>(
+            registry,
+            broker,
+            network.Object,
+            objectManager);
+
+        broker.Publish(this, new InstanceDestroyed<MobileParty>(party));
+
+        Assert.True(mobilePartyDestroyedPublished);
+        Assert.False(coalescer.HasPending);
+        var destroy = Assert.IsType<NetworkDestroyInstance<MobileParty>>(Assert.Single(sent));
+        Assert.Equal(fullPartyId, destroy.InstanceId);
+
+        coalescer.Flush(network.Object);
+        Assert.Single(sent);
+    }
+
+    private readonly struct PendingBehaviorUpdate : ICommand
+    {
+    }
+}

--- a/source/GameInterface/Services/MobileParties/MobilePartyRegistry.cs
+++ b/source/GameInterface/Services/MobileParties/MobilePartyRegistry.cs
@@ -6,6 +6,7 @@ using GameInterface.Registry.Auto;
 using GameInterface.Services.Entity;
 using GameInterface.Services.MobileParties.Messages;
 using GameInterface.Services.ObjectManager;
+using static GameInterface.Services.ObjectManager.ObjectManager;
 using HarmonyLib;
 using Serilog;
 using System;
@@ -126,7 +127,7 @@ internal class MobilePartyRegistry : AutoRegistryBase<MobileParty>
             // AutoRegistryHandler sends the MobileParty destroy after this callback. Drop any state
             // queued before or during teardown so no behavior update can follow that destroy.
             coalescer?.DropInstance(
-                ObjectManager.Compact(id, typeof(MobileParty)));
+                Compact(id, typeof(MobileParty)));
         }
     }
 }

--- a/source/GameInterface/Services/MobileParties/MobilePartyRegistry.cs
+++ b/source/GameInterface/Services/MobileParties/MobilePartyRegistry.cs
@@ -1,5 +1,6 @@
 ﻿using Common;
 using Common.Messaging;
+using Common.Network.Coalescing;
 using Common.Util;
 using GameInterface.Registry.Auto;
 using GameInterface.Services.Entity;
@@ -26,17 +27,20 @@ internal class MobilePartyRegistry : AutoRegistryBase<MobileParty>
 
     private readonly IControllerIdProvider controllerIdProvider;
     private readonly IMessageBroker messageBroker;
+    private readonly ISendCoalescer coalescer;
 
     public MobilePartyRegistry(
         IControllerIdProvider controllerIdProvider,
         IMessageBroker messageBroker,
         ILogger logger,
         IAutoRegistryFactory autoRegistryFactory,
-        IObjectManager objectManager)
+        IObjectManager objectManager,
+        ISendCoalescer coalescer = null)
         : base(logger, autoRegistryFactory, objectManager)
     {
         this.controllerIdProvider = controllerIdProvider;
         this.messageBroker = messageBroker;
+        this.coalescer = coalescer;
     }
 
     public override IEnumerable<MethodBase> Constructors => AccessTools.GetDeclaredConstructors(typeof(MobileParty));
@@ -105,14 +109,24 @@ internal class MobilePartyRegistry : AutoRegistryBase<MobileParty>
 
     public override void OnServerDestroyed(MobileParty obj, string id)
     {
-        obj.MemberRoster.Clear();
-        obj.PrisonRoster.Clear();
-        obj.Party.SetVisualAsDirty();
+        try
+        {
+            obj.MemberRoster.Clear();
+            obj.PrisonRoster.Clear();
+            obj.Party.SetVisualAsDirty();
 
-        messageBroker.Publish(this, new MobilePartyDestroyed(obj));
+            messageBroker.Publish(this, new MobilePartyDestroyed(obj));
 
-        // Sole publisher of the PartyBase teardown: PartyBaseRegistry.DestroyMethods is empty, so
-        // a PartyBase's lifetime ends with its party's, while everything is still registered.
-        messageBroker.Publish(this, new InstanceDestroyed<PartyBase>(obj.Party));
+            // Sole publisher of the PartyBase teardown: PartyBaseRegistry.DestroyMethods is empty, so
+            // a PartyBase's lifetime ends with its party's, while everything is still registered.
+            messageBroker.Publish(this, new InstanceDestroyed<PartyBase>(obj.Party));
+        }
+        finally
+        {
+            // AutoRegistryHandler sends the MobileParty destroy after this callback. Drop any state
+            // queued before or during teardown so no behavior update can follow that destroy.
+            coalescer?.DropInstance(
+                global::GameInterface.Services.ObjectManager.ObjectManager.Compact(id, typeof(MobileParty)));
+        }
     }
 }

--- a/source/GameInterface/Services/MobileParties/MobilePartyRegistry.cs
+++ b/source/GameInterface/Services/MobileParties/MobilePartyRegistry.cs
@@ -126,7 +126,7 @@ internal class MobilePartyRegistry : AutoRegistryBase<MobileParty>
             // AutoRegistryHandler sends the MobileParty destroy after this callback. Drop any state
             // queued before or during teardown so no behavior update can follow that destroy.
             coalescer?.DropInstance(
-                global::GameInterface.Services.ObjectManager.ObjectManager.Compact(id, typeof(MobileParty)));
+                ObjectManager.Compact(id, typeof(MobileParty)));
         }
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Destroying a mobile party can leave its last pending update behind, allowing that update to reach clients after the party is gone and produce a failed-id lookup.

## What is the new behavior?

Destroying a mobile party now discards its pending updates before its removal is sent, so clients do not receive state for a party that no longer exists.
