### PR TITLE
Fix E2E Cross Test State Leaks

### DIFF
--- a/source/E2E.Tests/Environment/E2ETestEnvironment.cs
+++ b/source/E2E.Tests/Environment/E2ETestEnvironment.cs
@@ -75,24 +75,33 @@ public class E2ETestEnvironment : IDisposable
             if (disposed) return;
             disposed = true;
 
-            if (AutoSyncConfiguration.Enabled)
+            try
             {
-                Server.Resolve<AutoSyncHandler>().Dispose();
+                if (AutoSyncConfiguration.Enabled)
+                {
+                    Server.Resolve<AutoSyncHandler>().Dispose();
+                    foreach (var client in Clients)
+                    {
+                        client.Resolve<AutoSyncHandler>().Dispose();
+                    }
+                }
+
+                Server.Dispose();
+
                 foreach (var client in Clients)
                 {
-                    client.Resolve<AutoSyncHandler>().Dispose();
+                    client.Dispose();
                 }
             }
-
-            Server.Dispose();
-
-            foreach (var client in Clients)
+            finally
             {
-                client.Dispose();
+                // Must run even when a disposal above throws: a live container left in ContainerProvider
+                // makes CallOriginalPolicy deny originals for every later environment-less test in the
+                // process (the shared Harmony patches stay applied), silently corrupting game-object
+                // construction there.
+                OutputSinkManager.RemoveLogCallback(TestOutputCallback);
+                ContainerProvider.Clear();
             }
-
-            OutputSinkManager.RemoveLogCallback(TestOutputCallback);
-            ContainerProvider.Clear();
         }
         finally
         {

--- a/source/E2E.Tests/Services/Missions/Tournaments/TournamentMissionRulesTests.cs
+++ b/source/E2E.Tests/Services/Missions/Tournaments/TournamentMissionRulesTests.cs
@@ -1,3 +1,4 @@
+using Common.Util;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Tournaments;
 using GameInterface.Services.Tournaments.Data;
@@ -58,17 +59,26 @@ public class TournamentMissionRulesTests
         string controllerId,
         Guid mountId = default,
         string mountCharacterId = "horse-character")
