### PR TITLE
[1852] Update simulation scoreboard upgrade column

### DIFF
--- a/source/GameInterface/Services/MapEvents/Handlers/BattleSimulationRunHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/BattleSimulationRunHandler.cs
@@ -172,7 +172,6 @@ internal class BattleSimulationRunHandler : IHandler
             var previousObserver = mapEvent.BattleObserver;
             mapEvent.BattleObserver = observer;
             mapEvent.SimulateBattleSetup(null);
-            // Setup must see an observer so vanilla tracks upgrades; discard its initial scoreboard population.
             observer.FlushRound();
 
             lock (simLock)

--- a/source/GameInterface/Services/MapEvents/Handlers/BattleSimulationRunHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/BattleSimulationRunHandler.cs
@@ -169,11 +169,11 @@ internal class BattleSimulationRunHandler : IHandler
         GameThread.RunSafe(() =>
         {
             // v1: simulate the full participating troop count (null), not the player's selected subset.
-            // Set up before attaching the observer: setup fires +1 TroopNumberChanged calls to populate the
-            // scoreboard, which the client already does for itself and must not receive twice.
             var previousObserver = mapEvent.BattleObserver;
-            mapEvent.SimulateBattleSetup(null);
             mapEvent.BattleObserver = observer;
+            mapEvent.SimulateBattleSetup(null);
+            // Setup must see an observer so vanilla tracks upgrades; discard its initial scoreboard population.
+            observer.FlushRound();
 
             lock (simLock)
             {

--- a/source/GameInterface/Services/MapEvents/Patches/TroopUpgradeTrackerUntrackedPartyPatch.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/TroopUpgradeTrackerUntrackedPartyPatch.cs
@@ -6,9 +6,8 @@ namespace GameInterface.Services.MapEvents.Patches;
 
 /// <summary>
 /// Returns 0 (nothing ready to upgrade) for an owner party the tracker never registered, instead of NREing.
-/// Vanilla finds the owner's MapEventParty and reads mapEventParty.Troops; in a coop battle the host spawns AI
-/// parties (siege defenders) added to the synced map event without a MapEventInvolvedPartiesAdded broadcast, so
-/// Find returns null and the deployment tick dies on every such troop. A tracked party runs vanilla unchanged.
+/// Vanilla finds the owner's MapEventParty and reads mapEventParty.Troops, but synced map events can contain parties
+/// missing from the local tracker's private list. A tracked party runs vanilla unchanged.
 /// </summary>
 [HarmonyPatch(typeof(TroopUpgradeTracker), "CalculateReadyToUpgradeSafe")]
 internal class TroopUpgradeTrackerUntrackedPartyPatch
@@ -16,8 +15,6 @@ internal class TroopUpgradeTrackerUntrackedPartyPatch
     [HarmonyPrefix]
     private static bool Prefix(TroopUpgradeTracker __instance, PartyBase owner, ref int __result)
     {
-        if (!BattleSpawnGate.IsCoopBattleActive) return true;
-
         if (__instance._mapEventParties.Find(p => p.Party == owner) == null)
         {
             __result = 0;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Troops that earn enough experience to become upgradeable during an auto-resolved battle still show `0` in the simulation scoreboard's **Upgrade** column. The available upgrades only become visible after opening the Party screen.

## What is the new behavior?

Resolves #1852

The simulation scoreboard updates the **Upgrade** column as troops become ready to upgrade, and its counts agree with the upgrades available afterward on the Party screen.
