### PR TITLE
Fix AI not moving

### DIFF
--- a/source/GameInterface/Services/MobilePartyAIs/Patches/PartiesThinkPatch.cs
+++ b/source/GameInterface/Services/MobilePartyAIs/Patches/PartiesThinkPatch.cs
@@ -2,7 +2,6 @@
 using Common.Logging;
 using HarmonyLib;
 using Serilog;
-using System;
 using System.Threading.Tasks;
 using TaleWorlds.CampaignSystem;
 
@@ -31,30 +30,16 @@ internal class PartiesThinkPatch
 
         delay = Task.Delay(TICK_DELAY_MS);
 
-        if (__instance.MobileParties.Count == 0) return false;
-
-        var currentStartIdx = CurrentStartIdx % __instance.MobileParties.Count;
-        CurrentStartIdx = (currentStartIdx + UPDATES_PER_TICK) % __instance.MobileParties.Count;
-
         for (int i = 0; i < UPDATES_PER_TICK; i++)
         {
-            if (__instance.MobileParties.Count == 0) break;
+            var currentIdx = (CurrentStartIdx + i) % __instance.MobileParties.Count;
 
-            var currentIdx = (currentStartIdx + i) % __instance.MobileParties.Count;
-            var mobileParty = __instance.MobileParties[currentIdx];
-            var ai = mobileParty?.Ai;
+            var ai = __instance.MobileParties[currentIdx]?.Ai;
 
-            if (ai == null) continue;
-
-            try
-            {
-                ai.Tick(dt);
-            }
-            catch (Exception exception)
-            {
-                Logger.Error(exception, "Failed to tick mobile party AI for {MobilePartyId}", mobileParty.StringId);
-            }
+            ai.Tick(dt);
         }
+
+        CurrentStartIdx = (CurrentStartIdx + UPDATES_PER_TICK) % __instance.MobileParties.Count;
 
         return false;
     }

--- a/source/GameInterface/Services/MobilePartyAIs/Patches/PartiesThinkPatch.cs
+++ b/source/GameInterface/Services/MobilePartyAIs/Patches/PartiesThinkPatch.cs
@@ -2,6 +2,7 @@
 using Common.Logging;
 using HarmonyLib;
 using Serilog;
+using System;
 using System.Threading.Tasks;
 using TaleWorlds.CampaignSystem;
 
@@ -30,16 +31,30 @@ internal class PartiesThinkPatch
 
         delay = Task.Delay(TICK_DELAY_MS);
 
+        if (__instance.MobileParties.Count == 0) return false;
+
+        var currentStartIdx = CurrentStartIdx % __instance.MobileParties.Count;
+        CurrentStartIdx = (currentStartIdx + UPDATES_PER_TICK) % __instance.MobileParties.Count;
+
         for (int i = 0; i < UPDATES_PER_TICK; i++)
         {
-            var currentIdx = (CurrentStartIdx + i) % __instance.MobileParties.Count;
+            if (__instance.MobileParties.Count == 0) break;
 
-            var ai = __instance.MobileParties[currentIdx]?.Ai;
+            var currentIdx = (currentStartIdx + i) % __instance.MobileParties.Count;
+            var mobileParty = __instance.MobileParties[currentIdx];
+            var ai = mobileParty?.Ai;
 
-            ai.Tick(dt);
+            if (ai == null) continue;
+
+            try
+            {
+                ai.Tick(dt);
+            }
+            catch (Exception exception)
+            {
+                Logger.Error(exception, "Failed to tick mobile party AI for {MobilePartyId}", mobileParty.StringId);
+            }
         }
-
-        CurrentStartIdx = (CurrentStartIdx + UPDATES_PER_TICK) % __instance.MobileParties.Count;
 
         return false;
     }

--- a/source/GameInterface/Services/MobilePartyAIs/Patches/PartyBehaviorPatch.cs
+++ b/source/GameInterface/Services/MobilePartyAIs/Patches/PartyBehaviorPatch.cs
@@ -71,6 +71,8 @@ public static class PartyBehaviorPatch
         return true;
     }
 
