### PR TITLE
Enable PoliticalStagnationAndBorderIncidentCampaignBehavior

### DIFF
--- a/source/GameInterface/Services/Settlements/Patches/Disable/DisablePoliticalStagnationAndBorderIncidentCampaignBehavior.cs
+++ b/source/GameInterface/Services/Settlements/Patches/Disable/DisablePoliticalStagnationAndBorderIncidentCampaignBehavior.cs
@@ -1,12 +1,38 @@
-﻿using HarmonyLib;
+﻿using Common;
+using GameInterface.Services.MobileParties.Extensions;
+using HarmonyLib;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Settlements;
 
 namespace GameInterface.Services.Settlements.Patches.Disable;
-
 
 [HarmonyPatch(typeof(PoliticalStagnationAndBorderIncidentCampaignBehavior))]
 internal class DisablePoliticalStagnationAndBorderIncidentCampaignBehavior
 {
     [HarmonyPatch(nameof(PoliticalStagnationAndBorderIncidentCampaignBehavior.RegisterEvents))]
-    static bool Prefix() => false;
+    static bool Prefix() => ModInformation.IsServer;
+}
+
+[HarmonyPatch(typeof(PoliticalStagnationAndBorderIncidentCampaignBehavior))]
+internal class PoliticalStagnationAndBorderIncidentCampaignBehaviorPatches
+{
+    [HarmonyPatch(nameof(PoliticalStagnationAndBorderIncidentCampaignBehavior.GetThreatValueOfEnemyToSettlement))]
+    [HarmonyPrefix]
+    public static bool GetThreatValueOfEnemyToSettlementPrefix(PoliticalStagnationAndBorderIncidentCampaignBehavior __instance, ref float __result, MobileParty mobileParty, Settlement settlement)
+    {
+        float num = __instance.GetThreatValueOfParty(mobileParty);
+
+        if (mobileParty.IsPlayerParty()) // Check for player party
+            num *= 2f;
+        if (!mobileParty.IsLordParty)
+            num *= 0.5f;
+        if (mobileParty.DefaultBehavior == AiBehavior.PatrolAroundPoint && mobileParty.TargetSettlement == settlement)
+            num *= 2f;
+        if (mobileParty.MapEvent != null && mobileParty.MapEvent.IsFieldBattle)
+            num = 3f * num;
+
+        __result = num;
+        return false;
+    }
 }

--- a/source/GameInterface/Services/Settlements/SettlementSync.cs
+++ b/source/GameInterface/Services/Settlements/SettlementSync.cs
@@ -51,10 +51,10 @@ internal class SettlementSync : IAutoSync
         AutoSyncRegistry.AddProperty(AccessTools.Property(typeof(Settlement), nameof(Settlement.GatePosition)));
         AutoSyncRegistry.AddProperty(AccessTools.Property(typeof(Settlement), nameof(Settlement.LocationComplex))); // Might not be needed
 
-        AutoSyncRegistry.AddProperty(AccessTools.Property(typeof(Settlement), nameof(Settlement.NearbyLandThreatIntensity)));
-        AutoSyncRegistry.AddProperty(AccessTools.Property(typeof(Settlement), nameof(Settlement.NearbyNavalThreatIntensity)));
-        AutoSyncRegistry.AddProperty(AccessTools.Property(typeof(Settlement), nameof(Settlement.NearbyLandAllyIntensity)));
-        AutoSyncRegistry.AddProperty(AccessTools.Property(typeof(Settlement), nameof(Settlement.NearbyNavalAllyIntensity)));
+        AutoSyncRegistry.AddProperty(AccessTools.Property(typeof(Settlement), nameof(Settlement.NearbyLandThreatIntensity)), coalesce: true);
+        AutoSyncRegistry.AddProperty(AccessTools.Property(typeof(Settlement), nameof(Settlement.NearbyNavalThreatIntensity)), coalesce: true);
+        AutoSyncRegistry.AddProperty(AccessTools.Property(typeof(Settlement), nameof(Settlement.NearbyLandAllyIntensity)), coalesce: true);
+        AutoSyncRegistry.AddProperty(AccessTools.Property(typeof(Settlement), nameof(Settlement.NearbyNavalAllyIntensity)), coalesce: true);
 
         //// Target Methods
         AutoSyncRegistry.AddTargetMethod(typeof(Settlement), AccessTools.Method(typeof(SettlementClaimantCampaignBehavior), nameof(SettlementClaimantCampaignBehavior.OnSettlementOwnerChanged)));


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`PoliticalStagnationAndBorderIncidentCampaignBehavior` is disabled. The most important part of this behaviour is setting the threat and ally intensity around settlements. This is needed by AI parties to more accurately decide where to patrol.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
`PoliticalStagnationAndBorderIncidentCampaignBehavior` is enabled. Manage ally and threat intensities for settlements with coalescer to avoid flooding network with messages.

## Other information
