### PR TITLE
Fix unpaid morale on clients + notification

### DIFF
--- a/source/GameInterface/Services/Clans/Patches/ClanDefaultClanFinanceModelPatches.cs
+++ b/source/GameInterface/Services/Clans/Patches/ClanDefaultClanFinanceModelPatches.cs
@@ -7,7 +7,6 @@ using System;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.GameComponents;
 using TaleWorlds.CampaignSystem.Party;
-using TaleWorlds.Library;
 
 namespace GameInterface.Services.Clans.Patches;
 

--- a/source/GameInterface/Services/Clans/Patches/ClanDefaultClanFinanceModelPatches.cs
+++ b/source/GameInterface/Services/Clans/Patches/ClanDefaultClanFinanceModelPatches.cs
@@ -3,9 +3,11 @@ using GameInterface.Services.Clans.Interfaces;
 using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Services.UI.Notifications.Messages;
 using HarmonyLib;
+using System;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.GameComponents;
 using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.Library;
 
 namespace GameInterface.Services.Clans.Patches;
 
@@ -35,13 +37,23 @@ internal class DefaultClanFinanceModelPatches
         return false;
     }
 
+    [ThreadStatic]
+    private static float initialRecentEventsMorale;
+
+    [HarmonyPatch(nameof(DefaultClanFinanceModel.ApplyMoraleEffect))]
+    [HarmonyPrefix]
+    public static void ApplyMoraleEffectPrefix(DefaultClanFinanceModel __instance, MobileParty mobileParty, int wage, int paymentAmount)
+    {
+        initialRecentEventsMorale = mobileParty.RecentEventsMorale;
+    }
+
     [HarmonyPatch(nameof(DefaultClanFinanceModel.ApplyMoraleEffect))]
     [HarmonyPostfix]
     public static void ApplyMoraleEffectPostfix(DefaultClanFinanceModel __instance, MobileParty mobileParty, int wage, int paymentAmount)
     {
         if (paymentAmount < wage && wage > 0 && mobileParty.IsPlayerParty())
         {
-            MessageBroker.Instance.Publish(__instance, new NotifyMoraleLossDueToFunds(mobileParty));
+            MessageBroker.Instance.Publish(__instance, new NotifyMoraleLossDueToFunds(mobileParty, mobileParty.RecentEventsMorale - initialRecentEventsMorale));
         }
     }
 }

--- a/source/GameInterface/Services/Clans/Patches/ClanDefaultClanFinanceModelPatches.cs
+++ b/source/GameInterface/Services/Clans/Patches/ClanDefaultClanFinanceModelPatches.cs
@@ -1,7 +1,14 @@
-﻿using GameInterface.Services.Clans.Interfaces;
+﻿using Common.Messaging;
+using GameInterface.Services.Clans.Interfaces;
+using GameInterface.Services.MobileParties.Extensions;
+using GameInterface.Services.UI.Notifications.Messages;
 using HarmonyLib;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.GameComponents;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
+using TaleWorlds.Localization;
 
 namespace GameInterface.Services.Clans.Patches;
 
@@ -29,5 +36,15 @@ internal class DefaultClanFinanceModelPatches
         financeModelInterface.CalculateClanIncomeInternal(__instance, clan, ref goldChange, applyWithdrawals, includeDetails);
 
         return false;
+    }
+
+    [HarmonyPatch(nameof(DefaultClanFinanceModel.ApplyMoraleEffect))]
+    [HarmonyPostfix]
+    public static void ApplyMoraleEffectPostfix(DefaultClanFinanceModel __instance, MobileParty mobileParty, int wage, int paymentAmount)
+    {
+        if (paymentAmount < wage && wage > 0 && mobileParty.IsPlayerParty())
+        {
+            MessageBroker.Instance.Publish(__instance, new NotifyMoraleLossDueToFunds(mobileParty));
+        }
     }
 }

--- a/source/GameInterface/Services/Clans/Patches/ClanDefaultClanFinanceModelPatches.cs
+++ b/source/GameInterface/Services/Clans/Patches/ClanDefaultClanFinanceModelPatches.cs
@@ -6,9 +6,6 @@ using HarmonyLib;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.GameComponents;
 using TaleWorlds.CampaignSystem.Party;
-using TaleWorlds.Core;
-using TaleWorlds.Library;
-using TaleWorlds.Localization;
 
 namespace GameInterface.Services.Clans.Patches;
 

--- a/source/GameInterface/Services/MobileParties/MobilePartySync.cs
+++ b/source/GameInterface/Services/MobileParties/MobilePartySync.cs
@@ -1,5 +1,6 @@
 ﻿using GameInterface.AutoSync;
 using HarmonyLib;
