### PR TITLE
[1879] Close zero-enemy map events after victory

### DIFF
--- a/source/E2E.Tests/Services/MapEvents/CoopBattleFinalizeTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/CoopBattleFinalizeTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Common.Messaging;
+using Common.Network;
 using Common.Util;
 using E2E.Tests.Environment.Instance;
 using GameInterface.Services.MapEvents;
@@ -9,6 +10,7 @@ using GameInterface.Services.MapEvents.Messages;
 using GameInterface.Services.MapEvents.Messages.Leave;
 using GameInterface.Services.MapEvents.Messages.Start;
 using GameInterface.Services.PlayerCaptivityService.Messages;
+using GameInterface.Services.Players;
 using HarmonyLib;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Encounters;
@@ -315,6 +317,81 @@ public class CoopBattleFinalizeTests : MapEventTestBase
     }
 
     [Fact]
+    public void SuccessorLeavingFallback_WithMatchingServerDepletion_ConcludesBattle()
+    {
+        var (ctx, _, _, _) = SetupTwoAlliedPlayersInBattle();
+        ClearPartyRoster(ctx.DefenderPartyId);
+
+        SetBattleHost(ctx.MapEventId);
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<MapEvent>(ctx.MapEventId, out var mapEvent));
+            Assert.True(mapEvent.AttackerSide.RecalculateMemberCountOfSide() > 0);
+            Assert.Equal(0, mapEvent.DefenderSide.RecalculateMemberCountOfSide());
+        });
+
+        var disabled = BattleMenuSurrenderDisabledMethods()
+            .Append(AccessTools.Method(typeof(MapEvent), "CaptureDefeatedPartyMembers"))
+            .Append(AccessTools.Method(typeof(GameMenu), nameof(GameMenu.ExitToLast)))
+            .Append(AccessTools.Method(typeof(MapEventRegistry), "CloseDestroyedMapEventEncounterIfNeeded"))
+            .ToList();
+
+        var successor = Clients.Last();
+        successor.Call(() => successor.Resolve<INetwork>().SendAll(
+            new NetworkChangeBattleState(ctx.MapEventId, BattleState.AttackerVictory, isLeavingFallback: true)),
+            disabled);
+
+        AssertMapEventRemoved(Server, ctx.MapEventId);
+        foreach (var client in Clients)
+            AssertMapEventRemoved(client, ctx.MapEventId);
+    }
+
+    [Fact]
+    public void SuccessorLeavingFallback_WhileServerLoserStillHealthy_IsRefused()
+    {
+        var (ctx, _, _, _) = SetupTwoAlliedPlayersInBattle();
+
+        SetBattleHost(ctx.MapEventId);
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<MapEvent>(ctx.MapEventId, out var mapEvent));
+            Assert.True(mapEvent.AttackerSide.RecalculateMemberCountOfSide() > 0);
+            Assert.True(mapEvent.DefenderSide.RecalculateMemberCountOfSide() > 0);
+        });
+
+        var successor = Clients.Last();
+        successor.Call(() => successor.Resolve<INetwork>().SendAll(
+            new NetworkChangeBattleState(ctx.MapEventId, BattleState.AttackerVictory, isLeavingFallback: true)),
+            MapEventDisabledMethods);
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<MapEvent>(ctx.MapEventId, out var mapEvent));
+            Assert.Equal(BattleState.None, mapEvent.BattleState);
+        });
+    }
+
+    [Fact]
+    public void NonHostVictoryWithoutLeavingFallback_IsRefusedWhenServerLoserIsDepleted()
+    {
+        var (ctx, _, _, _) = SetupTwoAlliedPlayersInBattle();
+        ClearPartyRoster(ctx.DefenderPartyId);
+        SetBattleHost(ctx.MapEventId);
+
+        var successor = Clients.Last();
+        successor.Call(() => successor.Resolve<INetwork>().SendAll(
+            new NetworkChangeBattleState(ctx.MapEventId, BattleState.AttackerVictory, isLeavingFallback: false)),
+            MapEventDisabledMethods);
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<MapEvent>(ctx.MapEventId, out var mapEvent));
+            Assert.Equal(BattleState.None, mapEvent.BattleState);
+        });
+    }
+
+    [Fact]
     public void DuplicateBattleStateChange_AfterServerConclusion_DoesNotPublishSecondClose()
     {
         var (ctx, _, _, _) = SetupTwoAlliedPlayersInBattle();
@@ -332,7 +409,8 @@ public class CoopBattleFinalizeTests : MapEventTestBase
             Assert.True(Server.ObjectManager.TryGetObject<MapEvent>(ctx.MapEventId, out var mapEvent));
             mapEvent._battleState = BattleState.AttackerVictory;
 
-            Server.Resolve<IMessageBroker>().Publish(this, new NetworkChangeBattleState(ctx.MapEventId, BattleState.AttackerVictory));
+            Server.Resolve<IMessageBroker>().Publish(this,
+                new NetworkChangeBattleState(ctx.MapEventId, BattleState.AttackerVictory, isLeavingFallback: false));
         }, disabled);
 
         Assert.True(Server.ObjectManager.TryGetObject<MapEvent>(ctx.MapEventId, out _));
