### PR TITLE
Keep delayed nightly builds on the scheduled date

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -96,8 +96,16 @@ jobs:
           PREVIOUS_SHA: ${{ steps.previous.outputs.result }}
         run: |
           set -eu
-          release_date=$(TZ=America/Chicago date +%F)
-          display_date=$(TZ=America/Chicago date +%m-%d-%Y)
+          release_epoch=$(date +%s)
+          if [ "$GITHUB_EVENT_NAME" = schedule ]; then
+            release_hour=$(TZ=America/Chicago date +%H)
+            release_minute=$(TZ=America/Chicago date +%M)
+            if [ "$release_hour" -lt 23 ] || { [ "$release_hour" -eq 23 ] && [ "$release_minute" -lt 57 ]; }; then
+              release_epoch=$((release_epoch - 86400))
+            fi
+          fi
+          release_date=$(TZ=America/Chicago date -d "@$release_epoch" +%F)
+          display_date=$(TZ=America/Chicago date -d "@$release_epoch" +%m-%d-%Y)
           file_name="Coop $display_date.7z"
           head_sha=$(git rev-parse HEAD)
           base_sha="$PREVIOUS_SHA"

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -5,6 +5,11 @@ on:
     - cron: '57 23 * * *'
       timezone: America/Chicago
   workflow_dispatch:
+    inputs:
+      release_date:
+        description: Release date to rebuild (YYYY-MM-DD); defaults to today in Central time
+        required: false
+        type: string
 
 permissions:
   actions: read
@@ -94,14 +99,27 @@ jobs:
         id: release
         env:
           PREVIOUS_SHA: ${{ steps.previous.outputs.result }}
+          REQUESTED_RELEASE_DATE: ${{ inputs.release_date }}
         run: |
           set -eu
-          release_epoch=$(date +%s)
-          if [ "$GITHUB_EVENT_NAME" = schedule ]; then
-            release_hour=$(TZ=America/Chicago date +%H)
-            release_minute=$(TZ=America/Chicago date +%M)
-            if [ "$release_hour" -lt 23 ] || { [ "$release_hour" -eq 23 ] && [ "$release_minute" -lt 57 ]; }; then
-              release_epoch=$((release_epoch - 86400))
+          if [ -n "$REQUESTED_RELEASE_DATE" ]; then
+            if ! printf '%s\n' "$REQUESTED_RELEASE_DATE" | grep -Eq '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
+              echo 'release_date must use YYYY-MM-DD' >&2
+              exit 1
+            fi
+            release_epoch=$(TZ=America/Chicago date -d "$REQUESTED_RELEASE_DATE 12:00:00" +%s)
+            if [ "$(TZ=America/Chicago date -d "@$release_epoch" +%F)" != "$REQUESTED_RELEASE_DATE" ]; then
+              echo 'release_date is not a valid calendar date' >&2
+              exit 1
+            fi
+          else
+            release_epoch=$(date +%s)
+            if [ "$GITHUB_EVENT_NAME" = schedule ]; then
+              release_hour=$(TZ=America/Chicago date +%H)
+              release_minute=$(TZ=America/Chicago date +%M)
+              if [ "$release_hour" -lt 23 ] || { [ "$release_hour" -eq 23 ] && [ "$release_minute" -lt 57 ]; }; then
+                release_epoch=$((release_epoch - 86400))
+              fi
             fi
           fi
           release_date=$(TZ=America/Chicago date -d "@$release_epoch" +%F)


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

GitHub can start the 11:57 PM scheduled workflow after midnight. The workflow uses its actual execution date, so a delayed run is labeled as the following night's release.

## What is the new behavior?

Scheduled runs that begin after midnight retain the date of the 11:57 PM schedule they belong to. Manual dispatches use their actual Central date by default and accept an optional validated release date for rebuilding a delayed or dropped nightly.

## Bot Changelog Entry


## Other information

Validated the date calculation in the pinned build container using the 2:12 AM delayed-run timestamp from nightly run #5.
