### PR TITLE
Skip Options in Character Creation + Sync Campaign Options

### DIFF
--- a/source/GameInterface/Services/CampaignService/Handlers/UpdateCampaignOptionsHandler.cs
+++ b/source/GameInterface/Services/CampaignService/Handlers/UpdateCampaignOptionsHandler.cs
@@ -1,0 +1,75 @@
+﻿using Common;
+using Common.Logging;
+using Common.Messaging;
+using Common.Network;
+using GameInterface.Services.CampaignService.Messages;
+using Serilog;
+using TaleWorlds.CampaignSystem;
+
+namespace GameInterface.Services.CampaignService.Handlers;
+
+internal class UpdateCampaignOptionsHandler : IHandler
+{
+    private static readonly ILogger Logger = LogManager.GetLogger<UpdateCampaignOptionsHandler>();
+
+    private readonly IMessageBroker messageBroker;
+    private readonly INetwork network;
+
+    public UpdateCampaignOptionsHandler(
+        IMessageBroker messageBroker,
+        INetwork network)
+    {
+        this.messageBroker = messageBroker;
+        this.network = network;
+
+        messageBroker.Subscribe<UpdateCampaignOptions>(Handle_UpdateCampaignOptions);
+        messageBroker.Subscribe<NetworkUpdateCampaignOptions>(Handle_NetworkUpdateCampaignOptions);
+    }
+
+    public void Dispose()
+    {
+        messageBroker.Unsubscribe<UpdateCampaignOptions>(Handle_UpdateCampaignOptions);
+        messageBroker.Unsubscribe<NetworkUpdateCampaignOptions>(Handle_NetworkUpdateCampaignOptions);
+    }
+
+    private void Handle_UpdateCampaignOptions(MessagePayload<UpdateCampaignOptions> obj)
+    {
+        GameThread.RunSafe(() =>
+        {
+            var message = new NetworkUpdateCampaignOptions(
+                CampaignOptions.AutoAllocateClanMemberPerks,
+                CampaignOptions.PlayerTroopsReceivedDamage,
+                CampaignOptions.RecruitmentDifficulty,
+                CampaignOptions.PlayerMapMovementSpeed,
+                CampaignOptions.StealthAndDisguiseDifficulty,
+                CampaignOptions.CombatAIDifficulty,
+                CampaignOptions.IsLifeDeathCycleDisabled,
+                CampaignOptions.PersuasionSuccessChance,
+                CampaignOptions.ClanMemberDeathChance,
+                CampaignOptions.IsIronmanMode,
+                CampaignOptions.BattleDeath
+            );
+            network.SendAll(message);
+        });
+    }
+
+    private void Handle_NetworkUpdateCampaignOptions(MessagePayload<NetworkUpdateCampaignOptions> obj)
+    {
+        var newOptions = obj.What;
+
+        GameThread.RunSafe(() =>
+        {
+            CampaignOptions.AutoAllocateClanMemberPerks = newOptions.AutoAllocateClanMemberPerks;
+            CampaignOptions.PlayerTroopsReceivedDamage = newOptions.PlayerTroopsReceivedDamage;
+            CampaignOptions.RecruitmentDifficulty = newOptions.RecruitmentDifficulty;
+            CampaignOptions.PlayerMapMovementSpeed = newOptions.PlayerMapMovementSpeed;
+            CampaignOptions.StealthAndDisguiseDifficulty = newOptions.StealthAndDisguiseDifficulty;
+            CampaignOptions.CombatAIDifficulty = newOptions.CombatAIDifficulty;
+            CampaignOptions.IsLifeDeathCycleDisabled = newOptions.IsLifeDeathCycleDisabled;
+            CampaignOptions.PersuasionSuccessChance = newOptions.PersuasionSuccessChance;
+            CampaignOptions.ClanMemberDeathChance = newOptions.ClanMemberDeathChance;
+            CampaignOptions.IsIronmanMode = newOptions.IsIronmanMode;
+            CampaignOptions.BattleDeath = newOptions.BattleDeath;
+        });
+    }
+}

