### PR TITLE
[1992] Fix crash when settlement defenders enter siege missions

### DIFF
--- a/source/Coop.Core/Server/Services/SiegeEvents/Handlers/ServerSiegeEntryHandler.cs
+++ b/source/Coop.Core/Server/Services/SiegeEvents/Handlers/ServerSiegeEntryHandler.cs
@@ -6,6 +6,7 @@ using Coop.Core.Client.Services.SiegeEvents.Messages;
 using Coop.Core.Server.Services.SiegeEvents.Messages;
 using GameInterface.Services.BesiegerCamps.Messages;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Players;
 using GameInterface.Services.SiegeEvents.Interfaces;
 using GameInterface.Services.SiegeEvents.Messages;
 using LiteNetLib;
@@ -29,13 +30,20 @@ internal class ServerSiegeEntryHandler : IHandler
     private readonly IMessageBroker messageBroker;
     private readonly INetwork network;
     private readonly IObjectManager objectManager;
+    private readonly IPlayerManager playerManager;
     private readonly ISiegeEventInterface siegeEventInterface;
 
-    public ServerSiegeEntryHandler(IMessageBroker messageBroker, INetwork network, IObjectManager objectManager, ISiegeEventInterface siegeEventInterface)
+    public ServerSiegeEntryHandler(
+        IMessageBroker messageBroker,
+        INetwork network,
+        IObjectManager objectManager,
+        IPlayerManager playerManager,
+        ISiegeEventInterface siegeEventInterface)
     {
         this.messageBroker = messageBroker;
         this.network = network;
         this.objectManager = objectManager;
+        this.playerManager = playerManager;
         this.siegeEventInterface = siegeEventInterface;
         messageBroker.Subscribe<NetworkRequestBesiegeSettlement>(HandleBesiege);
         messageBroker.Subscribe<NetworkRequestJoinSiegeCamp>(HandleJoin);
@@ -47,10 +55,12 @@ internal class ServerSiegeEntryHandler : IHandler
         messageBroker.Subscribe<SiegeCampPositionRolled>(HandleCampPosition);
     }
 
-    // Runs on the game thread already — published from the StartBattleAction patch; only resolves ids and broadcasts, so no GameThread.RunSafe.
+    // Runs on the game thread already; joins defenders with patches live before broadcasting the prompts.
     private void HandleAssaultStarted(MessagePayload<SiegeAssaultStarted> payload)
     {
         var obj = payload.What;
+
+        JoinConnectedSettlementDefenders(obj.AttackerParty, obj.Settlement);
 
         if (!objectManager.TryGetIdWithLogging(obj.AttackerParty, out var attackerPartyId)) return;
         if (!objectManager.TryGetIdWithLogging(obj.Settlement, out var settlementId)) return;
@@ -59,6 +69,23 @@ internal class ServerSiegeEntryHandler : IHandler
         network.SendAll(new NetworkPromptSiegeDefense(attackerPartyId, settlementId));
         // Also prompt the besieging players to adopt the replicated assault as their encounter so they can enter it.
         network.SendAll(new NetworkPromptSiegeAssault(attackerPartyId, settlementId));
+    }
+
+    private void JoinConnectedSettlementDefenders(MobileParty attackerParty, Settlement settlement)
+    {
+        var mapEvent = attackerParty?.MapEvent;
+        var defenderSide = mapEvent?.DefenderSide;
+        if (defenderSide == null) return;
+
+        foreach (var player in playerManager.Players)
+        {
+            if (!playerManager.IsConnected(player)) continue;
+            if (!objectManager.TryGetObjectWithLogging<MobileParty>(player.MobilePartyId, out var party)) continue;
+            if (party.CurrentSettlement != settlement || party.Party.MapEventSide != null) continue;
+            if (!mapEvent.CanPartyJoinBattle(party.Party, BattleSideEnum.Defender)) continue;
+
+            party.Party.MapEventSide = defenderSide;
+        }
     }
 
     // Runs on the game thread already — published from the StartSiegeEvent postfix, after the whole siege

--- a/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
+++ b/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Settlements;
 using static TaleWorlds.Library.CommandLineFunctionality;
@@ -89,6 +90,51 @@ public class SiegeDebugCommand
         Campaign.Current.SiegeEventManager.StartSiegeEvent(settlement, besieger);
 
         return $"{besieger.Name} ({besieger.StringId}) is now besieging {settlement.Name}";
