### PR TITLE
Validate client mobile-party movement requests

### DIFF
--- a/source/Coop.Core/Server/Services/MobileParties/PacketHandlers/PartyAIBehaviorPacketHandler.cs
+++ b/source/Coop.Core/Server/Services/MobileParties/PacketHandlers/PartyAIBehaviorPacketHandler.cs
@@ -1,4 +1,6 @@
-﻿using Common.Messaging;
+﻿using Common;
+using Common.Logging;
+using Common.Messaging;
 using Common.Network;
 using Common.Network.Coalescing;
 using Common.PacketHandlers;
@@ -7,9 +9,14 @@ using Coop.Core.Server.Services.MobileParties.Packets;
 using GameInterface.Services.MobileParties.Data;
 using GameInterface.Services.MobileParties.Messages.Behavior;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Players;
 using static GameInterface.Services.ObjectManager.ObjectManager;
 using LiteNetLib;
+using Serilog;
+using System;
+using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Settlements;
 
 namespace Coop.Core.Server.Services.MobileParties.PacketHandlers;
 
@@ -18,6 +25,8 @@ namespace Coop.Core.Server.Services.MobileParties.PacketHandlers;
 /// </summary>
 internal class RequestMobilePartyBehaviorPacketHandler : IPacketHandler
 {
+    private static readonly ILogger Logger = LogManager.GetLogger<RequestMobilePartyBehaviorPacketHandler>();
+
     // Coalescer channel for per-party behavior updates; only the latest behavior per party is sent each tick.
     private const string PartyBehaviorUpdateChannel = "PartyBehaviorUpdate";
 
@@ -29,6 +38,7 @@ internal class RequestMobilePartyBehaviorPacketHandler : IPacketHandler
     private readonly INetwork network;
     private readonly IObjectManager objectManager;
     private readonly IMobilePartyBehaviorSnapshot mobilePartyBehaviorSnapshot;
+    private readonly IPlayerManager playerManager;
 
     public RequestMobilePartyBehaviorPacketHandler(
         IPacketManager packetManager,
@@ -36,7 +46,8 @@ internal class RequestMobilePartyBehaviorPacketHandler : IPacketHandler
         IMessageBroker messageBroker,
         INetwork network,
         IObjectManager objectManager,
-        IMobilePartyBehaviorSnapshot mobilePartyBehaviorSnapshot)
+        IMobilePartyBehaviorSnapshot mobilePartyBehaviorSnapshot,
+        IPlayerManager playerManager)
     {
         this.packetManager = packetManager;
         this.coalescer = coalescer;
@@ -44,6 +55,7 @@ internal class RequestMobilePartyBehaviorPacketHandler : IPacketHandler
         this.network = network;
         this.objectManager = objectManager;
         this.mobilePartyBehaviorSnapshot = mobilePartyBehaviorSnapshot;
+        this.playerManager = playerManager;
         packetManager.RegisterPacketHandler(this);
 
         messageBroker.Subscribe<PartyBehaviorUpdated>(Handle_PartyBehaviorUpdated);
@@ -58,11 +70,227 @@ internal class RequestMobilePartyBehaviorPacketHandler : IPacketHandler
 
     public void HandlePacket(NetPeer peer, IPacket packet)
     {
-        RequestMobilePartyBehaviorPacket convertedPacket = (RequestMobilePartyBehaviorPacket)packet;
+        if (peer == null ||
+            !playerManager.TryGetPlayer(peer, out var player) ||
+            string.IsNullOrWhiteSpace(player.ControllerId))
+        {
+            Reject(peer, "the peer is not mapped to an authenticated player");
+            return;
+        }
 
+        if (packet is not RequestMobilePartyBehaviorPacket convertedPacket)
+        {
+            Reject(peer, "the packet payload has the wrong type");
+            return;
+        }
+
+        var controlledPartyId = player.MobilePartyId;
+        var controllerId = player.ControllerId;
         var data = convertedPacket.BehaviorUpdateData;
+        GameThread.RunSafe(
+            () => ValidateAndPublishRequest(peer, controlledPartyId, controllerId, data),
+            blocking: true,
+            context: nameof(HandlePacket));
+    }
+
+    private void ValidateAndPublishRequest(
+        NetPeer peer,
+        string controlledPartyId,
+        string controllerId,
+        PartyBehaviorUpdateData data)
+    {
+        if (!TryValidateClientSnapshot(controlledPartyId, data, out string reason))
+        {
+            Reject(peer, reason);
+            return;
+        }
+
+        // Both fields are server-authoritative. A client may predict its own movement, but it may
+        // neither spoof whose prediction this is nor force an immediate position/queue flush.
+        data.OriginControllerId = controllerId;
+        data.ForcePosition = false;
 
         messageBroker.Publish(this, new UpdatePartyBehavior(ref data));
+    }
+
+    private bool TryValidateClientSnapshot(
+        string controlledPartyId,
+        PartyBehaviorUpdateData data,
+        out string reason)
+    {
+        reason = null;
+
+        if (string.IsNullOrWhiteSpace(controlledPartyId) ||
+            string.IsNullOrWhiteSpace(data.MobilePartyId) ||
+            !SamePartyId(controlledPartyId, data.MobilePartyId))
+        {
+            reason = "the requested party is not controlled by the peer";
+            return false;
+        }
+
+        if (!objectManager.TryGetObject(data.MobilePartyId, out MobileParty _))
+        {
+            reason = "the controlled party does not exist";
+            return false;
+        }
+
+        if (!IsValidAiBehavior(data.NewAiBehavior) ||
+            !IsValidAiBehavior(data.DefaultBehavior) ||
+            !Enum.IsDefined(typeof(MobileParty.NavigationType), data.DesiredAiNavigationType) ||
+            !Enum.IsDefined(typeof(MoveModeType), data.PartyMoveMode) ||
+            !Enum.IsDefined(typeof(BehaviorInteractableKind), data.InteractableKind))
+        {
+            reason = "the snapshot contains an unknown behavior or movement enum";
+            return false;
+        }
+
+        if (!IsFinite(data.BestTargetPoint) ||
+            !IsFinite(data.PartyPosition) ||
+            !IsFinite(data.TargetPosition) ||
+            !IsFinite(data.MoveTargetPoint) ||
+            !IsFinite(data.NextTargetPosition))
+        {
+            reason = "the snapshot contains a non-finite map position";
+            return false;
+        }
+
+        if (!TryValidateInteractable(data, out PartyBase interactablePartyBase))
+        {
+            reason = "the behavior interactable is inconsistent or does not exist";
+            return false;
+        }
+
+        if (!TryResolveOptional(data.TargetPartyId, out MobileParty targetParty) ||
+            !TryResolveOptional(data.TargetSettlementId, out Settlement targetSettlement) ||
+            !TryResolveOptional(data.MoveTargetPartyId, out MobileParty moveTargetParty))
+        {
+            reason = "the snapshot contains an invalid target reference";
+            return false;
+        }
+
+        if (RequiresTargetParty(data.DefaultBehavior) && targetParty == null)
+        {
+            reason = "the default behavior requires a target party";
+            return false;
+        }
+
+        if (RequiresTargetSettlement(data.DefaultBehavior) && targetSettlement == null)
+        {
+            reason = "the default behavior requires a target settlement";
+            return false;
+        }
+
+        if (data.IsTargetingPort && targetSettlement == null)
+        {
+            reason = "port movement requires a target settlement";
+            return false;
+        }
+
+        if ((data.PartyMoveMode == MoveModeType.Party) != (moveTargetParty != null))
+        {
+            reason = "party navigation and its movement target disagree";
+            return false;
+        }
+
+        if (!TryValidateShortTermBehavior(
+                data,
+                interactablePartyBase,
+                moveTargetParty))
+        {
+            reason = "the short-term behavior and its target references disagree";
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool TryValidateInteractable(
+        PartyBehaviorUpdateData data,
+        out PartyBase partyBase)
+    {
+        partyBase = null;
+
+        if (!data.HasTarget)
+            return string.IsNullOrEmpty(data.InteractablePointId);
+
+        if (string.IsNullOrWhiteSpace(data.InteractablePointId))
+            return false;
+
+        return data.InteractableKind switch
+        {
+            BehaviorInteractableKind.PartyBase =>
+                objectManager.TryGetObject(data.InteractablePointId, out partyBase),
+            BehaviorInteractableKind.AnchorPoint =>
+                objectManager.TryGetObject(data.InteractablePointId, out MobileParty owner) &&
+                owner.Anchor != null,
+            _ => false,
+        };
+    }
+
+    private bool TryResolveOptional<T>(string id, out T value)
+        where T : class
+    {
+        value = null;
+        if (string.IsNullOrEmpty(id))
+            return true;
+
+        return !string.IsNullOrWhiteSpace(id) && objectManager.TryGetObject(id, out value);
+    }
+
+    private static bool TryValidateShortTermBehavior(
+        PartyBehaviorUpdateData data,
+        PartyBase interactablePartyBase,
+        MobileParty moveTargetParty)
+    {
+        if (RequiresInteractablePartyBase(data.NewAiBehavior))
+            return interactablePartyBase?.IsValid == true;
+
+        if (data.NewAiBehavior != AiBehavior.EngageParty)
+            return true;
+
+        var engagedParty = interactablePartyBase?.MobileParty;
+        return engagedParty != null && ReferenceEquals(engagedParty, moveTargetParty);
+    }
+
+    private static bool SamePartyId(string left, string right) =>
+        string.Equals(
+            Compact(left, typeof(MobileParty)),
+            Compact(right, typeof(MobileParty)),
+            StringComparison.Ordinal);
+
+    private static bool IsFinite(CampaignVec2 point) =>
+        !float.IsNaN(point.X) &&
+        !float.IsInfinity(point.X) &&
+        !float.IsNaN(point.Y) &&
+        !float.IsInfinity(point.Y);
+
+    private static bool IsValidAiBehavior(AiBehavior behavior) =>
+        behavior != AiBehavior.NumAiBehaviors &&
+        Enum.IsDefined(typeof(AiBehavior), behavior);
+
+    private static bool RequiresTargetParty(AiBehavior behavior) =>
+        behavior == AiBehavior.EngageParty ||
+        behavior == AiBehavior.GoAroundParty ||
+        behavior == AiBehavior.EscortParty;
+
+    private static bool RequiresTargetSettlement(AiBehavior behavior) =>
+        behavior == AiBehavior.GoToSettlement ||
+        behavior == AiBehavior.RaidSettlement ||
+        behavior == AiBehavior.BesiegeSettlement ||
+        behavior == AiBehavior.DefendSettlement;
+
+    private static bool RequiresInteractablePartyBase(AiBehavior behavior) =>
+        behavior == AiBehavior.GoToSettlement ||
+        behavior == AiBehavior.RaidSettlement ||
+        behavior == AiBehavior.AssaultSettlement ||
+        behavior == AiBehavior.BesiegeSettlement;
+
+    private static void Reject(NetPeer peer, string reason)
+    {
+        Logger.Warning(
+            "Rejected mobile-party behavior request from peer {PeerId}: {Reason}",
+            peer?.Id,
+            reason);
     }
 
     private void Handle_PartyBehaviorUpdated(MessagePayload<PartyBehaviorUpdated> payload)

--- a/source/Coop.Tests/Server/Services/MobileParties/RequestMobilePartyBehaviorPacketHandlerTests.cs
+++ b/source/Coop.Tests/Server/Services/MobileParties/RequestMobilePartyBehaviorPacketHandlerTests.cs
@@ -1,0 +1,392 @@
+﻿using Common;
+using Common.Messaging;
+using Common.Network;
+using Common.Network.Coalescing;
+using Common.PacketHandlers;
+using Common.Tests.Utils;
+using Common.Util;
+using Coop.Core.Server.Services.MobileParties.PacketHandlers;
+using Coop.Core.Server.Services.MobileParties.Packets;
+using Coop.Tests.Mocks;
+using GameInterface.Services.MobileParties.Data;
+using GameInterface.Services.MobileParties.Messages.Behavior;
+using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Players;
+using GameInterface.Services.Players.Data;
+using LiteNetLib;
+using Moq;
+using Serilog;
+using System;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.Library;
+using Xunit;
+
+namespace Coop.Tests.Server.Services.MobileParties;
+
+/// <summary>
+/// Verifies authentication and validation of client mobile-party behavior requests.
+/// </summary>
+public sealed class RequestMobilePartyBehaviorPacketHandlerTests : IDisposable
+{
+    private const string ControllerId = "controller-1";
+    private const string FullPartyId = "MobileParty_OwnedParty";
+    private const string CompactPartyId = "OwnedParty";
+
+    private readonly TestMessageBroker messageBroker = new TestMessageBroker();
+    private readonly Mock<IPacketManager> packetManager = new Mock<IPacketManager>();
+    private readonly Mock<ISendCoalescer> coalescer = new Mock<ISendCoalescer>();
+    private readonly Mock<INetwork> network = new Mock<INetwork>();
+    private readonly Mock<IPlayerManager> playerManager = new Mock<IPlayerManager>();
+    private readonly Mock<IMobilePartyBehaviorSnapshot> mobilePartyBehaviorSnapshot = new Mock<IMobilePartyBehaviorSnapshot>();
+    private readonly ObjectManager objectManager;
+    private readonly RequestMobilePartyBehaviorPacketHandler handler;
+    private readonly NetPeer peer;
+
+    public RequestMobilePartyBehaviorPacketHandlerTests()
+    {
+        objectManager = new ObjectManager(Mock.Of<ILogger>());
+        RegisterParty(FullPartyId);
+        var targetParty = RegisterParty("MobileParty_TargetParty");
+        RegisterParty("MobileParty_OtherParty");
+        RegisterMobilePartyBase("PartyBase_TargetPartyBase", targetParty);
+        RegisterSettlementPartyBase("PartyBase_TargetSettlementPartyBase");
+
+        peer = new TestNetwork().CreatePeer();
+        var player = new Player(ControllerId, string.Empty, FullPartyId, string.Empty, string.Empty);
+        playerManager
+            .Setup(manager => manager.TryGetPlayer(
+                It.Is<NetPeer>(candidate => ReferenceEquals(candidate, peer)),
+                out player))
+            .Returns(true);
+        var authoritativeData = CreateSnapshot();
+        mobilePartyBehaviorSnapshot
+            .Setup(snapshot => snapshot.TryCreateCurrent(
+                It.IsAny<MobileParty>(),
+                out authoritativeData))
+            .Returns(true);
+
+        handler = new RequestMobilePartyBehaviorPacketHandler(
+            packetManager.Object,
+            coalescer.Object,
+            messageBroker,
+            network.Object,
+            objectManager,
+            mobilePartyBehaviorSnapshot.Object,
+            playerManager.Object);
+    }
+
+    public void Dispose() => handler.Dispose();
+
+    [Fact]
+    public void OwnerRequest_WithCompactPartyId_IsPublished()
+    {
+        var data = CreateSnapshot();
+
+        handler.HandlePacket(peer, new RequestMobilePartyBehaviorPacket(data));
+
+        var update = Assert.Single(messageBroker.GetMessagesFromType<UpdatePartyBehavior>());
+        Assert.Equal(CompactPartyId, update.BehaviorUpdateData.MobilePartyId);
+        Assert.Equal(ControllerId, update.BehaviorUpdateData.OriginControllerId);
+    }
+
+    [Fact]
+    public void OwnerRequest_ValidationAndPublishRunOnGameThread()
+    {
+        var scheduledObjectManager = new Mock<IObjectManager>();
+        var controlledParty = ObjectHelper.SkipConstructor<MobileParty>();
+        bool lookupRanOnGameThread = false;
+        scheduledObjectManager
+            .Setup(manager => manager.TryGetObject(CompactPartyId, out controlledParty))
+            .Callback(() => lookupRanOnGameThread = GameThread.Instance.IsGameThread)
+            .Returns(true);
+        var scheduledMessageBroker = new TestMessageBroker();
+        bool publishRanOnGameThread = false;
+        scheduledMessageBroker.Subscribe<UpdatePartyBehavior>(
+            _ => publishRanOnGameThread = GameThread.Instance.IsGameThread);
+        var scheduledHandler = new RequestMobilePartyBehaviorPacketHandler(
+            packetManager.Object,
+            coalescer.Object,
+            scheduledMessageBroker,
+            network.Object,
+            scheduledObjectManager.Object,
+            Mock.Of<IMobilePartyBehaviorSnapshot>(),
+            playerManager.Object);
+
+        try
+        {
+            scheduledHandler.HandlePacket(peer, new RequestMobilePartyBehaviorPacket(CreateSnapshot()));
+
+            Assert.True(lookupRanOnGameThread);
+            Assert.True(publishRanOnGameThread);
+            Assert.Single(scheduledMessageBroker.GetMessagesFromType<UpdatePartyBehavior>());
+        }
+        finally
+        {
+            scheduledHandler.Dispose();
+        }
+    }
+
+    [Fact]
+    public void RequestForAnotherParty_IsRejected()
+    {
+        var data = CreateSnapshot(mobilePartyId: "OtherParty");
+
+        handler.HandlePacket(peer, new RequestMobilePartyBehaviorPacket(data));
+
+        Assert.Empty(messageBroker.GetMessagesFromType<UpdatePartyBehavior>());
+    }
+
+    [Fact]
+    public void RequestFromUnmappedPeer_IsRejected()
+    {
+        var unmappedPeer = new TestNetwork().CreatePeer();
+
+        handler.HandlePacket(unmappedPeer, new RequestMobilePartyBehaviorPacket(CreateSnapshot()));
+
+        Assert.Empty(messageBroker.GetMessagesFromType<UpdatePartyBehavior>());
+    }
+
+    [Fact]
+    public void OwnerRequest_WithConsistentPartyReferences_IsPublished()
+    {
+        var data = CreateSnapshot(
+            newBehavior: AiBehavior.EngageParty,
+            defaultBehavior: AiBehavior.EngageParty,
+            hasTarget: true,
+            interactablePointId: "TargetPartyBase");
+        data.TargetPartyId = "TargetParty";
+        data.PartyMoveMode = MoveModeType.Party;
+        data.MoveTargetPartyId = "TargetParty";
+
+        handler.HandlePacket(peer, new RequestMobilePartyBehaviorPacket(data));
+
+        Assert.Single(messageBroker.GetMessagesFromType<UpdatePartyBehavior>());
+    }
+
+    [Fact]
+    public void SpoofedOrigin_IsReplacedWithAuthenticatedController()
+    {
+        var data = CreateSnapshot();
+        data.OriginControllerId = "spoofed-controller";
+
+        handler.HandlePacket(peer, new RequestMobilePartyBehaviorPacket(data));
+
+        var update = Assert.Single(messageBroker.GetMessagesFromType<UpdatePartyBehavior>());
+        Assert.Equal(ControllerId, update.BehaviorUpdateData.OriginControllerId);
+    }
+
+    [Fact]
+    public void ClientForcePosition_IsClearedAndCannotBypassCoalescer()
+    {
+        var data = CreateSnapshot();
+        data.ForcePosition = true;
+
+        handler.HandlePacket(peer, new RequestMobilePartyBehaviorPacket(data));
+
+        var update = Assert.Single(messageBroker.GetMessagesFromType<UpdatePartyBehavior>());
+        Assert.False(update.BehaviorUpdateData.ForcePosition);
+
+        var sanitized = update.BehaviorUpdateData;
+        messageBroker.Publish(this, new PartyBehaviorUpdated(ref sanitized));
+
+        coalescer.Verify(
+            value => value.Enqueue(
+                It.Is<CoalesceKey>(key => key.InstanceId == CompactPartyId),
+                It.IsAny<ICoalescedPayload>()),
+            Times.Once());
+        coalescer.Verify(
+            value => value.FlushInstance(It.IsAny<string>(), It.IsAny<INetwork>()),
+            Times.Never());
+        network.Verify(value => value.SendAll(It.IsAny<IMessage>()), Times.Never());
+    }
+
+    [Theory]
+    [InlineData(AiBehavior.GoToSettlement)]
+    [InlineData(AiBehavior.RaidSettlement)]
+    [InlineData(AiBehavior.AssaultSettlement)]
+    [InlineData(AiBehavior.BesiegeSettlement)]
+    public void SettlementShortTermBehaviorWithoutPartyBase_IsRejected(AiBehavior behavior)
+    {
+        var data = CreateSnapshot(newBehavior: behavior);
+
+        handler.HandlePacket(peer, new RequestMobilePartyBehaviorPacket(data));
+
+        Assert.Empty(messageBroker.GetMessagesFromType<UpdatePartyBehavior>());
+    }
+
+    [Theory]
+    [InlineData(InvalidSnapshotKind.NewBehaviorEnum)]
+    [InlineData(InvalidSnapshotKind.NewBehaviorSentinel)]
+    [InlineData(InvalidSnapshotKind.DefaultBehaviorEnum)]
+    [InlineData(InvalidSnapshotKind.DefaultBehaviorSentinel)]
+    [InlineData(InvalidSnapshotKind.NavigationEnum)]
+    [InlineData(InvalidSnapshotKind.MoveModeEnum)]
+    [InlineData(InvalidSnapshotKind.InteractableKindEnum)]
+    [InlineData(InvalidSnapshotKind.TargetFlagWithoutReference)]
+    [InlineData(InvalidSnapshotKind.ReferenceWithoutTargetFlag)]
+    [InlineData(InvalidSnapshotKind.PartyModeWithoutMoveTarget)]
+    [InlineData(InvalidSnapshotKind.MoveTargetOutsidePartyMode)]
+    [InlineData(InvalidSnapshotKind.PartyBehaviorWithoutTargetParty)]
+    [InlineData(InvalidSnapshotKind.EngageWithoutInteractable)]
+    [InlineData(InvalidSnapshotKind.EngageWithSettlementInteractable)]
+    [InlineData(InvalidSnapshotKind.EngageWithDifferentMoveTarget)]
+    [InlineData(InvalidSnapshotKind.PortWithoutTargetSettlement)]
+    [InlineData(InvalidSnapshotKind.UnresolvedReference)]
+    [InlineData(InvalidSnapshotKind.NonFinitePosition)]
+    public void MalformedSnapshot_IsRejected(InvalidSnapshotKind kind)
+    {
+        var data = CreateInvalidSnapshot(kind);
+
+        handler.HandlePacket(peer, new RequestMobilePartyBehaviorPacket(data));
+
+        Assert.Empty(messageBroker.GetMessagesFromType<UpdatePartyBehavior>());
+    }
+
+    private MobileParty RegisterParty(string id)
+    {
+        var party = ObjectHelper.SkipConstructor<MobileParty>();
+        Assert.True(objectManager.AddExisting(id, party));
+        return party;
+    }
+
+    private void RegisterMobilePartyBase(string id, MobileParty mobileParty)
+    {
+        var partyBase = ObjectHelper.SkipConstructor<PartyBase>();
+        partyBase.MobileParty = mobileParty;
+        mobileParty.Party = partyBase;
+        Assert.True(objectManager.AddExisting(id, partyBase));
+    }
+
+    private void RegisterSettlementPartyBase(string id)
+    {
+        var settlement = ObjectHelper.SkipConstructor<Settlement>();
+        var partyBase = ObjectHelper.SkipConstructor<PartyBase>();
+        partyBase.Settlement = settlement;
+        settlement.Party = partyBase;
+        Assert.True(objectManager.AddExisting(id, partyBase));
+    }
+
+    private static PartyBehaviorUpdateData CreateSnapshot(
+        string mobilePartyId = CompactPartyId,
+        AiBehavior newBehavior = AiBehavior.Hold,
+        AiBehavior defaultBehavior = AiBehavior.Hold,
+        MobileParty.NavigationType navigationType = MobileParty.NavigationType.None,
+        bool hasTarget = false,
+        string interactablePointId = null)
+    {
+        var point = new CampaignVec2(new Vec2(10f, 20f), true);
+        return new PartyBehaviorUpdateData(
+            mobilePartyId,
+            newBehavior,
+            interactablePointId,
+            point,
+            hasTarget,
+            point,
+            defaultBehavior,
+            point,
+            navigationType)
+        {
+            MoveTargetPoint = point,
+            NextTargetPosition = point,
+            PartyMoveMode = MoveModeType.Hold,
+        };
+    }
+
+    private static PartyBehaviorUpdateData CreateInvalidSnapshot(InvalidSnapshotKind kind)
+    {
+        var data = kind switch
+        {
+            InvalidSnapshotKind.NewBehaviorEnum =>
+                CreateSnapshot(newBehavior: (AiBehavior)int.MaxValue),
+            InvalidSnapshotKind.NewBehaviorSentinel =>
+                CreateSnapshot(newBehavior: AiBehavior.NumAiBehaviors),
+            InvalidSnapshotKind.DefaultBehaviorEnum =>
+                CreateSnapshot(defaultBehavior: (AiBehavior)int.MaxValue),
+            InvalidSnapshotKind.DefaultBehaviorSentinel =>
+                CreateSnapshot(defaultBehavior: AiBehavior.NumAiBehaviors),
+            InvalidSnapshotKind.NavigationEnum =>
+                CreateSnapshot(navigationType: (MobileParty.NavigationType)int.MaxValue),
+            InvalidSnapshotKind.TargetFlagWithoutReference =>
+                CreateSnapshot(hasTarget: true),
+            InvalidSnapshotKind.ReferenceWithoutTargetFlag =>
+                CreateSnapshot(interactablePointId: "TargetPartyBase"),
+            InvalidSnapshotKind.PartyBehaviorWithoutTargetParty =>
+                CreateSnapshot(defaultBehavior: AiBehavior.EngageParty),
+            InvalidSnapshotKind.EngageWithoutInteractable =>
+                CreateSnapshot(newBehavior: AiBehavior.EngageParty),
+            InvalidSnapshotKind.EngageWithSettlementInteractable =>
+                CreateSnapshot(
+                    newBehavior: AiBehavior.EngageParty,
+                    hasTarget: true,
+                    interactablePointId: "TargetSettlementPartyBase"),
+            InvalidSnapshotKind.EngageWithDifferentMoveTarget =>
+                CreateSnapshot(
+                    newBehavior: AiBehavior.EngageParty,
+                    hasTarget: true,
+                    interactablePointId: "TargetPartyBase"),
+            _ => CreateSnapshot(),
+        };
+
+        switch (kind)
+        {
+            case InvalidSnapshotKind.MoveModeEnum:
+                data.PartyMoveMode = (MoveModeType)int.MaxValue;
+                break;
+            case InvalidSnapshotKind.InteractableKindEnum:
+                data.InteractableKind = (BehaviorInteractableKind)int.MaxValue;
+                break;
+            case InvalidSnapshotKind.PartyModeWithoutMoveTarget:
+                data.PartyMoveMode = MoveModeType.Party;
+                break;
+            case InvalidSnapshotKind.MoveTargetOutsidePartyMode:
+                data.MoveTargetPartyId = "TargetParty";
+                break;
+            case InvalidSnapshotKind.PortWithoutTargetSettlement:
+                data.IsTargetingPort = true;
+                break;
+            case InvalidSnapshotKind.UnresolvedReference:
+                data.TargetPartyId = "MissingParty";
+                break;
+            case InvalidSnapshotKind.NonFinitePosition:
+                data.PartyPosition = new CampaignVec2(new Vec2(float.NaN, 20f), true);
+                break;
+            case InvalidSnapshotKind.EngageWithSettlementInteractable:
+                data.PartyMoveMode = MoveModeType.Party;
+                data.MoveTargetPartyId = "TargetParty";
+                break;
+            case InvalidSnapshotKind.EngageWithDifferentMoveTarget:
+                data.PartyMoveMode = MoveModeType.Party;
+                data.MoveTargetPartyId = "OtherParty";
+                break;
+        }
+
+        return data;
+    }
+
+    /// <summary>
+    /// Enumerates malformed client snapshot variants exercised by validation tests.
+    /// </summary>
+    public enum InvalidSnapshotKind
+    {
+        NewBehaviorEnum,
+        NewBehaviorSentinel,
+        DefaultBehaviorEnum,
+        DefaultBehaviorSentinel,
+        NavigationEnum,
+        MoveModeEnum,
+        InteractableKindEnum,
+        TargetFlagWithoutReference,
+        ReferenceWithoutTargetFlag,
+        PartyModeWithoutMoveTarget,
+        MoveTargetOutsidePartyMode,
+        PartyBehaviorWithoutTargetParty,
+        EngageWithoutInteractable,
+        EngageWithSettlementInteractable,
+        EngageWithDifferentMoveTarget,
+        PortWithoutTargetSettlement,
+        UnresolvedReference,
+        NonFinitePosition,
+    }
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Movement requests can be applied without confirming that the sender still controls the party or that all target and position data are valid and internally consistent.

## What is the new behavior?

The server rejects requests from unmapped players, requests for a party the player does not control, and movement state containing invalid or inconsistent targets. Accepted requests are attributed to the authenticated player and cannot force an immediate position update.