### PR TITLE
[2075] Prevent duplicate prisoner sale payouts

### DIFF
--- a/source/GameInterface.Tests/Services/Party/PrisonerSaleValidatorTests.cs
+++ b/source/GameInterface.Tests/Services/Party/PrisonerSaleValidatorTests.cs
@@ -1,0 +1,101 @@
+﻿using Common.Util;
+using GameInterface.Services.Party;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Roster;
+using Xunit;
+
+namespace GameInterface.Tests.Services.Party;
+
+/// <summary>
+/// Tests authoritative prisoner sale validation.
+/// </summary>
+public class PrisonerSaleValidatorTests
+{
+    private readonly PrisonerSaleValidator validator = new();
+
+    [Fact]
+    public void Validate_RequestedPrisonersAvailable_ReturnsRequestedRoster()
+    {
+        var character = ObjectHelper.SkipConstructor<CharacterObject>();
+        var requested = Roster(Element(character, 4, 1));
+        var available = Roster(Element(character, 7, 3));
+
+        var result = validator.Validate(requested, available);
+
+        AssertElement(result, character, 4, 1);
+    }
+
+    [Fact]
+    public void Validate_PrisonersAlreadyRemoved_ReturnsEmptyRoster()
+    {
+        var character = ObjectHelper.SkipConstructor<CharacterObject>();
+        var requested = Roster(Element(character, 4, 1));
+        var available = Roster();
+
+        var result = validator.Validate(requested, available);
+
+        Assert.Equal(0, result.Count);
+    }
+
+    [Fact]
+    public void Validate_FewerPrisonersAvailable_ClampsTotal()
+    {
+        var character = ObjectHelper.SkipConstructor<CharacterObject>();
+        var requested = Roster(Element(character, 8, 2));
+        var available = Roster(Element(character, 3, 1));
+
+        var result = validator.Validate(requested, available);
+
+        AssertElement(result, character, 3, 1);
+    }
+
+    [Fact]
+    public void Validate_HealthyAndWoundedAvailability_ClampsIndependently()
+    {
+        var character = ObjectHelper.SkipConstructor<CharacterObject>();
+        var requested = Roster(Element(character, 6, 4));
+        var available = Roster(Element(character, 5, 1));
+
+        var result = validator.Validate(requested, available);
+
+        AssertElement(result, character, 3, 1);
+    }
+
+    private static TroopRoster Roster(params TroopRosterElement[] elements)
+    {
+        var roster = new TroopRoster();
+        foreach (var element in elements)
+        {
+            roster.AddToCounts(
+                element.Character,
+                element.Number,
+                false,
+                element.WoundedNumber,
+                element.Xp,
+                true);
+        }
+        return roster;
+    }
+
+    private static TroopRosterElement Element(
+        CharacterObject character,
+        int number,
+        int woundedNumber) =>
+        new(character)
+        {
+            Number = number,
+            WoundedNumber = woundedNumber,
+        };
+
+    private static void AssertElement(
+        TroopRoster roster,
+        CharacterObject character,
+        int number,
+        int woundedNumber)
+    {
+        var element = Assert.Single(roster.GetTroopRoster());
+        Assert.Same(character, element.Character);
+        Assert.Equal(number, element.Number);
+        Assert.Equal(woundedNumber, element.WoundedNumber);
+    }
+}

--- a/source/GameInterface/GameInterfaceModule.cs
+++ b/source/GameInterface/GameInterfaceModule.cs
@@ -16,6 +16,7 @@ using GameInterface.Services.MapEvents;
 using GameInterface.Services.MapEvents.Logging;
 using GameInterface.Services.MobileParties.Data;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Party;
 using GameInterface.Services.Players;
 using GameInterface.Services.TroopRosters.Logging;
 using GameInterface.Services.Time;
@@ -47,6 +48,7 @@ public class GameInterfaceModule : Module
         builder.RegisterType<MobilePartyBehaviorSnapshot>().As<IMobilePartyBehaviorSnapshot>().InstancePerDependency();
         builder.RegisterType<BattleHostRegistry>().As<IBattleHostRegistry>().InstancePerLifetimeScope();
         builder.RegisterType<MapEventContributionBarrier>().As<IMapEventContributionBarrier>().InstancePerDependency();
+        builder.RegisterType<PrisonerSaleValidator>().As<IPrisonerSaleValidator>().InstancePerDependency();
         builder.RegisterType<MapEventLogger>().As<IMapEventLogger>().InstancePerLifetimeScope();
         builder.RegisterType<TroopRosterLogger>().As<ITroopRosterLogger>().InstancePerLifetimeScope();
         builder.RegisterType<PartySyncPerformanceClock>().As<IPartySyncPerformanceClock>().InstancePerLifetimeScope();