@@ -393,6 +471,28 @@ public class CoopBattleFinalizeTests : MapEventTestBase
             .Append(AccessTools.Method(typeof(MapEvent), "CommitCalculatedMapEventResults"))
             .Append(AccessTools.Method(typeof(MapEvent), "MovePartyToSuitablePositionOnMapEventFinalize"))
             .ToList();
+
+    private void ClearPartyRoster(string partyId)
+    {
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(partyId, out var party));
+            party.MemberRoster.Clear();
+        });
+    }
+
+    private void SetBattleHost(string mapEventId)
+    {
+        var host = Clients.First();
+        var successor = Clients.Last();
+        Server.Call(() =>
+        {
+            var playerManager = Server.Resolve<IPlayerManager>();
+            playerManager.SetPeer("1", host.NetPeer);
+            playerManager.SetPeer("2", successor.NetPeer);
+            Server.Resolve<IBattleHostRegistry>().Set(mapEventId, new BattleHostAssignment("1", new[] { "2" }));
+        });
+    }
 
     /// <summary>
     /// Builds a shared battle with two opposing player parties, registers both as players, makes each client's

--- a/source/E2E.Tests/Services/MapEvents/PlayerPartyInteractionFlowTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/PlayerPartyInteractionFlowTests.cs
@@ -5,6 +5,7 @@ using Common.Util;
 using E2E.Tests.Environment.Instance;
 using GameInterface.Services.Entity;
 using GameInterface.Services.Inventory.Data;
+using GameInterface.Services.MapEvents;
 using GameInterface.Services.MapEvents.Messages;
 using GameInterface.Services.MapEvents.Messages.Conversation;
 using GameInterface.Services.MapEvents.Messages.Leave;
@@ -16,6 +17,7 @@ using GameInterface.Services.Stances.Messages;
 using GameInterface.Services.Villages.Interfaces;
 using GameInterface.Services.TroopRosters.Data;
 using HarmonyLib;
+using Missions.Messages;
 using System.Collections.Generic;
 using System.Reflection;
 using TaleWorlds.CampaignSystem;
@@ -1254,7 +1256,7 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
     }
 
     [Fact]
-    public void ExistingBattleJoin_UsesExistingAllowPath()
+    public void ExistingBattleJoin_WithAssignedMissionPlayer_UsesExistingAllowPath()
     {
         var (client1, _, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
         var mapEventSideId = CreateServerMapEventSide();
@@ -1265,6 +1267,9 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
             Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(responderPartyId, out var responderParty));
 
             responderParty.MapEventSide = side;
+            Server.Resolve<IBattleHostRegistry>().Set(
+                "live-battle",
+                new BattleHostAssignment("PlayerTwo", Array.Empty<string>()));
         }, MapEventDisabledMethods);
 
         RequestInteraction(client1, initiatorPartyId, responderPartyId);
@@ -1274,6 +1279,45 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
         Assert.Equal(responderPartyId, allowed.DefenderId);
         Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkConversationDenied>());
         Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>());
+    }
+
+    [Fact]
+    public void PlayerAwaitingBattleMissionExit_BlocksPlayerAndAiEncountersUntilMissionLeft()
+    {
+        var (client1, _, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+        var aiPartyId = CreateMobilePartyBase();
+        const string concludedBattleId = "concluded-battle";
+
+        Server.Call(() =>
+        {
+            Server.Resolve<IBattleHostRegistry>().Set(
+                concludedBattleId,
+                new BattleHostAssignment("PlayerTwo", Array.Empty<string>()));
+
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(aiPartyId, out var aiParty));
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(responderPartyId, out var responderParty));
+            Assert.False(InvokeStartPartyEncounterPrefix(aiParty, responderParty));
+        });
+
+        RequestInteraction(client1, initiatorPartyId, responderPartyId);
+
+        Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkConversationDenied>());
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>());
+
+        Server.NetworkSentMessages.Clear();
+        Server.Call(() =>
+        {
+            Server.Resolve<IMessageBroker>().Publish(this,
+                new MissionMemberDeparted("PlayerTwo", concludedBattleId, wasRetreat: true, isInstanceEmpty: true));
+
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(aiPartyId, out var aiParty));
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(responderPartyId, out var responderParty));
+            Assert.True(InvokeStartPartyEncounterPrefix(aiParty, responderParty));
+        });
+
+        RequestInteraction(client1, initiatorPartyId, responderPartyId);
+
+        Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>());
     }
 
     private (EnvironmentInstance client1, EnvironmentInstance client2, string initiatorPartyId, string responderPartyId) CreateTwoPlayerParties()
