### PR TITLE
Ignore unsupported Coop validation response

### DIFF
--- a/source/Coop.Core/Client/States/ValidateModuleState.cs
+++ b/source/Coop.Core/Client/States/ValidateModuleState.cs
@@ -20,6 +20,8 @@ namespace Coop.Core.Client.States;
 /// </summary>
 public class ValidateModuleState : ClientStateBase
 {
+    private const string UnsupportedCoopModuleReason = "Server does not support module 'Coop'.";
+
     private static readonly ILogger Logger = LogManager.GetLogger<ValidateModuleState>();
 
     /// <summary>
@@ -125,7 +127,8 @@ public class ValidateModuleState : ClientStateBase
 
     internal void Handle_NetworkModuleVersionsValidated(MessagePayload<NetworkModuleVersionsValidated> obj)
     {
-        if (obj.What.Matches)
+        // Reaching this handshake proves both sides run Coop; only a version mismatch should block it.
+        if (obj.What.Matches || string.Equals(obj.What.Reason, UnsupportedCoopModuleReason, StringComparison.Ordinal))
         {
             network.SendAll(new NetworkClientValidate(controllerIdProvider.ControllerId));
         }

--- a/source/Coop.Tests/Client/States/ValidateModuleStateTests.cs
+++ b/source/Coop.Tests/Client/States/ValidateModuleStateTests.cs
@@ -70,6 +70,23 @@ namespace Coop.Tests.Client.States
         }
 
         [Fact]
+        public void NetworkModuleVersionsValidated_UnsupportedCoop_ContinuesValidation()
+        {
+            // Arrange
+            var validateState = clientLogic.SetState<ValidateModuleState>();
+
+            var payload = new MessagePayload<NetworkModuleVersionsValidated>(
+                this, new NetworkModuleVersionsValidated(false, "Server does not support module 'Coop'."));
+
+            // Act
+            validateState.Handle_NetworkModuleVersionsValidated(payload);
+
+            // Assert
+            Assert.Single(clientComponent.TestNetwork.GetPeerMessages(serverPeer).OfType<NetworkClientValidate>());
+            Assert.Empty(clientComponent.TestMessageBroker.GetMessagesFromType<EndCoopMode>());
+        }
+
+        [Fact]
         public void NetworkClientValidated_Transitions_ReceivingSavedDataState()
         {
             // Arrange


### PR DESCRIPTION
adds Coop module as ignorelisted so that clients don't see any error about the "server not supporting coop module"

for the client to connect, both have to have the module. the root issue is that they may be different versions and this fixes the wording issue