### PR TITLE
[1998] Fix encyclopedia failing to open after hero creation

### DIFF
--- a/source/GameInterface/Services/Heroes/Handlers/HeroFieldsHandler.cs
+++ b/source/GameInterface/Services/Heroes/Handlers/HeroFieldsHandler.cs
@@ -1,4 +1,5 @@
-﻿using Common.Logging;
+﻿using Common;
+using Common.Logging;
 using Common.Messaging;
 using GameInterface.Services.Heroes.Messages;
 using GameInterface.Services.ObjectManager;
@@ -197,18 +198,14 @@ namespace GameInterface.Services.Heroes.Handlers
         private void Handle(MessagePayload<ChangeCharacterObject> payload)
         {
             var data = payload.What;
-            if (objectManager.TryGetObject<Hero>(data.HeroId, out var instance) == false)
-            {
-                Logger.Error("Unable to find {type} with id: {id}", typeof(Hero), data.HeroId);
-                return;
-            }
-            if (objectManager.TryGetObject<CharacterObject>(data.CharacterObjectId, out var character) == false)
-            {
-                Logger.Error("Unable to find {type} with id: {id}", typeof(CharacterObject), data.CharacterObjectId);
-                return;
-            }
 
-            instance._characterObject = character;
+            GameThread.RunSafe(() =>
+            {
+                if (!objectManager.TryGetObjectWithLogging<Hero>(data.HeroId, out var instance)) return;
+                if (!objectManager.TryGetObjectWithLogging<CharacterObject>(data.CharacterObjectId, out var character)) return;
+
+                instance._characterObject = character;
+            }, context: nameof(ChangeCharacterObject));
         }
         private void Handle(MessagePayload<ChangeLastTimeStamp> payload)
         {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Opening the encyclopedia can fail and leave the page closed after a hero is created while clients are connected.

## What is the new behavior?

Resolves #1998

The encyclopedia and its Heroes page open normally on every client after a hero is created.

## Bot Changelog Entry

- Fixed the encyclopedia sometimes failing to open.
