### PR TITLE
[1891] Fix noble liberation conversation soft lock 

### DIFF
--- a/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
@@ -75,6 +75,11 @@ public class MapEventDebugCommands
     [CommandLineArgumentFunction("start_nearest_looter", "coop.debug.mapevent")]
     public static string StartNearestLooterMapEvent(List<string> args)
     {
+        if (!TryGetObjectManager(out var objectManager))
+        {
+            return "Unable to resolve ObjectManager";
+        }
+
         var mainParty = MobileParty.MainParty;
         if (mainParty == null)
         {
@@ -95,7 +100,9 @@ public class MapEventDebugCommands
 
         EncounterManager.StartPartyEncounter(mainParty.Party, nearest.Party);
 
-        return $"Started encounter with {nearest.Name} ({nearest.StringId}), " +
+        var partyId = objectManager.TryGetId(nearest, out string registryId) ? registryId : nearest.StringId;
+
+        return $"Started encounter with {nearest.Name} (StringId {nearest.StringId}, registry id {partyId}), " +
                $"{nearest.MemberRoster.TotalManCount} troops, {nearest.Position.ToVec2().Distance(mainPos):0.0} away.";
     }
 

--- a/source/GameInterface/Services/PlayerCaptivityService/Commands/PlayerCaptivityCommands.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Commands/PlayerCaptivityCommands.cs
@@ -54,12 +54,13 @@ Captures the given hero and assigns a random mobile party as the captor.";
 
     private const string CapturePlayerUsage =
 @"Usage:
-  coop.debug.player_captivity.capture_player <heroId> <mobilePartyStringId>
+  coop.debug.player_captivity.capture_player <heroId> <mobilePartyId>
 
 Example:
-  coop.debug.player_captivity.capture_player Player looters_1
+  coop.debug.player_captivity.capture_player lord_1_29 MobileParty_looters_248
 
-Captures the given hero and assigns the given mobile party as the captor.";
+Captures the given hero and assigns the given mobile party as the captor. The party argument accepts
+a co-op registry id or a local StringId.";
 
     [CommandLineArgumentFunction("capture_player", "coop.debug.player_captivity")]
     public static string CapturePlayer(List<string> args)
@@ -78,7 +79,7 @@ Captures the given hero and assigns the given mobile party as the captor.";
         if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
             return error;
 
-        if (!ctx.TryGetArg(1, "mobilePartyStringId", out var captorPartyId, out error))
+        if (!ctx.TryGetArg(1, "mobilePartyId", out var captorPartyId, out error))
             return error;
 
         if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
@@ -87,7 +88,8 @@ Captures the given hero and assigns the given mobile party as the captor.";
         if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
             return "Failed to capture hero: " + error;
 
-        if (!CommandHelpers.TryGetMobileParty(captorPartyId, out var newCaptor, out error))
+        if (!objectManager.TryGetObject(captorPartyId, out MobileParty newCaptor)
+            && !CommandHelpers.TryGetMobileParty(captorPartyId, out newCaptor, out error))
             return "Failed to capture hero: " + error;
 
         return CaptureHero(hero, newCaptor);

--- a/source/GameInterface/Services/PlayerCaptivityService/Handlers/PlayerCaptivityClientHandler.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Handlers/PlayerCaptivityClientHandler.cs
@@ -1,4 +1,4 @@
-using Common;
+﻿using Common;
 using Common.Logging;
 using Common.Messaging;
 using Common.Network;
@@ -28,6 +28,8 @@ namespace GameInterface.Services.PlayerCaptivityService.Handlers;
 /// the battle.</item>
 /// <item><see cref="EndPlayerCaptivityAttempted"/> — a local captivity menu option ended captivity;
 /// ask the server to release the hero.</item>
+/// <item><see cref="EndCaptivityAttempted"/> — the player chose to release another hero; ask the
+/// server to apply the release.</item>
 /// <item><see cref="NetworkPlayerCaptivityEnded"/> — the server confirmed the release; leave the
 /// captivity menus.</item>
 /// </list>
@@ -54,6 +56,7 @@ internal class PlayerCaptivityClientHandler : IHandler
         messageBroker.Subscribe<PlayerCaptivityChanged>(Handle_PlayerCaptivityChanged);
         messageBroker.Subscribe<PlayerSurrendered>(Handle_PlayerSurrendered);
         messageBroker.Subscribe<EndPlayerCaptivityAttempted>(Handle_EndPlayerCaptivityAttempted);
+        messageBroker.Subscribe<EndCaptivityAttempted>(Handle_EndCaptivityAttempted);
         messageBroker.Subscribe<NetworkPlayerCaptivityEnded>(Handle_NetworkPlayerCaptivityEnded);
         messageBroker.Subscribe<NetworkPlayerCaptivityReleasePositionSet>(Handle_NetworkPlayerCaptivityReleasePositionSet);
     }
