### PR TITLE
Reduce packet-profiler CPU overhead

### DIFF
--- a/source/Common.Tests/Logging/PacketProfileAccumulatorTests.cs
+++ b/source/Common.Tests/Logging/PacketProfileAccumulatorTests.cs
@@ -1,0 +1,96 @@
+﻿using Common.Logging;
+using Common.PacketHandlers;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Common.Tests.Logging;
+
+/// <summary>Tests the packet profiler accumulator and allocation-free profile keys.</summary>
+public class PacketProfileAccumulatorTests
+{
+    [Fact]
+    public void Record_AccumulatesPacketCountAndBytes()
+    {
+        var accumulator = new PacketProfileAccumulator();
+        var key = new PacketProfileKey(typeof(TestPacket), null);
+
+        accumulator.Record(key, 10);
+        accumulator.Record(key, 15);
+
+        var snapshot = accumulator.Drain();
+        var stats = Assert.Single(snapshot).Value;
+        Assert.Equal(2, stats.PacketsSent);
+        Assert.Equal(25, stats.BytesSent);
+        Assert.Null(accumulator.Drain());
+    }
+
+    [Fact]
+    public void Drain_SeparatesReportingWindows()
+    {
+        var accumulator = new PacketProfileAccumulator();
+        var key = new PacketProfileKey(typeof(TestPacket), null);
+
+        accumulator.Record(key, 10);
+        var first = accumulator.Drain();
+        accumulator.Record(key, 20);
+        var second = accumulator.Drain();
+
+        Assert.Equal(10, Assert.Single(first).Value.BytesSent);
+        Assert.Equal(20, Assert.Single(second).Value.BytesSent);
+    }
+
+    [Fact]
+    public void Record_IsExactUnderConcurrentWriters()
+    {
+        const int Records = 10_000;
+        var accumulator = new PacketProfileAccumulator();
+        var key = new PacketProfileKey(typeof(TestPacket), null);
+
+        Parallel.For(0, Records, _ => accumulator.Record(key, 3));
+
+        var stats = Assert.Single(accumulator.Drain()).Value;
+        Assert.Equal(Records, stats.PacketsSent);
+        Assert.Equal(Records * 3, stats.BytesSent);
+    }
+
+    [Fact]
+    public void Record_AfterWarmupAllocatesNoManagedMemory()
+    {
+        const int Records = 1_000;
+        var accumulator = new PacketProfileAccumulator();
+        var key = new PacketProfileKey(typeof(TestPacket), null);
+
+        accumulator.Record(key, 1);
+        var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+
+        for (int i = 0; i < Records; i++)
+        {
+            accumulator.Record(key, 1);
+        }
+
+        var allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+        Assert.Equal(0, allocatedBytes);
+    }
+
+    [Fact]
+    public void Name_PreservesMessagePacketGenericTypeFormatting()
+    {
+        var key = new PacketProfileKey(
+            typeof(MessagePacket),
+            typeof(TestMessage<Dictionary<string, int>>));
+
+        Assert.Equal("MessagePacket:TestMessage<Dictionary<String, Int32>>", key.Name);
+    }
+
+    /// <summary>Packet type used to exercise profiler keys.</summary>
+    private sealed class TestPacket
+    {
+    }
+
+    /// <summary>Generic message type used to verify friendly names.</summary>
+    private sealed class TestMessage<T>
+    {
+    }
+}

--- a/source/Common.Tests/Logging/PacketProfilerRoleTests.cs
+++ b/source/Common.Tests/Logging/PacketProfilerRoleTests.cs
@@ -1,0 +1,31 @@
+﻿using Common.Logging;
+using System;
+using Xunit;
+
+namespace Common.Tests.Logging;
+
+/// <summary>
+/// Verifies packet profiling stays disabled on clients.
+/// </summary>
+[Collection(ModInformationRoleCollection.Name)]
+public sealed class PacketProfilerRoleTests : IDisposable
+{
+    private readonly bool wasServer = ModInformation.IsServer;
+
+    public void Dispose()
+    {
+        ModInformation.IsServer = wasServer;
+    }
+
+    [Fact]
+    public void Record_WhenPacketIsNull_ReturnsOnClientAndThrowsOnServer()
+    {
+        using var profiler = new PacketProfiler(TimeSpan.FromDays(1));
+
+        ModInformation.IsServer = false;
+        profiler.Record(null!, 1);
+
+        ModInformation.IsServer = true;
+        Assert.Throws<ArgumentNullException>(() => profiler.Record(null!, 1));
+    }
+}

