### PR TITLE
[2060] Preserve player age when joining

### DIFF
--- a/source/GameInterface/Services/Heroes/Interfaces/HeroInterface.cs
+++ b/source/GameInterface/Services/Heroes/Interfaces/HeroInterface.cs
@@ -157,6 +157,9 @@ internal class HeroInterface : IHeroInterface
 
     private void SetupNewHero(Hero hero, Action<Hero> assignNetworkIds)
     {
+        // Player birth dates come from a separate character-creation campaign, so rebase them to this campaign.
+        hero.SetBirthDay(CampaignTime.YearsFromNow(-hero._defaultAge));
+
         var party = hero.PartyBelongedTo;
 
         party.Anchor = new AnchorPoint(party);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

A newly created player can appear in the encyclopedia with an impossible negative age, such as -2640.

## What is the new behavior?

Resolves #2060

New player heroes keep the age chosen during character creation on the server and every client.

## Bot Changelog Entry

- Player characters now keep the correct age after joining a campaign.