@@ -63,6 +66,7 @@ internal class PlayerCaptivityClientHandler : IHandler
         messageBroker.Unsubscribe<PlayerCaptivityChanged>(Handle_PlayerCaptivityChanged);
         messageBroker.Unsubscribe<PlayerSurrendered>(Handle_PlayerSurrendered);
         messageBroker.Unsubscribe<EndPlayerCaptivityAttempted>(Handle_EndPlayerCaptivityAttempted);
+        messageBroker.Unsubscribe<EndCaptivityAttempted>(Handle_EndCaptivityAttempted);
         messageBroker.Unsubscribe<NetworkPlayerCaptivityEnded>(Handle_NetworkPlayerCaptivityEnded);
         messageBroker.Unsubscribe<NetworkPlayerCaptivityReleasePositionSet>(Handle_NetworkPlayerCaptivityReleasePositionSet);
     }
@@ -180,6 +184,27 @@ internal class PlayerCaptivityClientHandler : IHandler
             PlayerCaptivity.IsCaptive);
 
         network.SendAll(new NetworkPlayerSurrendered(playerPartyId, mapEventId));
+    }
+
+    /// <summary>
+    /// A local conversation or screen released another hero; forward the intent to the server and
+    /// remove that hero from the local post-battle queue so the conversation does not reopen.
+    /// </summary>
+    private void Handle_EndCaptivityAttempted(MessagePayload<EndCaptivityAttempted> payload)
+    {
+        if (ModInformation.IsServer) return;
+
+        var data = payload.What;
+
+        if (!objectManager.TryGetIdWithLogging(data.Prisoner, out string prisonerId)) return;
+
+        string facilitatorId = null;
+        if (data.Facilitator != null && !objectManager.TryGetIdWithLogging(data.Facilitator, out facilitatorId)) return;
+
+        network.SendAll(new NetworkEndCaptivityAttempted(prisonerId, data.Detail, facilitatorId, data.ShowNotification));
+
+        PlayerEncounter.Current?._capturedAlreadyPrisonerHeroes?
+            .RemoveAll(element => element.Character?.HeroObject == data.Prisoner);
     }
 
     /// <summary>

--- a/source/GameInterface/Services/PlayerCaptivityService/Handlers/PlayerCaptivityServerHandler.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Handlers/PlayerCaptivityServerHandler.cs
@@ -40,6 +40,8 @@ namespace GameInterface.Services.PlayerCaptivityService.Handlers;
 /// the server, which then captures the player through the normal defeat path.</item>
 /// <item><see cref="NetworkEndPlayerCaptivityAttempted"/> — a client requests release from captivity;
 /// apply it and confirm with <see cref="NetworkPlayerCaptivityEnded"/>.</item>
+/// <item><see cref="NetworkEndCaptivityAttempted"/> — a client chose to release another hero;
+/// apply the release through the authoritative game action.</item>
 /// <item><see cref="CampaignTick"/> — keep captive players' parties glued to their captor
 /// (the server-side replacement for native <see cref="PlayerCaptivity"/>.Update).</item>
 /// </list>
