### PR TITLE
[2078] Prevent captive player dialogue softlock

### DIFF
--- a/source/E2E.Tests/Services/MapEvents/PlayerPartyInteractionFlowTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/PlayerPartyInteractionFlowTests.cs
@@ -68,6 +68,25 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
     }
 
     [Fact]
+    public void ClientRequest_InactivePlayerParty_DeniesWithoutStartingDialog()
+    {
+        var (client1, _, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(responderPartyId, out var responderParty));
+            responderParty.MobileParty.IsActive = false;
+        });
+        Server.NetworkSentMessages.Clear();
+
+        RequestInteraction(client1, initiatorPartyId, responderPartyId);
+
+        Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkConversationDenied>());
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>());
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionState>());
+    }
+
+    [Fact]
     public void OppositeDirectionInteractionRequest_ForReservedPair_IsIdempotent()
     {
         var (client1, client2, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();

--- a/source/E2E.Tests/Services/MapEvents/PlayerPartyInteractionFlowTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/PlayerPartyInteractionFlowTests.cs
@@ -81,7 +81,8 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
 
         RequestInteraction(client1, initiatorPartyId, responderPartyId);
 
-        Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkConversationDenied>());
+        var denied = Server.NetworkSentMessages.GetMessages<NetworkConversationDenied>().Single();
+        Assert.Equal(ConversationDeniedReason.PlayerUnavailable, denied.Reason);
         Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>());
         Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionState>());
     }

--- a/source/GameInterface.Tests/Services/MapEvents/PlayerPartyPrisonerTalkPatchesTests.cs
+++ b/source/GameInterface.Tests/Services/MapEvents/PlayerPartyPrisonerTalkPatchesTests.cs
@@ -1,0 +1,60 @@
+﻿using Common.Util;
+using GameInterface.Services.Entity;
+using GameInterface.Services.MapEvents.PlayerPartyInteractions;
+using GameInterface.Services.Players;
+using GameInterface.Services.Players.Data;
+using HarmonyLib;
+using System.Runtime.CompilerServices;
+using TaleWorlds.CampaignSystem;
+using Xunit;
+
+namespace GameInterface.Tests.Services.MapEvents;
+
+/// <summary>Tests the Party Screen captured-player Talk gate.</summary>
+public class PlayerPartyPrisonerTalkPatchesTests
+{
+    private readonly ConditionalWeakTable<object, ControlledObjectInfo> playerObjects =
+        (ConditionalWeakTable<object, ControlledObjectInfo>)AccessTools
+            .Field(typeof(PlayerManager), "PlayerObjects")
+            .GetValue(null)!;
+
+    [Fact]
+    public void ShouldBlockTalk_PlayerPrisoner_ReturnsTrue()
+    {
+        var hero = ObjectHelper.SkipConstructor<Hero>();
+        playerObjects.Add(hero, new ControlledObjectInfo("PlayerOne", new ControllerIdProvider()));
+
+        try
+        {
+            Assert.True(PlayerPartyPrisonerTalkPatches.ShouldBlockTalk(hero, isPrisoner: true));
+        }
+        finally
+        {
+            playerObjects.Remove(hero);
+        }
+    }
+
+    [Fact]
+    public void ShouldBlockTalk_PlayerPartyMember_ReturnsFalse()
+    {
+        var hero = ObjectHelper.SkipConstructor<Hero>();
+        playerObjects.Add(hero, new ControlledObjectInfo("PlayerOne", new ControllerIdProvider()));
+
+        try
+        {
+            Assert.False(PlayerPartyPrisonerTalkPatches.ShouldBlockTalk(hero, isPrisoner: false));
+        }
+        finally
+        {
+            playerObjects.Remove(hero);
+        }
+    }
+
+    [Fact]
+    public void ShouldBlockTalk_NonPlayerPrisoner_ReturnsFalse()
+    {
+        var hero = ObjectHelper.SkipConstructor<Hero>();
+
+        Assert.False(PlayerPartyPrisonerTalkPatches.ShouldBlockTalk(hero, isPrisoner: true));
+    }
+}

