### PR TITLE
Trust nightly workflow checkout

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -29,6 +29,9 @@ jobs:
           ref: ${{ github.sha }}
           fetch-depth: 0
 
+      - name: Trust checkout directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Find previous nightly commit
         id: previous
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b


### PR DESCRIPTION
## PR Type

- [x] CI related changes

## What is the current behavior?

The nightly workflow container rejects the checkout as dubious ownership when the changelog step invokes Git.

## What is the new behavior?

Trust `$GITHUB_WORKSPACE` immediately after checkout so the nightly changelog Git commands can run.

## How to test

Run the Nightly Release workflow on `development`.
