### PR TITLE
[2035] Show settlement siege symbols on clients

### DIFF
--- a/source/GameInterface/Services/Settlements/Patches/SiegeEventVisualPatches.cs
+++ b/source/GameInterface/Services/Settlements/Patches/SiegeEventVisualPatches.cs
@@ -1,23 +1,48 @@
-﻿using HarmonyLib;
+﻿using Common;
+using HarmonyLib;
+using SandBox.GauntletUI.Map;
+using SandBox.View.Map;
 using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.CampaignSystem.Siege;
 
 namespace GameInterface.Services.Settlements.Patches;
 
 /// <summary>
-/// Refreshes the settlement map visual when its SiegeEvent reference changes. Vanilla dirties the
-/// visual in SiegeEventManager.StartSiegeEvent, FinalizeSiegeEvent, and the siege tick, which never
-/// run on clients, so the synced setter apply is the only place a client learns the siege camp
-/// appeared or went away. The siege/civilian scene level mask is separate from the visual dirty flag;
-/// without recalculating it, siege-only slot parents can stay hidden even after preparation completes.
+/// Refreshes client settlement presentation when its synced SiegeEvent reference changes. Vanilla dirties the
+/// map visual and raises the nameplate events only in server-side siege lifecycle paths, so the client setter
+/// apply must recreate those presentation side effects.
 /// </summary>
 [HarmonyPatch(typeof(Settlement))]
 internal class SiegeEventVisualPatches
 {
     [HarmonyPatch(nameof(Settlement.SiegeEvent), MethodType.Setter)]
+    [HarmonyPrefix]
+    private static void SetSiegeEventPrefix(Settlement __instance, out SiegeEvent __state)
+    {
+        __state = __instance.SiegeEvent;
+    }
+
+    [HarmonyPatch(nameof(Settlement.SiegeEvent), MethodType.Setter)]
     [HarmonyPostfix]
-    private static void SetSiegeEventPostfix(Settlement __instance)
+    private static void SetSiegeEventPostfix(Settlement __instance, SiegeEvent value, SiegeEvent __state)
     {
         __instance.Party?.SetLevelMaskIsDirty();
         __instance.Party?.SetVisualAsDirty();
+
+        if (ModInformation.IsServer || __state == value) return;
+
+        var nameplate = MapScreen.Instance?
+            .GetMapView<GauntletMapSettlementNameplateView>()?
+            ._dataSource?
+            .GetNameplateOfSettlement(__instance);
+
+        if (value == null)
+        {
+            nameplate?.OnSiegeEventEndedOnSettlement(__state);
+        }
+        else
+        {
+            nameplate?.OnSiegeEventStartedOnSettlement(value);
+        }
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Starting a siege can leave connected clients' settlement nameplates without the siege symbol, even though the server shows the settlement as besieged.

## What is the new behavior?

Resolves #2035

Starting or ending a siege now updates the settlement nameplate on connected clients, so the siege symbol appears and clears with the server's siege state.

## Bot Changelog Entry

- Fixed settlement siege symbols not appearing on clients when a siege starts.
