### PR TITLE
[2021] Fix settlement takeover menu crash

### DIFF
--- a/source/GameInterface/Services/SiegeEvents/Interfaces/SiegeEventInterface.cs
+++ b/source/GameInterface/Services/SiegeEvents/Interfaces/SiegeEventInterface.cs
@@ -527,12 +527,13 @@ internal class SiegeEventInterface : ISiegeEventInterface, IDisposable
 
         using (new AllowedThread())
         {
-            // The live encounter is the STALE pre-mission siege encounter the mission popped back to, whose map
-            // event the server already destroyed; its dead "encounter" menu NREs on the null MapEvent. Finish it.
+            // Auto-resolve drops PlayerEncounter before the event teardown arrives; detach so settlement entry can run.
+            if (MobileParty.MainParty.Party._mapEventSide != null)
+                MobileParty.MainParty.Party._mapEventSide = null;
+
+            // Finish the stale pre-mission siege encounter whose map event the server already ended.
             if (PlayerEncounter.Current != null)
             {
-                if (MobileParty.MainParty.Party._mapEventSide != null)
-                    MobileParty.MainParty.Party._mapEventSide = null;
                 PlayerEncounter.Finish(forcePlayerOutFromSettlement: false);
             }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Capturing a settlement after choosing Send troops can throw an exception while opening the Devastate, Pillage, and Show Mercy menu.

## What is the new behavior?

Resolves #2021

After a simulated or live siege victory, the capturing player enters the settlement before the Devastate, Pillage, and Show Mercy menu opens, so the aftermath choices display normally.

## Bot Changelog Entry

- Fixed a crash when opening the settlement aftermath menu after choosing Send troops in a player-led siege.
