### PR TITLE
[1835] Preserve player health after field battles

### DIFF
--- a/source/E2E.Tests/Services/Missions/BattleHeroDamageSyncTests.cs
+++ b/source/E2E.Tests/Services/Missions/BattleHeroDamageSyncTests.cs
@@ -1,7 +1,12 @@
-using System;
+﻿using System;
 using Common.Messaging;
+using Common.Util;
 using E2E.Tests.Environment;
 using E2E.Tests.Environment.MockEngine;
+using GameInterface.Services.MapEvents.TroopSupply;
+using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Players;
+using GameInterface.Services.Players.Data;
 using Missions;
 using Missions.Battles;
 using Missions.Messages;
@@ -14,14 +19,8 @@ using Xunit.Abstractions;
 namespace E2E.Tests.Services.Missions;
 
 /// <summary>
-/// Reproduces the live bug: damage to a HERO in a coop battle does not update its <see cref="Hero.HitPoints"/>,
-/// so the server (and everyone else) never sees the hero's health drop. The routed-damage handler
-/// (<c>CoopBattleController.Handle_NetworkApplyBattleDamage</c>) applies the blow to the agent's in-mission
-/// Health only; nothing bridges that back to the campaign <c>Hero.HitPoints</c>, which is the value that syncs
-/// to the server (via <c>HeroHitPointsRequestPatch</c>). The handler now mirrors the owned hero's post-blow
-/// <c>Agent.Health</c> onto <c>Hero.HitPoints</c>, so a surviving-but-wounded hero's health reaches the server.
-/// This is the green spec for that fix; the HitPoints→server sync itself is covered by
-/// <c>ClientWoundsControlledHero_RequestsHitPoints_SyncsToServerAndClients</c>.
+/// Covers campaign-health propagation from a co-op battle hero's routed blows and final agent removal.
+/// Client-to-server <see cref="Hero.HitPoints"/> forwarding is covered by the map-event environment tests.
 /// </summary>
 public class BattleHeroDamageSyncTests : MissionTestEnvironment
 {
@@ -64,6 +63,50 @@ public class BattleHeroDamageSyncTests : MissionTestEnvironment
             Assert.Equal(70, hero.HitPoints);
 
             GC.KeepAlive(controller);
+        });
+    }
+
+    [Theory]
+    [InlineData(42.6f, 43)]
+    [InlineData(0f, 1)]
+    public void OwnedHeroAgentRemoval_UpdatesHeroHitPoints(float agentHealth, int expectedHitPoints)
+    {
+        AssertAgentRemovalHealth("owner", "owner", agentHealth, expectedHitPoints);
+    }
+
+    [Fact]
+    public void RemoteHeroAgentRemoval_DoesNotUpdateHeroHitPoints()
+    {
+        AssertAgentRemovalHealth("owner", "observer", 25f, 100);
+    }
+
+    private void AssertAgentRemovalHealth(string ownerControllerId, string localControllerId, float agentHealth, int expectedHitPoints)
+    {
+        var client = Clients.First();
+        SetControllerId(client, localControllerId);
+
+        client.Call(() =>
+        {
+            var character = Assert.IsType<CharacterObject>(Game.Current.PlayerTroop);
+            var hero = character.HeroObject;
+            var objectManager = client.Resolve<IObjectManager>();
+            if (!objectManager.TryGetId(hero, out var heroId))
+            {
+                heroId = $"Issue1835Hero_{Guid.NewGuid():N}";
+                Assert.True(objectManager.AddExisting(heroId, hero));
+            }
+
+            var playerManager = client.Resolve<IPlayerManager>();
+            Assert.True(playerManager.AddPlayer(new Player(ownerControllerId, heroId, string.Empty, string.Empty, string.Empty)));
+
+            using (new AllowedThread())
+            {
+                hero.HitPoints = 100;
+                var origin = new CoopAgentOrigin(character, null, -1, null, new UniqueTroopDescriptor(1));
+                origin.OnAgentRemoved(agentHealth);
+            }
+
+            Assert.Equal(expectedHitPoints, hero.HitPoints);
         });
     }
 }