--- a/source/GameInterface/Services/MapEvents/ConversationPartyHold.cs
+++ b/source/GameInterface/Services/MapEvents/ConversationPartyHold.cs
@@ -20,7 +20,8 @@ internal static class ConversationPartyHold
 {
     private static readonly TimeSpan BlockedMessageCooldown = TimeSpan.FromSeconds(5);
 
-    private static DateTime lastBlockedMessageUtc = DateTime.MinValue;
+    private static DateTime lastInteractionBlockedMessageUtc = DateTime.MinValue;
+    private static DateTime lastPlayerUnavailableMessageUtc = DateTime.MinValue;
 
     /// <summary>
     /// Shows the local player why their interaction with an engaged party did nothing, at most once per cooldown
@@ -28,12 +29,24 @@ internal static class ConversationPartyHold
     /// </summary>
     public static void ShowInteractionBlockedMessage()
     {
-        var now = DateTime.UtcNow;
-        if (now - lastBlockedMessageUtc < BlockedMessageCooldown) return;
-        lastBlockedMessageUtc = now;
+        ShowBlockedMessage(
+            ref lastInteractionBlockedMessageUtc,
+            "You cannot interact with the party while another player is interacting with it");
+    }
 
-        InformationManager.DisplayMessage(new InformationMessage(
-            "You cannot interact with the party while another player is interacting with it"));
+    /// <summary>Shows the local player that the targeted player cannot currently be spoken to.</summary>
+    public static void ShowPlayerUnavailableMessage()
+    {
+        ShowBlockedMessage(ref lastPlayerUnavailableMessageUtc, "You cannot speak to this player right now");
+    }
+
+    private static void ShowBlockedMessage(ref DateTime lastMessageUtc, string message)
+    {
+        var now = DateTime.UtcNow;
+        if (now - lastMessageUtc < BlockedMessageCooldown) return;
+        lastMessageUtc = now;
+
+        InformationManager.DisplayMessage(new InformationMessage(message));
     }
 
     /// <summary>

--- a/source/GameInterface/Services/MapEvents/Handlers/ConversationRequestHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/ConversationRequestHandler.cs
@@ -182,7 +182,7 @@ internal class ConversationRequestHandler : IHandler
             Logger.Debug(
                 "Rejecting PvP conversation: a player party is inactive. AttackerId={AttackerId}, DefenderId={DefenderId}",
                 request.AttackerId, request.DefenderId);
-            network.Send(requestingPeer, new NetworkConversationDenied());
+            network.Send(requestingPeer, new NetworkConversationDenied(ConversationDeniedReason.PlayerUnavailable));
             return false;
         }
 
@@ -208,7 +208,7 @@ internal class ConversationRequestHandler : IHandler
                 Logger.Debug(
                     "Rejecting PvP conversation: a party is already conversing with another player. AttackerId={AttackerId}, DefenderId={DefenderId}",
                     request.AttackerId, request.DefenderId);
-                network.Send(requestingPeer, new NetworkConversationDenied());
+                network.Send(requestingPeer, new NetworkConversationDenied(ConversationDeniedReason.PartyEngaged));
                 return false;
             }
 
@@ -287,7 +287,7 @@ internal class ConversationRequestHandler : IHandler
             Logger.Debug(
                 "Rejecting shared conversation for a non-hostile party. PartyId={PartyId}",
                 aiPartyId);
-            network.Send(requestingPeer, new NetworkConversationDenied());
+            network.Send(requestingPeer, new NetworkConversationDenied(ConversationDeniedReason.PartyEngaged));
             return;
         }
 
@@ -297,7 +297,7 @@ internal class ConversationRequestHandler : IHandler
             Logger.Debug(
                 "Rejecting conversation request: the party or the requester is already engaged. PartyId={PartyId}",
                 aiPartyId);
-            network.Send(requestingPeer, new NetworkConversationDenied());
+            network.Send(requestingPeer, new NetworkConversationDenied(ConversationDeniedReason.PartyEngaged));
             return;
         }
 
@@ -450,12 +450,15 @@ internal class ConversationRequestHandler : IHandler
         EndPvpInteraction(peer);
     }
 
-    /// <summary>[Client] The server denied the request because the party is engaged; tell the player why.</summary>
+    /// <summary>[Client] The server denied the request; tell the player why.</summary>
     private void Handle_NetworkConversationDenied(MessagePayload<NetworkConversationDenied> payload)
     {
         if (ModInformation.IsServer) return;
 
-        GameThread.Run(ConversationPartyHold.ShowInteractionBlockedMessage);
+        Action showMessage = payload.What.Reason == ConversationDeniedReason.PlayerUnavailable
+            ? ConversationPartyHold.ShowPlayerUnavailableMessage
+            : ConversationPartyHold.ShowInteractionBlockedMessage;
+        GameThread.RunSafe(showMessage, context: "Show conversation denied");
     }
 
     /// <summary>[Server] The defender's client reports it is showing the "hold on" popup; record its peer so a

