### PR TITLE
Cap managed servers at 60 FPS

### DIFF
--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -53,8 +53,11 @@ namespace Coop
 
         private static string ClientServerModeMessage = "";
 
+        private const int ServerFramesPerSecond = 60;
+
         private bool isServer = false;
         private bool isAutoConnect = false;
+        private FrameLimiter serverFrameLimiter;
         public override void NoHarmonyInit() 
         {
             AssemblyHellscape.CreateAssemblyBindingRedirects();
@@ -387,6 +390,24 @@ namespace Coop
 #if DEBUG
             TryAutoConnect();
 #endif
+
+            LimitServerFrameRate();
+        }
+
+        private void LimitServerFrameRate()
+        {
+            if (ModInformation.IsServer)
+            {
+                if (serverFrameLimiter == null)
+                {
+                    serverFrameLimiter = new FrameLimiter(TimeSpan.FromSeconds(1d / ServerFramesPerSecond));
+                }
+
+                serverFrameLimiter.Throttle();
+                return;
+            }
+
+            serverFrameLimiter = null;
         }
 
         private bool _managedAutoStarted = false;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

The managed server follows the same high frame limit configured for clients, so it can consume unnecessary CPU and compete with the owner’s field-battle client.

## What is the new behavior?

The managed server is capped at 60 FPS. A lower frame limit selected in Bannerlord’s existing video settings still applies, and client frame limits are unchanged.

## Bot Changelog Entry

- Managed servers now run at up to 60 FPS while respecting lower frame-limit settings.