+using TaleWorlds.CampaignSystem.GameComponents;
 using TaleWorlds.CampaignSystem.Party;
 
 namespace GameInterface.Services.MobileParties;
@@ -8,7 +9,7 @@ internal class MobilePartySync : IAutoSync
     public MobilePartySync(AutoSyncRegistry autoSyncBuilder)
     {
         // Sync Fields
-        //autoSyncBuilder.AddTargetMethod(typeof(MobileParty), AccessTools.Method(typeof(DefaultClanFinanceModel), nameof(DefaultClanFinanceModel.ApplyMoraleEffect)));
+        autoSyncBuilder.AddTargetMethod(typeof(MobileParty), AccessTools.Method(typeof(DefaultClanFinanceModel), nameof(DefaultClanFinanceModel.ApplyMoraleEffect)));
         autoSyncBuilder.AddTargetMethod(typeof(MobileParty), AccessTools.Method(typeof(MobilePartyAi), nameof(MobilePartyAi.GetFleeBehavior)));
 
         autoSyncBuilder.AddField(AccessTools.Field(typeof(MobileParty), nameof(MobileParty.HasUnpaidWages)));

--- a/source/GameInterface/Services/UI/Notifications/Handlers/OtherNotificationsHandler.cs
+++ b/source/GameInterface/Services/UI/Notifications/Handlers/OtherNotificationsHandler.cs
@@ -324,7 +324,7 @@ internal class OtherNotificationsHandler : IHandler
         {
             if (!objectManager.TryGetIdWithLogging(obj.What.MobileParty, out var mobilePartyId)) return;
 
-            network.SendAll(new NetworkNotifyMoraleLossDueToFunds(mobilePartyId));
+            network.SendAll(new NetworkNotifyMoraleLossDueToFunds(mobilePartyId, obj.What.MoraleChange));
         });
     }
 
@@ -336,6 +336,7 @@ internal class OtherNotificationsHandler : IHandler
 
             if (mobileParty != MobileParty.MainParty) return;
 
+            MBTextManager.SetTextVariable("reg1", MathF.Round(MathF.Abs(obj.What.MoraleChange), 1), 2);
             MBInformationManager.AddQuickInformation(GameTexts.FindText("str_party_loses_moral_due_to_insufficent_funds", null), 0, null, null, "");
         });
     }

--- a/source/GameInterface/Services/UI/Notifications/Handlers/OtherNotificationsHandler.cs
+++ b/source/GameInterface/Services/UI/Notifications/Handlers/OtherNotificationsHandler.cs
@@ -57,6 +57,9 @@ internal class OtherNotificationsHandler : IHandler
         messageBroker.Subscribe<NotifyRelationsIncreasedWithNotables>(Handle_NotifyRelationsIncreasedWithNotables);
         messageBroker.Subscribe<NetworkNotifyRelationsIncreasedWithNotables>(Handle_NetworkNotifyRelationsIncreasedWithNotables);
 
+        messageBroker.Subscribe<NotifyMoraleLossDueToFunds>(Handle_NotifyMoraleLossDueToFunds);
+        messageBroker.Subscribe<NetworkNotifyMoraleLossDueToFunds>(Handle_NetworkNotifyMoraleLossDueToFunds);
+
         messageBroker.Subscribe<NetworkNotifyRemovedSupporter>(Handle_NetworkNotifyRemovedSupporter);
     }
 
@@ -85,6 +88,9 @@ internal class OtherNotificationsHandler : IHandler
 
         messageBroker.Unsubscribe<NotifyRelationsIncreasedWithNotables>(Handle_NotifyRelationsIncreasedWithNotables);
         messageBroker.Unsubscribe<NetworkNotifyRelationsIncreasedWithNotables>(Handle_NetworkNotifyRelationsIncreasedWithNotables);
+
+        messageBroker.Unsubscribe<NotifyMoraleLossDueToFunds>(Handle_NotifyMoraleLossDueToFunds);
+        messageBroker.Unsubscribe<NetworkNotifyMoraleLossDueToFunds>(Handle_NetworkNotifyMoraleLossDueToFunds);
 
         messageBroker.Unsubscribe<NetworkNotifyRemovedSupporter>(Handle_NetworkNotifyRemovedSupporter);
     }
@@ -309,6 +315,28 @@ internal class OtherNotificationsHandler : IHandler
                     InformationManager.DisplayMessage(new InformationMessage(new TextObject("{=0h5BrVdA}Your relation with notables in some of your settlements increased due to high loyalty", null).ToString()));
                 }
             }