@@ -1422,6 +1466,15 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
                 forcePlayerOutFromSettlement: false,
                 ConversationRestartSource.PlayerEncounter)),
             disabledMethods);
+    }
+
+    private static bool InvokeStartPartyEncounterPrefix(PartyBase attackerParty, PartyBase defenderParty)
+    {
+        var patchType = AccessTools.TypeByName("GameInterface.Services.MapEvents.Patches.EncounterManagerPatches");
+        var prefix = AccessTools.Method(patchType, "StartPartyEncounterPrefix");
+        Assert.NotNull(prefix);
+
+        return (bool)prefix.Invoke(null, new object[] { attackerParty, defenderParty })!;
     }
 
     private void SubmitOption(

--- a/source/E2E.Tests/Services/Missions/CoopBattleResultCommitTests.cs
+++ b/source/E2E.Tests/Services/Missions/CoopBattleResultCommitTests.cs
@@ -1,11 +1,14 @@
 using GameInterface.Services.MapEvents;
+using GameInterface.Services.ObjectManager;
 using System;
 using System.Linq;
 using Common.Messaging;
+using Common.Network;
 using E2E.Tests.Environment;
 using E2E.Tests.Environment.MockEngine;
 using GameInterface.Services.MapEvents.Messages;
 using Missions.Battles;
+using Moq;
 using TaleWorlds.CampaignSystem.MapEvents;
 using TaleWorlds.Core;
 using Xunit;
@@ -59,6 +62,42 @@ public class CoopBattleResultCommitTests : MissionTestEnvironment
 
         // The host committed the AI's victory, which the server applies (OnBattleWon -> capture) and auto-finalizes.
         Assert.Equal(BattleState.DefenderVictory, committed);
+    }
+
+    [Fact]
+    public void SuccessorLeavesWithResolvedVictory_SubmitsValidatedFallback()
+    {
+        using var fixture = new MissionEngineFixture();
+        var successor = Clients.First();
+
+        successor.Call(() =>
+        {
+            var mock = fixture.CreateMission(successor);
+            mock.Shell.MissionResult = new MissionResult(BattleState.AttackerVictory,
+                playerVictory: true, playerDefeated: false, enemyRetreated: false);
+
+            var mapEvent = successor.CreateRegisteredObject<MapEvent>("mapEvent1");
+            mapEvent._battleState = BattleState.AttackerVictory;
+
+            var objectManager = new Mock<IObjectManager>();
+            var session = new Mock<IBattleSession>();
+            var hostRegistry = new Mock<IBattleHostRegistry>();
+            var network = new Mock<INetwork>();
+            IMessage sent = null;
+
+            objectManager.Setup(x => x.TryGetObject<MapEvent>("mapEvent1", out mapEvent)).Returns(true);
+            session.SetupGet(x => x.InstanceId).Returns("mapEvent1");
+            session.SetupGet(x => x.IsLocalHost).Returns(false);
+            network.Setup(x => x.SendAll(It.IsAny<IMessage>())).Callback<IMessage>(message => sent = message);
+
+            var committer = new BattleResultCommitter(objectManager.Object, session.Object, hostRegistry.Object, network.Object);
+            committer.CommitResolvedResult();
+
+            var fallback = Assert.IsType<NetworkChangeBattleState>(sent);
+            Assert.Equal("mapEvent1", fallback.MapEventId);
+            Assert.Equal(BattleState.AttackerVictory, fallback.BattleState);
+            Assert.True(fallback.IsLeavingFallback);
+        });
     }
 
     /// <summary>

--- a/source/GameInterface/Services/MapEvents/BattleConclusionGate.cs
+++ b/source/GameInterface/Services/MapEvents/BattleConclusionGate.cs
@@ -13,4 +13,6 @@ public static class BattleConclusionGate
     public static bool IsInCoopBattleMission;
 
     public static bool IsLocalBattleHost;
+
+    public static bool SuppressNextHostVictoryRelay;
 }

--- a/source/GameInterface/Services/MapEvents/BattleHostRegistry.cs
+++ b/source/GameInterface/Services/MapEvents/BattleHostRegistry.cs
@@ -43,6 +43,29 @@ public class BattleHostRegistry : IBattleHostRegistry
         }
     }
 
