### PR TITLE
[1971] Keep sieges active during army conversations

### DIFF
--- a/source/GameInterface/Services/MapEvents/ConversationPartyHold.cs
+++ b/source/GameInterface/Services/MapEvents/ConversationPartyHold.cs
@@ -10,11 +10,11 @@ namespace GameInterface.Services.MapEvents;
 /// keeping the bookkeeping in <see cref="ConversationPartyTracker"/> and the party's AI state in step.
 /// </summary>
 /// <remarks>
-/// Holding stops the party's current movement (<see cref="MobileParty.SetMoveModeHold"/>) and freezes its decision
-/// making (<see cref="MobilePartyAi.DisableAi"/>) so it stays in place while campaign time keeps running for the
-/// other players. <c>MobilePartyAi._isDisabled</c> is dynamically synced, so clients see the held state too. A
-/// party whose AI was already disabled (e.g. by a quest) is tracked but left untouched. All methods must run on
-/// the game's main thread.
+/// Holding stops a roaming party's current movement (<see cref="MobileParty.SetMoveModeHold"/>) and freezes its
+/// decision making (<see cref="MobilePartyAi.DisableAi"/>) so it stays in place while campaign time keeps running
+/// for the other players. Besiegers retain their siege movement state because the camp already keeps them stationary.
+/// <c>MobilePartyAi._isDisabled</c> is dynamically synced, so clients see the held state too. A party whose AI was
+/// already disabled (e.g. by a quest) is tracked but left untouched. All methods must run on the game's main thread.
 /// </remarks>
 internal static class ConversationPartyHold
 {
@@ -50,7 +50,9 @@ internal static class ConversationPartyHold
 
         if (!wasAiDisabled)
         {
-            party.SetMoveModeHold();
+            // A besieger is already stationary; SetMoveModeHold clears BesiegeSettlement and vanilla evicts it next tick.
+            if (party.BesiegerCamp == null)
+                party.SetMoveModeHold();
 
             // Certain parties such as caravans are still able to make new decisions even with their AI disabled
             // Setting DoNotMakeNewDecisions to true blocks setting new behaviors for these parties


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Talking to an army that is besieging a settlement interrupts the siege.

## What is the new behavior?

Resolves #1971

Talking to the besieging army no longer interrupts the siege, which continues during and after the conversation.
<img width="468" height="383" alt="image" src="https://github.com/user-attachments/assets/881e53ab-a8ff-4789-b25b-68c4bc32c962" />


## Bot Changelog Entry

- Talking to an army no longer interrupts its active siege.