--- a/source/Common.Tests/ModInformationRoleCollection.cs
+++ b/source/Common.Tests/ModInformationRoleCollection.cs
@@ -1,0 +1,12 @@
+﻿using Xunit;
+
+namespace Common.Tests;
+
+/// <summary>
+/// Serializes tests that mutate the process-wide server/client role.
+/// </summary>
+[CollectionDefinition(nameof(ModInformationRoleCollection), DisableParallelization = true)]
+public class ModInformationRoleCollection
+{
+    public const string Name = nameof(ModInformationRoleCollection);
+}

--- a/source/Common/Logging/PacketProfiler.cs
+++ b/source/Common/Logging/PacketProfiler.cs
@@ -2,7 +2,6 @@
 using Common.Util;
 using Serilog;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -27,7 +26,7 @@ public sealed class PacketProfiler : IDisposable
     // A task to periodically dump the accumulated stats.
     private readonly Poller poller;
 
-    private readonly ConcurrentDictionary<string, Stats> stats = new ConcurrentDictionary<string, Stats>();
+    private readonly PacketProfileAccumulator stats = new PacketProfileAccumulator();
 
     /// <summary>
     /// Optional provider of a one-line live-state summary (e.g. per-peer reliable-queue depth and ping)
@@ -54,31 +53,27 @@ public sealed class PacketProfiler : IDisposable
         // Only the server profiles network traffic.
         if (ModInformation.IsClient) return;
 
-        var packetName = GetPacketName(packet);
-
-        stats.AddOrUpdate(packetName, _ => new Stats(1, byteSize), (_, existing) => existing.Add(byteSize));
+        stats.Record(PacketProfileKey.FromPacket(packet), byteSize);
     }
 
     // Dumps the accumulated stats and clears them for the next window.
     private void Poll(TimeSpan dt)
     {
-        if (stats.IsEmpty) return;
-
-        // Drain the stats into a snapshot, clearing the dictionary for the next window.
-        var snapshot = new Dictionary<string, Stats>(stats.Count);
-        foreach (var packetName in stats.Keys)
-        {
-            if (stats.TryRemove(packetName, out var packetStats))
-            {
-                snapshot[packetName] = packetStats;
-            }
-        }
+        var snapshot = stats.Drain();
+        if (snapshot == null) return;
 
         // Order by bytes sent (largest first) and format each entry as a friendly line. A list is
         // rendered in order by Serilog (a Dictionary's key order is not preserved by the sinks).
         var ordered = snapshot
-            .OrderByDescending(entry => entry.Value.BytesSent)
-            .Select(entry => $"{entry.Key}: {entry.Value.PacketsSent} packets, {entry.Value.BytesSent:N0} bytes")
+            .GroupBy(entry => entry.Key.Name)
+            .Select(group => new
+            {
+                Name = group.Key,
+                PacketsSent = group.Sum(entry => entry.Value.PacketsSent),
+                BytesSent = group.Sum(entry => entry.Value.BytesSent)
+            })
+            .OrderByDescending(entry => entry.BytesSent)
+            .Select(entry => $"{entry.Name}: {entry.PacketsSent} packets, {entry.BytesSent:N0} bytes")
             .ToList();
 
         // Average outbound throughput over the window: total bytes sent divided by the elapsed seconds.
@@ -105,17 +100,94 @@ public sealed class PacketProfiler : IDisposable
         }
     }
 
-    private static string GetPacketName(IPacket packet)
+    /// <summary>
+    /// Disposes of the PacketProfiler, stopping the periodic dump.
+    /// </summary>
+    public void Dispose()
     {
-        var packetName = packet.GetType().Name;
+        poller.Stop();
+    }
+}
 
