### PR TITLE
Fix ransom prisoners screen

### DIFF
--- a/source/E2E.Tests/Services/Party/PartyDoneLogicInfluenceSyncTests.cs
+++ b/source/E2E.Tests/Services/Party/PartyDoneLogicInfluenceSyncTests.cs
@@ -88,7 +88,8 @@ public class PartyDoneLogicInfluenceSyncTests : IDisposable
                 partyGoldChangeAmount: 0,
                 partyInfluenceChangeAmount: influenceGain,
                 partyMoraleChangeAmount: 0,
-                doNotApplyGoldTransactions: true);
+                doNotApplyGoldTransactions: true,
+                Helpers.PartyScreenHelper.PartyScreenMode.Normal);
 
             requestingClient.SimulateMessage(this, message);
         });

--- a/source/GameInterface.Tests/Services/Party/PlayerCaptivityReleasePositionTests.cs
+++ b/source/GameInterface.Tests/Services/Party/PlayerCaptivityReleasePositionTests.cs
@@ -170,7 +170,8 @@ public class PlayerCaptivityReleasePositionTests
             0,
             0,
             true,
-            releasePosition);
+            releasePosition,
+            Helpers.PartyScreenHelper.PartyScreenMode.Normal);
 
         byte[] bytes;
         using (var ms = new MemoryStream())

--- a/source/GameInterface/Services/GameMenus/Handlers/GameMenuRefreshHandler.cs
+++ b/source/GameInterface/Services/GameMenus/Handlers/GameMenuRefreshHandler.cs
@@ -4,7 +4,6 @@ using Common.Messaging;
 using GameInterface.Services.GameMenus.Messages;
 using GameInterface.Services.ObjectManager;
 using Serilog;
-using System;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.GameMenus;
 
@@ -12,7 +11,7 @@ namespace GameInterface.Services.GameMenus.Handlers;
 
 internal class GameMenuRefreshHandler : IHandler
 {
-    private static readonly ILogger logger = LogManager.GetLogger<GameMenuRefreshHandler>();
+    private static readonly ILogger Logger = LogManager.GetLogger<GameMenuRefreshHandler>();
 
     private readonly IMessageBroker messageBroker;
     private readonly IObjectManager objectManager;
@@ -34,20 +33,13 @@ internal class GameMenuRefreshHandler : IHandler
 
     private void Handle_RefreshGameMenu(MessagePayload<RefreshGameMenu> obj)
     {
-        if (!objectManager.TryGetObjectWithLogging<Hero>(obj.What.TargetHeroId, out var targetHero) || targetHero != Hero.MainHero) return;
-
         var menuName = obj.What.MenuName;
-        // SwitchToMenu changes the active menu/screen, which is only safe on the main thread.
-        GameThread.Run(() =>
+
+        GameThread.RunSafe(() =>
         {
-            try
-            {
-                GameMenu.SwitchToMenu(menuName);
-            }
-            catch (Exception e)
-            {
-                logger.Error(e, "Failed to refresh game menu to {MenuName}", menuName);
-            }
+            if (!objectManager.TryGetObjectWithLogging<Hero>(obj.What.TargetHeroId, out var targetHero) || targetHero != Hero.MainHero) return;
+
+            GameMenu.SwitchToMenu(menuName);
         });
     }
 }

--- a/source/GameInterface/Services/Party/Handlers/PartyDoneLogicHandler.cs
+++ b/source/GameInterface/Services/Party/Handlers/PartyDoneLogicHandler.cs
@@ -105,7 +105,8 @@ internal class PartyDoneLogicHandler : IHandler
             obj.What.PartyInfluenceChangeAmount,
             obj.What.PartyMoraleChangeAmount,
             obj.What.DoNotApplyGoldTransactions,
-            releaserPartyPosition
+            releaserPartyPosition,
+            obj.What.PartyScreenMode
         );
 
         network.SendAll(message);
@@ -152,7 +153,12 @@ internal class PartyDoneLogicHandler : IHandler
                 rightPrisonerRosterData);
 
             PublishPlayerCaptivityReleaseEvents(releasedPlayerCaptivityEvents);
