### PR TITLE
[2020] Fix mounted ranged combat XP

### DIFF
--- a/source/E2E.Tests/Services/Missions/BattleSpawnGateTests.cs
+++ b/source/E2E.Tests/Services/Missions/BattleSpawnGateTests.cs
@@ -1,4 +1,4 @@
-using GameInterface.Services.MapEvents;
+﻿using GameInterface.Services.MapEvents;
 using TaleWorlds.Core;
 
 namespace E2E.Tests.Services.Missions;
@@ -54,5 +54,24 @@ public class BattleSpawnGateTests : IDisposable
 
         Assert.False(BattleSpawnGate.IsMissingReserveSideAccepted(BattleSideEnum.Defender));
         Assert.False(BattleSpawnGate.IsMissingReserveSideAccepted(BattleSideEnum.Attacker));
+    }
+
+    [Fact]
+    public void RoutedAttackerWeapon_IsScopedAndRestored()
+    {
+        var outerWeapon = new WeaponComponentData(null, WeaponClass.Arrow, default);
+        var innerWeapon = new WeaponComponentData(null, WeaponClass.Bolt, default);
+
+        Assert.Null(BattleSpawnGate.RoutedAttackerWeapon);
+
+        BattleSpawnGate.RunWithRoutedAttackerWeapon(outerWeapon, () =>
+        {
+            Assert.Same(outerWeapon, BattleSpawnGate.RoutedAttackerWeapon);
+            BattleSpawnGate.RunWithRoutedAttackerWeapon(innerWeapon,
+                () => Assert.Same(innerWeapon, BattleSpawnGate.RoutedAttackerWeapon));
+            Assert.Same(outerWeapon, BattleSpawnGate.RoutedAttackerWeapon);
+        });
+
+        Assert.Null(BattleSpawnGate.RoutedAttackerWeapon);
     }
 }

--- a/source/E2E.Tests/Services/Missions/NetworkAgentShootSerializationTests.cs
+++ b/source/E2E.Tests/Services/Missions/NetworkAgentShootSerializationTests.cs
@@ -62,7 +62,7 @@ public class NetworkAgentShootSerializationTests
     }
 
     [Fact]
-    public void NetworkApplyBattleDamage_RoundTripsMissileShotSequence()
+    public void NetworkApplyBattleDamage_RoundTripsMissileContext()
     {
         var blow = new Blow(17)
         {
@@ -71,13 +71,15 @@ public class NetworkAgentShootSerializationTests
         };
         blow.WeaponRecord._isMissile = true;
         blow.WeaponRecord.AffectorWeaponSlotOrMissileIndex = 42;
+        var attackerWeapon = new WeaponComponentData(null, WeaponClass.Arrow, default);
 
         var original = new NetworkApplyBattleDamage(
             Guid.NewGuid(),
             Guid.NewGuid(),
             blow,
             default,
-            missileShotSequence: 4_500_000_123L);
+            missileShotSequence: 4_500_000_123L,
+            attackerWeapon: attackerWeapon);
 
         var serializer = new ProtoBufSerializer(new SerializableTypeMapper());
         MessagePacket packet = MessagePacket.Create(original, serializer);
@@ -88,5 +90,7 @@ public class NetworkAgentShootSerializationTests
         Assert.Equal(original.AttackerAgentId, result.AttackerAgentId);
         Assert.True(result.IsMissile);
         Assert.Equal(4_500_000_123L, result.MissileShotSequence);
+        Assert.NotNull(result.AttackerWeapon);
+        Assert.Equal(WeaponClass.Arrow, result.AttackerWeapon.WeaponClass);
     }
 }

--- a/source/GameInterface/Services/MapEvents/BattleSpawnGate.cs
+++ b/source/GameInterface/Services/MapEvents/BattleSpawnGate.cs
@@ -81,7 +81,7 @@ public static class BattleSpawnGate
     /// </summary>
     public static Func<Agent, bool?> MountAuthorityProbe { get; set; }
 
