### PR TITLE
[1846] Capture players defeated by looters

### DIFF
--- a/source/GameInterface/Services/MapEvents/Interfaces/MapEventResultsInterface.cs
+++ b/source/GameInterface/Services/MapEvents/Interfaces/MapEventResultsInterface.cs
@@ -225,15 +225,17 @@ public class MapEventResultsInterface : IMapEventResultsInterface
                     MapEventParty lootReceiver = MapEvent.FindWinnerPartyToGetCurrentLootObjectBasedOnChances(lootCasualtyChances);
                     if (lootReceiver == null) continue;
 
+                    bool playerReceivesLoot = playerLootRosters.TryGetValue(lootReceiver, out ItemRoster playerLootRoster);
+
                     LootCasualtyCharacter(
                         character,
                         lootReceiver,
                         defeatedParty,
                         aiTradePenalty,
-                        winnerPlayerParties.Contains(lootReceiver)
+                        playerReceivesLoot
                             ? MBRandom.RoundRandomized(playerLootFactors[lootReceiver])
                             : int.MinValue,
-                        playerLootRosters[lootReceiver]);
+                        playerLootRoster);
                 }
             }
 
@@ -248,15 +250,17 @@ public class MapEventResultsInterface : IMapEventResultsInterface
                     MapEventParty lootReceiver = MapEvent.FindWinnerPartyToGetCurrentLootObjectBasedOnChances(lootCasualtyChances);
                     if (lootReceiver == null) continue;
 
+                    bool playerReceivesLoot = playerLootRosters.TryGetValue(lootReceiver, out ItemRoster playerLootRoster);
+
                     LootCasualtyCharacter(
                         character,
                         lootReceiver,
                         defeatedParty,
                         aiTradePenalty,
-                        winnerPlayerParties.Contains(lootReceiver)
+                        playerReceivesLoot
                             ? MBRandom.RoundRandomized(playerLootFactors[lootReceiver])
                             : int.MinValue,
-                        playerLootRosters[lootReceiver]);
+                        playerLootRoster);
                 }
             }
 
@@ -279,8 +283,10 @@ public class MapEventResultsInterface : IMapEventResultsInterface
     private void LootCasualtyCharacter(CharacterObject casualtyCharacter, MapEventParty winnerParty, MapEventParty defeatedParty, float aiTradePenalty, int maxLootedItemsPerBodyForMainParty, ItemRoster mainPartyLootFromCasualties)
     {
         Hero leaderHero = winnerParty.Party.LeaderHero;
+        if (leaderHero == null) return;
+
         float expectedLootedItemValueFromCasualty = Campaign.Current.Models.BattleRewardModel.GetExpectedLootedItemValueFromCasualty(leaderHero, casualtyCharacter);
-        if (leaderHero == null || expectedLootedItemValueFromCasualty.ApproximatelyEqualsTo(0f, 1E-05f)) return;
+        if (expectedLootedItemValueFromCasualty.ApproximatelyEqualsTo(0f, 1E-05f)) return;
 
         if (!leaderHero.IsPlayerHero())
         {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Losing a field battle to looters returns the defeated player to the campaign map without taking them prisoner.

## What is the new behavior?

Resolves #1846

Losing a field battle to looters now takes the defeated player prisoner and closes the battle normally.

The looter victory no longer tries to store AI casualty loot in a player-only loot roster, so battle result processing can continue to the player-capture step.
