### PR TITLE
[2037] Prevent simulated siege losses from freezing the server

### DIFF
--- a/source/E2E.Tests/Services/MapEvents/MapEventLifetimeTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/MapEventLifetimeTests.cs
@@ -1,5 +1,14 @@
-﻿using E2E.Tests.Util;
+﻿using Common.Messaging;
+using E2E.Tests.Util;
+using GameInterface.Registry.Auto;
+using GameInterface.Services.MapEventSides.Messages;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.MapEvents;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.CampaignSystem.Siege;
+using TaleWorlds.Core;
 using Xunit.Abstractions;
 
 namespace E2E.Tests.Services.MapEvents;
@@ -58,6 +67,85 @@ public class MapEventLifetimeTests : MapEventTestBase
         foreach (var client in Clients)
         {
             Assert.False(client.ObjectManager.TryGetObject<MapEvent>(mapEventCtx.MapEventId, out _));
+        }
+    }
+
+    [Fact]
+    public void DefenderVictorySiege_FinalizesOnceAfterSideCleanup()
+    {
+        string? mapEventId = null;
+        MapEvent? mapEvent = null;
+        MobileParty? attacker = null;
+        PartyBase? defender = null;
+        MobileParty? mainPartyStandIn = null;
+        var disabledMethods = MapEventDisabledMethods
+            .Append(AccessTools.Method(typeof(MobileParty), "OnPartyJoinedSiegeInternal"))
+            .Append(AccessTools.Method(typeof(BesiegerCamp), nameof(BesiegerCamp.InitializeSiegeEventSide)))
+            .Append(AccessTools.Method(typeof(Settlement), nameof(Settlement.InitializeSiegeEventSide)))
+            .Append(AccessTools.Method(typeof(MapEvent), "ControlAndUpdateDefeatedPartiesAfterBattle"))
+            .ToList();
+
+        Server.Call(() =>
+        {
+            attacker = GameObjectCreator.CreateInitializedObject<MobileParty>();
+            mainPartyStandIn = GameObjectCreator.CreateInitializedObject<MobileParty>();
+            var settlement = GameObjectCreator.CreateInitializedObject<Settlement>();
+            var siegeEvent = new SiegeEvent(settlement, attacker);
+
+            siegeEvent.BesiegerCamp._besiegerParties.Add(attacker);
+            siegeEvent.BesiegerCamp._leaderParty = attacker;
+            siegeEvent.BesiegerCamp._faction = attacker.MapFaction;
+
+            mapEvent = GameObjectCreator.CreateInitializedObject<MapEvent>();
+            mapEvent._mapEventType = MapEvent.BattleTypes.Siege;
+            mapEvent.MapEventSettlement = settlement;
+
+            var defenderSide = new MapEventSide(mapEvent, BattleSideEnum.Defender, settlement.Party);
+            var attackerSide = new MapEventSide(mapEvent, BattleSideEnum.Attacker, attacker.Party);
+            mapEvent._sides[(int)BattleSideEnum.Defender] = defenderSide;
+            mapEvent._sides[(int)BattleSideEnum.Attacker] = attackerSide;
+            MessageBroker.Instance.Publish(mapEvent,
+                new MapEventSideAssigned(mapEvent, defenderSide, BattleSideEnum.Defender));
+            MessageBroker.Instance.Publish(mapEvent,
+                new MapEventSideAssigned(mapEvent, attackerSide, BattleSideEnum.Attacker));
+
+            attacker.Party.MapEventSide = attackerSide;
+            settlement.Party.MapEventSide = defenderSide;
+            mapEvent._battleState = BattleState.DefenderVictory;
+            defender = settlement.Party;
+
+            Campaign.Current.MapEventManager.OnMapEventCreated(mapEvent);
+            Assert.True(Server.ObjectManager.TryGetId(mapEvent, out mapEventId));
+        }, disabledMethods);
+
+        Assert.NotNull(mapEventId);
+        Server.InternalMessages.Clear();
+        Server.NetworkSentMessages.Clear();
+
+        Server.Call(() =>
+        {
+            var previousMainParty = Campaign.Current.MainParty;
+            Campaign.Current.MainParty = mainPartyStandIn;
+            try
+            {
+                mapEvent!.FinalizeEventAux();
+            }
+            finally
+            {
+                Campaign.Current.MainParty = previousMainParty;
+            }
+
+            Assert.All(mapEvent._sides, side => Assert.Empty(side.Parties));
+            Assert.Null(attacker!.Party.MapEventSide);
+            Assert.Null(defender!.MapEventSide);
+            Assert.False(Server.ObjectManager.TryGetObject<MapEvent>(mapEventId!, out _));
+        }, disabledMethods);
+
+        Assert.Single(Server.InternalMessages.GetMessages<InstanceDestroyed<MapEvent>>());
+        Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkDestroyInstance<MapEvent>>());
+        foreach (var client in Clients)
+        {
+            Assert.False(client.ObjectManager.TryGetObject<MapEvent>(mapEventId, out _));
         }
     }
 