+    public bool IsControllerAssigned(string controllerId)
+    {
+        if (string.IsNullOrEmpty(controllerId))
+            return false;
+
+        lock (gate)
+        {
+            foreach (var assignment in assignments.Values)
+            {
+                if (assignment.HostControllerId == controllerId)
+                    return true;
+
+                foreach (var successorId in assignment.SuccessorControllerIds)
+                {
+                    if (successorId == controllerId)
+                        return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     public void Remove(string mapEventId)
     {
         lock (gate)

--- a/source/GameInterface/Services/MapEvents/Commands/BattleTeamKillCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/BattleTeamKillCommands.cs
@@ -20,6 +20,29 @@ internal class BattleTeamKillCommands
 {
     public static readonly ILogger Logger = LogManager.GetLogger<BattleTeamKillCommands>();
 
+    private const string SuppressVictoryRelayUsage =
+@"Usage:
+  coop.debug.mapevent.suppress_next_host_victory_relay
+
+Suppresses the elected battle host's next mission-derived victory relay. Diagnostic only: use immediately before
+coop.debug.mapevent.kill_enemy_team to reproduce a missing authoritative battle conclusion.";
+
+    [CommandLineArgumentFunction("suppress_next_host_victory_relay", "coop.debug.mapevent")]
+    public static string SuppressNextHostVictoryRelay(List<string> args)
+    {
+        var ctx = new CommandContext("suppress_next_host_victory_relay", SuppressVictoryRelayUsage, args);
+        if (!ctx.RequireArgCount(0, out var error))
+            return error;
+
+        if (!BattleConclusionGate.IsInCoopBattleMission)
+            return "Failed: no active coop battle mission.";
+        if (!BattleConclusionGate.IsLocalBattleHost)
+            return "Failed: run this on the elected battle host.";
+
+        BattleConclusionGate.SuppressNextHostVictoryRelay = true;
+        return "Armed: the elected host's next victory relay will be suppressed.";
+    }
+
     private const string KillEnemyUsage =
 @"Usage:
   coop.debug.mapevent.kill_enemy

--- a/source/GameInterface/Services/MapEvents/Handlers/ConversationRequestHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/ConversationRequestHandler.cs
@@ -9,6 +9,7 @@ using GameInterface.Services.MapEvents.Messages.Conversation;
 using GameInterface.Services.MapEvents.PlayerPartyInteractions;
 using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Players;
 using GameInterface.Services.Villages.Interfaces;
 using LiteNetLib;
 using Serilog;
@@ -44,6 +45,7 @@ internal class ConversationRequestHandler : IHandler
     private readonly IObjectManager objectManager;
     private readonly ConversationPartyTracker conversationPartyTracker;
     private readonly PlayerPartyInteractionHandler playerPartyInteractionHandler;
+    private readonly IBattleHostRegistry battleHostRegistry;
 
     private DateTime lastRequestSentUtc = DateTime.MinValue;
 
@@ -57,13 +59,15 @@ internal class ConversationRequestHandler : IHandler
         INetwork network,
         IObjectManager objectManager,
         ConversationPartyTracker conversationPartyTracker,
-        PlayerPartyInteractionHandler playerPartyInteractionHandler)
+        PlayerPartyInteractionHandler playerPartyInteractionHandler,
+        IBattleHostRegistry battleHostRegistry)
     {
         this.messageBroker = messageBroker;
         this.network = network;
         this.objectManager = objectManager;
         this.conversationPartyTracker = conversationPartyTracker;
         this.playerPartyInteractionHandler = playerPartyInteractionHandler;
+        this.battleHostRegistry = battleHostRegistry;
 
         messageBroker.Subscribe<ConversationRequested>(Handle_ConversationRequested);
         messageBroker.Subscribe<NetworkRequestConversation>(Handle_NetworkRequestConversation);
@@ -176,6 +180,17 @@ internal class ConversationRequestHandler : IHandler
         var attackerInMapEvent = attacker.MapEvent != null;
         var defenderInMapEvent = defender.MapEvent != null;
 
+        // A concluded map event is finalized before every client has to leave its victory screen. Keep those
+        // remaining mission parties unavailable until their MissionLeft removes them from the host assignment.
+        if (IsAwaitingBattleMissionExit(attacker) || IsAwaitingBattleMissionExit(defender))
+        {
+            Logger.Information(
+                "[BattleMissionGuard] Refused campaign interaction while a party is still leaving its battle mission. AttackerId={AttackerId}, DefenderId={DefenderId}",
+                request.AttackerId, request.DefenderId);
+            network.Send(requestingPeer, new NetworkConversationDenied());
+            return false;
+        }
+
         // PvP: a party joining an existing battle (exactly one side is already in a map event) is allowed through so
         // the joining player's PlayerEncounter can attach to that battle. There is no AI party to hold for a join.
         if (attackerInMapEvent ^ defenderInMapEvent)
@@ -240,6 +255,15 @@ internal class ConversationRequestHandler : IHandler
             request.AttackerId, request.DefenderId);
 
         return true;
+    }
+
+    private bool IsAwaitingBattleMissionExit(PartyBase party)
+    {
+        if (party?.MapEvent != null || party?.MobileParty == null)
+            return false;
+
+        return PlayerManager.TryGetControlledObjectInfo(party.MobileParty, out var controlledObject)
+            && battleHostRegistry.IsControllerAssigned(controlledObject.ObjectControllerId);
     }
 
     /// <summary>

--- a/source/GameInterface/Services/MapEvents/Handlers/MapEventHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/MapEventHandler.cs
@@ -62,7 +62,7 @@ internal class MapEventHandler : IHandler
             "Sending network battle state change. BattleState={BattleState}",
             payload.What.BattleState);
 
-        var message = new NetworkChangeBattleState(mapEventId, payload.What.BattleState);
+        var message = new NetworkChangeBattleState(mapEventId, payload.What.BattleState, isLeavingFallback: false);
         network.SendAll(message);
     }
 
@@ -79,7 +79,7 @@ internal class MapEventHandler : IHandler
         var mapEventId = payload.What.MapEventId;
         var battleState = payload.What.BattleState;
         var sender = payload.Who as NetPeer;
-        GameThread.Run(() =>
+        GameThread.RunSafe(() =>
         {
             if (!objectManager.TryGetObjectWithLogging<MapEvent>(mapEventId, out var mapEvent))
                 return;
@@ -97,17 +97,26 @@ internal class MapEventHandler : IHandler
                 return;
             }
 
-            // Only the elected battle host's conclusion is authoritative: a non-host's local mission can
-            // conclude a victory the shared battle never reached (its enemies arrive as another client's
-            // puppets). Applying it would run the full capture/finalize on a battle still being fought.
+            // A leaving non-host may replace a missing host conclusion only when the server's live rosters
+            // independently produce the same victory.
             if ((battleState == BattleState.AttackerVictory || battleState == BattleState.DefenderVictory)
                 && sender != null && hostRegistry.TryGet(mapEventId, out var hostAssignment)
                 && playerManager.TryGetPlayer(sender, out var sendingPlayer)
                 && sendingPlayer.ControllerId != hostAssignment.HostControllerId)
             {
-                Logger.Information("Refused battle state {BattleState} for {MapEventId} from non-host {ControllerId}",
-                    battleState, mapEventId, sendingPlayer.ControllerId);
-                return;
+                var authoritativeVictory = GetAuthoritativeVictory(mapEvent, out var attackerHealthy, out var defenderHealthy);
+                if (!payload.What.IsLeavingFallback || authoritativeVictory != battleState)
+                {
+                    Logger.Information(
+                        "Refused battle state {BattleState} for {MapEventId} from non-host {ControllerId}; leavingFallback={LeavingFallback} attackerHealthy={AttackerHealthy} defenderHealthy={DefenderHealthy}",
+                        battleState, mapEventId, sendingPlayer.ControllerId, payload.What.IsLeavingFallback,
+                        attackerHealthy, defenderHealthy);
+                    return;
+                }
+
+                Logger.Information(
+                    "Accepted leaving fallback {BattleState} for {MapEventId} from non-host {ControllerId}; attackerHealthy={AttackerHealthy} defenderHealthy={DefenderHealthy}",
+                    battleState, mapEventId, sendingPlayer.ControllerId, attackerHealthy, defenderHealthy);
             }
 
             var playerPartyIds = MapEventPlayerPartyCollector.CollectPartyIds(mapEvent, objectManager);
@@ -127,6 +136,17 @@ internal class MapEventHandler : IHandler
             if (battleState == BattleState.AttackerVictory || battleState == BattleState.DefenderVictory)
                 messageBroker.Publish(this, new MapEventConcluded(mapEventId, playerPartyIds));
         });
+    }
+
+    private static BattleState GetAuthoritativeVictory(MapEvent mapEvent, out int attackerHealthy, out int defenderHealthy)
+    {
+        attackerHealthy = mapEvent.AttackerSide?.RecalculateMemberCountOfSide() ?? -1;
+        defenderHealthy = mapEvent.DefenderSide?.RecalculateMemberCountOfSide() ?? -1;
+
+        if (attackerHealthy < 0 || defenderHealthy < 0 || (attackerHealthy != 0 && defenderHealthy != 0))
+            return BattleState.None;
+
+        return attackerHealthy <= 0 ? BattleState.DefenderVictory : BattleState.AttackerVictory;
     }
 
     private void Handle_MapEventSurrenderAttempted(MessagePayload<MapEventSurrenderAttempted> payload)