-            troopRosterInterface.ApplyTroopRosterDeltas(rosterDeltas);
+
+            // Only apply deltas if not ransoming. SellPrisonersAction already changes troop rosters
+            if (message.PartyScreenMode != Helpers.PartyScreenHelper.PartyScreenMode.Ransom)
+            {
+                troopRosterInterface.ApplyTroopRosterDeltas(rosterDeltas);
+            }
             ApplyRightOwnerPartyItemRoster(mainHero, message);
             NotifyDonatedPrisonersChanged(donatedPrisonersRoster);
             ApplyPartyRewardChanges(mainHero, message);

--- a/source/GameInterface/Services/Party/Handlers/SellPrisonersHandler.cs
+++ b/source/GameInterface/Services/Party/Handlers/SellPrisonersHandler.cs
@@ -2,16 +2,17 @@
 using Common.Logging;
 using Common.Messaging;
 using Common.Network;
+using Common.Network.Coalescing;
 using GameInterface.Services.GameMenus.Messages;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Party.Messages;
 using GameInterface.Services.TroopRosters.Interfaces;
-using GameInterface.Services.UI.Notifications.Messages;
 using LiteNetLib;
 using Serilog;
 using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Roster;
+using static GameInterface.Services.ObjectManager.ObjectManager;
 
 namespace GameInterface.Services.Party.Handlers;
 
@@ -23,17 +24,20 @@ internal class SellPrisonersHandler : IHandler
     private readonly IObjectManager objectManager;
     private readonly INetwork network;
     private readonly ITroopRosterInterface troopRosterInterface;
+    private readonly ISendCoalescer sendCoalescer;
 
     public SellPrisonersHandler(
         IMessageBroker messageBroker,
         IObjectManager objectManager,
         INetwork network,
-        ITroopRosterInterface troopRosterInterface)
+        ITroopRosterInterface troopRosterInterface,
+        ISendCoalescer sendCoalescer = null)
     {
         this.messageBroker = messageBroker;
         this.objectManager = objectManager;
         this.network = network;
         this.troopRosterInterface = troopRosterInterface;
+        this.sendCoalescer = sendCoalescer;
 
         messageBroker.Subscribe<PrisonersSold>(Handle_PrisonersSold);
         messageBroker.Subscribe<SellPrisoners>(Handle_SellPrisoners);
@@ -57,14 +61,19 @@ internal class SellPrisonersHandler : IHandler
 
     private void Handle_SellPrisoners(MessagePayload<SellPrisoners> obj)
     {
-        if (!objectManager.TryGetObjectWithLogging<PartyBase>(obj.What.SellingPartyId, out var sellingParty)) return;
-
         GameThread.RunSafe(() =>
         {
+            if (!objectManager.TryGetObjectWithLogging<PartyBase>(obj.What.SellingPartyId, out var sellingParty)) return;
+
             TroopRoster leftPrisonerRoster = new();
             troopRosterInterface.UpdateWithData(leftPrisonerRoster, obj.What.LeftPrisonerRosterData, sellingParty.LeaderHero);
 
             SellPrisonersAction.ApplyForSelectedPrisoners(sellingParty, null, leftPrisonerRoster);
+
+            objectManager.TryGetId(sellingParty.PrisonRoster, out var rosterId);
+            var compactId = Compact(rosterId, typeof(TroopRoster));
+
+            sendCoalescer?.FlushInstance(compactId, network);
 
             // Refresh the menu to show updated menu items
             if (!objectManager.TryGetIdWithLogging(sellingParty.LeaderHero, out var heroId)) return;

--- a/source/GameInterface/Services/Party/Messages/NetworkCompleteDoneLogic.cs
+++ b/source/GameInterface/Services/Party/Messages/NetworkCompleteDoneLogic.cs
@@ -2,6 +2,7 @@
 using GameInterface.Services.MapEventParties;
 using GameInterface.Services.Party.Data;
 using GameInterface.Services.TroopRosters.Data;
+using Helpers;
 using ProtoBuf;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.Core;
@@ -62,6 +63,9 @@ internal readonly struct NetworkCompleteDoneLogic : ICommand
     [ProtoMember(17)]
     public readonly CampaignVec2 ReleaserPartyPosition;
 
+    [ProtoMember(18)]
+    public readonly PartyScreenHelper.PartyScreenMode PartyScreenMode;
+
     public NetworkCompleteDoneLogic(
         string mainHeroId,
         FlattenedTroop[] takenPrisonersRoster,
@@ -79,7 +83,8 @@ internal readonly struct NetworkCompleteDoneLogic : ICommand
         int partyInfluenceChangeAmount,
         int partyMoraleChangeAmount,
         bool doNotApplyGoldTransactions,
-        CampaignVec2 releaserPartyPosition)
+        CampaignVec2 releaserPartyPosition,
+        PartyScreenHelper.PartyScreenMode partyScreenMode)
     {
         MainHeroId = mainHeroId;
         TakenPrisonersRoster = takenPrisonersRoster;
@@ -98,5 +103,6 @@ internal readonly struct NetworkCompleteDoneLogic : ICommand
         PartyMoraleChangeAmount = partyMoraleChangeAmount;
         DoNotApplyGoldTransactions = doNotApplyGoldTransactions;
         ReleaserPartyPosition = releaserPartyPosition;
+        PartyScreenMode = partyScreenMode;
     }
 }

--- a/source/GameInterface/Services/Party/Messages/PartyDoneLogicAttempted.cs
+++ b/source/GameInterface/Services/Party/Messages/PartyDoneLogicAttempted.cs
@@ -1,4 +1,5 @@
 ﻿using Common.Messaging;
+using Helpers;
 using System;
 using System.Collections.Generic;
 using TaleWorlds.CampaignSystem;
@@ -30,6 +31,7 @@ public readonly struct PartyDoneLogicAttempted : IEvent
     public readonly int PartyInfluenceChangeAmount;
     public readonly int PartyMoraleChangeAmount;
     public readonly bool DoNotApplyGoldTransactions;
+    public readonly PartyScreenHelper.PartyScreenMode PartyScreenMode;
 
     public PartyDoneLogicAttempted(
         Hero mainHero,
@@ -50,7 +52,8 @@ public readonly struct PartyDoneLogicAttempted : IEvent
         int partyGoldChangeAmount,
         int partyInfluenceChangeAmount,
         int partyMoraleChangeAmount,
-        bool doNotApplyGoldTransactions)
+        bool doNotApplyGoldTransactions,
+        PartyScreenHelper.PartyScreenMode partyScreenMode)
     {
         MainHero = mainHero;
         TakenPrisonersRoster = takenPrisonersRoster;
@@ -71,5 +74,6 @@ public readonly struct PartyDoneLogicAttempted : IEvent
         PartyInfluenceChangeAmount = partyInfluenceChangeAmount;
         PartyMoraleChangeAmount = partyMoraleChangeAmount;
         DoNotApplyGoldTransactions = doNotApplyGoldTransactions;
+        PartyScreenMode = partyScreenMode;
     }
 }

