### PR TITLE
Allow sorting troops in party interface

### DIFF
--- a/source/GameInterface.Tests/Services/Party/PlayerCaptivityReleasePositionTests.cs
+++ b/source/GameInterface.Tests/Services/Party/PlayerCaptivityReleasePositionTests.cs
@@ -171,7 +171,8 @@ public class PlayerCaptivityReleasePositionTests
             0,
             true,
             releasePosition,
-            Helpers.PartyScreenHelper.PartyScreenMode.Normal);
+            Helpers.PartyScreenHelper.PartyScreenMode.Normal,
+            new TroopRosterOrderData(new()));
 
         byte[] bytes;
         using (var ms = new MemoryStream())

--- a/source/GameInterface/Services/Party/Handlers/PartyDoneLogicHandler.cs
+++ b/source/GameInterface/Services/Party/Handlers/PartyDoneLogicHandler.cs
@@ -10,6 +10,7 @@ using GameInterface.Services.Party.Messages;
 using GameInterface.Services.PlayerCaptivityService.Messages;
 using GameInterface.Services.TroopRosters.Data;
 using GameInterface.Services.TroopRosters.Interfaces;
+using GameInterface.Services.TroopRosters.Messages;
 using GameInterface.Services.UI.Notifications.Messages;
 using LiteNetLib;
 using Serilog;
@@ -86,6 +87,8 @@ internal class PartyDoneLogicHandler : IHandler
         var rightMemberRosterData = troopRosterInterface.PackTroopRosterDelta(obj.What.RightMemberRoster, obj.What.InitialRightMemberRoster);
         var rightPrisonerRosterData = troopRosterInterface.PackTroopRosterDelta(obj.What.RightPrisonerRoster, obj.What.InitialRightPrisonerRoster);
 
+        var rightMemberOrderData = troopRosterInterface.PackTroopRosterOrderData(obj.What.RightMemberRoster);
+
         var releaserPartyPosition = GetReleaserPartyPosition(obj.What.MainHero);
 
         var message = new NetworkCompleteDoneLogic(
@@ -106,7 +109,8 @@ internal class PartyDoneLogicHandler : IHandler
             obj.What.PartyMoraleChangeAmount,
             obj.What.DoNotApplyGoldTransactions,
             releaserPartyPosition,
-            obj.What.PartyScreenMode
+            obj.What.PartyScreenMode,
+            rightMemberOrderData
         );
 
         network.SendAll(message);
@@ -164,6 +168,8 @@ internal class PartyDoneLogicHandler : IHandler
             ApplyPartyRewardChanges(mainHero, message);
             ApplyUpgradedTroopHistory(mainHero, upgradedTroopHistory);
             ApplyPrisonerRecruitmentEffects(mainHero, message, recruitedPrisonersRoster);
+
+            ApplyRosterOrder(mainHero.PartyBelongedTo.MemberRoster, message.RightMemberOrderData);
         });
     }
 
@@ -306,6 +312,11 @@ internal class PartyDoneLogicHandler : IHandler
         // Replace ApplyPrisonerRecruitmentEffects
         int prisonerRecruitmentMoraleEffect = Campaign.Current.Models.PrisonerRecruitmentCalculationModel.GetPrisonerRecruitmentMoraleEffect(mainHero.PartyBelongedTo.Party, characterObject, 1);
         mainHero.PartyBelongedTo.RecentEventsMorale += (float)prisonerRecruitmentMoraleEffect;
+    }
+
+    private void ApplyRosterOrder(TroopRoster roster, TroopRosterOrderData orderData)
+    {
+        messageBroker.Publish(this, new ApplyTroopRosterOrder(roster, orderData));
     }
 
     internal List<PlayerCaptivityEndedByServer> CreatePlayerCaptivityReleaseEvents(

--- a/source/GameInterface/Services/Party/Messages/NetworkCompleteDoneLogic.cs
+++ b/source/GameInterface/Services/Party/Messages/NetworkCompleteDoneLogic.cs
@@ -66,6 +66,9 @@ internal readonly struct NetworkCompleteDoneLogic : ICommand
     [ProtoMember(18)]
     public readonly PartyScreenHelper.PartyScreenMode PartyScreenMode;
 
+    [ProtoMember(19)]
+    public readonly TroopRosterOrderData RightMemberOrderData;
+
     public NetworkCompleteDoneLogic(
         string mainHeroId,
         FlattenedTroop[] takenPrisonersRoster,
@@ -84,7 +87,8 @@ internal readonly struct NetworkCompleteDoneLogic : ICommand
         int partyMoraleChangeAmount,
         bool doNotApplyGoldTransactions,
         CampaignVec2 releaserPartyPosition,
-        PartyScreenHelper.PartyScreenMode partyScreenMode)
+        PartyScreenHelper.PartyScreenMode partyScreenMode,
+        TroopRosterOrderData rightMemberOrderData)
     {
         MainHeroId = mainHeroId;
         TakenPrisonersRoster = takenPrisonersRoster;
@@ -104,5 +108,6 @@ internal readonly struct NetworkCompleteDoneLogic : ICommand
         DoNotApplyGoldTransactions = doNotApplyGoldTransactions;
         ReleaserPartyPosition = releaserPartyPosition;
         PartyScreenMode = partyScreenMode;
+        RightMemberOrderData = rightMemberOrderData;
     }
 }