--- a/source/GameInterface/Services/MapEvents/Handlers/PvPInteractionClientHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/PvPInteractionClientHandler.cs
@@ -6,6 +6,7 @@ using GameInterface.Services.MapEvents.Messages;
 using GameInterface.Services.MapEvents.Messages.Conversation;
 using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.PlayerCaptivityService.Messages;
 using Serilog;
 using System;
 using TaleWorlds.CampaignSystem;
@@ -38,6 +39,8 @@ internal class PvPInteractionClientHandler : IHandler
     // Party id the popup is currently shown for (always this client's own party), or null when nothing is shown.
     // Only touched on the game main thread.
     private string shownDefenderPartyId;
+    private PartyBase pendingEncounterParty;
+    private MapEvent pendingEncounterMapEvent;
 
     // This instance's player hero name, to tell instances apart in a combined log.
     private static string Who => Hero.MainHero?.Name?.ToString() ?? "?";
@@ -52,6 +55,7 @@ internal class PvPInteractionClientHandler : IHandler
         messageBroker.Subscribe<NetworkPlayerInteractionEnded>(Handle_NetworkPlayerInteractionEnded);
         messageBroker.Subscribe<NetworkHidePvpPopup>(Handle_NetworkHidePvpPopup);
         messageBroker.Subscribe<NetworkClosePvpEncounter>(Handle_NetworkClosePvpEncounter);
