### PR TITLE
Fix Steam lobby advertising for start-server.bat

### DIFF
--- a/source/Coop.Core/CoopartiveMultiplayerExperience.cs
+++ b/source/Coop.Core/CoopartiveMultiplayerExperience.cs
@@ -37,6 +37,7 @@ namespace Coop.Core
         private IContainer container;
         private readonly SteamOrDirectJoinEndpointPreparer joinEndpointPreparer = new SteamOrDirectJoinEndpointPreparer();
         private readonly ServerProcessManager serverProcessManager;
+        private readonly bool standaloneServerProcess;
         private volatile bool coopStarting;
         private volatile bool hostedSession;
         private volatile bool clientConnectedOnce;
@@ -47,12 +48,13 @@ namespace Coop.Core
         // A spawned server has to load the whole campaign save before it binds its port.
         public static readonly TimeSpan HostedServerStartTimeout = TimeSpan.FromMinutes(5);
 
-        public CoopartiveMultiplayerExperience()
+        public CoopartiveMultiplayerExperience(bool standaloneServerProcess = false)
         {
             // TODO use DI maybe?
             messageBroker = MessageBroker.Instance;
             configuration = new NetworkConfig();
             serverProcessManager = new ServerProcessManager(messageBroker);
+            this.standaloneServerProcess = standaloneServerProcess;
 
             messageBroker.Subscribe<AttemptJoin>(Handle);
             messageBroker.Subscribe<AttemptHost>(Handle);
@@ -127,6 +129,18 @@ namespace Coop.Core
             }
 
             AbandonAnyStartingSession();
+
+            // start-server.bat already launched this process with /server and its anonymous
+            // Steam game-server session owns the fixed Steam ports. Host here so the existing
+            // server container advertises the lobby instead of spawning a second server that
+            // competes for those ports.
+            if (standaloneServerProcess)
+            {
+                Logger.Information("Standalone server process hosting save '{SaveName}' in-process",
+                    obj.What.SaveName);
+                StartAsServer(obj.What.SaveName, password, visibility);
+                return;
+            }
 
             // Off Steam, keep the in-process dedicated-server behavior: this instance becomes
             // the server, and the player launches a second instance to join it.

--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -261,7 +261,7 @@ namespace Coop
 
         public override void NoHarmonyLoad()
         {
-            Coop = new CoopartiveMultiplayerExperience();
+            Coop = new CoopartiveMultiplayerExperience(isServer);
 
             Updateables.Add(GameThread.Instance);
 


### PR DESCRIPTION
## Summary

- pass the `/server` process role into the co-op experience
- host the selected save in the existing standalone-server process
- preserve the normal Steam client flow that spawns and joins a child server

## Root cause

`start-server.bat` launches Bannerlord with `/server`, so that process already initializes Steam's anonymous game-server session and owns the fixed Steam ports. The Host action only checked whether Steam was available and therefore spawned a second server process. That child competed for the same Steam ports and could not reliably advertise a lobby.

The `/server` path now calls `StartAsServer` in-process. Once the gameplay listener binds, the existing server advertisement lifecycle starts the Steam tunnel and creates the configured lobby.

## Impact

Servers launched with `start-server.bat` can publish their Steam lobby without spawning a competing child process. Regular players hosting from a normal Steam launch retain the existing child-server and automatic loopback-join behavior.

## Bot Changelog Entry

- The steam server now correctly starts when running through  `start-server.bat`