--- a/source/GameInterface/Services/MapEvents/TroopSupply/CoopAgentOrigin.cs
+++ b/source/GameInterface/Services/MapEvents/TroopSupply/CoopAgentOrigin.cs
@@ -104,8 +104,8 @@ public class CoopAgentOrigin : IAgentOriginBase
     public void SetRouted(bool isOrderRetreat) { }
     public void OnAgentRemoved(float agentHealth)
     {
-        // Vanilla transfers final agent health in this origin hook. The coop casualty path only handles killed or
-        // unconscious agents, so it cannot preserve an injured survivor's health during mission teardown.
+        // Unlike the casualty hooks above, final agent health has no other path back to Hero.HitPoints. Vanilla
+        // performs this transfer in the origin hook, which also covers injured survivors removed during teardown.
         if (!_troop.IsHero) return;
 
         var hero = _troop.HeroObject;

--- a/source/GameInterface/Services/MapEvents/TroopSupply/CoopAgentOrigin.cs
+++ b/source/GameInterface/Services/MapEvents/TroopSupply/CoopAgentOrigin.cs
@@ -104,6 +104,8 @@ public class CoopAgentOrigin : IAgentOriginBase
     public void SetRouted(bool isOrderRetreat) { }
     public void OnAgentRemoved(float agentHealth)
     {
+        // Vanilla transfers final agent health in this origin hook. The coop casualty path only handles killed or
+        // unconscious agents, so it cannot preserve an injured survivor's health during mission teardown.
         if (!_troop.IsHero) return;
 
         var hero = _troop.HeroObject;

--- a/source/GameInterface/Services/MapEvents/TroopSupply/CoopAgentOrigin.cs
+++ b/source/GameInterface/Services/MapEvents/TroopSupply/CoopAgentOrigin.cs
@@ -1,4 +1,5 @@
-using Common.Messaging;
+﻿using Common.Messaging;
+using GameInterface.Services.Heroes.Extensions;
 using GameInterface.Services.MapEventParties.Messages;
 using Helpers;
 using TaleWorlds.CampaignSystem;
@@ -10,13 +11,9 @@ using TaleWorlds.Library;
 namespace GameInterface.Services.MapEvents.TroopSupply;
 
 /// <summary>
-/// Agent origin for server-supplied coop battle troops. Mirrors <c>SimpleAgentOrigin</c> but carries the
-/// troop's <see cref="Party"/> for EVERY troop (not just heroes) — <c>SimpleAgentOrigin.Party</c> is null for
-/// non-heroes, which leaves <c>BattleCombatant</c> null so the engine can't put an enemy soldier on a team
-/// (it never spawns) and can't recognise the player's hero (the player isn't attached). Casualty hooks are
-/// no-ops: deaths flow through the existing <c>Agent.Die</c> → server path, so applying them here too would
-/// double-count. Score hits are the exception — they have no other path, so <c>OnScoreHit</c> reports them
-/// to the server (see the method).
+/// Agent origin for server-supplied coop battle troops. It carries each troop's party so the engine can assign
+/// teams, leaves roster casualties to the network death path, and preserves the controlled hero's final health.
+/// Score hits are reported here because they have no other server path.
 /// </summary>
 public class CoopAgentOrigin : IAgentOriginBase
 {
@@ -105,7 +102,16 @@ public class CoopAgentOrigin : IAgentOriginBase
     public void SetWounded() { }
     public void SetKilled() { }
     public void SetRouted(bool isOrderRetreat) { }
-    public void OnAgentRemoved(float agentHealth) { }
+    public void OnAgentRemoved(float agentHealth)
+    {
+        if (!_troop.IsHero) return;
+
+        var hero = _troop.HeroObject;
+        if (hero.HeroState == Hero.CharacterStates.Dead) return;
+        if (!hero.IsControlledByThisInstance()) return;
+
+        hero.HitPoints = MathF.Max(1, MathF.Round(agentHealth));
+    }
 
     // Unlike the casualty hooks above, score hits have NO other path to the map event party in a coop battle
     // (the native PartyGroupAgentOrigin → supplier chain is substituted away), so this is where they are


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

A player who finishes a field battle wounded can return to the campaign map at 100% health.

## What is the new behavior?

Resolves #1835

A wounded player now returns to the campaign map with their remaining battle health, while an unconscious player returns with 1 hit point. The value matches on the server and clients.