@@ -69,6 +71,7 @@ internal class PlayerCaptivityServerHandler : IHandler
         messageBroker.Subscribe<PrisonerTaken>(Handle_PrisonerTaken);
         messageBroker.Subscribe<NetworkPlayerSurrendered>(Handle_NetworkPlayerSurrendered);
         messageBroker.Subscribe<NetworkEndPlayerCaptivityAttempted>(Handle_NetworkEndPlayerCaptivityAttempted);
+        messageBroker.Subscribe<NetworkEndCaptivityAttempted>(Handle_NetworkEndCaptivityAttempted);
         messageBroker.Subscribe<PlayerCaptivityEndedByServer>(Handle_PlayerCaptivityEndedByServer);
         messageBroker.Subscribe<CampaignTick>(Handle_CampaignTick);
     }
@@ -78,6 +81,7 @@ internal class PlayerCaptivityServerHandler : IHandler
         messageBroker.Unsubscribe<PrisonerTaken>(Handle_PrisonerTaken);
         messageBroker.Unsubscribe<NetworkPlayerSurrendered>(Handle_NetworkPlayerSurrendered);
         messageBroker.Unsubscribe<NetworkEndPlayerCaptivityAttempted>(Handle_NetworkEndPlayerCaptivityAttempted);
+        messageBroker.Unsubscribe<NetworkEndCaptivityAttempted>(Handle_NetworkEndCaptivityAttempted);
         messageBroker.Unsubscribe<PlayerCaptivityEndedByServer>(Handle_PlayerCaptivityEndedByServer);
         messageBroker.Unsubscribe<CampaignTick>(Handle_CampaignTick);
     }
@@ -187,6 +191,31 @@ internal class PlayerCaptivityServerHandler : IHandler
                 Logger.Error(ex, "Failed to surrender");
             }
         }, blocking: true);
+    }
+
+    /// <summary>
+    /// A client chose to release another hero. Apply the vanilla action on the server so its
+    /// patches and synchronized side effects remain authoritative.
+    /// </summary>
+    private void Handle_NetworkEndCaptivityAttempted(MessagePayload<NetworkEndCaptivityAttempted> payload)
+    {
+        if (ModInformation.IsClient) return;
+
+        var data = payload.What;
+
+        GameThread.RunSafe(() =>
+        {
+            if (!objectManager.TryGetObjectWithLogging<Hero>(data.PrisonerId, out var prisoner)) return;
+            if (!prisoner.IsPrisoner) return;
+
+            Hero facilitator = null;
+            if (data.FacilitatorId != null && !objectManager.TryGetObjectWithLogging(data.FacilitatorId, out facilitator)) return;
+
+            PlayerCaptivityLogger.Debug("Handle_NetworkEndCaptivityAttempted (server): prisoner={HeroId} detail={Detail} facilitator={FacilitatorId}",
+                prisoner.StringId, data.Detail, facilitator?.StringId);
+
+            EndCaptivityAction.ApplyInternal(prisoner, data.Detail, facilitator, data.ShowNotification);
+        }, context: nameof(Handle_NetworkEndCaptivityAttempted));
     }
 
     /// <summary>

--- a/source/GameInterface/Services/PlayerCaptivityService/Messages/EndCaptivityAttempted.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Messages/EndCaptivityAttempted.cs
@@ -1,0 +1,24 @@
+﻿using Common.Messaging;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Actions;
+
+namespace GameInterface.Services.PlayerCaptivityService.Messages;
+
+/// <summary>
+/// A client-local action attempted to release a hero controlled by the server.
+/// </summary>
+internal readonly struct EndCaptivityAttempted : IEvent
+{
+    public readonly Hero Prisoner;
+    public readonly EndCaptivityDetail Detail;
+    public readonly Hero Facilitator;
+    public readonly bool ShowNotification;
+
+    public EndCaptivityAttempted(Hero prisoner, EndCaptivityDetail detail, Hero facilitator, bool showNotification)
+    {
+        Prisoner = prisoner;
+        Detail = detail;
+        Facilitator = facilitator;
+        ShowNotification = showNotification;
+    }
+}

