### PR TITLE
Fix Coop app config case

### DIFF
--- a/source/Coop/Coop.csproj
+++ b/source/Coop/Coop.csproj
@@ -209,7 +209,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="app.config" />
     <None Include="Lib\NoHarmony\LICENSE" />
     <None Include="Lib\NoHarmony\README.md" />
     <None Include="packages.config" />


### PR DESCRIPTION
## PR Type

- [x] Bug fix
- [x] Build related changes

## What is the current behavior?

`Coop.csproj` references `App.config`, but Git tracks the file as `app.config`. Windows builds hide the mismatch, while the Linux nightly runner fails with `MSB3249` because paths are case-sensitive.

## What is the new behavior?

The project reference matches the tracked lowercase filename, so clean Linux builds can find the application configuration.

## How to test

Built `Coop/Coop.csproj` in the pinned nightly image from a clean case-sensitive checkout: 78 warnings, 0 errors.