--- a/source/GameInterface/Services/MapEvents/Handlers/ConversationRequestHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/ConversationRequestHandler.cs
@@ -176,6 +176,16 @@ internal class ConversationRequestHandler : IHandler
         var attackerInMapEvent = attacker.MapEvent != null;
         var defenderInMapEvent = defender.MapEvent != null;
 
+        if ((attackerIsPlayer && !attacker.MobileParty.IsActive) ||
+            (defenderIsPlayer && !defender.MobileParty.IsActive))
+        {
+            Logger.Debug(
+                "Rejecting PvP conversation: a player party is inactive. AttackerId={AttackerId}, DefenderId={DefenderId}",
+                request.AttackerId, request.DefenderId);
+            network.Send(requestingPeer, new NetworkConversationDenied());
+            return false;
+        }
+
         // PvP: a party joining an existing battle (exactly one side is already in a map event) is allowed through so
         // the joining player's PlayerEncounter can attach to that battle. There is no AI party to hold for a join.
         if (attackerInMapEvent ^ defenderInMapEvent)

--- a/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkConversationDenied.cs
+++ b/source/GameInterface/Services/MapEvents/Messages/Conversation/NetworkConversationDenied.cs
@@ -1,14 +1,26 @@
-using Common.Messaging;
+﻿using Common.Messaging;
 using ProtoBuf;
 
 namespace GameInterface.Services.MapEvents.Messages.Conversation;
 
 /// <summary>
-/// Server to Client notification that a conversation request was denied because the targeted party is engaged in
-/// another player's conversation. The client shows the player why their interaction did nothing; carrying no
-/// payload, it identifies the request implicitly (one outstanding request per client at a time).
+/// Server to Client notification that a conversation request was denied. The client shows the player why their
+/// interaction did nothing; the request is identified implicitly (one outstanding request per client at a time).
 /// </summary>
 [ProtoContract(SkipConstructor = true)]
 internal readonly struct NetworkConversationDenied : ICommand
 {
+    [ProtoMember(1)]
+    public readonly ConversationDeniedReason Reason;
+
+    public NetworkConversationDenied(ConversationDeniedReason reason)
+    {
+        Reason = reason;
+    }
+}
+
+internal enum ConversationDeniedReason
+{
+    PartyEngaged,
+    PlayerUnavailable
 }

--- a/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyPrisonerTalkPatches.cs
+++ b/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyPrisonerTalkPatches.cs
@@ -1,0 +1,29 @@
+﻿using Common;
+using GameInterface.Services.Heroes.Extensions;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.ViewModelCollection.Party;
+
+namespace GameInterface.Services.MapEvents.PlayerPartyInteractions;
+
+/// <summary>Prevents the Party Screen from opening a local conversation with a captured player.</summary>
+[HarmonyPatch(typeof(PartyVM))]
+internal static class PlayerPartyPrisonerTalkPatches
+{
+    [HarmonyPatch(nameof(PartyVM.ExecuteTalk))]
+    [HarmonyPrefix]
+    private static bool ExecuteTalkPrefix(PartyVM __instance)
+    {
+        if (ModInformation.IsServer) return true;
+
+        var currentCharacter = __instance?.CurrentCharacter;
+        if (!ShouldBlockTalk(currentCharacter?.Character?.HeroObject, currentCharacter?.IsPrisoner == true))
+            return true;
+
+        ConversationPartyHold.ShowPlayerUnavailableMessage();
+        return false;
+    }
+
+    internal static bool ShouldBlockTalk(Hero hero, bool isPrisoner) =>
+        isPrisoner && hero?.IsPlayerHero() == true;
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Trying to talk to a captured player from the Party Screen could leave the captor stuck waiting for a response that the captive could not provide.

## What is the new behavior?

Resolves #2078

Talking to a captured player no longer starts an unanswered player-party conversation, so the captor can leave the Party Screen and continue playing.

## Bot Changelog Entry

- Fixed captors becoming stuck waiting for a response after trying to talk to a captured player.
