### PR TITLE
Include commit SHA in nightly builds

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -84,6 +84,8 @@ jobs:
           dotnet build Coop/Coop.csproj \
             -c Release \
             -p:CustomAfterMicrosoftCommonTargets="$RUNNER_TEMP/net472/build/Microsoft.NETFramework.ReferenceAssemblies.net472.targets" \
+            -p:SourceRevisionId="$GITHUB_SHA" \
+            -p:IncludeSourceRevisionInInformationalVersion=true \
             -p:ModName= \
             -p:NuGetAudit=false \
             --consoleLoggerParameters:ErrorsOnly


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Official nightly builds log only the base version, such as `0.0.2`, because the build container does not populate `SourceRevisionId` from the checkout.

## What is the new behavior?

The nightly workflow passes its immutable `GITHUB_SHA` to MSBuild, so `Common.dll` records an informational version such as `0.0.2+5aad100ab911ef5756e5dae0ae95d6039080f514` and supplied logs identify their exact build.

## Bot Changelog Entry


## Other information

Built `Common.csproj` with an explicit 40-character `SourceRevisionId` and confirmed the generated `AssemblyInformationalVersion` includes the full SHA.