--- a/source/GameInterface/Services/CampaignService/Messages/UpdateCampaignOptions.cs
+++ b/source/GameInterface/Services/CampaignService/Messages/UpdateCampaignOptions.cs
@@ -1,0 +1,70 @@
+﻿using Common.Messaging;
+using ProtoBuf;
+using TaleWorlds.CampaignSystem;
+
+namespace GameInterface.Services.CampaignService.Messages;
+
+public readonly struct UpdateCampaignOptions : IEvent { }
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkUpdateCampaignOptions : ICommand
+{
+    [ProtoMember(1)]
+    public readonly bool AutoAllocateClanMemberPerks;
+
+    [ProtoMember(2)]
+    public readonly CampaignOptions.Difficulty PlayerTroopsReceivedDamage;
+
+    [ProtoMember(3)]
+    public readonly CampaignOptions.Difficulty RecruitmentDifficulty;
+
+    [ProtoMember(4)]
+    public readonly CampaignOptions.Difficulty PlayerMapMovementSpeed;
+
+    [ProtoMember(5)]
+    public readonly CampaignOptions.Difficulty StealthAndDisguiseDifficulty;
+
+    [ProtoMember(6)]
+    public readonly CampaignOptions.Difficulty CombatAIDifficulty;
+
+    [ProtoMember(7)]
+    public readonly bool IsLifeDeathCycleDisabled;
+
+    [ProtoMember(8)]
+    public readonly CampaignOptions.Difficulty PersuasionSuccessChance;
+
+    [ProtoMember(9)]
+    public readonly CampaignOptions.Difficulty ClanMemberDeathChance;
+
+    [ProtoMember(10)]
+    public readonly bool IsIronmanMode;
+
+    [ProtoMember(11)]
+    public readonly CampaignOptions.Difficulty BattleDeath;
+
+    public NetworkUpdateCampaignOptions(
+        bool autoAllocateClanMemberPerks,
+        CampaignOptions.Difficulty playerTroopsReceivedDamage,
+        CampaignOptions.Difficulty recruitmentDifficulty,
+        CampaignOptions.Difficulty playerMapMovementSpeed,
+        CampaignOptions.Difficulty stealthAndDisguiseDifficulty,
+        CampaignOptions.Difficulty combatAIDifficulty,
+        bool isLifeDeathCycleDisabled,
+        CampaignOptions.Difficulty persuasianSuccessChance,
+        CampaignOptions.Difficulty clanMemberDeathChance,
+        bool isIronmanMode,
+        CampaignOptions.Difficulty battleDeath)
+    {
+        AutoAllocateClanMemberPerks = autoAllocateClanMemberPerks;
+        PlayerTroopsReceivedDamage = playerTroopsReceivedDamage;
+        RecruitmentDifficulty = recruitmentDifficulty;
+        PlayerMapMovementSpeed = playerMapMovementSpeed;
+        StealthAndDisguiseDifficulty = stealthAndDisguiseDifficulty;
+        CombatAIDifficulty = combatAIDifficulty;
+        IsLifeDeathCycleDisabled = isLifeDeathCycleDisabled;
+        PersuasionSuccessChance = persuasianSuccessChance;
+        ClanMemberDeathChance = clanMemberDeathChance;
+        IsIronmanMode = isIronmanMode;
+        BattleDeath = battleDeath;
+    }
+}

--- a/source/GameInterface/Services/CampaignService/Patches/UpdateCampaignOptionsPatch.cs
+++ b/source/GameInterface/Services/CampaignService/Patches/UpdateCampaignOptionsPatch.cs
@@ -1,0 +1,24 @@
+﻿using Common;
+using Common.Messaging;
+using GameInterface.Services.CampaignService.Messages;
+using HarmonyLib;
+using SandBox.View.Map;
+
+namespace GameInterface.Services.CampaignService.Patches;
+
+/// <summary>
+/// Send a message to update campaign options for clients when host closes options menu
+/// </summary>
+[HarmonyPatch(typeof(MapScreen))]
+internal class UpdateCampaignOptionsPatch
+{
+    [HarmonyPatch(nameof(MapScreen.CloseCampaignOptions))]
+    [HarmonyPostfix]
+    public static void CloseCampaignOptionsPostfix(MapScreen __instance)
+    {
+        if (ModInformation.IsClient) return;
+
+        var message = new UpdateCampaignOptions();
+        MessageBroker.Instance.Publish(__instance, message);
+    }
+}

