### PR TITLE
Reduce client field-battle background map work

### DIFF
--- a/source/GameInterface.Tests/Services/Time/Patches/GameStateManagerPatchesTests.cs
+++ b/source/GameInterface.Tests/Services/Time/Patches/GameStateManagerPatchesTests.cs
@@ -1,0 +1,48 @@
+﻿using GameInterface.Services.Time.Patches;
+using TaleWorlds.CampaignSystem.GameState;
+using TaleWorlds.MountAndBlade;
+using Xunit;
+
+namespace GameInterface.Tests.Services.Time.Patches;
+
+/// <summary>
+/// Tests the background campaign-map tick gate used while another game state is active.
+/// </summary>
+public class GameStateManagerPatchesTests
+{
+    [Fact]
+    public void ShouldRunBackgroundCampaignSimulation_ForClientFieldBattleMission_ReturnsFalse()
+    {
+        Assert.False(GameStateManagerPatches.ShouldRunBackgroundCampaignSimulation(
+            new MissionState(),
+            isClient: true,
+            isCoopFieldBattleActive: true));
+    }
+
+    [Fact]
+    public void ShouldRunBackgroundCampaignSimulation_ForServerFieldBattleMission_ReturnsTrue()
+    {
+        Assert.True(GameStateManagerPatches.ShouldRunBackgroundCampaignSimulation(
+            new MissionState(),
+            isClient: false,
+            isCoopFieldBattleActive: true));
+    }
+
+    [Fact]
+    public void ShouldRunBackgroundCampaignSimulation_ForClientOtherMission_ReturnsTrue()
+    {
+        Assert.True(GameStateManagerPatches.ShouldRunBackgroundCampaignSimulation(
+            new MissionState(),
+            isClient: true,
+            isCoopFieldBattleActive: false));
+    }
+
+    [Fact]
+    public void ShouldRunBackgroundCampaignSimulation_ForActiveClientMap_ReturnsTrue()
+    {
+        Assert.True(GameStateManagerPatches.ShouldRunBackgroundCampaignSimulation(
+            new MapState(),
+            isClient: true,
+            isCoopFieldBattleActive: true));
+    }
+}

--- a/source/GameInterface/Services/Time/Patches/GameStateManagerPatches.cs
+++ b/source/GameInterface/Services/Time/Patches/GameStateManagerPatches.cs
@@ -1,5 +1,8 @@
-﻿using HarmonyLib;
+﻿using Common;
+using GameInterface.Services.MapEvents;
+using HarmonyLib;
 using SandBox.View.Map;
+using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.GameState;
 using TaleWorlds.Core;
 using TaleWorlds.MountAndBlade;
@@ -17,30 +20,44 @@ namespace GameInterface.Services.Time.Patches
         [HarmonyPatch(nameof(GameStateManager.OnTick))]
         static void Prefix(ref GameStateManager __instance, float dt)
         {
-            if (!(__instance.ActiveState is MapState))
-            {
-                MapState mapState = __instance.LastOrDefault<MapState>();
-                if (mapState == null) return;
+            var activeState = __instance.ActiveState;
+            if (activeState is MapState) return;
 
-                // Co-op keeps the (now backgrounded) map ticking so the world keeps simulating
-                // without pausing while another screen (clan, kingdom, inventory, crafting, etc.) is on top.
-                // Unlike vanilla, that forced tick also runs the inactive map handler's UI/input callbacks.
-                // Those callbacks read stale input and can take focus from the active screen, which triggers
-                // map hotkeys while typing and immediately clears fields such as the blacksmith weapon name.
-                // Temporarily detach the handler so campaign simulation keeps ticking without the inactive
-                // map UI. Always restore it in finally: if OnTick throws and the handler stays null, later map
-                // input and lifecycle callbacks would remain broken for the rest of the session.
-                var handler = mapState.Handler;
-                mapState.Handler = null;
-                try
-                {
-                    mapState.OnTick(dt);
-                }
-                finally
-                {
-                    mapState.Handler = handler;
-                }
+            bool isCoopFieldBattleActive =
+                Campaign.Current?.MainParty?.MapEvent?.IsFieldBattle == true &&
+                BattleSpawnGate.IsCoopBattleActive;
+            if (!ShouldRunBackgroundCampaignSimulation(
+                    activeState,
+                    ModInformation.IsClient,
+                    isCoopFieldBattleActive))
+            {
+                // Keep server-time correction live without simulating the hidden client map.
+                Campaign.Current?.TickMapTime(dt);
+                return;
             }
+
+            MapState mapState = __instance.LastOrDefault<MapState>();
+            if (mapState == null) return;
+
+            // Co-op keeps the background map simulating under non-battle screens without ticking its UI.
+            var handler = mapState.Handler;
+            mapState.Handler = null;
+            try
+            {
+                mapState.OnTick(dt);
+            }
+            finally
+            {
+                mapState.Handler = handler;
+            }
+        }
+
+        internal static bool ShouldRunBackgroundCampaignSimulation(
+            TaleWorlds.Core.GameState activeState,
+            bool isClient,
+            bool isCoopFieldBattleActive)
+        {
+            return !isClient || activeState is not MissionState || !isCoopFieldBattleActive;
         }
     }
 

--- a/source/GameInterface/Services/Time/Patches/GameStateManagerPatches.cs
+++ b/source/GameInterface/Services/Time/Patches/GameStateManagerPatches.cs
@@ -31,8 +31,6 @@ namespace GameInterface.Services.Time.Patches
                     ModInformation.IsClient,
                     isCoopFieldBattleActive))
             {
-                // Keep server-time correction live without simulating the hidden client map.
-                Campaign.Current?.TickMapTime(dt);
                 return;
             }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

During a field battle, the battle client also runs the inactive campaign map’s map-state, save-check, and encounter-menu bookkeeping every mission frame. On the same machine as the server, that extra work can worsen freezes for everyone.

## What is the new behavior?

During an active co-op field battle, the battle client now skips the inactive map’s full tick, including its map-state, save-check, and encounter-menu bookkeeping. Campaign-time correction remains pending during the battle and applies on the next normal map tick after returning to the map, matching the previous client timing behavior. This narrower path applies only to field-battle clients; servers, active maps, menus, sieges, and other missions retain the previous background tick.

## Bot Changelog Entry

- Reduced battle-host client CPU usage by skipping inactive map bookkeeping during field battles.
