### PR TITLE
[2005] Remove friends IP address field

### DIFF
--- a/UIMovies/CoopConnectionUIMovie.xml
+++ b/UIMovies/CoopConnectionUIMovie.xml
@@ -65,30 +65,6 @@
                     </ListPanel>
 
                     <ListPanel WidthSizePolicy="Fixed" SuggestedWidth="760" HeightSizePolicy="Fixed" SuggestedHeight="76"
-                               HorizontalAlignment="Center" IsVisible="@PublicAddressVisible"
-                               StackLayout.LayoutMethod="HorizontalLeftToRight">
-                      <Children>
-                        <TextWidget WidthSizePolicy="Fixed" SuggestedWidth="270" HeightSizePolicy="StretchToParent"
-                                    Brush="Clan.TabControl.Text" Brush.FontSize="28"
-                                    Brush.TextHorizontalAlignment="Right" Brush.TextVerticalAlignment="Center"
-                                    MarginRight="20" Text="@PublicAddressText"/>
-                        <EditableTextWidget WidthSizePolicy="Fixed" SuggestedWidth="390" HeightSizePolicy="Fixed" SuggestedHeight="58"
-                                            VerticalAlignment="Center" Brush="ScoreboardPanels_2" Brush.AlphaFactor="0.75"
-                                            Brush.FontSize="28" Brush.TextHorizontalAlignment="Center"
-                                            Brush.TextVerticalAlignment="Center" Text="@PublicAddress"/>
-                        <HintWidget DataSource="{FriendsAddressHint}" WidthSizePolicy="Fixed" SuggestedWidth="44"
-                                    HeightSizePolicy="StretchToParent" MarginLeft="14"
-                                    Command.HoverBegin="ExecuteBeginHint" Command.HoverEnd="ExecuteEndHint">
-                          <Children>
-                            <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent"
-                                        DoNotAcceptEvents="true" Brush="Clan.TabControl.Text"
-                                        Brush.TextVerticalAlignment="Center" Text="(i)"/>
-                          </Children>
-                        </HintWidget>
-                      </Children>
-                    </ListPanel>
-
-                    <ListPanel WidthSizePolicy="Fixed" SuggestedWidth="760" HeightSizePolicy="Fixed" SuggestedHeight="76"
                                HorizontalAlignment="Center" StackLayout.LayoutMethod="HorizontalLeftToRight">
                       <Children>
                         <TextWidget WidthSizePolicy="Fixed" SuggestedWidth="270" HeightSizePolicy="StretchToParent"

--- a/source/Coop.Core/Client/Services/Session/ConfiguredSessionJoinInfoSource.cs
+++ b/source/Coop.Core/Client/Services/Session/ConfiguredSessionJoinInfoSource.cs
@@ -1,22 +1,18 @@
 ﻿using Common;
-using Common.Network.Session;
 using Common.Network;
-using Coop.Core.Common.Configuration;
+using Common.Network.Session;
 
 namespace Coop.Core.Client.Services.Session;
 
 /// <summary>