-    /// <summary>Runs a routed blow with its original missile weapon available to the hit-reward patch.</summary>
+    /// <summary>Temporarily exposes a routed missile's serialized weapon while vanilla calculates hit rewards.</summary>
     public static void RunWithRoutedAttackerWeapon(WeaponComponentData attackerWeapon, Action applyBlow)
     {
         var previousWeapon = _routedAttackerWeapon;

--- a/source/GameInterface/Services/MapEvents/BattleSpawnGate.cs
+++ b/source/GameInterface/Services/MapEvents/BattleSpawnGate.cs
@@ -51,6 +51,9 @@ public static class BattleSpawnGate
     [System.ThreadStatic]
     private static int _currentRoutedPlayerHitDamage;
 
+    [System.ThreadStatic]
+    private static WeaponComponentData _routedAttackerWeapon;
+
     /// <summary>
     /// Set around a puppet spawn (<c>CoopBattleController.SpawnPuppet</c>) so the spawn-capture patch does NOT
     /// re-capture and re-broadcast it — only locally owned native spawns should be captured. Thread-local: it
@@ -77,6 +80,23 @@ public static class BattleSpawnGate
     /// rider-keyed gating. Process-global like the rest of this gate: one live battle per game process.
     /// </summary>
     public static Func<Agent, bool?> MountAuthorityProbe { get; set; }
+
+    /// <summary>Runs a routed blow with its original missile weapon available to the hit-reward patch.</summary>
+    public static void RunWithRoutedAttackerWeapon(WeaponComponentData attackerWeapon, Action applyBlow)
+    {
+        var previousWeapon = _routedAttackerWeapon;
+        _routedAttackerWeapon = attackerWeapon;
+        try
+        {
+            applyBlow();
+        }
+        finally
+        {
+            _routedAttackerWeapon = previousWeapon;
+        }
+    }
+
+    public static WeaponComponentData RoutedAttackerWeapon => _routedAttackerWeapon;
 
     /// <summary>Runs a replicated puppet death with the owner's kill-feed metadata available to UI patches.</summary>
     public static void RunWithReplicatedDeath(
@@ -318,6 +338,7 @@ public static class BattleSpawnGate
         }
 
         EndCombatLog();
+        _routedAttackerWeapon = null;
     }
 
     private static void RemoveExpiredRoutedPlayerHitNotifications()

--- a/source/GameInterface/Services/MapEvents/Patches/BattleAgentLogicPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/BattleAgentLogicPatches.cs
@@ -20,6 +20,9 @@ internal class BattleAgentLogicHitRewardPatch
     {
         if (ModInformation.IsServer) return true;
 
+        if (lastAttackerWeapon == null)
+            lastAttackerWeapon = BattleSpawnGate.RoutedAttackerWeapon;
+
         if (affectedAgent.Origin == null || affectorAgent == null || affectorAgent.Origin == null || affectorAgent.Team == null || !affectorAgent.Team.IsValid || affectedAgent.Team == null || !affectedAgent.Team.IsValid)
             return false;
 

--- a/source/Missions/Battles/BattleDamageRouter.cs
+++ b/source/Missions/Battles/BattleDamageRouter.cs
@@ -210,6 +210,8 @@ public class BattleDamageRouter : IBattleDamageRouter
             int missileIndex = payload.What.Blow.WeaponRecord.AffectorWeaponSlotOrMissileIndex;
             if (Mission.Current?._missilesDictionary.TryGetValue(missileIndex, out var missile) == true)
                 attackerWeapon = missile.Weapon.CurrentUsageItem;
+            else
+                Logger.Error("Failed to resolve routed missile weapon at source index {MissileIndex}", missileIndex);
 
             if (coopMissionComponent.MissileHandler.TryTakeLocalShot(missileIndex,
                 out Guid shotAgentId, out shotSequence))

--- a/source/Missions/Battles/BattleDamageRouter.cs
+++ b/source/Missions/Battles/BattleDamageRouter.cs
@@ -1,4 +1,4 @@
-using Common;
+﻿using Common;
 using Common.Logging;
 using Common.Messaging;
 using GameInterface.Services.MapEvents;
@@ -204,9 +204,13 @@ public class BattleDamageRouter : IBattleDamageRouter
         }
 
         long shotSequence = 0;