--- a/source/GameInterface/Services/Party/Handlers/SellPrisonersHandler.cs
+++ b/source/GameInterface/Services/Party/Handlers/SellPrisonersHandler.cs
@@ -24,6 +24,7 @@ internal class SellPrisonersHandler : IHandler
     private readonly IObjectManager objectManager;
     private readonly INetwork network;
     private readonly ITroopRosterInterface troopRosterInterface;
+    private readonly IPrisonerSaleValidator prisonerSaleValidator;
     private readonly ISendCoalescer sendCoalescer;
 
     public SellPrisonersHandler(
@@ -31,12 +32,14 @@ internal class SellPrisonersHandler : IHandler
         IObjectManager objectManager,
         INetwork network,
         ITroopRosterInterface troopRosterInterface,
+        IPrisonerSaleValidator prisonerSaleValidator,
         ISendCoalescer sendCoalescer = null)
     {
         this.messageBroker = messageBroker;
         this.objectManager = objectManager;
         this.network = network;
         this.troopRosterInterface = troopRosterInterface;
+        this.prisonerSaleValidator = prisonerSaleValidator;
         this.sendCoalescer = sendCoalescer;
 
         messageBroker.Subscribe<PrisonersSold>(Handle_PrisonersSold);
@@ -67,8 +70,11 @@ internal class SellPrisonersHandler : IHandler
 
             TroopRoster leftPrisonerRoster = new();
             troopRosterInterface.UpdateWithData(leftPrisonerRoster, obj.What.LeftPrisonerRosterData, sellingParty.LeaderHero);
+            var validatedPrisonerRoster = prisonerSaleValidator.Validate(
+                leftPrisonerRoster,
+                sellingParty.PrisonRoster);
 
-            SellPrisonersAction.ApplyForSelectedPrisoners(sellingParty, null, leftPrisonerRoster);
+            SellPrisonersAction.ApplyForSelectedPrisoners(sellingParty, null, validatedPrisonerRoster);
 
             objectManager.TryGetId(sellingParty.PrisonRoster, out var rosterId);
             var compactId = Compact(rosterId, typeof(TroopRoster));

--- a/source/GameInterface/Services/Party/PrisonerSaleValidator.cs
+++ b/source/GameInterface/Services/Party/PrisonerSaleValidator.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using TaleWorlds.CampaignSystem.Roster;
+
+namespace GameInterface.Services.Party;
+
+internal interface IPrisonerSaleValidator
+{
+    TroopRoster Validate(TroopRoster requestedRoster, TroopRoster availableRoster);
+}
+
+/// <summary>
+/// Clamps a requested prisoner sale to the prisoners in the authoritative roster.
+/// </summary>
+internal class PrisonerSaleValidator : IPrisonerSaleValidator
+{
+    public TroopRoster Validate(TroopRoster requestedRoster, TroopRoster availableRoster)
+    {
+        var validatedRoster = new TroopRoster();
+
+        foreach (var requested in requestedRoster.GetTroopRoster())
+        {
+            var availableIndex = availableRoster.FindIndexOfTroop(requested.Character);
+            if (availableIndex < 0)
+                continue;
+
+            var available = availableRoster.GetElementCopyAtIndex(availableIndex);
+            var requestedWounded = Math.Min(Math.Max(requested.WoundedNumber, 0), Math.Max(requested.Number, 0));
+            var requestedHealthy = Math.Max(requested.Number - requestedWounded, 0);
+            var availableWounded = Math.Min(Math.Max(available.WoundedNumber, 0), Math.Max(available.Number, 0));
+            var availableHealthy = Math.Max(available.Number - availableWounded, 0);
+            var woundedToSell = Math.Min(requestedWounded, availableWounded);
+            var healthyToSell = Math.Min(requestedHealthy, availableHealthy);
+            var totalToSell = healthyToSell + woundedToSell;
+
+            if (totalToSell == 0)
+                continue;
+
+            validatedRoster.AddToCounts(
+                requested.Character,
+                totalToSell,
+                false,
+                woundedToSell,
+                0,
+                true);
+        }
+
+        return validatedRoster;
+    }
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Submitting a prisoner ransom more than once before the server catches up can award the same ransom repeatedly after the prisoner has already been removed.

## What is the new behavior?

Part of #2075

Each prisoner pays ransom only once. A repeated or delayed sale only sells prisoners still held by the party.

## Bot Changelog Entry

- Fixed prisoners sometimes paying ransom more than once.