--- a/source/GameInterface/Services/TroopRosters/Data/TroopRosterOrderData.cs
+++ b/source/GameInterface/Services/TroopRosters/Data/TroopRosterOrderData.cs
@@ -1,0 +1,16 @@
+﻿using ProtoBuf;
+using System.Collections.Generic;
+
+namespace GameInterface.Services.TroopRosters.Data;
+
+[ProtoContract(SkipConstructor = true)]
+public class TroopRosterOrderData
+{
+    [ProtoMember(1)]
+    public readonly Dictionary<int, string> IndexCharacterIds;
+
+    public TroopRosterOrderData(Dictionary<int, string> indexCharacterIds)
+    {
+        IndexCharacterIds = indexCharacterIds;
+    }
+}

--- a/source/GameInterface/Services/TroopRosters/Handlers/TroopRosterReorderHandler.cs
+++ b/source/GameInterface/Services/TroopRosters/Handlers/TroopRosterReorderHandler.cs
@@ -52,6 +52,8 @@ internal class TroopRosterReorderHandler : IHandler
         {
             if (!objectManager.TryGetIdWithLogging(data.TroopRoster, out var troopRosterId)) return;
 
+            if (data.OrderData == null) return;
+
             // Apply on the server
             ApplyReorder(data.OrderData.IndexCharacterIds, data.TroopRoster);
 

--- a/source/GameInterface/Services/TroopRosters/Handlers/TroopRosterReorderHandler.cs
+++ b/source/GameInterface/Services/TroopRosters/Handlers/TroopRosterReorderHandler.cs
@@ -2,6 +2,7 @@
 using Common.Logging;
 using Common.Messaging;
 using Common.Network;
+using Common.Network.Coalescing;
 using Common.Util;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.TroopRosters.Messages;
@@ -9,6 +10,7 @@ using Serilog;
 using System.Collections.Generic;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Roster;
+using static GameInterface.Services.ObjectManager.ObjectManager;
 
 namespace GameInterface.Services.TroopRosters.Handlers;
 
@@ -24,15 +26,18 @@ internal class TroopRosterReorderHandler : IHandler
     private readonly IMessageBroker messageBroker;
     private readonly IObjectManager objectManager;
     private readonly INetwork network;
+    private readonly ISendCoalescer sendCoalescer;
 
     public TroopRosterReorderHandler(
         IMessageBroker messageBroker,
         IObjectManager objectManager,
-        INetwork network)
+        INetwork network,
+        ISendCoalescer sendCoalescer = null)
     {
         this.messageBroker = messageBroker;
         this.objectManager = objectManager;
         this.network = network;
+        this.sendCoalescer = sendCoalescer;
 
         messageBroker.Subscribe<ApplyTroopRosterOrder>(Handle_ApplyTroopRosterOrder);
         messageBroker.Subscribe<NetworkApplyTroopRosterOrder>(Handle_NetworkApplyTroopRosterOrder);
@@ -69,6 +74,9 @@ internal class TroopRosterReorderHandler : IHandler
         GameThread.RunSafe(() =>
         {
             if (!objectManager.TryGetObjectWithLogging<TroopRoster>(data.TroopRosterId, out var troopRoster)) return;
+
+            var compactId = Compact(data.TroopRosterId, typeof(TroopRoster));
+            sendCoalescer?.FlushInstance(compactId, network);
 
             // Apply on clients
             using (new AllowedThread())

--- a/source/GameInterface/Services/TroopRosters/Handlers/TroopRosterReorderHandler.cs
+++ b/source/GameInterface/Services/TroopRosters/Handlers/TroopRosterReorderHandler.cs
@@ -62,6 +62,9 @@ internal class TroopRosterReorderHandler : IHandler
             // Apply on the server
             ApplyReorder(data.OrderData.IndexCharacterIds, data.TroopRoster);
 
+            var compactId = Compact(troopRosterId, typeof(TroopRoster));
+            sendCoalescer?.FlushInstance(compactId, network);
+
             var message = new NetworkApplyTroopRosterOrder(troopRosterId, data.OrderData);
             network.SendAll(message);
         });
@@ -74,9 +77,6 @@ internal class TroopRosterReorderHandler : IHandler
         GameThread.RunSafe(() =>
         {
             if (!objectManager.TryGetObjectWithLogging<TroopRoster>(data.TroopRosterId, out var troopRoster)) return;
-
-            var compactId = Compact(data.TroopRosterId, typeof(TroopRoster));
-            sendCoalescer?.FlushInstance(compactId, network);
 
             // Apply on clients
             using (new AllowedThread())

--- a/source/GameInterface/Services/TroopRosters/Handlers/TroopRosterReorderHandler.cs
+++ b/source/GameInterface/Services/TroopRosters/Handlers/TroopRosterReorderHandler.cs
@@ -1,0 +1,89 @@
+﻿using Common;
+using Common.Logging;
+using Common.Messaging;
+using Common.Network;
+using Common.Util;
+using GameInterface.Services.ObjectManager;
+using GameInterface.Services.TroopRosters.Messages;
+using Serilog;
+using System.Collections.Generic;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Roster;
+
+namespace GameInterface.Services.TroopRosters.Handlers;
+
+/// <summary>
+/// Players can set the order of their roster from the party management screen.
+/// Only player rosters matter in this case so handle separately when needed.
+/// This doesn't change the contents of a roster, it only re-orders it after deltas have been applied.
+/// </summary>
+internal class TroopRosterReorderHandler : IHandler
+{
+    private static readonly ILogger Logger = LogManager.GetLogger<TroopRosterReorderHandler>();
+
+    private readonly IMessageBroker messageBroker;
+    private readonly IObjectManager objectManager;
+    private readonly INetwork network;
+
+    public TroopRosterReorderHandler(
+        IMessageBroker messageBroker,
+        IObjectManager objectManager,
+        INetwork network)
+    {
+        this.messageBroker = messageBroker;
+        this.objectManager = objectManager;
+        this.network = network;
+
+        messageBroker.Subscribe<ApplyTroopRosterOrder>(Handle_ApplyTroopRosterOrder);
+        messageBroker.Subscribe<NetworkApplyTroopRosterOrder>(Handle_NetworkApplyTroopRosterOrder);
+    }
+
+    public void Dispose()
+    {
+        messageBroker.Unsubscribe<ApplyTroopRosterOrder>(Handle_ApplyTroopRosterOrder);
+        messageBroker.Unsubscribe<NetworkApplyTroopRosterOrder>(Handle_NetworkApplyTroopRosterOrder);
+    }
+
+    private void Handle_ApplyTroopRosterOrder(MessagePayload<ApplyTroopRosterOrder> obj)
+    {
+        var data = obj.What;
+
+        GameThread.RunSafe(() =>
+        {
+            if (!objectManager.TryGetIdWithLogging(data.TroopRoster, out var troopRosterId)) return;
+
+            // Apply on the server
+            ApplyReorder(data.OrderData.IndexCharacterIds, data.TroopRoster);
+
+            var message = new NetworkApplyTroopRosterOrder(troopRosterId, data.OrderData);
+            network.SendAll(message);
+        });
+    }
+
+    private void Handle_NetworkApplyTroopRosterOrder(MessagePayload<NetworkApplyTroopRosterOrder> obj)
+    {
+        var data = obj.What;
+
+        GameThread.RunSafe(() =>
+        {
+            if (!objectManager.TryGetObjectWithLogging<TroopRoster>(data.TroopRosterId, out var troopRoster)) return;
+
+            // Apply on clients
+            using (new AllowedThread())
+            {
+                ApplyReorder(data.OrderData.IndexCharacterIds, troopRoster);
+            }
+        });
+    }
+
+    private void ApplyReorder(Dictionary<int, string> indexCharacterIds, TroopRoster troopRoster)
+    {
+        foreach (var orderData in indexCharacterIds)
+        {
+            if (!objectManager.TryGetObjectWithLogging<CharacterObject>(orderData.Value, out var character)) return;
+
+            var characterIndex = troopRoster.FindIndexOfTroop(character);
+            troopRoster.SwapTroopsAtIndices(characterIndex, orderData.Key);
+        }
+    }
+}

--- a/source/GameInterface/Services/TroopRosters/Interfaces/TroopRosterInterface.cs
+++ b/source/GameInterface/Services/TroopRosters/Interfaces/TroopRosterInterface.cs
@@ -56,6 +56,12 @@ public interface ITroopRosterInterface : IGameAbstraction
     /// Runs troop recruitment logic for client requests.
     /// </summary>
     void HandleOnRecruitmentDone(string mobilePartyId, TroopInfo[] troopsInCart);
+
+    /// <summary>
+    /// Players are able to change the order of their party roster.
+    /// Used to pack the order of elements in a TroopRoster to reshuffle after apply deltas.
+    /// </summary>
+    TroopRosterOrderData PackTroopRosterOrderData(TroopRoster roster);
 }
 
 internal class TroopRosterInterface : ITroopRosterInterface
@@ -255,5 +261,19 @@ internal class TroopRosterInterface : ITroopRosterInterface
         }
 
         GiveGoldAction.ApplyBetweenCharacters(mobileParty.LeaderHero, null, cost, false);
+    }
+
+    public TroopRosterOrderData PackTroopRosterOrderData(TroopRoster roster)
+    {
+        var troopRosterOrderData = new TroopRosterOrderData(new());
+        for (int i = 0; i < roster.data.Length; i++)
+        {
+            var character = roster.data[i].Character;
+
+            if (!objectManager.TryGetIdWithLogging(character, out var characterId)) continue;
+
+            troopRosterOrderData.IndexCharacterIds[i] = characterId;
+        }
+        return troopRosterOrderData;
     }
 }