-/// Builds the advertised join info from what the hosting player configured: their public
-/// address (possibly empty) and the port their session runs on.
+/// Builds the advertised join info for a client hosting a Steam tunnel to its local server.
 /// </summary>
 public class ConfiguredSessionJoinInfoSource : ISessionJoinInfoSource
 {
-    private readonly SessionAdvertisementConfig advertisementConfig;
     private readonly INetworkConfig networkConfig;
 
-    public ConfiguredSessionJoinInfoSource(SessionAdvertisementConfig advertisementConfig, INetworkConfig networkConfig)
+    public ConfiguredSessionJoinInfoSource(INetworkConfig networkConfig)
     {
-        this.advertisementConfig = advertisementConfig;
         this.networkConfig = networkConfig;
     }
 
@@ -24,7 +20,6 @@ public class ConfiguredSessionJoinInfoSource : ISessionJoinInfoSource
     {
         return new SessionJoinInfo
         {
-            Address = advertisementConfig.PublicAddress,
             Port = networkConfig.Port,
             ModVersion = ModInformation.BuildVersion,
             PasswordRequired = !string.IsNullOrEmpty(networkConfig.Token),

--- a/source/Coop.Core/Client/Services/Session/SessionAdvertisementHandler.cs
+++ b/source/Coop.Core/Client/Services/Session/SessionAdvertisementHandler.cs
@@ -64,7 +64,7 @@ public class SessionAdvertisementHandler : IHandler
             if (!info.HasAddress && !sessionTunnelHost.IsListening)
             {
                 messageBroker.Publish(this, new SendInformationMessage(
-                    "Steam invites are on but no public address is set; friends cannot connect until you set one on the co-op screen"));
+                    "Steam invites are on but no public address or Steam relay is available; friends cannot connect"));
             }
         }, context: "AdvertiseSession");
     }

--- a/source/Coop.Core/Common/Configuration/SessionAdvertisementConfig.cs
+++ b/source/Coop.Core/Common/Configuration/SessionAdvertisementConfig.cs
@@ -3,8 +3,7 @@
 namespace Coop.Core.Common.Configuration;
 
 /// <summary>
-/// The hosting player's choices for advertising the session, carried from the connect
-/// screen into the client container.
+/// The session advertisement choices carried into the client or server container.
 /// </summary>
 public class SessionAdvertisementConfig
 {
@@ -12,10 +11,4 @@ public class SessionAdvertisementConfig
 
     /// <summary>Who can discover a standalone server through Steam.</summary>
     public ServerVisibility Visibility { get; set; } = ServerVisibility.Public;
-
-    /// <summary>
-    /// The externally reachable address friends should dial (the host's public IP or
-    /// domain). Empty when the host has not provided one.
-    /// </summary>
-    public string PublicAddress { get; set; } = string.Empty;
 }

--- a/source/Coop.Core/CoopartiveMultiplayerExperience.cs
+++ b/source/Coop.Core/CoopartiveMultiplayerExperience.cs
@@ -92,7 +92,6 @@ namespace Coop.Core
             var advertisementConfig = new SessionAdvertisementConfig
             {
                 EnableSteamInvites = connectMessage.EnableSteamInvites,
-                PublicAddress = connectMessage.PublicAddress ?? string.Empty,
             };
 
             StartAsClient(configuration, advertisementConfig);
@@ -173,7 +172,6 @@ namespace Coop.Core
                 // The spawned server owns the Steam listener and public lobby. This loopback
                 // client must not create a second lobby and user-flavor tunnel.
                 EnableSteamInvites = false,
-                PublicAddress = string.Empty,
                 Visibility = visibility,
             };
 

--- a/source/Coop.Core/Server/Services/Session/ServerSessionJoinInfoSource.cs
+++ b/source/Coop.Core/Server/Services/Session/ServerSessionJoinInfoSource.cs
@@ -1,37 +1,28 @@
-using Common;
+﻿using Common;
 using Common.Network;
 using Common.Network.Session;
-using Coop.Core.Common.Configuration;
 using Coop.Steam;
 
 namespace Coop.Core.Server.Services.Session;
 
 /// <summary>