+        WeaponComponentData attackerWeapon = null;
         if (payload.What.Blow.IsMissile)
         {
             int missileIndex = payload.What.Blow.WeaponRecord.AffectorWeaponSlotOrMissileIndex;
+            if (Mission.Current?._missilesDictionary.TryGetValue(missileIndex, out var missile) == true)
+                attackerWeapon = missile.Weapon.CurrentUsageItem;
+
             if (coopMissionComponent.MissileHandler.TryTakeLocalShot(missileIndex,
                 out Guid shotAgentId, out shotSequence))
             {
@@ -231,7 +235,7 @@ public class BattleDamageRouter : IBattleDamageRouter
             {
                 network.SendAll(new NetworkApplyBattleDamage(victimInfo.AgentId, attackerId,
                     payload.What.Blow, payload.What.CollisionData,
-                    missileShotSequence: shotSequence));
+                    missileShotSequence: shotSequence, attackerWeapon: attackerWeapon));
                 return;
             }
 
@@ -240,7 +244,7 @@ public class BattleDamageRouter : IBattleDamageRouter
             {
                 network.SendAll(new NetworkApplyBattleDamage(riderInfo.AgentId, attackerId,
                     payload.What.Blow, payload.What.CollisionData, isMount: true,
-                    missileShotSequence: shotSequence));
+                    missileShotSequence: shotSequence, attackerWeapon: attackerWeapon));
                 return;
             }
 
@@ -425,7 +429,8 @@ public class BattleDamageRouter : IBattleDamageRouter
 
         Logger.Information("[BattleSync] Applying routed blow to {Agent}: dmg={Damage}, missile={Missile}, health={Health}",
             victim.Name, blow.InflictedDamage, wasMissile, victim.Health);
-        victim.RegisterBlow(blow, in collisionData);
+        BattleSpawnGate.RunWithRoutedAttackerWeapon(damage.AttackerWeapon,
+            () => victim.RegisterBlow(blow, in collisionData));
 
         if (victim.Health > 0 && victim.Character is CharacterObject character && character.IsHero
             && character.HeroObject is Hero hero)

--- a/source/Missions/Messages/NetworkApplyBattleDamage.cs
+++ b/source/Missions/Messages/NetworkApplyBattleDamage.cs
@@ -1,6 +1,7 @@
-using Common.Messaging;
+﻿using Common.Messaging;
 using ProtoBuf;
 using System;
+using TaleWorlds.Core;
 using TaleWorlds.MountAndBlade;
 
 namespace Missions.Messages;
@@ -46,8 +47,11 @@ public class NetworkApplyBattleDamage : IEvent
     /// </summary>
     [ProtoMember(7)]
     public bool IsMissile { get; }
+    /// <summary>The original missile weapon used by vanilla to select the combat skill reward.</summary>
+    [ProtoMember(8)]
+    public WeaponComponentData AttackerWeapon { get; }
     public NetworkApplyBattleDamage(Guid victimAgentId, Guid attackerAgentId, Blow blow, AttackCollisionData collisionData,
-        bool isMount = false, long missileShotSequence = 0)
+        bool isMount = false, long missileShotSequence = 0, WeaponComponentData attackerWeapon = null)
     {
         VictimAgentId = victimAgentId;
         AttackerAgentId = attackerAgentId;
@@ -56,5 +60,6 @@ public class NetworkApplyBattleDamage : IEvent
         IsMount = isMount;
         MissileShotSequence = missileShotSequence;
         IsMissile = blow.IsMissile;
+        AttackerWeapon = attackerWeapon;
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Mounted players can receive Athletics XP when their ranged attacks hit enemies owned by another client.

## What is the new behavior?

Resolves #2020

Mounted ranged hits now award the weapon skill and Riding XP without incorrectly awarding Athletics XP. Dismounted ranged hits continue to award Athletics XP normally.

## Bot Changelog Entry

- Fixed mounted ranged attacks incorrectly granting Athletics XP.