+        messageBroker.Subscribe<CampaignTick>(Handle_CampaignTick);
     }
 
     public void Dispose()
@@ -60,6 +64,10 @@ internal class PvPInteractionClientHandler : IHandler
         messageBroker.Unsubscribe<NetworkPlayerInteractionEnded>(Handle_NetworkPlayerInteractionEnded);
         messageBroker.Unsubscribe<NetworkHidePvpPopup>(Handle_NetworkHidePvpPopup);
         messageBroker.Unsubscribe<NetworkClosePvpEncounter>(Handle_NetworkClosePvpEncounter);
+        messageBroker.Unsubscribe<CampaignTick>(Handle_CampaignTick);
+
+        pendingEncounterParty = null;
+        pendingEncounterMapEvent = null;
 
         // Make sure a popup never outlives the co-op session.
         if (shownDefenderPartyId != null)
@@ -143,7 +151,15 @@ internal class PvPInteractionClientHandler : IHandler
         {
             return;
         }
-        ClearMapEventBackReferences(partyIds);
+        var activeMission = MissionState.Current != null || Mission.Current != null;
+        var localMapEvent = activeMission ? localParty?.MapEvent : null;
+        ClearMapEventBackReferences(partyIds, localMapEvent != null ? localParty : null);
+
+        if (localMapEvent != null)
+        {
+            pendingEncounterParty = localParty;
+            pendingEncounterMapEvent = localMapEvent;
+        }
 
         Logger.Information("[PvPEncounterClose] Closing local encounter; partyIds=[{PartyIds}] surrenderedPartyId={SurrenderedPartyId} mapEventId={MapEventId}",
             FormatIds(partyIds),
@@ -158,16 +174,34 @@ internal class PvPInteractionClientHandler : IHandler
         CloseEncounter(localParty);
     }
 
-    private void ClearMapEventBackReferences(string[] partyIds)
+    private void ClearMapEventBackReferences(string[] partyIds, PartyBase deferredParty = null)
     {
         foreach (var partyId in partyIds ?? Array.Empty<string>())
         {
             if (!objectManager.TryGetObject<PartyBase>(partyId, out var party))
                 continue;
 
+            if (party == deferredParty)
+                continue;
+
             if (party.MapEventSide != null)
                 party._mapEventSide = null;
         }
+    }
+
+    private void Handle_CampaignTick(MessagePayload<CampaignTick> payload)
+    {
+        if (ModInformation.IsServer) return;
+        if (pendingEncounterMapEvent == null) return;
+        if (MissionState.Current != null || Mission.Current != null || PlayerEncounter.Current != null) return;
+
+        var party = pendingEncounterParty;
+        var mapEvent = pendingEncounterMapEvent;
+        pendingEncounterParty = null;
+        pendingEncounterMapEvent = null;
+
+        if (party?.MapEvent == mapEvent)
+            party._mapEventSide = null;
     }
 
     private bool TryGetLocalParty(string[] partyIds, out PartyBase party)
@@ -407,8 +441,9 @@ internal class PvPInteractionClientHandler : IHandler
 
         if (MissionState.Current != null || Mission.Current != null)
         {
-            Logger.Information("[PvPEncounterClose] Ending active mission before forced campaign close");
-            ForceEndCurrentMission();
+            // Keep this party attached until vanilla processes its result screens after the player exits the mission.
+            Logger.Information("[PvPEncounterClose] Leaving active mission open until the local player exits");
+            return;
         }
 
         // A joiner stays bound to its map-event side after the attacker abandons the encounter: the abandon tears
@@ -430,25 +465,6 @@ internal class PvPInteractionClientHandler : IHandler
 
         // Leaving an encounter is handled by PlayerEncounter.Update, which is required to bring up loot screens and more
         // Do not finish the PlayerEncounter here
