### PR TITLE
Disable managed-server campaign-map visual ticks

### DIFF
--- a/source/GameInterface/Services/PartyVisuals/Patches/ServerMapVisualTickPatches.cs
+++ b/source/GameInterface/Services/PartyVisuals/Patches/ServerMapVisualTickPatches.cs
@@ -1,0 +1,40 @@
+﻿using Common;
+using HarmonyLib;
+using SandBox.View;
+using SandBox.View.Map;
+
+namespace GameInterface.Services.PartyVisuals.Patches;
+
+/// <summary>Suppresses server map rendering while preserving vanilla scene maintenance.</summary>
+[HarmonyPatch]
+internal static class ServerMapVisualTickPatches
+{
+    [HarmonyPatch(typeof(SandBoxViewVisualManager), nameof(SandBoxViewVisualManager.OnTick))]
+    [HarmonyPrefix]
+    private static bool SandBoxViewVisualManagerOnTickPrefix() => ModInformation.IsClient;
+
+    [HarmonyPatch(typeof(SandBoxViewVisualManager), nameof(SandBoxViewVisualManager.OnFrameTick))]
+    [HarmonyPrefix]
+    private static bool SandBoxViewVisualManagerOnFrameTickPrefix() => ModInformation.IsClient;
+
+    [HarmonyPatch(typeof(MapScreen), nameof(MapScreen.TickVisuals))]
+    [HarmonyPrefix]
+    private static void MapScreenTickVisualsPrefix(out bool __state)
+    {
+        __state = MapScreen.DisableVisualTicks;
+        if (ModInformation.IsServer)
+        {
+            MapScreen.DisableVisualTicks = true;
+        }
+    }
+
+    [HarmonyPatch(typeof(MapScreen), nameof(MapScreen.TickVisuals))]
+    [HarmonyFinalizer]
+    private static void MapScreenTickVisualsFinalizer(bool __state)
+    {
+        if (ModInformation.IsServer)
+        {
+            MapScreen.DisableVisualTicks = __state;
+        }
+    }
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

The managed-server process runs its own campaign-map rendering and per-frame visual updates even though each client renders a separate local map view from synchronized campaign state. That server-only rendering consumes CPU and can worsen freezes when the server owner’s client hosts a field battle on the same machine.

## What is the new behavior?

The managed-server process skips its own map rendering and per-frame visual updates while retaining scene maintenance, authoritative campaign simulation, and synchronization. Every client continues rendering its own map view through the unchanged client visual path.

## Bot Changelog Entry

- Reduced managed-server CPU usage by skipping the server process’s unused map rendering.
