### PR TITLE
Fix flaky tests

### DIFF
--- a/source/Coop.Core/Server/Services/Time/Handlers/CampaignTimeSyncHandler.cs
+++ b/source/Coop.Core/Server/Services/Time/Handlers/CampaignTimeSyncHandler.cs
@@ -27,7 +27,9 @@ public class CampaignTimeSyncHandler : IHandler
     private readonly INetwork network;
     private readonly IMapTimeTrackerInterface mapTimeTrackerInterface;
 
+    private readonly object publishGate = new object();
     private readonly Timer publishTimer;
+    private bool disposed;
 
     public CampaignTimeSyncHandler(INetwork network, IMapTimeTrackerInterface mapTimeTrackerInterface)
     {
@@ -44,33 +46,37 @@ public class CampaignTimeSyncHandler : IHandler
 
     public void Dispose()
     {
-        publishTimer.Elapsed -= PublishCampaignTime;
-        publishTimer.Stop();
-        publishTimer.Dispose();
+        lock (publishGate)
+        {
+            if (disposed) return;
+
+            disposed = true;
+            publishTimer.Elapsed -= PublishCampaignTime;
+            publishTimer.Stop();
+            publishTimer.Dispose();
+        }
     }
 
     private void PublishCampaignTime(object sender, ElapsedEventArgs e)
     {
-        try
+        lock (publishGate)
         {
-            // No campaign loaded yet, nothing authoritative to broadcast.
-            if (mapTimeTrackerInterface.TryGetCurrentTicks(out long currentTicks) == false) return;
+            if (disposed) return;
 
-            network.SendAll(new CampaignTimePacket(currentTicks));
-        }
-        catch (Exception ex)
-        {
-            Logger.Error(ex, "Failed to broadcast {message}", nameof(CampaignTimePacket));
-        }
-        finally
-        {
             try
             {
-                publishTimer.Start();
+                // No campaign loaded yet, nothing authoritative to broadcast.
+                if (mapTimeTrackerInterface.TryGetCurrentTicks(out long currentTicks) == false) return;
+
+                network.SendAll(new CampaignTimePacket(currentTicks));
             }
-            catch (ObjectDisposedException)
+            catch (Exception ex)
             {
-                // Disposed while this broadcast was in flight; no further ticks.
+                Logger.Error(ex, "Failed to broadcast {message}", nameof(CampaignTimePacket));
+            }
+            finally
+            {
+                if (!disposed) publishTimer.Start();
             }
         }
     }

--- a/source/Coop.Tests/ModInformationRoleCollection.cs
+++ b/source/Coop.Tests/ModInformationRoleCollection.cs
@@ -1,0 +1,12 @@
+﻿using Xunit;
+
+namespace Coop.Tests;
+
+/// <summary>
+/// Serializes tests that mutate the process-wide server/client role.
+/// </summary>
+[CollectionDefinition(nameof(ModInformationRoleCollection), DisableParallelization = true)]
+public class ModInformationRoleCollection
+{
+    public const string Name = nameof(ModInformationRoleCollection);
+}

--- a/source/Coop.Tests/Server/Services/Connection/TacticalUnitSymbolsConfigSnapshotHandlerTests.cs
+++ b/source/Coop.Tests/Server/Services/Connection/TacticalUnitSymbolsConfigSnapshotHandlerTests.cs
@@ -1,7 +1,8 @@
-using Common;
+﻿using Common;
 using Common.Messaging;
 using Coop.Core.Server.Connections.Messages;
 using Coop.Core.Server.Services.Connection.Handlers;
+using Coop.Tests;
 using Coop.Tests.Mocks;
 using GameInterface.Services.UI.Interfaces;
 using Moq;
@@ -12,6 +13,7 @@ using Xunit;
 
 namespace Coop.Tests.Server.Services.Connection;
 
+[Collection(ModInformationRoleCollection.Name)]
 public class TacticalUnitSymbolsConfigSnapshotHandlerTests
 {
     static TacticalUnitSymbolsConfigSnapshotHandlerTests()

--- a/source/Coop.Tests/Server/Services/MapEvents/SiegeEngineStateCommitHandlerTests.cs
+++ b/source/Coop.Tests/Server/Services/MapEvents/SiegeEngineStateCommitHandlerTests.cs
@@ -1,5 +1,6 @@
-using Common;
+﻿using Common;
 using Common.Tests.Utils;
+using Coop.Tests;
 using GameInterface.Services.MapEvents;
 using GameInterface.Services.MapEvents.Handlers;
 using GameInterface.Services.MapEvents.Messages;
@@ -28,6 +29,7 @@ namespace Coop.Tests.Server.Services.MapEvents;
 /// <c>MissionSiegeEnginesLogic</c> and stays covered by code review only.
 /// </para>
 /// </summary>
+[Collection(ModInformationRoleCollection.Name)]
 public class SiegeEngineStateCommitHandlerTests : IDisposable
 {
     private const string MapEventId = "map-event-1";

--- a/source/Coop.Tests/Server/Services/Time/CampaignTimeSyncHandlerTests.cs
+++ b/source/Coop.Tests/Server/Services/Time/CampaignTimeSyncHandlerTests.cs
@@ -1,0 +1,59 @@
+﻿using Common.Network;
+using Common.PacketHandlers;
+using Coop.Core.Server.Services.Time.Handlers;
+using GameInterface.Services.Time.Interfaces;
+using Moq;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Coop.Tests.Server.Services.Time;
+
+public class CampaignTimeSyncHandlerTests
+{
+    [Fact]
+    public void Dispose_WaitsForInFlightBroadcast()
+    {
+        using var sendStarted = new ManualResetEventSlim();
+        using var releaseSend = new ManualResetEventSlim();
+        using var disposeStarted = new ManualResetEventSlim();
+
+        var network = new Mock<INetwork>();
+        network
+            .Setup(n => n.SendAll(It.IsAny<IPacket>()))
+            .Callback(() =>
+            {
+                sendStarted.Set();
+                releaseSend.Wait();
+            });
+
+        long currentTicks = 123456L;
+        var mapTimeTracker = new Mock<IMapTimeTrackerInterface>();
+        mapTimeTracker
+            .Setup(m => m.TryGetCurrentTicks(out currentTicks))
+            .Returns(true);
+
+        var handler = new CampaignTimeSyncHandler(network.Object, mapTimeTracker.Object);
+
+        Assert.True(sendStarted.Wait(TimeSpan.FromSeconds(5)));
+
+        var disposeTask = Task.Run(() =>
+        {
+            disposeStarted.Set();
+            handler.Dispose();
+        });
+
+        try
+        {
+            Assert.True(disposeStarted.Wait(TimeSpan.FromSeconds(5)));
+            Assert.False(disposeTask.Wait(TimeSpan.FromMilliseconds(250)));
+        }
+        finally
+        {
+            releaseSend.Set();
+        }
+
+        Assert.True(disposeTask.Wait(TimeSpan.FromSeconds(5)));
+    }
+}


### PR DESCRIPTION
## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

The campaign time timer can still be broadcasting while its Autofac scope is disposed, which can leave later E2E tests using a disposed container. Two Coop test classes also mutate the process-wide server/client role in parallel, so the snapshot handler test can run as a client and time out.

## What is the new behavior?

`CampaignTimeSyncHandler.Dispose` waits for an in-flight broadcast before returning, and its timer cannot restart after disposal. Coop tests that mutate `ModInformation.IsServer` now run in a non-parallel collection.