--- a/source/GameInterface/Services/Party/Patches/PartyScreenLogicPatches.cs
+++ b/source/GameInterface/Services/Party/Patches/PartyScreenLogicPatches.cs
@@ -8,6 +8,7 @@ using Serilog;
 using System;
 using System.Collections.Generic;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.GameState;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Roster;
 using TaleWorlds.Core;
@@ -61,6 +62,12 @@ internal class PartyScreenLogicPatches
                 recruitedPrisonersRoster.Add(tuple.Item1, tuple.Item2, 0);
             }
 
+            var partyScreenMode = __instance._partyScreenMode;
+            if (Game.Current.GameStateManager.ActiveState is PartyState partyState)
+            {
+                partyScreenMode = partyState.PartyScreenMode;
+            }
+
             var message = new PartyDoneLogicAttempted(
                 Hero.MainHero,
                 takenPrisonersRoster,
@@ -80,7 +87,8 @@ internal class PartyScreenLogicPatches
                 __instance.CurrentData.PartyGoldChangeAmount,
                 __instance.CurrentData.PartyInfluenceChangeAmount.Item2,
                 __instance.CurrentData.PartyMoraleChangeAmount,
-                __instance.DoNotApplyGoldTransactions
+                __instance.DoNotApplyGoldTransactions,
+                partyScreenMode
             );
 
             MessageBroker.Instance.Publish(__instance, message);


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- Ransom screen isn't updating properly when a client ransoms prisoners.
- Selling prisoners from the party screen is doubling prisoner changes.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #2019 
<!-- Describe functionality added. Add images or videos to show how it works if applies -->

- Ransom screen updates correctly
- Selling prisoners from party screen no longer doubles prisoner changes.
