### PR TITLE
[1906] Fix mercenary conversation soft lock

### DIFF
--- a/source/GameInterface/Services/Clans/Handlers/MercenaryServiceHandler.cs
+++ b/source/GameInterface/Services/Clans/Handlers/MercenaryServiceHandler.cs
@@ -47,6 +47,7 @@ internal class MercenaryServiceHandler : IHandler
 
     private void HandleMercenaryServiceAccepted(MessagePayload<MercenaryServiceAccepted> payload)
     {
+        // Conversation consequences publish synchronously on the game thread.
         if (!objectManager.TryGetIdWithLogging(payload.What.Kingdom, out var kingdomId)) return;
 
         network.SendAll(new RequestMercenaryService(kingdomId));
@@ -56,6 +57,7 @@ internal class MercenaryServiceHandler : IHandler
     {
         if (ModInformation.IsClient) return;
 
+        // Peer associations use a ConcurrentDictionary and are safe to resolve on the poll thread.
         if (!(payload.Who is NetPeer peer) || !playerManager.TryGetPlayer(peer, out var player))
         {
             Logger.Error("Received {Message} without a registered player peer", nameof(RequestMercenaryService));
@@ -69,6 +71,7 @@ internal class MercenaryServiceHandler : IHandler
 
     private void ApplyMercenaryService(string clanId, string heroId, string kingdomId)
     {
+        // Only called from the GameThread.RunSafe action above.
         if (!objectManager.TryGetObjectWithLogging<Clan>(clanId, out var clan)) return;
         if (!objectManager.TryGetObjectWithLogging<Hero>(heroId, out var hero)) return;
         if (!objectManager.TryGetObjectWithLogging<Kingdom>(kingdomId, out var kingdom)) return;

--- a/source/GameInterface/Services/Clans/Handlers/MercenaryServiceHandler.cs
+++ b/source/GameInterface/Services/Clans/Handlers/MercenaryServiceHandler.cs
@@ -1,0 +1,93 @@
+﻿using Common;
+using Common.Logging;
+using Common.Messaging;
+using Common.Network;
+using GameInterface.Services.Clans.Messages;
+using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Players;
+using LiteNetLib;
+using Serilog;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Actions;
+
+namespace GameInterface.Services.Clans.Handlers;
+
+/// <summary>
+/// Applies accepted mercenary contracts on the server and lets existing synchronization publish the results.
+/// </summary>
+internal class MercenaryServiceHandler : IHandler
+{
+    private static readonly ILogger Logger = LogManager.GetLogger<MercenaryServiceHandler>();
+
+    private readonly IMessageBroker messageBroker;
+    private readonly IObjectManager objectManager;
+    private readonly INetwork network;
+    private readonly IPlayerManager playerManager;
+
+    public MercenaryServiceHandler(
+        IMessageBroker messageBroker,
+        IObjectManager objectManager,
+        INetwork network,
+        IPlayerManager playerManager)
+    {
+        this.messageBroker = messageBroker;
+        this.objectManager = objectManager;
+        this.network = network;
+        this.playerManager = playerManager;
+
+        messageBroker.Subscribe<MercenaryServiceAccepted>(HandleMercenaryServiceAccepted);
+        messageBroker.Subscribe<RequestMercenaryService>(HandleRequestMercenaryService);
+    }
+
+    public void Dispose()
+    {
+        messageBroker.Unsubscribe<MercenaryServiceAccepted>(HandleMercenaryServiceAccepted);
+        messageBroker.Unsubscribe<RequestMercenaryService>(HandleRequestMercenaryService);
+    }
+
+    private void HandleMercenaryServiceAccepted(MessagePayload<MercenaryServiceAccepted> payload)
+    {
+        if (!objectManager.TryGetIdWithLogging(payload.What.Kingdom, out var kingdomId)) return;
+
+        network.SendAll(new RequestMercenaryService(kingdomId));
+    }
+
+    private void HandleRequestMercenaryService(MessagePayload<RequestMercenaryService> payload)
+    {
+        if (ModInformation.IsClient) return;
+
+        if (!(payload.Who is NetPeer peer) || !playerManager.TryGetPlayer(peer, out var player))
+        {
+            Logger.Error("Received {Message} without a registered player peer", nameof(RequestMercenaryService));
+            return;
+        }
+
+        GameThread.RunSafe(
+            () => ApplyMercenaryService(player.ClanId, player.HeroId, payload.What.KingdomId),
+            context: nameof(MercenaryServiceHandler));
+    }
+
+    private void ApplyMercenaryService(string clanId, string heroId, string kingdomId)
+    {
+        if (!objectManager.TryGetObjectWithLogging<Clan>(clanId, out var clan)) return;
+        if (!objectManager.TryGetObjectWithLogging<Hero>(heroId, out var hero)) return;
+        if (!objectManager.TryGetObjectWithLogging<Kingdom>(kingdomId, out var kingdom)) return;
+
+        if (hero.Clan != clan)
+        {
+            Logger.Warning("Rejected mercenary service request because hero {HeroId} does not belong to clan {ClanId}", heroId, clanId);
+            return;
+        }
+
+        if (clan.Kingdom != null || clan.IsUnderMercenaryService)
+        {
+            Logger.Warning("Rejected mercenary service request because clan {ClanId} already belongs to a kingdom", clanId);
+            return;
+        }
+
+        int awardMultiplier = Campaign.Current.Models.MinorFactionsModel.GetMercenaryAwardFactorToJoinKingdom(clan, kingdom);
+
+        ChangeKingdomAction.ApplyByJoinFactionAsMercenary(clan, kingdom, default, awardMultiplier);
+        GainKingdomInfluenceAction.ApplyForJoiningFaction(hero, 5f);
+    }
+}

--- a/source/GameInterface/Services/Clans/Messages/MercenaryServiceAccepted.cs
+++ b/source/GameInterface/Services/Clans/Messages/MercenaryServiceAccepted.cs
@@ -1,0 +1,14 @@
+﻿using Common.Messaging;
+using TaleWorlds.CampaignSystem;
+
+namespace GameInterface.Services.Clans.Messages;
+
+internal readonly struct MercenaryServiceAccepted : IEvent
+{
+    public readonly Kingdom Kingdom;
+
+    public MercenaryServiceAccepted(Kingdom kingdom)
+    {
+        Kingdom = kingdom;
+    }
+}

--- a/source/GameInterface/Services/Clans/Messages/RequestMercenaryService.cs
+++ b/source/GameInterface/Services/Clans/Messages/RequestMercenaryService.cs
@@ -1,0 +1,16 @@
+﻿using Common.Messaging;
+using ProtoBuf;
+
+namespace GameInterface.Services.Clans.Messages;
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct RequestMercenaryService : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string KingdomId;
+
+    public RequestMercenaryService(string kingdomId)
+    {
+        KingdomId = kingdomId;
+    }
+}

--- a/source/GameInterface/Services/Clans/Patches/MercenaryServiceConversationPatch.cs
+++ b/source/GameInterface/Services/Clans/Patches/MercenaryServiceConversationPatch.cs
@@ -1,9 +1,7 @@
 ﻿using Common;
-using Common.Logging;
 using Common.Messaging;
 using GameInterface.Services.Clans.Messages;
 using HarmonyLib;
-using Serilog;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
 
@@ -15,8 +13,6 @@ namespace GameInterface.Services.Clans.Patches;
 [HarmonyPatch(typeof(LordConversationsCampaignBehavior))]
 internal class MercenaryServiceConversationPatch
 {
-    private static readonly ILogger Logger = LogManager.GetLogger<MercenaryServiceConversationPatch>();
-
     [HarmonyPatch(nameof(LordConversationsCampaignBehavior.conversation_mercenary_player_accepts_lord_answer_on_consequence))]
     [HarmonyPrefix]
     public static bool ConversationMercenaryPlayerAcceptsLordAnswerOnConsequencePrefix(
@@ -24,13 +20,7 @@ internal class MercenaryServiceConversationPatch
     {
         if (ModInformation.IsClient)
         {
-            var kingdom = Hero.OneToOneConversationHero?.Clan?.Kingdom;
-            if (kingdom == null)
-            {
-                Logger.Error("Unable to request mercenary service because the conversation hero has no kingdom");
-                return false;
-            }
-
+            var kingdom = Hero.OneToOneConversationHero.Clan.Kingdom;
             MessageBroker.Instance.Publish(__instance, new MercenaryServiceAccepted(kingdom));
             return false;
         }

--- a/source/GameInterface/Services/Clans/Patches/MercenaryServiceConversationPatch.cs
+++ b/source/GameInterface/Services/Clans/Patches/MercenaryServiceConversationPatch.cs
@@ -1,0 +1,40 @@
+﻿using Common;
+using Common.Logging;
+using Common.Messaging;
+using GameInterface.Services.Clans.Messages;
+using HarmonyLib;
+using Serilog;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.CampaignBehaviors;
+
+namespace GameInterface.Services.Clans.Patches;
+
+/// <summary>
+/// Routes the mercenary-service conversation consequence through the authoritative server.
+/// </summary>
+[HarmonyPatch(typeof(LordConversationsCampaignBehavior))]
+internal class MercenaryServiceConversationPatch
+{
+    private static readonly ILogger Logger = LogManager.GetLogger<MercenaryServiceConversationPatch>();
+
+    [HarmonyPatch(nameof(LordConversationsCampaignBehavior.conversation_mercenary_player_accepts_lord_answer_on_consequence))]
+    [HarmonyPrefix]
+    public static bool ConversationMercenaryPlayerAcceptsLordAnswerOnConsequencePrefix(
+        LordConversationsCampaignBehavior __instance)
+    {
+        if (ModInformation.IsClient)
+        {
+            var kingdom = Hero.OneToOneConversationHero?.Clan?.Kingdom;
+            if (kingdom == null)
+            {
+                Logger.Error("Unable to request mercenary service because the conversation hero has no kingdom");
+                return false;
+            }
+
+            MessageBroker.Instance.Publish(__instance, new MercenaryServiceAccepted(kingdom));
+            return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Accepting a noble's mercenary offer can leave the conversation stuck instead of completing the contract.

## What is the new behavior?

Resolves #1906

Mercenary offers now complete without freezing the conversation. Accepting joins the player's clan to the noble's kingdom as a mercenary and awards the normal influence, while declining returns to the noble's regular dialogue.
