### PR TITLE
[1996] Prevent siege ambush menu exceptions

### DIFF
--- a/source/GameInterface/Services/SiegeEvents/Patches/DisableSiegeAmbushMenuPatch.cs
+++ b/source/GameInterface/Services/SiegeEvents/Patches/DisableSiegeAmbushMenuPatch.cs
@@ -1,7 +1,8 @@
-﻿using Common;
-using HarmonyLib;
+﻿using HarmonyLib;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
 using TaleWorlds.CampaignSystem.GameMenus;
+using TaleWorlds.CampaignSystem.Siege;
+using TaleWorlds.Core;
 using TaleWorlds.Localization;
 
 namespace GameInterface.Services.SiegeEvents.Patches;
@@ -15,12 +16,15 @@ internal class DisableSiegeAmbushMenuPatch
 {
     private static readonly TextObject DisabledTooltip = new("{=!}Siege ambushes are not yet supported in Co-op.");
 
-    [HarmonyPostfix]
-    private static void Postfix(MenuCallbackArgs args, bool __result)
+    [HarmonyPrefix]
+    private static bool Prefix(MenuCallbackArgs args, ref bool __result)
     {
-        if (!__result) return;
+        __result = PlayerSiege.PlayerSiegeEvent != null && PlayerSiege.PlayerSide == BattleSideEnum.Defender;
+        if (!__result) return false;
 
+        args.optionLeaveType = GameMenuOption.LeaveType.SiegeAmbush;
         args.IsEnabled = false;
         args.Tooltip = DisabledTooltip;
+        return false;
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Opening the siege strategy menu while defending can repeatedly throw errors and break the client's siege encounter, even though Ambush is unsupported.

## What is the new behavior?

Resolves #1996

The Ambush option remains visible but disabled with its co-op tooltip, and refreshing the siege strategy menu no longer breaks the client's encounter.

## Bot Changelog Entry

- Fixed siege strategy menus breaking for defenders while the unsupported Ambush option was visible.