-    }
-
-    private void ForceEndCurrentMission()
-    {
-        var mission = Mission.Current ?? MissionState.Current?.CurrentMission;
-        if (mission == null)
-        {
-            return;
-        }
-
-        try
-        {
-            if (!mission.MissionEnded && !mission.MissionIsEnding)
-                mission.EndMission();
-        }
-        catch (Exception ex)
-        {
-            Logger.Error(ex, "[PvPEncounterClose] ForceEndCurrentMission failed");
-        }
     }
 
     private static void ExitMapMenuMode(Campaign campaign, MapState mapState)

--- a/source/GameInterface/Services/MapEvents/IBattleHostRegistry.cs
+++ b/source/GameInterface/Services/MapEvents/IBattleHostRegistry.cs
@@ -31,5 +31,8 @@ public interface IBattleHostRegistry
     /// <summary>True if this instance is the elected host for the given battle.</summary>
     bool IsHost(string mapEventId);
 
+    /// <summary>True while the controller is still present in an elected battle mission.</summary>
+    bool IsControllerAssigned(string controllerId);
+
     void Remove(string mapEventId);
 }

--- a/source/GameInterface/Services/MapEvents/Messages/NetworkChangeBattleState.cs
+++ b/source/GameInterface/Services/MapEvents/Messages/NetworkChangeBattleState.cs
@@ -11,10 +11,13 @@ public readonly struct NetworkChangeBattleState : ICommand
     public readonly string MapEventId;
     [ProtoMember(2)]
     public readonly BattleState BattleState;
+    [ProtoMember(3)]
+    public readonly bool IsLeavingFallback;
 
-    public NetworkChangeBattleState(string mapEventId, BattleState battleState)
+    public NetworkChangeBattleState(string mapEventId, BattleState battleState, bool isLeavingFallback)
     {
         MapEventId = mapEventId;
         BattleState = battleState;
+        IsLeavingFallback = isLeavingFallback;
     }
 }

--- a/source/GameInterface/Services/MapEvents/Patches/EncounterManagerPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/EncounterManagerPatches.cs
@@ -6,6 +6,7 @@ using GameInterface.Services.MapEvents.Initialization;
 using GameInterface.Services.MapEvents.Messages.Conversation;
 using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Services.MobileParties.Messages.Behavior;
+using GameInterface.Services.Players;
 using HarmonyLib;
 using Serilog;
 using TaleWorlds.CampaignSystem;
@@ -55,6 +56,9 @@ internal class EncounterManagerPatches
         if (IsPendingParty(attackerParty) || IsPendingParty(defenderParty))
             return false;
 
+        if (IsAwaitingBattleMissionExit(attackerParty) || IsAwaitingBattleMissionExit(defenderParty))
+            return false;
+
         if (CallOriginalPolicy.IsOriginalAllowed()) return true;
 
         if (TryRequestActiveSlowRaidSettlementEncounter(attackerParty, defenderParty))
@@ -98,6 +102,18 @@ internal class EncounterManagerPatches
 
     internal static bool IsPendingParty(PartyBase party) =>
         PendingMapEventPartyMovementPatch.IsPending(party);
+
+    internal static bool IsAwaitingBattleMissionExit(PartyBase party)
+    {
+        if (ModInformation.IsClient || party?.MapEvent != null || party?.MobileParty == null)
+            return false;
+
+        if (!PlayerManager.TryGetControlledObjectInfo(party.MobileParty, out var controlledObject))
+            return false;
+
+        return ContainerProvider.TryResolve<IBattleHostRegistry>(out var hostRegistry)
+            && hostRegistry.IsControllerAssigned(controlledObject.ObjectControllerId);
+    }
 
     // EncounterManager.RestartPlayerEncounter is private; patch by name. It is the path that opens the encounter
     // menu/conversation (it calls PlayerEncounter.Current.Init). Parameter order here is (attacker, defender).

--- a/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
@@ -109,9 +109,21 @@ internal class MapEventPatches
         // fights. Only the battle host relays a mission victory; the local set still runs so the
         // peer's own mission winds down, and the real result arrives through the sync.
         if ((value == BattleState.AttackerVictory || value == BattleState.DefenderVictory)
-            && BattleConclusionGate.IsInCoopBattleMission && !BattleConclusionGate.IsLocalBattleHost)
+            && BattleConclusionGate.IsInCoopBattleMission)
         {
-            return true;
+            if (!BattleConclusionGate.IsLocalBattleHost)
+            {
+                return true;
+            }
+
+            if (BattleConclusionGate.SuppressNextHostVictoryRelay)
+            {
+                BattleConclusionGate.SuppressNextHostVictoryRelay = false;
+                Logger.Warning("[BattleSyncRepro] Suppressed elected host victory relay for {MapEventId}; state={BattleState}",
+                    __instance.StringId,
+                    value);
+                return true;
+            }
         }
 
         var message = new MapEventBattleStateChangeAttempted(__instance, value);