+    // Vanilla seeds GoToSettlement from TargetPosition without recomputing the settlement gate.
+    // A saved current-position target therefore feeds back forever unless we repair it here.
     private static void RepairInvalidSettlementTarget(
         MobilePartyAi partyAi,
         AiBehavior behavior,
@@ -94,7 +96,7 @@ public static class PartyBehaviorPatch
         if (!correctedTarget.IsValid() || correctedTarget == party.Position)
             return;
 
-        Logger.Warning(
+        Logger.Information(
             "Repairing current-position settlement target for {PartyId}: {SettlementId} at {Target}",
             party.StringId,
             settlement.StringId,

--- a/source/GameInterface/Services/MobilePartyAIs/Patches/PartyBehaviorPatch.cs
+++ b/source/GameInterface/Services/MobilePartyAIs/Patches/PartyBehaviorPatch.cs
@@ -51,6 +51,8 @@ public static class PartyBehaviorPatch
             return true;
         }
 
+        RepairInvalidSettlementTarget(__instance, newAiBehavior, interactablePoint, ref bestTargetPoint);
+
         __state = !BehaviorIsSame(__instance, newAiBehavior, interactablePoint, bestTargetPoint) &&
             __instance._mobileParty.IsControlledByThisInstance();
         if (!__state)
@@ -67,6 +69,38 @@ public static class PartyBehaviorPatch
         }
 
         return true;
+    }
+
+    private static void RepairInvalidSettlementTarget(
+        MobilePartyAi partyAi,
+        AiBehavior behavior,
+        IInteractablePoint interactable,
+        ref CampaignVec2 target)
+    {
+        var party = partyAi._mobileParty;
+        if (behavior != AiBehavior.GoToSettlement ||
+            target != party.Position ||
+            interactable is not PartyBase partyBase ||
+            !partyBase.IsSettlement)
+            return;
+
+        var settlement = partyBase.Settlement;
+        if (settlement == null || party.CurrentSettlement == settlement)
+            return;
+
+        var correctedTarget = party.IsTargetingPort && settlement.HasPort
+            ? settlement.PortPosition
+            : settlement.GatePosition;
+        if (!correctedTarget.IsValid() || correctedTarget == party.Position)
+            return;
+
+        Logger.Warning(
+            "Repairing current-position settlement target for {PartyId}: {SettlementId} at {Target}",
+            party.StringId,
+            settlement.StringId,
+            correctedTarget);
+        party.TargetPosition = correctedTarget;
+        target = correctedTarget;
     }
 
     [HarmonyPostfix]

--- a/source/GameInterface/Services/MobilePartyAIs/Patches/PartyBehaviorPatch.cs
+++ b/source/GameInterface/Services/MobilePartyAIs/Patches/PartyBehaviorPatch.cs
@@ -71,8 +71,11 @@ public static class PartyBehaviorPatch
         return true;
     }
 
-    // Vanilla seeds GoToSettlement from TargetPosition without recomputing the settlement gate.
-    // A saved current-position target therefore feeds back forever unless we repair it here.
+    // Vanilla saves TargetPosition, TargetSettlement, and DefaultBehavior independently, while NavigationPath is discarded on load.
+    // A save can therefore retain GoToSettlement intent with a current-position target after the in-memory path masked the mismatch.
+    // On same-map loads Campaign.CheckMapUpdate skips CheckAiForMapChangeAndUpdateIfNeeded, so vanilla does not normalize those fields.
+    // MobilePartyAi.GetBehaviors seeds GoToSettlement from the saved TargetPosition and never replaces it with the settlement gate.
+    // That current position feeds back every AI tick, and our behavior deduplication would preserve it forever.
     private static void RepairInvalidSettlementTarget(
         MobilePartyAi partyAi,
         AiBehavior behavior,

--- a/source/GameInterface/Services/MobilePartyAIs/Patches/PartyBehaviorPatch.cs
+++ b/source/GameInterface/Services/MobilePartyAIs/Patches/PartyBehaviorPatch.cs
@@ -73,7 +73,6 @@ public static class PartyBehaviorPatch
 
     // Vanilla saves TargetPosition, TargetSettlement, and DefaultBehavior independently, while NavigationPath is discarded on load.
     // A save can therefore retain GoToSettlement intent with a current-position target after the in-memory path masked the mismatch.
-    // On same-map loads Campaign.CheckMapUpdate skips CheckAiForMapChangeAndUpdateIfNeeded, so vanilla does not normalize those fields.
     // MobilePartyAi.GetBehaviors seeds GoToSettlement from the saved TargetPosition and never replaces it with the settlement gate.
     // That current position feeds back every AI tick, and our behavior deduplication would preserve it forever.
     private static void RepairInvalidSettlementTarget(


### PR DESCRIPTION
## PR Checklist

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?

Server campaign party AI ticking can get stuck behind one bad mobile party entry, leaving villagers, caravans, and lord parties stopped on the campaign map.


## What is the new behavior?

Resolves #2024

The server AI tick scheduler skips not-ready parties, logs individual AI tick failures, and keeps advancing so one party cannot stop later campaign parties from receiving AI ticks.


## Bot Changelog Entry

- Fixed campaign parties getting stuck on the map after a server save/load.


## Other information

Tests:
- `MSBuild.exe source/GameInterface/GameInterface.csproj /p:Configuration=Debug /p:Platform=AnyCPU /p:PostBuildEvent=`
- Docker CI equivalent: `dotnet build CoopTests.slnf -c Release`
- Docker CI equivalent: `dotnet test CoopTests.slnf -c Release --no-build --consoleLoggerParameters:ErrorsOnly` (698 passed, 4 skipped)

Manual runtime verification passed with `villagersstuck.sav` server-only from 20:34:07 to 20:49:30; tracked in `MANUAL_TESTING.md`.
