### PR TITLE
[2075] Prevent stale settlement encounters under lag

### DIFF
--- a/source/Coop.Core/Client/Services/MobileParties/Handlers/ClientSettlementExitEnterHandler.cs
+++ b/source/Coop.Core/Client/Services/MobileParties/Handlers/ClientSettlementExitEnterHandler.cs
@@ -1,5 +1,4 @@
-using System;
-using Common;
+﻿using Common;
 using Common.Messaging;
 using Common.Network;
 using Common.Util;
@@ -21,15 +20,15 @@ namespace Coop.Core.Client.Services.MobileParties.Handlers;
 /// </summary>
 public class ClientSettlementExitEnterHandler : IHandler
 {
-    private static readonly TimeSpan RequestCooldown = TimeSpan.FromMilliseconds(500);
-
     private readonly IMessageBroker messageBroker;
     private readonly INetwork network;
     private readonly IObjectManager objectManager;
     private readonly ISettlementInterface settlementInterface;
     private readonly IKingdomCreationSettlementTracker settlementTracker;
 
-    private DateTime lastRequestSentUtc = DateTime.MinValue;
+    private readonly object pendingEncounterLock = new object();
+    private string pendingPartyId;
+    private string pendingSettlementId;
 
     public ClientSettlementExitEnterHandler(
         IMessageBroker messageBroker,
@@ -47,6 +46,7 @@ public class ClientSettlementExitEnterHandler : IHandler
         messageBroker.Subscribe<EndSettlementEncounterAttempted>(Handle);
         messageBroker.Subscribe<NetworkEndSettlementEncounter>(Handle);
         messageBroker.Subscribe<NetworkStartSettlementEncounter>(Handle);
+        messageBroker.Subscribe<NetworkSettlementEncounterRejected>(Handle);
 
         messageBroker.Subscribe<NetworkPartyEnterSettlement>(Handle);
         messageBroker.Subscribe<NetworkPartyLeaveSettlement>(Handle);
@@ -58,6 +58,7 @@ public class ClientSettlementExitEnterHandler : IHandler
         messageBroker.Unsubscribe<EndSettlementEncounterAttempted>(Handle);
         messageBroker.Unsubscribe<NetworkEndSettlementEncounter>(Handle);
         messageBroker.Unsubscribe<NetworkStartSettlementEncounter>(Handle);
+        messageBroker.Unsubscribe<NetworkSettlementEncounterRejected>(Handle);
 
         messageBroker.Unsubscribe<NetworkPartyEnterSettlement>(Handle);
         messageBroker.Unsubscribe<NetworkPartyLeaveSettlement>(Handle);
@@ -65,20 +66,19 @@ public class ClientSettlementExitEnterHandler : IHandler
 
     private void Handle(MessagePayload<StartSettlementEncounterAttempted> obj)
     {
-        // This only ever runs for the single party this client controls (the publisher gates on
-        // IsControlledByThisInstance). That party re-attempts the settlement encounter every campaign tick
-        // until its PlayerEncounter is set up, which on a client only happens once the server round-trip
-        // completes. Rate-limit the request so those per-tick re-attempts do not flood the server.
-        var now = DateTime.UtcNow;
-        if (now - lastRequestSentUtc < RequestCooldown)
-            return;
-
         var payload = obj.What;
 
         if (!objectManager.TryGetIdWithLogging(payload.Party, out var partyId)) return;
         if (!objectManager.TryGetIdWithLogging(payload.Settlement, out var settlementId)) return;
 
-        lastRequestSentUtc = now;
+        lock (pendingEncounterLock)
+        {
+            if (pendingPartyId != null)
+                return;
+
+            pendingPartyId = partyId;
+            pendingSettlementId = settlementId;
+        }
 
         var message = new NetworkRequestStartSettlementEncounter(partyId, settlementId);
 
@@ -88,6 +88,8 @@ public class ClientSettlementExitEnterHandler : IHandler
     private void Handle(MessagePayload<EndSettlementEncounterAttempted> obj)
     {
         var payload = obj.What;
+
+        ClearPendingEncounter();
 
         if (!objectManager.TryGetIdWithLogging(payload.Party, out var partyId)) return;
 
@@ -106,6 +108,9 @@ public class ClientSettlementExitEnterHandler : IHandler
     {
         var payload = obj.What;
 
+        if (!TryCompletePendingEncounter(payload.PartyId, payload.SettlementId))
+            return;
+
         // Client applies a replicated change: run it on the game thread inside an AllowedThread so the
         // patched action proceeds without being re-intercepted/re-broadcast.
         GameThread.RunSafe(() =>
@@ -121,6 +126,34 @@ public class ClientSettlementExitEnterHandler : IHandler
                     GameMenu.SwitchToMenu("raid_occupied");
             }
         });
+    }
+
+    private void Handle(MessagePayload<NetworkSettlementEncounterRejected> obj)
+    {
+        var payload = obj.What;
+        TryCompletePendingEncounter(payload.PartyId, payload.SettlementId);
+    }
+
+    private bool TryCompletePendingEncounter(string partyId, string settlementId)
+    {
+        lock (pendingEncounterLock)
+        {
+            if (pendingPartyId != partyId || pendingSettlementId != settlementId)
+                return false;
+
+            pendingPartyId = null;
+            pendingSettlementId = null;
+            return true;
+        }
+    }
+
+    private void ClearPendingEncounter()
+    {
+        lock (pendingEncounterLock)
+        {
+            pendingPartyId = null;
+            pendingSettlementId = null;
+        }
     }
 
     private static bool ShouldShowRaidOccupiedMenu(MobileParty party, Settlement settlement)

--- a/source/Coop.Core/Client/Services/MobileParties/Messages/NetworkSettlementEncounterRejected.cs
+++ b/source/Coop.Core/Client/Services/MobileParties/Messages/NetworkSettlementEncounterRejected.cs
@@ -1,0 +1,24 @@
+﻿using Common.Messaging;
+using Coop.Core.Server.Services.MobileParties.Messages;
+using ProtoBuf;
+
+namespace Coop.Core.Client.Services.MobileParties.Messages;
+
+/// <summary>
+/// Message from the server rejecting a requested settlement encounter.
+/// </summary>
+[ProtoContract(SkipConstructor = true)]
+internal class NetworkSettlementEncounterRejected : ICommand
+{
+    [ProtoMember(1)]
+    public string PartyId;
+
+    [ProtoMember(2)]
+    public string SettlementId;
+
+    public NetworkSettlementEncounterRejected(NetworkRequestStartSettlementEncounter payload)
+    {
+        PartyId = payload.PartyId;
+        SettlementId = payload.SettlementId;
+    }
+}

--- a/source/Coop.Core/Server/Services/MobileParties/Handlers/ServerSettlementExitEnterHandler.cs
+++ b/source/Coop.Core/Server/Services/MobileParties/Handlers/ServerSettlementExitEnterHandler.cs
@@ -63,14 +63,42 @@ public class ServerSettlementExitEnterHandler : IHandler
 
         GameThread.RunSafe(() =>
         {
-            if (!objectManager.TryGetObjectWithLogging(payload.PartyId, out MobileParty mobileParty)) return;
-            if (!objectManager.TryGetObjectWithLogging(payload.SettlementId, out Settlement settlement)) return;
+            if (!objectManager.TryGetObjectWithLogging(payload.PartyId, out MobileParty mobileParty))
+            {
+                RejectSettlementEncounter(peer, payload);
+                return;
+            }
+            if (!objectManager.TryGetObjectWithLogging(payload.SettlementId, out Settlement settlement))
+            {
+                RejectSettlementEncounter(peer, payload);
+                return;
+            }
 
             if (mobileParty.Party?.MapEventSide != null)
             {
                 Logger.Warning(
                     "Rejecting settlement entry for party {PartyId} because it is already in a map event",
                     payload.PartyId);
+                RejectSettlementEncounter(peer, payload);
+                return;
+            }
+
+            if (mobileParty.CurrentSettlement != null)
+            {
+                if (mobileParty.CurrentSettlement == settlement)
+                {
+                    network.Send(peer, new NetworkStartSettlementEncounter(payload));
+                }
+                else
+                {
+                    Logger.Warning(
+                        "Rejecting settlement entry for party {PartyId} because it is already in settlement {SettlementId}",
+                        payload.PartyId,
+                        objectManager.TryGetId(mobileParty.CurrentSettlement, out var currentSettlementId)
+                            ? currentSettlementId
+                            : mobileParty.CurrentSettlement.StringId);
+                    RejectSettlementEncounter(peer, payload);
+                }
                 return;
             }
 
@@ -81,6 +109,13 @@ public class ServerSettlementExitEnterHandler : IHandler
 
             settlementInterface.PartyEnterSettlement(mobileParty, settlement);
         }, context: nameof(NetworkRequestStartSettlementEncounter));
+    }
+
+    private void RejectSettlementEncounter(
+        NetPeer peer,
+        NetworkRequestStartSettlementEncounter payload)
+    {
+        network.Send(peer, new NetworkSettlementEncounterRejected(payload));
     }
 
     private void Handle(MessagePayload<NetworkRequestEndSettlementEncounter> obj)

--- a/source/Coop.Core/Server/Services/MobileParties/Handlers/ServerSettlementExitEnterHandler.cs
+++ b/source/Coop.Core/Server/Services/MobileParties/Handlers/ServerSettlementExitEnterHandler.cs
@@ -65,12 +65,12 @@ public class ServerSettlementExitEnterHandler : IHandler
         {
             if (!objectManager.TryGetObjectWithLogging(payload.PartyId, out MobileParty mobileParty))
             {
-                RejectSettlementEncounter(peer, payload);
+                network.Send(peer, new NetworkSettlementEncounterRejected(payload));
                 return;
             }
             if (!objectManager.TryGetObjectWithLogging(payload.SettlementId, out Settlement settlement))
             {
-                RejectSettlementEncounter(peer, payload);
+                network.Send(peer, new NetworkSettlementEncounterRejected(payload));
                 return;
             }
 
@@ -79,7 +79,7 @@ public class ServerSettlementExitEnterHandler : IHandler
                 Logger.Warning(
                     "Rejecting settlement entry for party {PartyId} because it is already in a map event",
                     payload.PartyId);
-                RejectSettlementEncounter(peer, payload);
+                network.Send(peer, new NetworkSettlementEncounterRejected(payload));
                 return;
             }
 
@@ -97,7 +97,7 @@ public class ServerSettlementExitEnterHandler : IHandler
                         objectManager.TryGetId(mobileParty.CurrentSettlement, out var currentSettlementId)
                             ? currentSettlementId
                             : mobileParty.CurrentSettlement.StringId);
