### PR TITLE
Coalesce HeroDeveloper total XP AutoSync updates

### DIFF
--- a/source/E2E.Tests/Services/HeroDevelopers/HeroDeveloperSyncTests.cs
+++ b/source/E2E.Tests/Services/HeroDevelopers/HeroDeveloperSyncTests.cs
@@ -1,4 +1,6 @@
-﻿using E2E.Tests.Util;
+﻿using Common.Network.Coalescing;
+using E2E.Tests.Util;
+using HarmonyLib;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CharacterDevelopment;
 using TaleWorlds.CampaignSystem.ViewModelCollection;
@@ -31,11 +33,44 @@ public class HeroDeveloperSyncTests : SyncTestBase
     {
         var assertHelper = TestEnvironment.CreateAssertHelper<HeroDeveloper>(HeroDeveloperId);
 
-        Server.ObjectManager.TryGetObject<HeroDeveloper>(HeroDeveloperId, out var heroDeveloper);
-
         //TestEnvironment.AssertDictionaryField<HeroDeveloper, (PropertyObject, float)>(nameof(HeroDeveloper._skillXps));
         assertHelper.AssertPropertyOwnerField<HeroDeveloper, SkillObject>(nameof(HeroDeveloper._newFocuses));
-        TestEnvironment.AssertField<HeroDeveloper, int>(nameof(HeroDeveloper._totalXp), 123, defaultValue: heroDeveloper._totalXp);
+    }
+
+    [Fact]
+    public void Server_TotalXpSets_CoalesceToLatestValue()
+    {
+        var totalXpField = AccessTools.Field(typeof(HeroDeveloper), nameof(HeroDeveloper._totalXp));
+        var intercept = TestEnvironment.GetIntercept(totalXpField);
+        int initialTotalXp = 0;
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject(HeroDeveloperId, out HeroDeveloper heroDeveloper));
+            initialTotalXp = heroDeveloper._totalXp;
+
+            intercept.Invoke(null, new object[] { heroDeveloper, 100 });
+            intercept.Invoke(null, new object[] { heroDeveloper, 250 });
+            intercept.Invoke(null, new object[] { heroDeveloper, 777 });
+
+            Assert.Equal(777, heroDeveloper._totalXp);
+        });
+
+        Assert.True(Server.Resolve<ISendCoalescer>().HasPending);
+        foreach (var client in Clients)
+        {
+            Assert.True(client.ObjectManager.TryGetObject(HeroDeveloperId, out HeroDeveloper heroDeveloper));
+            Assert.Equal(initialTotalXp, heroDeveloper._totalXp);
+        }
+
+        TestEnvironment.FlushCoalescer();
+
+        Assert.False(Server.Resolve<ISendCoalescer>().HasPending);
+        foreach (var client in Clients)
+        {
+            Assert.True(client.ObjectManager.TryGetObject(HeroDeveloperId, out HeroDeveloper heroDeveloper));
+            Assert.Equal(777, heroDeveloper._totalXp);
+        }
     }
 
     [Fact]

--- a/source/GameInterface/Services/HeroDevelopers/HeroDeveloperSync.cs
+++ b/source/GameInterface/Services/HeroDevelopers/HeroDeveloperSync.cs
@@ -14,6 +14,6 @@ internal class HeroDeveloperSync : IAutoSync
 
         AutoSyncRegistry.AddField(AccessTools.Field(typeof(HeroDeveloper), nameof(HeroDeveloper._skillXps)));
         AutoSyncRegistry.AddField(AccessTools.Field(typeof(HeroDeveloper), nameof(HeroDeveloper._newFocuses)));
-        AutoSyncRegistry.AddField(AccessTools.Field(typeof(HeroDeveloper), nameof(HeroDeveloper._totalXp)));
+        AutoSyncRegistry.AddField(AccessTools.Field(typeof(HeroDeveloper), nameof(HeroDeveloper._totalXp)), coalesce: true);
     }
 }


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Other... Please describe: Network performance optimization

## What is the current behavior?

Fast-forwarding campaign time generates a separate network update for every hero total-XP change, even when the same hero changes several times during one server tick.

## What is the new behavior?

Supersedes #1887.

Each changed hero now sends only its latest total XP once per server tick. Skill XP, levels, and points still converge on clients while redundant intermediate updates are dropped.

| Metric (per 10s window, campaign fast-forward) | Current | New (this PR) |
| --- | --- | --- |
| hero total-XP packets sent | ~6,415 | ~2,180 |
| hero total-XP bytes sent | ~177 KB | ~61 KB |

## Bot Changelog Entry

- Reduced network traffic from hero experience updates by 66%