--- a/source/Missions/Battles/BattleResultCommitter.cs
+++ b/source/Missions/Battles/BattleResultCommitter.cs
@@ -1,5 +1,7 @@
 using Common.Logging;
+using Common.Network;
 using GameInterface.Services.MapEvents;
+using GameInterface.Services.MapEvents.Messages;
 using GameInterface.Services.ObjectManager;
 using Serilog;
 using TaleWorlds.CampaignSystem.MapEvents;
@@ -19,9 +21,8 @@ public interface IBattleResultCommitter
     /// Commit this concluded battle's result. Setting <c>MapEvent.BattleState</c> runs the native
     /// setter, which the coop intercept (<c>MapEventPatches</c>) syncs to the server; there it runs
     /// <c>OnBattleWon</c> (capturing the defeated players) and the auto-finalize (closing every player's
-    /// encounter). A retreat (unresolved result) commits nothing; an already-resolved state is left untouched.
-    /// This is intentionally not host-gated: the first client to finish the battle and click Done must
-    /// resolve the shared campaign battle for everyone.
+    /// encounter). A retreat (unresolved result) commits nothing. A leaving successor submits its resolved
+    /// result as a fallback, which the server validates against its live rosters.
     /// </summary>
     void CommitResolvedResult();
 }
@@ -34,12 +35,15 @@ public class BattleResultCommitter : IBattleResultCommitter
     private readonly IObjectManager objectManager;
     private readonly IBattleSession session;
     private readonly IBattleHostRegistry hostRegistry;
+    private readonly INetwork network;
 
-    public BattleResultCommitter(IObjectManager objectManager, IBattleSession session, IBattleHostRegistry hostRegistry)
+    public BattleResultCommitter(IObjectManager objectManager, IBattleSession session, IBattleHostRegistry hostRegistry,
+        INetwork network)
     {
         this.objectManager = objectManager;
         this.session = session;
         this.hostRegistry = hostRegistry;
+        this.network = network;
     }
 
     public void CommitResolvedResult()
@@ -62,15 +66,22 @@ public class BattleResultCommitter : IBattleResultCommitter
             return;
         }
 
+        if (!session.IsLocalHost)
+        {
+            Logger.Information("[BattleSync] Submitting leaving fallback {State} for instance {Instance}",
+                result.BattleState, session.InstanceId);
+            network.SendAll(new NetworkChangeBattleState(session.InstanceId, result.BattleState, isLeavingFallback: true));
+            return;
+        }
+
         if (mapEvent.BattleState != BattleState.None)
         {
             return;
         }
 
-        // If the current host is leaving while successors are still assigned, this mission end is a retreat or
-        // host handoff, not the shared battle's Done result. A successor will commit once the battle truly ends.
-        if (session.IsLocalHost &&
-            hostRegistry.TryGet(session.InstanceId, out var assignment) &&
+        // A host leaving while successors remain is a retreat or handoff. A successor supplies any missing
+        // resolved result when it later leaves.
+        if (hostRegistry.TryGet(session.InstanceId, out var assignment) &&
             assignment.SuccessorControllerIds.Count > 0)
         {
             Logger.Information("[BattleSync] Not committing battle result for {Instance}: {Count} successor(s) still in the battle",

--- a/source/Missions/Battles/CoopBattleController.cs
+++ b/source/Missions/Battles/CoopBattleController.cs
@@ -109,7 +109,7 @@ public class CoopBattleController : CoopMissionController
         hostRegistryRef = hostRegistry;
         Session = session;
         Deployment = deployment;
-        ResultCommitter = new BattleResultCommitter(objectManager, session, hostRegistry);
+        ResultCommitter = new BattleResultCommitter(objectManager, session, hostRegistry, relayNetwork);
         siegeEngineStateReporter = new SiegeEngineStateReporter(objectManager, session, hostRegistry, relayNetwork);
     }
 
@@ -137,6 +137,7 @@ public class CoopBattleController : CoopMissionController
         SiegeMissionAuthorityGate.ResetClaimedMachines();
         BattleConclusionGate.IsInCoopBattleMission = false;
         BattleConclusionGate.IsLocalBattleHost = false;
+        BattleConclusionGate.SuppressNextHostVictoryRelay = false;
 
         base.Dispose();
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Winning a field battle can leave the player who exits stuck in the encounter after the enemy reaches zero troops if the elected battle host remains in the mission. The only remaining option is `Capture the Enemy`, which does not close the battle.

## What is the new behavior?

Resolves #1879

After a shared victory, each player can leave the field battle when they choose. The zero-enemy encounter closes when the first player leaves, while players who remain in the mission are not forced out.
