### PR TITLE
[2068] Fix daily gold change notifications

### DIFF
--- a/source/GameInterface/Services/UI/Notifications/Patches/DailyGoldChangePatch.cs
+++ b/source/GameInterface/Services/UI/Notifications/Patches/DailyGoldChangePatch.cs
@@ -1,10 +1,10 @@
-﻿using Common.Messaging;
+﻿using Common;
+using Common.Messaging;
 using GameInterface.Services.Clans.Extensions;
 using GameInterface.Services.UI.Notifications.Messages;
 using HarmonyLib;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
-using TaleWorlds.Library;
 
 namespace GameInterface.Services.UI.Notifications.Patches;
 
@@ -13,16 +13,23 @@ internal class DailyGoldChangePatch
 {
     [HarmonyPatch(nameof(ClanVariablesCampaignBehavior.DailyTickClan))]
     [HarmonyPrefix]
-    public static bool DailyTickClanPrefix(ref ClanVariablesCampaignBehavior __instance, Clan clan)
+    public static void DailyTickClanPrefix(Clan clan, out int? __state)
     {
-        // Only need to notify of daily gold change for player clans
-        if (clan == null || !clan.IsPlayerClan()) return true;
+        __state = null;
+        if (ModInformation.IsServer && clan != null && clan.IsPlayerClan())
+        {
+            __state = clan.Gold;
+        }
+    }
 
-        int goldChange = MathF.Round(Campaign.Current.Models.ClanFinanceModel.CalculateClanGoldChange(clan, false, false, false).ResultNumber);
+    [HarmonyPatch(nameof(ClanVariablesCampaignBehavior.DailyTickClan))]
+    [HarmonyPostfix]
+    public static void DailyTickClanPostfix(ClanVariablesCampaignBehavior __instance, Clan clan, int? __state)
+    {
+        if (!__state.HasValue) return;
 
+        int goldChange = clan.Gold - __state.Value;
         var message = new NotifyDailyGoldChange(clan, goldChange);
         MessageBroker.Instance.Publish(__instance, message);
-
-        return true;
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Daily gold notifications show the full forecast expense even when the clan cannot afford it, so a player at zero gold can be told they lost thousands despite their balance not changing.

## What is the new behavior?

Resolves #2068

Daily gold notifications now show the amount actually added to or removed from the player's balance. Gold still stops at zero, and unaffordable wages retain their normal unpaid-wage effects.

## Bot Changelog Entry

- Daily gold notifications now match the amount actually added to or removed from the player's balance.
