### PR TITLE
Run nightly release at 11:57 PM

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -2,7 +2,7 @@ name: Nightly Release
 
 on:
   schedule:
-    - cron: '1 0 * * *'
+    - cron: '57 23 * * *'
       timezone: America/Chicago
   workflow_dispatch:
 
@@ -31,6 +31,9 @@ jobs:
 
       - name: Trust checkout directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Install timezone data
+        run: apk add --no-cache tzdata >/dev/null
 
       - name: Find previous nightly commit
         id: previous


### PR DESCRIPTION
## PR Type

- [x] CI related changes

## What is the current behavior?

The nightly workflow runs at 12:01 AM Central, and manual runs use the UTC date because the build container does not have timezone data.

## What is the new behavior?

Run the nightly workflow at 11:57 PM Central and install `tzdata` before calculating the release date. The bot's matching scheduler has also been moved to 11:57 PM Central.

## How to test

Run the Nightly Release workflow on `development` and confirm the artifact date matches the Central calendar date.
