### PR TITLE
Enable NotablePowerManagementBehavior

### DIFF
--- a/source/GameInterface/Services/Heroes/Patches/Disable/DisableNotablePowerManagementBehavior.cs
+++ b/source/GameInterface/Services/Heroes/Patches/Disable/DisableNotablePowerManagementBehavior.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using Common;
+using HarmonyLib;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
 
 namespace GameInterface.Services.Heroes.Patches.Disable;
@@ -7,5 +8,5 @@ namespace GameInterface.Services.Heroes.Patches.Disable;
 internal class DisableNotablePowerManagementBehavior
 {
     [HarmonyPatch(nameof(NotablePowerManagementBehavior.RegisterEvents))]
-    static bool Prefix() => false;
+    static bool Prefix() => ModInformation.IsServer;
 }


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`NotablePowerManagementBehavior` is disabled. This behaviour is responsible for drifting the power of notables up or down as well adjusting the amount of gold they have.

Notable power is tied to the map economy. Power of notables affects spawn chances of caravans and recruits.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
`NotablePowerManagementBehavior` is enabled.