+        });
+    }
+
+    private void Handle_NotifyMoraleLossDueToFunds(MessagePayload<NotifyMoraleLossDueToFunds> obj)
+    {
+        GameThread.RunSafe(() =>
+        {
+            if (!objectManager.TryGetIdWithLogging(obj.What.MobileParty, out var mobilePartyId)) return;
+
+            network.SendAll(new NetworkNotifyMoraleLossDueToFunds(mobilePartyId));
+        });
+    }
+
+    private void Handle_NetworkNotifyMoraleLossDueToFunds(MessagePayload<NetworkNotifyMoraleLossDueToFunds> obj)
+    {
+        GameThread.RunSafe(() =>
+        {
+            if (!objectManager.TryGetObjectWithLogging<MobileParty>(obj.What.MobilePartyId, out var mobileParty)) return;
+
+            if (mobileParty != MobileParty.MainParty) return;
+
+            MBInformationManager.AddQuickInformation(GameTexts.FindText("str_party_loses_moral_due_to_insufficent_funds", null), 0, null, null, "");
         });
     }
 

--- a/source/GameInterface/Services/UI/Notifications/Messages/NetworkNotifyMoraleLossDueToFunds.cs
+++ b/source/GameInterface/Services/UI/Notifications/Messages/NetworkNotifyMoraleLossDueToFunds.cs
@@ -1,0 +1,16 @@
+﻿using Common.Messaging;
+using ProtoBuf;
+
+namespace GameInterface.Services.UI.Notifications.Messages;
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkNotifyMoraleLossDueToFunds : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string MobilePartyId;
+
+    public NetworkNotifyMoraleLossDueToFunds(string mobilePartyId)
+    {
+        MobilePartyId = mobilePartyId;
+    }
+}

--- a/source/GameInterface/Services/UI/Notifications/Messages/NetworkNotifyMoraleLossDueToFunds.cs
+++ b/source/GameInterface/Services/UI/Notifications/Messages/NetworkNotifyMoraleLossDueToFunds.cs
@@ -9,8 +9,12 @@ internal readonly struct NetworkNotifyMoraleLossDueToFunds : ICommand
     [ProtoMember(1)]
     public readonly string MobilePartyId;
 
-    public NetworkNotifyMoraleLossDueToFunds(string mobilePartyId)
+    [ProtoMember(2)]
+    public readonly float MoraleChange;
+
+    public NetworkNotifyMoraleLossDueToFunds(string mobilePartyId, float moraleChange)
     {
         MobilePartyId = mobilePartyId;
+        MoraleChange = moraleChange;
     }
 }

--- a/source/GameInterface/Services/UI/Notifications/Messages/NotifyMoraleLossDueToFunds.cs
+++ b/source/GameInterface/Services/UI/Notifications/Messages/NotifyMoraleLossDueToFunds.cs
@@ -1,0 +1,14 @@
+﻿using Common.Messaging;
+using TaleWorlds.CampaignSystem.Party;
+
+namespace GameInterface.Services.UI.Notifications.Messages;
+
+public readonly struct NotifyMoraleLossDueToFunds : IEvent
+{
+    public readonly MobileParty MobileParty;
+
+    public NotifyMoraleLossDueToFunds(MobileParty mobileParty)
+    {
+        MobileParty = mobileParty;
+    }
+}

--- a/source/GameInterface/Services/UI/Notifications/Messages/NotifyMoraleLossDueToFunds.cs
+++ b/source/GameInterface/Services/UI/Notifications/Messages/NotifyMoraleLossDueToFunds.cs
@@ -6,9 +6,11 @@ namespace GameInterface.Services.UI.Notifications.Messages;
 public readonly struct NotifyMoraleLossDueToFunds : IEvent
 {
     public readonly MobileParty MobileParty;
+    public readonly float MoraleChange;
 
-    public NotifyMoraleLossDueToFunds(MobileParty mobileParty)
+    public NotifyMoraleLossDueToFunds(MobileParty mobileParty, float moraleChange)
     {
         MobileParty = mobileParty;
+        MoraleChange = moraleChange;
     }
 }


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
AutoSync for MobileParty doesn't include `DefaultClanFinanceModel.ApplyMoraleEffect` as a target method, resulting in clients seeing the wrong morale calculation.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #2104
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Re-added `DefaultClanFinanceModel.ApplyMoraleEffect` as a target method and added notification for clients when the morale penalty is applied.

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Fixed unpaid wages morale penalty.
