### PR TITLE
[1994] Fix underground field battle spawns

### DIFF
--- a/source/GameInterface/Services/MapEvents/FieldBattleMissionInitializer.cs
+++ b/source/GameInterface/Services/MapEvents/FieldBattleMissionInitializer.cs
@@ -1,8 +1,7 @@
-using TaleWorlds.CampaignSystem;
+﻿using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Encounters;
 using TaleWorlds.CampaignSystem.Map;
 using TaleWorlds.CampaignSystem.MapEvents;
-using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
 
@@ -17,14 +16,14 @@ internal class FieldBattleMissionInitializer : IBattleMissionInitializer
     public MissionInitializerRecord Create(MapEvent battle, int randomTerrainSeed, AtmosphereInfo atmosphereOnCampaign)
     {
         bool isNavalEncounter = PlayerEncounter.IsNavalEncounter();
-        CampaignVec2 position = MobileParty.MainParty.Position;
+        CampaignVec2 position = battle.Position;
 
         IMapScene mapSceneWrapper = Campaign.Current.MapSceneWrapper;
         MapPatchData mapPatchAtPosition = mapSceneWrapper.GetMapPatchAtPosition(position);
 
         string battleScene = Campaign.Current.Models.SceneModel.GetBattleSceneForMapPatch(mapPatchAtPosition, isNavalEncounter);
         MissionInitializerRecord record = new MissionInitializerRecord(battleScene);
-        TerrainType faceTerrainType2 = Campaign.Current.MapSceneWrapper.GetFaceTerrainType(MobileParty.MainParty.CurrentNavigationFace);
+        TerrainType faceTerrainType2 = Campaign.Current.MapSceneWrapper.GetFaceTerrainType(position.Face);
         record.TerrainType = (int)faceTerrainType2;
         record.DamageToFriendsMultiplier = Campaign.Current.Models.DifficultyModel.GetPlayerTroopsReceivedDamageMultiplier();
         record.DamageFromPlayerToFriendsMultiplier = Campaign.Current.Models.DifficultyModel.GetPlayerTroopsReceivedDamageMultiplier();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Starting a field battle after pursuing another party could load mismatched terrain, making the player appear oversized during deployment and spawn below the ground after the battle started.

## What is the new behavior?

Resolves #1994

Field battles now use the encounter's synchronized location when loading terrain, so deployment and battle start place the player on the ground at the correct scale.

## Bot Changelog Entry

- Fixed players spawning below the terrain when starting field battles.
