### PR TITLE
[1878] Prevent player interaction menu from reopening

### DIFF
--- a/source/E2E.Tests/Services/MapEvents/PlayerPartyInteractionFlowTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/PlayerPartyInteractionFlowTests.cs
@@ -800,6 +800,29 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
     }
 
     [Fact]
+    public void ConversationRequest_WhilePlayerInteractionActive_IsIgnoredUntilInteractionEnds()
+    {
+        var (client1, _, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+        RequestInteraction(client1, initiatorPartyId, responderPartyId);
+        var sessionId = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>().Single().SessionId;
+
+        client1.Call(() => Assert.True(PlayerPartyInteractionDialogState.HasActiveState));
+        client1.NetworkSentMessages.Clear();
+
+        PublishConversationRequest(client1, initiatorPartyId, responderPartyId);
+
+        Assert.Empty(client1.NetworkSentMessages.GetMessages<NetworkRequestConversation>());
+
+        SubmitOption(client1, sessionId, initiatorPartyId, PlayerPartyInteractionOption.Leave);
+        AssertInteractionStateCleared(client1);
+        client1.NetworkSentMessages.Clear();
+
+        PublishConversationRequest(client1, initiatorPartyId, responderPartyId);
+
+        Assert.Single(client1.NetworkSentMessages.GetMessages<NetworkRequestConversation>());
+    }
+
+    [Fact]
     public void EndedInteraction_IgnoresDelayedStateForSameSession()
     {
         var (client1, _, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
@@ -1442,6 +1465,24 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
                 forcePlayerOutFromSettlement: false,
                 ConversationRestartSource.PlayerEncounter)),
             disabledMethods);
+    }
+
+    private void PublishConversationRequest(
+        EnvironmentInstance client,
+        string initiatorPartyId,
+        string responderPartyId)
+    {
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<PartyBase>(initiatorPartyId, out var initiatorParty));
+            Assert.True(client.ObjectManager.TryGetObject<PartyBase>(responderPartyId, out var responderParty));
+
+            client.Resolve<IMessageBroker>().Publish(this, new ConversationRequested(
+                responderParty,
+                initiatorParty,
+                forcePlayerOutFromSettlement: false,
+                ConversationRestartSource.PlayerEncounter));
+        });
     }
 
     private void SubmitOption(

--- a/source/GameInterface/Services/MapEvents/Handlers/ConversationRequestHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/ConversationRequestHandler.cs
@@ -87,9 +87,12 @@ internal class ConversationRequestHandler : IHandler
         messageBroker.Unsubscribe<PlayerDisconnected>(Handle_PlayerDisconnected);
     }
 
-    /// <summary>[Client] Rate-limit, resolve ids, and forward the request to the server.</summary>
+    /// <summary>[Client] Ignore requests during a player interaction; otherwise rate-limit, resolve ids, and forward.</summary>
     private void Handle_ConversationRequested(MessagePayload<ConversationRequested> payload)
     {
+        if (PlayerPartyInteractionDialogState.HasActiveState)
+            return;
+
         var now = DateTime.UtcNow;
         if (now - lastRequestSentUtc < RequestCooldown)
             return; // drop: at most one request per cooldown window


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Leaving a player-party interaction during lag can cause the interaction menu to reopen, sometimes repeatedly.

## What is the new behavior?

Resolves #1878

The interaction menu now stays closed after leaving during lag, and deliberately starting a new interaction still opens normally.

## Bot Changelog Entry

- Player interaction menus no longer reopen after leaving during lag.