-/// Builds standalone join metadata from the game-server identity, detected or configured public
-/// address, mod build, and password-required flag.
+/// Builds standalone join metadata from the game-server identity, detected public address,
+/// mod build, and password-required flag.
 /// </summary>
 public class ServerSessionJoinInfoSource : ISessionJoinInfoSource
 {
-    private readonly SessionAdvertisementConfig advertisementConfig;
     private readonly INetworkConfig networkConfig;
 
-    public ServerSessionJoinInfoSource(SessionAdvertisementConfig advertisementConfig, INetworkConfig networkConfig)
+    public ServerSessionJoinInfoSource(INetworkConfig networkConfig)
     {
-        this.advertisementConfig = advertisementConfig;
         this.networkConfig = networkConfig;
     }
 
     public SessionJoinInfo Get()
     {
-        // The Steam-detected public IP seeds the direct-connect fallback, but an explicitly
-        // configured address wins (a detected IP is not always the reachable one).
-        var address = string.IsNullOrEmpty(advertisementConfig.PublicAddress)
-            ? SteamGameServerBoot.PublicIp
-            : advertisementConfig.PublicAddress;
-
         return new SessionJoinInfo
         {
-            Address = address,
+            Address = SteamGameServerBoot.PublicIp,
             Port = networkConfig.Port,
             ServerSteamId = SteamGameServerBoot.GameServerSteamId,
             ModVersion = ModInformation.BuildVersion,

--- a/source/Coop.Tests/Client/Services/Session/ConfiguredSessionJoinInfoSourceTests.cs
+++ b/source/Coop.Tests/Client/Services/Session/ConfiguredSessionJoinInfoSourceTests.cs
@@ -1,4 +1,4 @@
-using Coop.Core.Client.Services.Session;
+﻿using Coop.Core.Client.Services.Session;
 using Coop.Core.Common.Configuration;
 using Xunit;
 
@@ -11,9 +11,7 @@ public class ConfiguredSessionJoinInfoSourceTests
     [InlineData("Secret", true)]
     public void Get_AdvertisesOnlyWhetherPasswordIsRequired(string password, bool expected)
     {
-        var source = new ConfiguredSessionJoinInfoSource(
-            new SessionAdvertisementConfig(),
-            new NetworkConfig { Token = password });
+        var source = new ConfiguredSessionJoinInfoSource(new NetworkConfig { Token = password });
 
         var info = source.Get();
 

--- a/source/Coop.Tests/Server/Services/Session/ServerSessionJoinInfoSourceTests.cs
+++ b/source/Coop.Tests/Server/Services/Session/ServerSessionJoinInfoSourceTests.cs
@@ -1,4 +1,4 @@
-using Coop.Core.Common.Configuration;
+﻿using Coop.Core.Common.Configuration;
 using Coop.Core.Server.Services.Session;
 using Xunit;
 
@@ -12,7 +12,7 @@ public class ServerSessionJoinInfoSourceTests
     public void Get_AdvertisesOnlyWhetherPasswordIsRequired(string password, bool expected)
     {
         var networkConfig = new NetworkConfig { Token = password };
-        var source = new ServerSessionJoinInfoSource(new SessionAdvertisementConfig(), networkConfig);
+        var source = new ServerSessionJoinInfoSource(networkConfig);
 
         var info = source.Get();
 

--- a/source/GameInterface/Services/UI/CoopConnectMenuVM.cs
+++ b/source/GameInterface/Services/UI/CoopConnectMenuVM.cs
@@ -1,4 +1,4 @@
-using Common.Messaging;
+﻿using Common.Messaging;
 using Common.Network;
 using Common.Network.Session;
 using Common.Network.Session.Messages;
@@ -53,15 +53,10 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
     public string IpText => "Server IP Address:";
     public string PortText => "Port:";
     public string PasswordText => "Password:";
-    public string PublicAddressText => "IP Address for Friends:";
 
     [DataSourceProperty]
     public HintViewModel ServerAddressHint { get; } = new HintViewModel(new TextObject(
         "The address of the co-op server to join. Keep localhost if you are the host; otherwise, type the address your friend shared to join their game."));
-
-    [DataSourceProperty]
-    public HintViewModel FriendsAddressHint { get; } = new HintViewModel(new TextObject(
-        "When you're hosting, this is the address friends use to reach your session over the internet. Search 'what is my IP' to find it, and forward UDP ports 4200-4201 on your router. Friends on your own network can use your LAN address instead: run ipconfig in command prompt and share the 'IPv4 Address' with your friends."));
 
     [DataSourceProperty]
     public HintViewModel PortHint { get; } = new HintViewModel(new TextObject(
@@ -74,7 +69,6 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
     public string connectIP = "localhost";
     public string connectPort = "4200";
     public string connectPassword = "";
-    public string publicAddress = "";
 
     public CoopConnectMenuVM()
         : this(SessionDiscovery.SteamLobbyBrowser, MessageBroker.Instance)
@@ -176,24 +170,6 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
     [DataSourceProperty]
     public bool IsSteamLobbyStatusVisible => !string.IsNullOrEmpty(SteamLobbyStatusText);
 
-    // Connecting to your own local server is hosting, so the public address to advertise
-    // to Steam friends is asked for exactly then; any other address is a direct join.
-    [DataSourceProperty]
-    public bool PublicAddressVisible => SessionDiscovery.SteamAvailable && IsLoopbackAddress(connectIP);
-
-    [DataSourceProperty]
-    public string PublicAddress
-    {
-        get => publicAddress;
-        set
-        {
-            if (value == publicAddress) return;
-
-            publicAddress = value;
-            OnPropertyChanged(nameof(PublicAddress));
-        }
-    }
-
     [DataSourceProperty]
     public string Ip
     {
@@ -204,7 +180,6 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
 
             connectIP = value;
             OnPropertyChanged(nameof(Ip));
-            OnPropertyChanged(nameof(PublicAddressVisible));
         }
     }
 
@@ -289,8 +264,7 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
 
         try
         {
-            // Advertise exactly when the screen offered the public address field.
-            bool steamInvites = PublicAddressVisible;
+            bool steamInvites = SessionDiscovery.SteamAvailable && IsLoopbackAddress(connectIP);
 
             IPAddress ip;
 
@@ -310,8 +284,7 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
                 }
             }
 
-            messageBroker.Publish(this, new AttemptJoin(
-                ip, port, connectPassword, steamInvites, publicAddress?.Trim()));
+            messageBroker.Publish(this, new AttemptJoin(ip, port, connectPassword, steamInvites));
         }
         catch (Exception ex)
         {

--- a/source/GameInterface/Services/UI/Messages/AttemptJoin.cs
+++ b/source/GameInterface/Services/UI/Messages/AttemptJoin.cs
@@ -5,24 +5,22 @@ namespace GameInterface.Services.UI.Messages;
 
 public record AttemptJoin : ICommand
 {
-    public AttemptJoin(IPAddress address, int port, bool enableSteamInvites = false, string publicAddress = null)
-        : this(address, port, null, enableSteamInvites, publicAddress)
+    public AttemptJoin(IPAddress address, int port, bool enableSteamInvites = false)
+        : this(address, port, null, enableSteamInvites)
     {
     }
 
     public AttemptJoin(IPAddress address, int port, string password,
-        bool enableSteamInvites = false, string publicAddress = null)
+        bool enableSteamInvites = false)
     {
         Address = address;
         Port = port;
         Password = password;
         EnableSteamInvites = enableSteamInvites;
-        PublicAddress = publicAddress;
     }
 
     public IPAddress Address { get; }
     public int Port { get; }
     public string Password { get; }
     public bool EnableSteamInvites { get; }
-    public string PublicAddress { get; }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

The Direct connection screen shows an `IP Address for Friends` field when the server address is local, which makes players think they must find and enter a second address before friends can join.

## What is the new behavior?

Resolves #2005

The Direct connection screen only asks for the server IP, port, and optional password. Locally hosted sessions continue to advertise through Steam without requiring anyone to enter a public IP.
<img width="833" height="384" alt="image" src="https://github.com/user-attachments/assets/195f62a6-1bd8-40f3-88cc-41dbfaf3836a" />


## Bot Changelog Entry

- Removed the no-longer-necessary `IP Address for Friends` field from the Direct connection screen.