--- a/source/GameInterface/Services/CharacterCreation/Patches/SkipCampaignOptionsPatch.cs
+++ b/source/GameInterface/Services/CharacterCreation/Patches/SkipCampaignOptionsPatch.cs
@@ -1,0 +1,64 @@
+﻿using Common;
+using HarmonyLib;
+using SandBox.GauntletUI.CharacterCreation;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using TaleWorlds.CampaignSystem.CharacterCreationContent;
+using TaleWorlds.Core.ViewModelCollection;
+using TaleWorlds.Localization;
+
+namespace GameInterface.Services.CharacterCreation.Patches;
+
+/// <summary>
+/// Skip adding the options stage to the character creation on clients
+/// </summary>
+[HarmonyPatch(typeof(CharacterCreationManager))]
+internal class SkipCampaignOptionsPatch
+{
+    [HarmonyPatch(nameof(CharacterCreationManager.AddStage))]
+    [HarmonyPrefix]
+    public static bool AddStagePrefix(CharacterCreationManager __instance, CharacterCreationStageBase stage)
+    {
+        return ModInformation.IsServer || stage.GetType() != typeof(CharacterCreationOptionsStage);
+    }
+}
+
+/// <summary>
+/// Replaces "Next" text in the review stage to show client this is the last stage before joining
+/// </summary>
+[HarmonyPatch(typeof(CharacterCreationReviewStageView), MethodType.Constructor,
+    new[] { typeof(CharacterCreationManager), typeof(ControlCharacterCreationStage),
+    typeof(TextObject), typeof(ControlCharacterCreationStage),
+    typeof(TextObject), typeof(ControlCharacterCreationStage),
+    typeof(ControlCharacterCreationStageReturnInt),
+    typeof(ControlCharacterCreationStageReturnInt),
+    typeof(ControlCharacterCreationStageReturnInt),
+    typeof(ControlCharacterCreationStageWithInt) })]
+internal static class ReplaceCharacterReviewStageTextPatch
+{
+    private static readonly string ReplacementText = "Join Coop";
+
+    private static readonly MethodInfo GetAffirmativeButtonTextMethod = AccessTools.Method(typeof(ReplaceCharacterReviewStageTextPatch), nameof(GetAffirmativeButtonText));
+
+    [HarmonyTranspiler]
+    public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        foreach (var instruction in instructions)
+        {
+            if (instruction.opcode == OpCodes.Ldstr && instruction.operand as string == "{=Rvr1bcu8}Next")
+            {
+                yield return new CodeInstruction(OpCodes.Call, GetAffirmativeButtonTextMethod);
+
+                continue;
+            }
+
+            yield return instruction;
+        }
+    }
+
+    private static string GetAffirmativeButtonText()
+    {
+        return ModInformation.IsClient ? ReplacementText : "{=Rvr1bcu8}Next";
+    }
+}

--- a/source/GameInterface/Services/GameMenus/Patches/DisableCampaignOptionsOnClients.cs
+++ b/source/GameInterface/Services/GameMenus/Patches/DisableCampaignOptionsOnClients.cs
@@ -1,0 +1,26 @@
+﻿using Common;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem.ViewModelCollection;
+
+namespace GameInterface.Services.GameMenus.Patches;
+
+/// <summary>
+/// Disable changing campaign options on clients.
+/// This solution still lets clients see the current configuration while preventing any changes.
+/// </summary>
+[HarmonyPatch(typeof(CampaignOptionData))]
+internal class DisableManagingCampaignOptionsOnClients
+{
+    [HarmonyPatch(nameof(CampaignOptionData.GetIsDisabledWithReason))]
+    [HarmonyPrefix]
+    public static bool GetIsDisabledWithReasonPrefix(CampaignOptionData __instance, ref CampaignOptionDisableStatus __result)
+    {
+        if (ModInformation.IsClient)
+        {
+            __result = new(true, "Managing campaign options is disabled on clients; the host does this.", -1f);
+            return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] New feature (non-breaking change that adds functionality)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- Character creation on clients includes the campaign options stage at the end.
- Campaign options are not synced. The server and clients can individually manage campaign options.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #1938
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
- Skip campaign options stage and end character creation on clients after the character review stage.
- Sync campaign options when the server changes them.
- Clients can no longer adjust campaign options in the options menu but can still look at them.