### PR TITLE
[1978] Fix issue where nonhost clients would not see any troops other than their own

### DIFF
--- a/source/Missions/Services/Network/LiteNetP2PClient.cs
+++ b/source/Missions/Services/Network/LiteNetP2PClient.cs
@@ -236,8 +236,22 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
             return;
         }
 
-        Logger.Information("Connecting P2P: {TargetEndPoint}", targetEndPoint);
-        netManager.Connect(targetEndPoint, token);
+        // The NAT token names the newcomer, so only existing members initiate the connection.
+        if (connectionToken.ControllerId == ControllerId) return;
+
+        lock (peerGate)
+        {
+            if (instanceId != connectionToken.InstanceId || HasTrackedPeer(connectionToken.ControllerId)) return;
+
+            Logger.Information("Connecting P2P: {TargetEndPoint}", targetEndPoint);
+            var peer = netManager.Connect(
+                targetEndPoint,
+                new ConnectionToken(ControllerId, connectionToken.InstanceId));
+            if (peer != null)
+            {
+                pendingPeerControllers[peer] = connectionToken.ControllerId;
+            }
+        }
     }
 
     public void OnPeerDisconnected(NetPeer peer, DisconnectInfo disconnectInfo)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

After a second client joins an active field battle, it can load with only its own party and no enemy or allied-player troops. Leaving and rejoining does not restore the missing agents.

## What is the new behavior?

Resolves #1978

A client joining or rejoining an active field battle now loads the complete battle, including the other players and enemy troops.
