### PR TITLE
[2066] Fix AI-only siege assault simulation

### DIFF
--- a/source/E2E.Tests/Services/MapEvents/MapEventUpdateAuthorityTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/MapEventUpdateAuthorityTests.cs
@@ -1,0 +1,82 @@
+﻿using Common.Util;
+using E2E.Tests.Util;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem.MapEvents;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Settlements;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace E2E.Tests.Services.MapEvents;
+
+/// <summary>
+/// Verifies which map-event participant types allow the server's native campaign simulation to advance.
+/// </summary>
+public class MapEventUpdateAuthorityTests : MapEventTestBase
+{
+    public MapEventUpdateAuthorityTests(ITestOutputHelper output) : base(output) { }
+
+    [Fact]
+    public void AiOnlyMapEvent_WithSettlementParty_ServerUpdateIsAllowed()
+    {
+        var context = CreateServerMapEvent();
+        var settlementId = TestEnvironment.CreateRegisteredObject<Settlement>();
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<MapEvent>(context.MapEventId, out var mapEvent));
+            Assert.True(Server.ObjectManager.TryGetObject<Settlement>(settlementId, out var settlement));
+
+            AddSyntheticMapEventParty(mapEvent.DefenderSide, settlement.Party);
+
+            Assert.True(InvokeMapEventUpdatePrefix(mapEvent));
+        }, MapEventDisabledMethods);
+    }
+
+    [Fact]
+    public void MapEvent_WithPlayerMobileParty_ServerUpdateIsBlocked()
+    {
+        var context = CreateServerMapEvent();
+        var (_, playerPartyId) = CreatePlayerHeroParty("player");
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<MapEvent>(context.MapEventId, out var mapEvent));
+            Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(playerPartyId, out var playerParty));
+
+            AddSyntheticMapEventParty(mapEvent.AttackerSide, playerParty.Party);
+
+            Assert.False(InvokeMapEventUpdatePrefix(mapEvent));
+        }, MapEventDisabledMethods);
+    }
+
+    [Fact]
+    public void MapEvent_WithMissingParty_ServerUpdateIsBlocked()
+    {
+        var context = CreateServerMapEvent();
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<MapEvent>(context.MapEventId, out var mapEvent));
+
+            mapEvent.DefenderSide._battleParties.Add(ObjectHelper.SkipConstructor<MapEventParty>());
+
+            Assert.False(InvokeMapEventUpdatePrefix(mapEvent));
+        }, MapEventDisabledMethods);
+    }
+
+    private static void AddSyntheticMapEventParty(MapEventSide side, PartyBase party)
+    {
+        party._mapEventSide = side;
+        side._battleParties.Add(new MapEventParty(party));
+    }
+
+    private static bool InvokeMapEventUpdatePrefix(MapEvent mapEvent)
+    {
+        var patchType = AccessTools.TypeByName("GameInterface.Services.MapEvents.Patches.MapEventPatches");
+        var prefix = AccessTools.Method(patchType, "PrefixUpdate");
+        Assert.NotNull(prefix);
+
+        return (bool)prefix.Invoke(null, new object[] { mapEvent })!;
+    }
+}

--- a/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
@@ -223,13 +223,13 @@ internal class MapEventPatches
                 return true;
         }
 
-        // Skip if any parties are not set
-        if (__instance.InvolvedParties.Any(x => x?.MobileParty is null))
+        // A settlement PartyBase is a complete participant even though it has no MobileParty.
+        if (__instance.InvolvedParties.Any(x => x is null || (!x.IsMobile && !x.IsSettlement)))
             return false;
 
         // Don't update if a player is involved
         // Prevents server from instantly finishing the battle and waits for client finish request
-        if (__instance.InvolvedParties.Any(x => !x.MobileParty.IsControlledByThisInstance()))
+        if (__instance.InvolvedParties.Any(x => x.IsMobile && !x.MobileParty.IsControlledByThisInstance()))
             return false;
 
         return true;

--- a/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
+++ b/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
@@ -2,6 +2,7 @@
 using Common;
 using Common.Logging;
 using GameInterface.Services.MapEvents;
+using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Services.ObjectManager;
 using Serilog;
 using System;
@@ -9,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Settlements;
 using static TaleWorlds.Library.CommandLineFunctionality;
@@ -72,7 +74,8 @@ public class SiegeDebugCommand
         else
         {
             besieger = MobileParty.AllLordParties
-                .Where(party => party.MapFaction?.IsAtWarWith(settlement.MapFaction) == true
+                .Where(party => !party.IsPlayerParty()
+                    && party.MapFaction?.IsAtWarWith(settlement.MapFaction) == true
                     && party.LeaderHero != null && party.CurrentSettlement == null
                     && party.MapEvent == null && party.BesiegerCamp == null && party.Army == null)
                 .OrderByDescending(party => party.Party.CalculateCurrentStrength())
@@ -89,6 +92,66 @@ public class SiegeDebugCommand
         Campaign.Current.SiegeEventManager.StartSiegeEvent(settlement, besieger);
 
         return $"{besieger.Name} ({besieger.StringId}) is now besieging {settlement.Name}";
+    }
+
+    /// <summary>
+    /// Starts the wall assault for an existing AI-led siege. Server only; the resulting map event uses the
+    /// same authoritative action as campaign AI.
+    /// </summary>
+    [CommandLineArgumentFunction("assault", "coop.debug.siege")]
+    public static string StartAssault(List<string> args)
+    {
+        if (args.Count != 1)
+        {
+            return "Usage: coop.debug.siege.assault <settlementId>";
+        }
+
+        if (ModInformation.IsClient)
+        {
+            return "This command can only be used by the server";
+        }
+
+        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
+        {
+            return "Unable to resolve ObjectManager";
+        }
+
+        if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
+        {
+            return $"Settlement with id {args[0]} not found";
+        }
+
+        var attacker = settlement.SiegeEvent?.BesiegerCamp?.LeaderParty;
+        if (attacker == null)
+        {
+            return $"{settlement.Name} has no active siege leader";
+        }
+
+        if (attacker.IsPlayerParty())
+        {
+            return $"{settlement.Name} is player-led; this command only starts AI assaults";
+        }
+
+        if (attacker.MapEvent != null)
+        {
+            return $"{attacker.Name} is already in an active map event";
+        }
+
+        if (settlement.Party.MapEvent != null)
+        {
+            return $"{settlement.Name} already has an active map event";
+        }
+
+        StartBattleAction.ApplyStartAssaultAgainstWalls(attacker, settlement);
+
+        var mapEvent = settlement.Party.MapEvent;
+        if (mapEvent?.IsSiegeAssault != true)
+        {
+            return $"Failed to start an AI siege assault against {settlement.Name}";
+        }
+
+        var mapEventId = objectManager.TryGetId(mapEvent, out string id) ? id : mapEvent.StringId;
+        return $"Started AI siege assault by {attacker.Name} against {settlement.Name} (MapEvent {mapEventId})";
     }
 
     // coop.debug.siege.list


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

AI-only siege assaults do not progress, so neither side takes simulated casualties and the battle never ends.

## What is the new behavior?

Resolves #2066

AI-only siege assaults now simulate normally while player-involved map events continue waiting for the controlling client. A server debug command can start the assault phase directly for runtime testing.

## Bot Changelog Entry

- Fixed AI-only siege assaults getting stuck without simulated casualties.