-                    RejectSettlementEncounter(peer, payload);
+                    network.Send(peer, new NetworkSettlementEncounterRejected(payload));
                 }
                 return;
             }
@@ -109,13 +109,6 @@ public class ServerSettlementExitEnterHandler : IHandler
 
             settlementInterface.PartyEnterSettlement(mobileParty, settlement);
         }, context: nameof(NetworkRequestStartSettlementEncounter));
-    }
-
-    private void RejectSettlementEncounter(
-        NetPeer peer,
-        NetworkRequestStartSettlementEncounter payload)
-    {
-        network.Send(peer, new NetworkSettlementEncounterRejected(payload));
     }
 
     private void Handle(MessagePayload<NetworkRequestEndSettlementEncounter> obj)

--- a/source/Coop.IntegrationTests/Environment/TestNetworkRouter.cs
+++ b/source/Coop.IntegrationTests/Environment/TestNetworkRouter.cs
@@ -11,6 +11,8 @@ namespace Coop.IntegrationTests.Environment;
 /// </summary>
 public class TestNetworkRouter
 {
+    public bool IsMessageRoutingEnabled { get; set; } = true;
+
     private ServerInstance Server;
     private List<ClientInstance> Clients = new List<ClientInstance>();
 
@@ -26,6 +28,8 @@ public class TestNetworkRouter
 
     public void Send(NetPeer sender, NetPeer receiver, IMessage message)
     {
+        if (!IsMessageRoutingEnabled) return;
+
         if (receiver == Server.NetPeer)
         {
             Server.SimulateMessage(sender, message);
@@ -39,6 +43,8 @@ public class TestNetworkRouter
     }
     public void SendAll(NetPeer sender, IMessage message)
     {
+        if (!IsMessageRoutingEnabled) return;
+
         if (sender == Server.NetPeer)
         {
             foreach (var client in Clients)
@@ -54,6 +60,8 @@ public class TestNetworkRouter
 
     public void SendAllBut(NetPeer sender, NetPeer ignored, IMessage message)
     {
+        if (!IsMessageRoutingEnabled) return;
+
         if (sender == Server.NetPeer)
         {
             foreach (var client in Clients.Where(c => c.NetPeer != ignored))

--- a/source/Coop.IntegrationTests/MobileParties/EnterExitSettlementTest.cs
+++ b/source/Coop.IntegrationTests/MobileParties/EnterExitSettlementTest.cs
@@ -74,40 +74,83 @@ namespace Coop.IntegrationTests.MobileParties
             }
         }
 
-        /// <summary>
-        /// While the first settlement-encounter request is still in flight, the controlled party re-attempts the
-        /// encounter every campaign tick. Verify those rapid retries are rate-limited to a single network request
-        /// instead of flooding the server, and the entry is applied via ISettlementInterface exactly once.
-        /// </summary>
         [Fact]
-        public void RapidEnterAttempts_RateLimited_ToOneRequest()
+        public void EnterAttempts_WhileRequestPending_SendOneRequest()
         {
-            // Arrange
             var client1 = TestEnvironment.Clients.First();
-
             var party = ObjectHelper.SkipConstructor<MobileParty>();
             var settlement = ObjectHelper.SkipConstructor<Settlement>();
             TestEnvironment.RegisterObjectInNetwork(party, "party1");
             TestEnvironment.RegisterObjectInNetwork(settlement, "settlement1");
-
             var message = new StartSettlementEncounterAttempted(party, settlement);
+            var router = client1.Resolve<TestNetworkRouter>();
+            router.IsMessageRoutingEnabled = false;
 
-            // Act - two attempts in immediate succession, well within the request cooldown
             RunOnGameThread(() =>
             {
                 client1.SimulateMessage(this, message);
                 client1.SimulateMessage(this, message);
             });
 
-            // Assert - only the first attempt reaches the server; the second is dropped by the rate limiter
             Assert.Equal(1, client1.NetworkSentMessages.GetMessageCount<NetworkRequestStartSettlementEncounter>());
+        }
 
-            // And the entry is applied via ISettlementInterface on the other clients exactly once
-            foreach (var client in TestEnvironment.Clients.Where(c => c != client1))
-            {
-                client.Resolve<Mock<ISettlementInterface>>()
-                    .Verify(s => s.PartyEnterSettlement(party, settlement), Times.Once);
-            }
+        [Fact]
+        public void RejectedEnterAttempt_AllowsNextRequest()
+        {
+            var client1 = TestEnvironment.Clients.First();
+            var party = ObjectHelper.SkipConstructor<MobileParty>();
+            var settlement = ObjectHelper.SkipConstructor<Settlement>();
+            TestEnvironment.RegisterObjectInNetwork(party, "party1");
+            TestEnvironment.RegisterObjectInNetwork(settlement, "settlement1");
+            var router = client1.Resolve<TestNetworkRouter>();
+            router.IsMessageRoutingEnabled = false;
+
+            RunOnGameThread(() =>
+                client1.SimulateMessage(this, new StartSettlementEncounterAttempted(party, settlement)));
+
+            client1.SimulateMessage(
+                TestEnvironment.Server.NetPeer,
+                new NetworkSettlementEncounterRejected(
+                    new NetworkRequestStartSettlementEncounter("party1", "settlement1")));
+
+            RunOnGameThread(() =>
+                client1.SimulateMessage(this, new StartSettlementEncounterAttempted(party, settlement)));
+
+            Assert.Equal(2, client1.NetworkSentMessages.GetMessageCount<NetworkRequestStartSettlementEncounter>());
+        }
+
+        [Fact]
+        public void StaleEnterResponse_DoesNotClearOrApplyPendingRequest()
+        {
+            var client1 = TestEnvironment.Clients.First();
+            var party = ObjectHelper.SkipConstructor<MobileParty>();
+            var pendingSettlement = ObjectHelper.SkipConstructor<Settlement>();
+            var staleSettlement = ObjectHelper.SkipConstructor<Settlement>();
+            TestEnvironment.RegisterObjectInNetwork(party, "party1");
+            TestEnvironment.RegisterObjectInNetwork(pendingSettlement, "settlement1");
+            TestEnvironment.RegisterObjectInNetwork(staleSettlement, "settlement2");
+            var router = client1.Resolve<TestNetworkRouter>();
+            router.IsMessageRoutingEnabled = false;
+
+            RunOnGameThread(() =>
+                client1.SimulateMessage(
+                    this,
+                    new StartSettlementEncounterAttempted(party, pendingSettlement)));
+
+            RunOnGameThread(() =>
+                client1.SimulateMessage(
+                    TestEnvironment.Server.NetPeer,
+                    new NetworkStartSettlementEncounter(
+                        new NetworkRequestStartSettlementEncounter("party1", "settlement2"))));
+            RunOnGameThread(() =>
+                client1.SimulateMessage(
+                    this,
+                    new StartSettlementEncounterAttempted(party, staleSettlement)));
+
+            client1.Resolve<Mock<ISettlementInterface>>()
+                .Verify(s => s.StartSettlementEncounter(It.IsAny<MobileParty>(), It.IsAny<Settlement>()), Times.Never);
+            Assert.Equal(1, client1.NetworkSentMessages.GetMessageCount<NetworkRequestStartSettlementEncounter>());
         }
 
         [Fact]
@@ -128,7 +171,58 @@ namespace Coop.IntegrationTests.MobileParties
 
             TestEnvironment.Server.Resolve<Mock<ISettlementInterface>>()
                 .Verify(s => s.PartyEnterSettlement(It.IsAny<MobileParty>(), It.IsAny<Settlement>()), Times.Never);
-            Assert.Empty(TestEnvironment.Server.NetworkSentMessages.Messages);
+            Assert.Equal(
+                1,
+                TestEnvironment.Server.NetworkSentMessages.GetMessageCount<NetworkSettlementEncounterRejected>());
+            Assert.Equal(0, TestEnvironment.Server.NetworkSentMessages.GetMessageCount<NetworkPartyEnterSettlement>());
+        }
+
+        [Fact]
+        public void EnterSettlement_PartyAlreadyInDifferentSettlement_IsRejected()
+        {
+            var client1 = TestEnvironment.Clients.First();
+            var party = ObjectHelper.SkipConstructor<MobileParty>();
+            var currentSettlement = ObjectHelper.SkipConstructor<Settlement>();
+            var requestedSettlement = ObjectHelper.SkipConstructor<Settlement>();
+            party._currentSettlement = currentSettlement;
+            TestEnvironment.RegisterObjectInNetwork(party, "party1");
+            TestEnvironment.RegisterObjectInNetwork(currentSettlement, "settlement1");
+            TestEnvironment.RegisterObjectInNetwork(requestedSettlement, "settlement2");
+            TestEnvironment.Server.NetworkSentMessages.Clear();
+
+            RunOnGameThread(() =>
+                client1.SimulateMessage(
+                    this,
+                    new StartSettlementEncounterAttempted(party, requestedSettlement)));
+
+            TestEnvironment.Server.Resolve<Mock<ISettlementInterface>>()
+                .Verify(s => s.PartyEnterSettlement(It.IsAny<MobileParty>(), It.IsAny<Settlement>()), Times.Never);
+            Assert.Equal(
+                1,
+                TestEnvironment.Server.NetworkSentMessages.GetMessageCount<NetworkSettlementEncounterRejected>());
+            Assert.Equal(0, TestEnvironment.Server.NetworkSentMessages.GetMessageCount<NetworkPartyEnterSettlement>());
+        }
+
+        [Fact]
+        public void EnterSettlement_PartyAlreadyInRequestedSettlement_AcknowledgesWithoutReapplyingEntry()
+        {
+            var client1 = TestEnvironment.Clients.First();
+            var party = ObjectHelper.SkipConstructor<MobileParty>();
+            var settlement = ObjectHelper.SkipConstructor<Settlement>();
+            party._currentSettlement = settlement;
+            TestEnvironment.RegisterObjectInNetwork(party, "party1");
+            TestEnvironment.RegisterObjectInNetwork(settlement, "settlement1");
+            TestEnvironment.Server.NetworkSentMessages.Clear();
+
+            RunOnGameThread(() =>
+                client1.SimulateMessage(
+                    this,
+                    new StartSettlementEncounterAttempted(party, settlement)));
+
+            TestEnvironment.Server.Resolve<Mock<ISettlementInterface>>()
+                .Verify(s => s.PartyEnterSettlement(It.IsAny<MobileParty>(), It.IsAny<Settlement>()), Times.Never);
+            Assert.Equal(1, TestEnvironment.Server.NetworkSentMessages.GetMessageCount<NetworkStartSettlementEncounter>());
+            Assert.Equal(0, TestEnvironment.Server.NetworkSentMessages.GetMessageCount<NetworkPartyEnterSettlement>());
         }
 
         /// <summary>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

If the server stalls while a player enters a town, the interaction can open several times after it recovers, show the wrong settlement-style menu, or leave the party outside the gate unable to interact.

## What is the new behavior?

Part of #2075

A delayed town entry opens once. If the party enters a battle or another settlement before the response arrives, the old interaction is discarded and the player can enter the town normally afterward.

## Bot Changelog Entry

- Fixed delayed settlement interactions opening incorrectly or leaving parties stuck outside town gates.