-        // Break MessagePacket out by the message type it wraps so it is not one opaque bucket.
-        if (packet is MessagePacket messagePacket && messagePacket.MessageType != null)
+/// <summary>Accumulates packet totals and atomically separates reporting windows.</summary>
+internal sealed class PacketProfileAccumulator
+{
+    private readonly object gate = new object();
+    private Dictionary<PacketProfileKey, PacketProfileStats> stats =
+        new Dictionary<PacketProfileKey, PacketProfileStats>();
+
+    public void Record(PacketProfileKey key, int byteSize)
+    {
+        lock (gate)
         {
-            packetName += $":{GetFriendlyTypeName(messagePacket.MessageType)}";
-        }
+            if (!stats.TryGetValue(key, out var existing))
+            {
+                existing = new PacketProfileStats();
+                stats.Add(key, existing);
+            }
 
-        return packetName;
+            existing.Add(byteSize);
+        }
+    }
+
+    public Dictionary<PacketProfileKey, PacketProfileStats> Drain()
+    {
+        lock (gate)
+        {
+            if (stats.Count == 0) return null;
+
+            var snapshot = stats;
+            stats = new Dictionary<PacketProfileKey, PacketProfileStats>();
+            return snapshot;
+        }
+    }
+}
+
+/// <summary>Identifies either a packet type or one wrapped message type without formatting strings.</summary>
+internal readonly struct PacketProfileKey : IEquatable<PacketProfileKey>
+{
+    private readonly Type packetType;
+    private readonly Type messageType;
+
+    public PacketProfileKey(Type packetType, Type messageType)
+    {
+        if (packetType == null) throw new ArgumentNullException(nameof(packetType));
+
+        this.packetType = packetType;
+        this.messageType = messageType;
+    }
+
+    public string Name
+    {
+        get
+        {
+            var packetName = packetType.Name;
+            return messageType == null
+                ? packetName
+                : $"{packetName}:{GetFriendlyTypeName(messageType)}";
+        }
+    }
+
+    public static PacketProfileKey FromPacket(IPacket packet)
+    {
+        if (packet == null) throw new ArgumentNullException(nameof(packet));
+
+        // Keep wrapped messages in separate buckets without formatting their names on every send.
+        var messageType = packet is MessagePacket messagePacket ? messagePacket.MessageType : null;
+        return new PacketProfileKey(packet.GetType(), messageType);
+    }
+
+    public bool Equals(PacketProfileKey other) =>
+        packetType == other.packetType && messageType == other.messageType;
+
+    public override bool Equals(object obj) => obj is PacketProfileKey other && Equals(other);
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            return (packetType.GetHashCode() * 397) ^ (messageType?.GetHashCode() ?? 0);
+        }
     }
 
     private static string GetFriendlyTypeName(Type type)
@@ -138,27 +210,17 @@ public sealed class PacketProfiler : IDisposable
 
         return $"{name}<{string.Join(", ", argNames)}>";
     }
+}
 
-    /// <summary>
-    /// Disposes of the PacketProfiler, stopping the periodic dump.
-    /// </summary>
-    public void Dispose()
+/// <summary>Running packet count and serialized-byte total for one profile key.</summary>
+internal sealed class PacketProfileStats
+{
+    public long PacketsSent { get; private set; }
+    public long BytesSent { get; private set; }
+
+    public void Add(int byteSize)
     {
-        poller.Stop();
-    }
-
-    // Running per-type totals: how many packets were sent and their combined serialized byte size.
-    private readonly struct Stats
-    {
-        public readonly long PacketsSent;
-        public readonly long BytesSent;
-
-        public Stats(long packetsSent, long bytesSent)
-        {
-            PacketsSent = packetsSent;
-            BytesSent = bytesSent;
-        }
-
-        public Stats Add(int byteSize) => new Stats(PacketsSent + 1, BytesSent + byteSize);
+        PacketsSent++;
+        BytesSent += byteSize;
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

On the server, the enabled packet profiler formats packet and wrapped-message names and performs allocating concurrent-dictionary updates for every outgoing packet. Clients already return before recording packet statistics.

## What is the new behavior?

Server recording now uses packet and message types as keys, updates mutable counters behind a short lock, swaps the completed reporting window atomically, and formats names only when writing the ten-second report. Packet counts, byte totals, throughput, peer statistics, wrapped-message naming, and the existing client early-return are unchanged.

Matched field-battle CPU sample with one server and two clients:

| Matched combat window | Development | PR #2085 | Change |
|---|---:|---:|---:|
| Server average CPU | 30.80% | 29.92% | -2.8% |
| Server p95 CPU | 36.22% | 34.62% | -4.4% |
| Combined client average | 16.28% | 16.35% | +0.4%, noise-level |
| Combined client p95 | 20.55% | 19.63% | -4.4% |

## Bot Changelog Entry

- Reduced managed-server CPU and allocation overhead from packet profiling during busy sessions.