+    }
+
+    // coop.debug.siege.assault
+    /// <summary>
+    /// Starts the wall assault for an active siege. Server only; the assault replicates to clients.
+    /// </summary>
+    /// <param name="args">first arg : settlementId</param>
+    /// <returns>Result of the operation as a string</returns>
+    [CommandLineArgumentFunction("assault", "coop.debug.siege")]
+    public static string StartAssault(List<string> args)
+    {
+        if (args.Count != 1)
+        {
+            return "Usage: coop.debug.siege.assault <settlementId>";
+        }
+
+        if (ModInformation.IsClient)
+        {
+            return "This command can only be used by the server";
+        }
+
+        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
+        {
+            return "Unable to resolve ObjectManager";
+        }
+
+        if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
+        {
+            return $"Settlement with id {args[0]} not found";
+        }
+
+        var leaderParty = settlement.SiegeEvent?.BesiegerCamp?.LeaderParty;
+        if (leaderParty == null)
+        {
+            return $"{settlement.Name} is not under siege";
+        }
+
+        if (settlement.Party.MapEvent != null)
+        {
+            return $"{settlement.Name} already has an active siege assault";
+        }
+
+        StartBattleAction.ApplyStartAssaultAgainstWalls(leaderParty, settlement);
+
+        return $"{leaderParty.Name} ({leaderParty.StringId}) started an assault against {settlement.Name}";
     }
 
     // coop.debug.siege.list

--- a/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
+++ b/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using TaleWorlds.CampaignSystem;
-using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Settlements;
 using static TaleWorlds.Library.CommandLineFunctionality;
@@ -90,51 +89,6 @@ public class SiegeDebugCommand
         Campaign.Current.SiegeEventManager.StartSiegeEvent(settlement, besieger);
 
         return $"{besieger.Name} ({besieger.StringId}) is now besieging {settlement.Name}";
-    }
-
-    // coop.debug.siege.assault
-    /// <summary>
-    /// Starts the wall assault for an active siege. Server only; the assault replicates to clients.
-    /// </summary>
-    /// <param name="args">first arg : settlementId</param>
-    /// <returns>Result of the operation as a string</returns>
-    [CommandLineArgumentFunction("assault", "coop.debug.siege")]
-    public static string StartAssault(List<string> args)
-    {
-        if (args.Count != 1)
-        {
-            return "Usage: coop.debug.siege.assault <settlementId>";
-        }
-
-        if (ModInformation.IsClient)
-        {
-            return "This command can only be used by the server";
-        }
-
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
-        {
-            return "Unable to resolve ObjectManager";
-        }
-
-        if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
-        {
-            return $"Settlement with id {args[0]} not found";
-        }
-
-        var leaderParty = settlement.SiegeEvent?.BesiegerCamp?.LeaderParty;
-        if (leaderParty == null)
-        {
-            return $"{settlement.Name} is not under siege";
-        }
-
-        if (settlement.Party.MapEvent != null)
-        {
-            return $"{settlement.Name} already has an active siege assault";
-        }
-
-        StartBattleAction.ApplyStartAssaultAgainstWalls(leaderParty, settlement);
-
-        return $"{leaderParty.Name} ({leaderParty.StringId}) started an assault against {settlement.Name}";
     }
 
     // coop.debug.siege.list

--- a/source/GameInterface/Services/SiegeEvents/Interfaces/SiegeEventInterface.cs
+++ b/source/GameInterface/Services/SiegeEvents/Interfaces/SiegeEventInterface.cs
@@ -434,11 +434,18 @@ internal class SiegeEventInterface : ISiegeEventInterface, IDisposable
         var mapEvent = attackerParty.MapEvent;
         if (mapEvent == null) return;
 
-        if (!mapEvent.CanPartyJoinBattle(PartyBase.MainParty, settlement.BattleSide))
+        if (PartyBase.MainParty.MapEventSide != mapEvent.DefenderSide)
         {
-            // Vanilla kicks a non-joinable defender out of the settlement. Runs outside AllowedThread so
-            // the leave routes through the normal co-op settlement-exit flow and replicates.
-            LeaveSettlementAction.ApplyForParty(MobileParty.MainParty);
+            if (!mapEvent.CanPartyJoinBattle(PartyBase.MainParty, settlement.BattleSide))
+            {
+                // Vanilla kicks a non-joinable defender out of the settlement. Runs outside AllowedThread so
+                // the leave routes through the normal co-op settlement-exit flow and replicates.
+                LeaveSettlementAction.ApplyForParty(MobileParty.MainParty);
+            }
+            else
+            {
+                Logger.Warning("Skipped the siege defense prompt at {Settlement}: the authoritative defender assignment is missing", settlement.StringId);
+            }
             return;
         }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

A player defending a besieged settlement can crash on the campaign map after clicking `Attack!`, and their party can be missing from the defender force.

## What is the new behavior?

Resolves #1992

Defenders inside the assaulted settlement now join the defending force, and clicking `Attack!` opens the siege mission without the missing-party crash.

## Bot Changelog Entry

- Fixed a crash when a settlement defender clicked `Attack!` to enter a siege mission.