--- a/source/GameInterface/Services/PlayerCaptivityService/Messages/NetworkEndCaptivityAttempted.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Messages/NetworkEndCaptivityAttempted.cs
@@ -1,0 +1,29 @@
+﻿using Common.Messaging;
+using ProtoBuf;
+using TaleWorlds.CampaignSystem.Actions;
+
+namespace GameInterface.Services.PlayerCaptivityService.Messages;
+
+/// <summary>
+/// Requests that the server release a hero on behalf of a client action.
+/// </summary>
+[ProtoContract]
+internal readonly struct NetworkEndCaptivityAttempted : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string PrisonerId;
+    [ProtoMember(2)]
+    public readonly EndCaptivityDetail Detail;
+    [ProtoMember(3)]
+    public readonly string FacilitatorId;
+    [ProtoMember(4)]
+    public readonly bool ShowNotification;
+
+    public NetworkEndCaptivityAttempted(string prisonerId, EndCaptivityDetail detail, string facilitatorId, bool showNotification)
+    {
+        PrisonerId = prisonerId;
+        Detail = detail;
+        FacilitatorId = facilitatorId;
+        ShowNotification = showNotification;
+    }
+}

--- a/source/GameInterface/Services/PlayerCaptivityService/Patches/EndCaptivityActionPatches.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Patches/EndCaptivityActionPatches.cs
@@ -1,11 +1,9 @@
-using Common;
-using Common.Logging;
+﻿using Common;
 using Common.Messaging;
 using GameInterface.Policies;
 using GameInterface.Services.Heroes.Extensions;
 using GameInterface.Services.PlayerCaptivityService.Messages;
 using HarmonyLib;
-using Serilog;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Actions;
 
@@ -14,11 +12,9 @@ namespace GameInterface.Services.PlayerCaptivityService.Patches;
 [HarmonyPatch]
 internal class EndCaptivityActionPatches
 {
-    private static readonly ILogger Logger = LogManager.GetLogger<EndCaptivityActionPatches>();
-
     [HarmonyPatch(typeof(EndCaptivityAction), nameof(EndCaptivityAction.ApplyInternal))]
     [HarmonyPrefix]
-    private static bool Prefix(Hero prisoner, EndCaptivityDetail detail, Hero facilitatior)
+    private static bool Prefix(Hero prisoner, EndCaptivityDetail detail, Hero facilitatior, bool showNotification)
     {
         if (CallOriginalPolicy.IsOriginalAllowed()) return true;
 
@@ -40,10 +36,13 @@ internal class EndCaptivityActionPatches
             return true;
         }
 
-        // Clients only act for their own hero; every other hero's captivity is server-driven.
+        // A local release of another hero is player intent, so ask the authoritative server to apply it.
         if (prisoner != Hero.MainHero)
         {
-            Logger.Error("Client attempted to end captivity for non-controlled hero {HeroId}", prisoner?.StringId);
+            PlayerCaptivityLogger.Debug("EndCaptivityAction.ApplyInternal intercepted for non-controlled hero {HeroId}: detail={Detail} facilitator={FacilitatorId}, publishing EndCaptivityAttempted",
+                prisoner?.StringId, detail, facilitatior?.StringId);
+
+            MessageBroker.Instance.Publish(prisoner, new EndCaptivityAttempted(prisoner, detail, facilitatior, showNotification));
             return false;
         }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Freeing a rescued lord after battle leaves the liberation conversation open and repeats the same prisoner instead of continuing to the loot screens.

## What is the new behavior?

Resolves #1891

Freeing a rescued lord closes the liberation conversation after one sequence, releases the lord for every player, and continues the post-battle flow.