--- a/source/GameInterface/Services/TroopRosters/Interfaces/TroopRosterInterface.cs
+++ b/source/GameInterface/Services/TroopRosters/Interfaces/TroopRosterInterface.cs
@@ -266,6 +266,8 @@ internal class TroopRosterInterface : ITroopRosterInterface
     public TroopRosterOrderData PackTroopRosterOrderData(TroopRoster roster)
     {
         var troopRosterOrderData = new TroopRosterOrderData(new());
+        if (roster == null || roster.data == null) return null;
+
         for (int i = 0; i < roster.data.Length; i++)
         {
             var character = roster.data[i].Character;

--- a/source/GameInterface/Services/TroopRosters/Interfaces/TroopRosterInterface.cs
+++ b/source/GameInterface/Services/TroopRosters/Interfaces/TroopRosterInterface.cs
@@ -268,7 +268,7 @@ internal class TroopRosterInterface : ITroopRosterInterface
         var troopRosterOrderData = new TroopRosterOrderData(new());
         if (roster == null || roster.data == null) return null;
 
-        for (int i = 0; i < roster.data.Length; i++)
+        for (int i = 0; i < roster.Count; i++)
         {
             var character = roster.data[i].Character;
 

--- a/source/GameInterface/Services/TroopRosters/Messages/ApplyTroopRosterOrder.cs
+++ b/source/GameInterface/Services/TroopRosters/Messages/ApplyTroopRosterOrder.cs
@@ -1,0 +1,17 @@
+﻿using Common.Messaging;
+using GameInterface.Services.TroopRosters.Data;
+using TaleWorlds.CampaignSystem.Roster;
+
+namespace GameInterface.Services.TroopRosters.Messages;
+
+public readonly struct ApplyTroopRosterOrder : IEvent
+{
+    public readonly TroopRoster TroopRoster;
+    public readonly TroopRosterOrderData OrderData;
+
+    public ApplyTroopRosterOrder(TroopRoster troopRoster, TroopRosterOrderData orderData)
+    {
+        TroopRoster = troopRoster;
+        OrderData = orderData;
+    }
+}

--- a/source/GameInterface/Services/TroopRosters/Messages/NetworkApplyTroopRosterOrder.cs
+++ b/source/GameInterface/Services/TroopRosters/Messages/NetworkApplyTroopRosterOrder.cs
@@ -1,0 +1,21 @@
+﻿using Common.Messaging;
+using GameInterface.Services.TroopRosters.Data;
+using ProtoBuf;
+
+namespace GameInterface.Services.TroopRosters.Messages;
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkApplyTroopRosterOrder : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string TroopRosterId;
+
+    [ProtoMember(2)]
+    public readonly TroopRosterOrderData OrderData;
+
+    public NetworkApplyTroopRosterOrder(string troopRosterId, TroopRosterOrderData orderData)
+    {
+        TroopRosterId = troopRosterId;
+        OrderData = orderData;
+    }
+}


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Players can't re-order their party roster in the party management screen.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #2122
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Allow players to re-order their party. Doesn't interfere with troop roster deltas and new logic is only used in the party done logic.

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Fixed not being able to re-order troops in party management screen.