### PR TITLE
[2111] Close losing simulated field battle encounters

### DIFF
--- a/source/E2E.Tests/Services/MapEvents/BattleResultDistributionTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/BattleResultDistributionTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Common.Logging;
 using Common.Messaging;
 using Common.Network;
 using Common.Util;
@@ -92,6 +93,46 @@ public class BattleResultDistributionTests : MapEventTestBase
             AssertRosterHolds(unpacked.LootedPrisoners, partyA, troopB, 1, notContaining: troopA);
             AssertRosterHolds(unpacked.LootedPrisoners, partyB, troopA, 1, notContaining: troopB);
         }, MapEventDisabledMethods);
+    }
+
+    [Fact]
+    public void SerializedEmptyLoot_PlayerDefeatEndsEncounterWithoutUnpackError()
+    {
+        var ctx = CreateServerMapEvent();
+        RegisterAsPlayerParty("1", TestEnvironment.CreateRegisteredObject<Hero>(), ctx.AttackerPartyId);
+
+        var client = Clients.First();
+        SetMainPartyInBattle(client, ctx.AttackerPartyId);
+        SetMockPlayerEncounter(client);
+
+        var wireMessage = Server.EnsureSerializable(new NetworkCommitMapEventResults(
+            ctx.MapEventId,
+            BattleSideEnum.Defender,
+            new NetworkPlayerLootData(new(), new(), new())));
+
+        Assert.Null(wireMessage.PlayerLootData.LootedItems);
+        Assert.Null(wireMessage.PlayerLootData.LootedMembers);
+        Assert.Null(wireMessage.PlayerLootData.LootedPrisoners);
+
+        var unpackErrors = new List<string>();
+        void CaptureUnpackError(string message)
+        {
+            if (message.Contains(nameof(MapEventResultsInterface.UnpackPlayerLootData)))
+                unpackErrors.Add(message);
+        }
+
+        OutputSinkManager.AddLogCallback(CaptureUnpackError);
+        try
+        {
+            client.SimulateMessage(Server.NetPeer, wireMessage);
+        }
+        finally
+        {
+            OutputSinkManager.RemoveLogCallback(CaptureUnpackError);
+        }
+
+        Assert.Empty(unpackErrors);
+        AssertPlayerEncounterState(client, PlayerEncounterState.End);
     }
 
     /// <summary>

--- a/source/GameInterface/Services/MapEvents/Interfaces/MapEventResultsInterface.cs
+++ b/source/GameInterface/Services/MapEvents/Interfaces/MapEventResultsInterface.cs
@@ -79,11 +79,14 @@ public class MapEventResultsInterface : IMapEventResultsInterface
         var lootedItems = new Dictionary<MapEventParty, ItemRoster>();
         var lootedMembers = new Dictionary<MapEventParty, TroopRoster>();
         var lootedPrisoners = new Dictionary<MapEventParty, TroopRoster>();
+        var networkLootedItems = networkPlayerLootData.LootedItems ?? new();
+        var networkLootedMembers = networkPlayerLootData.LootedMembers ?? new();
+        var networkLootedPrisoners = networkPlayerLootData.LootedPrisoners ?? new();
 
         GameThread.RunSafe(() =>
         {
             // Pack looted items
-            foreach (var playerLootedItems in networkPlayerLootData.LootedItems)
+            foreach (var playerLootedItems in networkLootedItems)
             {
                 if (!objectManager.TryGetObjectWithLogging<MapEventParty>(playerLootedItems.Key, out var mapEventParty)) continue;
 
@@ -95,7 +98,7 @@ public class MapEventResultsInterface : IMapEventResultsInterface
             }
 
             // Pack looted members (prisoners freed from defeated party)
-            foreach (var playerLootedMembers in networkPlayerLootData.LootedMembers)
+            foreach (var playerLootedMembers in networkLootedMembers)
             {
                 if (!objectManager.TryGetObjectWithLogging<MapEventParty>(playerLootedMembers.Key, out var mapEventParty)) continue;
 
@@ -110,7 +113,7 @@ public class MapEventResultsInterface : IMapEventResultsInterface
             }
 
             // Pack looted prisoners (troops taken prisoner from defeated party)
-            foreach (var playerLootedPrisoners in networkPlayerLootData.LootedPrisoners)
+            foreach (var playerLootedPrisoners in networkLootedPrisoners)
             {
                 if (!objectManager.TryGetObjectWithLogging<MapEventParty>(playerLootedPrisoners.Key, out var mapEventParty)) continue;
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

After losing a field battle through Send Troops and closing the Defeat screen, the encounter menu can remain open but stop responding. In the reported case the party still showed 76 troops, but choosing Send Troops again did not start another simulation.

## What is the new behavior?

Resolves #2111

Closing the Defeat screen after a Send Troops loss now finishes the concluded encounter and closes its menu normally instead of leaving the player at an unresponsive encounter menu.

## Bot Changelog Entry

- Fixed the encounter menu becoming unresponsive after losing a field battle through Send Troops.
