### PR TITLE
Prevent abusing player ransoms

### DIFF
--- a/source/GameInterface/Services/Party/Patches/RansomPlayerValuePatch.cs
+++ b/source/GameInterface/Services/Party/Patches/RansomPlayerValuePatch.cs
@@ -1,0 +1,23 @@
+﻿using GameInterface.Services.Heroes.Extensions;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.GameComponents;
+
+namespace GameInterface.Services.Party.Patches;
+
+[HarmonyPatch(typeof(DefaultRansomValueCalculationModel))]
+internal class RansomPlayerValuePatch
+{
+    [HarmonyPatch(nameof(DefaultRansomValueCalculationModel.PrisonerRansomValue))]
+    [HarmonyPrefix]
+    public static bool PrisonerRansomValuePrefix(ref int __result, CharacterObject prisoner, Hero sellerHero = null)
+    {
+        if (prisoner.IsHero && prisoner.HeroObject.IsPlayerHero())
+        {
+            __result = 0;
+            return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Players can do as many PvP battles as they want and ransom each other for money.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #1864
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Overrides ransom value for player heroes to be 0. Clients can still ransom player prisoners at settlements but there is no incentive to repeatedly do this.

## Other information
