### PR TITLE
[2023] Fix post-battle settlement entry

### DIFF
--- a/source/GameInterface/Services/Heroes/Patches/Disable/DisableHeroAgentSpawnCampaignBehavior.cs
+++ b/source/GameInterface/Services/Heroes/Patches/Disable/DisableHeroAgentSpawnCampaignBehavior.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using Common;
+using HarmonyLib;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
 
 namespace GameInterface.Services.Heroes.Patches.Disable;
@@ -6,7 +7,6 @@ namespace GameInterface.Services.Heroes.Patches.Disable;
 [HarmonyPatch(typeof(HeroAgentSpawnCampaignBehavior))]
 internal class DisableHeroAgentSpawnCampaignBehavior
 {
-    // Needs to also run on the client
-    [HarmonyPatch(nameof(HeroAgentSpawnCampaignBehavior.RegisterEvents))]
-    static bool Prefix() => true;
+    [HarmonyPatch(nameof(HeroAgentSpawnCampaignBehavior.OnSettlementEntered))]
+    static bool Prefix() => ModInformation.IsServer;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

After completing a shared field battle, entering a settlement can repeatedly fail on both clients. Players cannot open settlement locations until they disconnect and rejoin.

## What is the new behavior?

Resolves #2023

Players can enter settlements and open their locations immediately after completing a shared field battle without reconnecting.

## Bot Changelog Entry

- Fixed players being unable to enter settlement locations after a shared battle.