--- a/source/E2E.Tests/Services/MapEvents/MapEventTestBase.cs
+++ b/source/E2E.Tests/Services/MapEvents/MapEventTestBase.cs
@@ -114,12 +114,10 @@ public abstract class MapEventTestBase : IDisposable
         {
             Assert.True(Server.ObjectManager.TryGetObject<MapEvent>(mapEventId, out var mapEvent));
 
-            // Finalize the way the live server does — through FinalizeEvent, the public path battles take on
-            // the host. The AutoRegistry watches FinalizeEventAux (MapEventRegistry.DestroyMethods), which
-            // FinalizeEvent funnels into, so this drives the same destroy hook the running game does. It must
-            // NOT run inside an AllowedThread: LifetimePatches.DestroyPostfix only broadcasts the removal to
-            // clients when the call is *not* an allowed/original-policy call, so wrapping it would silently
-            // skip the sync.
+            // Finalize the way the live server does through FinalizeEvent, the public path battles take on
+            // the host. FinalizeEvent funnels into the patched FinalizeEventAux, which broadcasts removal
+            // after vanilla teardown completes. It must not run inside an AllowedThread because that makes
+            // the patches stand down and skips the sync.
             mapEvent.FinalizeEvent();
         }, MapEventDisabledMethods);
     }

--- a/source/GameInterface/Services/MapEvents/MapEventRegistry.cs
+++ b/source/GameInterface/Services/MapEvents/MapEventRegistry.cs
@@ -41,16 +41,9 @@ internal class MapEventRegistry : AutoRegistryBase<MapEvent>
 
     public override IEnumerable<MethodBase> Constructors => AccessTools.GetDeclaredConstructors(typeof(MapEvent));
 
-    // Watch FinalizeEventAux, not FinishBattle: every way a battle ends on the server funnels through
-    // FinalizeEventAux (FinishBattle -> FinalizeEventAux, FinalizeEvent -> FinalizeEventAux, and the
-    // finalize-on-request handler calls it directly), whereas FinishBattle is a tiny wrapper the JIT
-    // inlines into MapEvent.Update, so a postfix on it never runs and the destroy is never replicated.
-    public override IEnumerable<MethodBase> DestroyMethods => new MethodBase[]
-    {
-        AccessTools.Method(typeof(MapEvent), nameof(MapEvent.FinishBattle)),
-        AccessTools.Method(typeof(MapEvent), nameof(MapEvent.FinalizeEvent)),
-        AccessTools.Method(typeof(MapEvent), nameof(MapEvent.FinalizeEventAux))
-    };
+    // FinalizeEventAux re-enters during siege teardown, so MapEventPatches publishes destruction
+    // only after the outer call completes.
+    public override IEnumerable<MethodBase> DestroyMethods => Array.Empty<MethodBase>();
 
     public override void RegisterAllObjects()
     {

--- a/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
@@ -2,6 +2,7 @@
 using Common.Logging;
 using Common.Messaging;
 using GameInterface.Policies;
+using GameInterface.Registry.Auto;
 using GameInterface.Services.MapEvents.Messages;
 using GameInterface.Services.MapEvents.Messages.Leave;
 using GameInterface.Services.MapEvents.Messages.Start;
@@ -45,13 +46,18 @@ internal class MapEventPatches
 
     [HarmonyPatch(nameof(MapEvent.FinalizeEventAux))]
     [HarmonyPrefix]
-    private static bool Prefix_FinalizeEventAux(MapEvent __instance)
+    private static bool Prefix_FinalizeEventAux(MapEvent __instance, out bool __state)
     {
+        __state = false;
+
         if (CallOriginalPolicy.IsOriginalAllowed())
             return true;
 
         if (ModInformation.IsServer)
+        {
+            __state = !__instance.IsFinalized;
             return true;
+        }
 
         var message = new MapEventFinalizeAttempted(__instance);
         MessageBroker.Instance.Publish(__instance, message);
@@ -61,14 +67,14 @@ internal class MapEventPatches
 
     [HarmonyPatch(nameof(MapEvent.FinalizeEventAux))]
     [HarmonyPostfix]
-    private static void Postfix_FinalizeEventAux(MapEvent __instance)
+    private static void Postfix_FinalizeEventAux(MapEvent __instance, bool __state, bool __runOriginal)
     {
-        // By this point the event's parties have left it, so the server can
-        // re-evaluate whether any player is still in a map event.
-        if (ModInformation.IsClient)
+        if (!__runOriginal || !__state)
             return;
 
+        // Keep the event registered while finalized handlers clear their per-event state.
         MessageBroker.Instance.Publish(__instance, new MapEventFinalized(__instance));
+        MessageBroker.Instance.Publish(__instance, new InstanceDestroyed<MapEvent>(__instance));
     }
 
     [HarmonyPatch(nameof(MapEvent.BattleState), MethodType.Setter)]


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Losing a simulated siege as the attacker can freeze the dedicated server during map event finalization. Clients remain connected in `PausedForServer` while the server repeatedly broadcasts troop-roster cleanup.

## What is the new behavior?

Resolves #2037

Map event destruction now runs once after the outer finalization completes, so siege teardown clears both sides before the registry graph is removed. A defender-victory siege regression test covers the nested finalization path.

## Bot Changelog Entry

- Fixed server freezing when an attacking player loses a simulated siege.