-        => new TournamentAgentSpawnData(
-            agentId, slotId, characterId, seed, teamId, color, null, controllerId,
-            EquipmentAt(EquipmentIndex.WeaponItemBeginSlot, new ItemObject("weapon")),
-            new Vec3(1, 2, 3), new Vec2(0, 1), 100,
-            mountId,
-            mountId == Guid.Empty ? null : mountCharacterId,
-            77,
-            mountId == Guid.Empty
-                ? Array.Empty<EquipmentElement>()
-                : EquipmentAt(EquipmentIndex.Horse, new ItemObject("horse-item")),
-            mountId == Guid.Empty ? 0 : 90);
+    {
+        // This class runs without a test environment, but the process-wide Harmony patches from earlier
+        // environment-based tests stay applied, and MBObjectBasePatches gates the StringId setter on the
+        // ambient sync policy. AllowedThread makes ItemObject construction run the original regardless of
+        // what container state a previously-run test left behind.
+        using (new AllowedThread())
+        {
+            return new TournamentAgentSpawnData(
+                agentId, slotId, characterId, seed, teamId, color, null, controllerId,
+                EquipmentAt(EquipmentIndex.WeaponItemBeginSlot, new ItemObject("weapon")),
+                new Vec3(1, 2, 3), new Vec2(0, 1), 100,
+                mountId,
+                mountId == Guid.Empty ? null : mountCharacterId,
+                77,
+                mountId == Guid.Empty
+                    ? Array.Empty<EquipmentElement>()
+                    : EquipmentAt(EquipmentIndex.Horse, new ItemObject("horse-item")),
+                mountId == Guid.Empty ? 0 : 90);
+        }
+    }
 
     private static EquipmentElement[] EquipmentAt(EquipmentIndex index, ItemObject item)
     {

--- a/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyInteractionHandler.cs
+++ b/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyInteractionHandler.cs
@@ -116,6 +116,11 @@ internal class PlayerPartyInteractionHandler : IHandler
         messageBroker.Unsubscribe<NetworkPlayerPartyTradeOfferUpdated>(Handle_NetworkPlayerPartyTradeOfferUpdated);
         messageBroker.Unsubscribe<NetworkPlayerPartyTradeAcceptChanged>(Handle_NetworkPlayerPartyTradeAcceptChanged);
         messageBroker.Unsubscribe<PlayerDisconnected>(Handle_PlayerDisconnected);
+
+        // The dialog state is a process-wide static, not container state: a session that ends mid-dialog
+        // would otherwise leave HasActiveState set after this handler's container is torn down, and
+        // ConversationRequestHandler silently drops every conversation request while it is set.
+        PlayerPartyInteractionDialogState.Clear();
     }
 
     public bool TryStartSession(


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?

Two E2E tests fail in CI depending on xUnit test-class order (which shifts between builds), while always passing when run solo or per-class. Both were failing on the `FixClanBannersNotShowingInBattles` PR (#2088) through no fault of that branch:

1. **`VillageHostileActionTests.ActiveSlowRaidMapEvent_StartSettlementEncounterRequestsJoinConversation`** — fails with `Sequence contains no elements`. `PlayerPartyInteractionDialogState` is a process-wide static; several `PlayerPartyInteractionFlowTests` end mid-dialog and leave `HasActiveState = true` after their environment is torn down. `ConversationRequestHandler.Handle_ConversationRequested` silently drops every conversation request while that flag is set, so the village test's `NetworkRequestConversation` never gets sent when the flow tests run earlier in the same process. This is also a real game bug: leaving a coop session mid-dialog left the flag set for the rest of the process, silently blocking all later encounter conversations.

2. **`TournamentMissionRulesTests.MountedManifest_RoundTripsExactMountIdentityAndRejectsNullAgentArrays`** — fails with `Expected: "horse-item" / Actual: null`. The class runs without a test environment, but the process-wide Harmony patches from earlier environment-based tests stay applied. `MBObjectBasePatches` gates the `MBObjectBase.StringId` **setter** on the ambient sync policy, and `new ItemObject("...")` routes through it. When a previous teardown leaks a live container into `ContainerProvider` (E2E's `TestPolicy` denies all originals), the setter is silently skipped and the item's `StringId` stays null. `E2ETestEnvironment.Dispose` could leak exactly that way: any throw during teardown skipped `ContainerProvider.Clear()`.

## What is the new behavior?

- `PlayerPartyInteractionHandler.Dispose()` clears `PlayerPartyInteractionDialogState`, so the dialog state cannot outlive its session (fixes the game-side leak) or leak across test environments (fixes the village test).
- `TournamentMissionRulesTests` builds its spawn manifest under an `AllowedThread`, making game-object construction immune to whatever container/policy state a previously-run test left behind.
- `E2ETestEnvironment.Dispose` runs `ContainerProvider.Clear()` (and the log-callback removal) in a `finally`, so a throwing disposal can no longer poison later environment-less tests.

Both mechanisms were reproduced deterministically with a forced-order harness (running the polluting test and the victim test in one process): the village test fails after a mid-dialog flow test and passes with the fix; `new ItemObject("probe").StringId` is null under a leaked deny-policy container and the hardened tournament test passes regardless.

Verification: full E2E suite 694 passed / 0 failed / 4 skipped; GameInterface.Tests 576 passed; Coop.Tests 431 passed; Coop.IntegrationTests 114 passed.

## Bot Changelog Entry

- Fixed flakey test

## Other information

Cherry-picked from the two fix commits originally pushed to `FixClanBannersNotShowingInBattles`; that branch is being reset to its own work so it no longer carries these commits.
