### PR TITLE
[2065] Prevent duplicate player surrender requests

### DIFF
--- a/source/E2E.Tests/Services/MapEvents/BattleSurrenderTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/BattleSurrenderTests.cs
@@ -61,6 +61,10 @@ public class BattleSurrenderTests : MapEventTestBase
             var encounter = PlayerEncounter.Current;
             Assert.NotNull(encounter);
             InvokePatchedSurrender(encounter);
+            Assert.True(encounter._playerSurrender);
+
+            // A second menu activation while the authoritative response is in flight must not enqueue another request.
+            InvokePatchedSurrender(encounter);
         }, BattleMenuSurrenderDisabledMethods());
 
         // Exactly one surrender request was forwarded, carrying the participating (surrendering) player's party.

--- a/source/GameInterface/Services/MapEvents/Patches/PlayerEncounterPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/PlayerEncounterPatches.cs
@@ -113,6 +113,10 @@ internal class PlayerEncounterPatches
 
         if (ModInformation.IsServer) return true;
 
+        // Preserve vanilla's local pending state so a delayed server response cannot enqueue duplicate surrender requests.
+        if (__instance._playerSurrender) return false;
+        __instance._playerSurrender = true;
+
         Logger.Information(
             "[PvPBattleEncounterTrace] Battle encounter option clicked: surrender; party={PartyId} mapEvent={MapEventId} menu={Menu} encounter={Encounter}",
             DescribePartyForTrace(MobileParty.MainParty?.Party),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

After losing a battle, selecting Surrender could leave the encounter menu open, and each additional click submitted another surrender request.

## What is the new behavior?

Resolves #2065

Selecting Surrender now records the pending action immediately, so repeated clicks do not submit duplicate requests while the battle resolves and the player transitions to captivity.

## Bot Changelog Entry

- Prevented repeated surrender requests from leaving defeated players stuck in the encounter menu.
