### PR TITLE
[2064] Prevent negative focus points after player join

### DIFF
--- a/source/E2E.Tests/Services/HeroDevelopers/HeroDeveloperSyncTests.cs
+++ b/source/E2E.Tests/Services/HeroDevelopers/HeroDeveloperSyncTests.cs
@@ -1,5 +1,8 @@
-﻿using Common.Network.Coalescing;
+﻿using Common.Network;
+using Common.Network.Coalescing;
+using E2E.Tests.Environment.Instance;
 using E2E.Tests.Util;
+using GameInterface.Services.CharacterDevelopers.Messages;
 using HarmonyLib;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CharacterDevelopment;
@@ -95,5 +98,89 @@ public class HeroDeveloperSyncTests : SyncTestBase
 
             Assert.Equal(3, heroDeveloper.GetFocus(skill));
         }
+    }
+
+    [Fact]
+    public void Client_StaleFocusTarget_DoesNotSpendServerPoints()
+    {
+        var skillId = TestEnvironment.CreateRegisteredObject<SkillObject>();
+        SetServerFocusState(new[] { skillId }, focusLevel: 4, unspentFocusPoints: 1);
+
+        SendFocusTargets(Clients.First(), new[] { skillId }, new[] { 4 });
+
+        AssertFocusState(Server, skillId, focusLevel: 4, unspentFocusPoints: 1);
+        foreach (var client in Clients)
+        {
+            AssertFocusState(client, skillId, focusLevel: 4, unspentFocusPoints: 1);
+        }
+    }
+
+    [Fact]
+    public void Client_FocusTarget_SpendsOnceAndPropagatesToClients()
+    {
+        var skillId = TestEnvironment.CreateRegisteredObject<SkillObject>();
+        SetServerFocusState(new[] { skillId }, focusLevel: 3, unspentFocusPoints: 2);
+        var client = Clients.First();
+
+        SendFocusTargets(client, new[] { skillId }, new[] { 5 });
+        SendFocusTargets(client, new[] { skillId }, new[] { 5 });
+
+        AssertFocusState(Server, skillId, focusLevel: 5, unspentFocusPoints: 0);
+        foreach (var currentClient in Clients)
+        {
+            AssertFocusState(currentClient, skillId, focusLevel: 5, unspentFocusPoints: 0);
+        }
+    }
+
+    [Fact]
+    public void Client_UnaffordableFocusTargets_ApplyNoChanges()
+    {
+        var firstSkillId = TestEnvironment.CreateRegisteredObject<SkillObject>();
+        var secondSkillId = TestEnvironment.CreateRegisteredObject<SkillObject>();
+        SetServerFocusState(new[] { firstSkillId, secondSkillId }, focusLevel: 1, unspentFocusPoints: 1);
+
+        SendFocusTargets(Clients.First(), new[] { firstSkillId, secondSkillId }, new[] { 2, 2 });
+
+        AssertFocusState(Server, firstSkillId, focusLevel: 1, unspentFocusPoints: 1);
+        AssertFocusState(Server, secondSkillId, focusLevel: 1, unspentFocusPoints: 1);
+        foreach (var client in Clients)
+        {
+            AssertFocusState(client, firstSkillId, focusLevel: 1, unspentFocusPoints: 1);
+            AssertFocusState(client, secondSkillId, focusLevel: 1, unspentFocusPoints: 1);
+        }
+    }
+
+    private void SetServerFocusState(IEnumerable<string> skillIds, int focusLevel, int unspentFocusPoints)
+    {
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject(HeroDeveloperId, out HeroDeveloper heroDeveloper));
+            foreach (string skillId in skillIds)
+            {
+                Assert.True(Server.ObjectManager.TryGetObject(skillId, out SkillObject skill));
+                heroDeveloper.SetFocus(skill, focusLevel);
+            }
+
+            heroDeveloper.UnspentFocusPoints = unspentFocusPoints;
+        });
+    }
+
+    private void SendFocusTargets(EnvironmentInstance client, IEnumerable<string> skillIds, IEnumerable<int> focusLevels)
+    {
+        client.Call(() => client.Resolve<INetwork>().SendAll(new NetworkApplyChanges(
+            HeroDeveloperId,
+            new List<string>(),
+            new List<string>(),
+            new List<int>(),
+            skillIds.ToList(),
+            focusLevels.ToList())));
+    }
+
+    private void AssertFocusState(EnvironmentInstance instance, string skillId, int focusLevel, int unspentFocusPoints)
+    {
+        Assert.True(instance.ObjectManager.TryGetObject(HeroDeveloperId, out HeroDeveloper heroDeveloper));
+        Assert.True(instance.ObjectManager.TryGetObject(skillId, out SkillObject skill));
+        Assert.Equal(focusLevel, heroDeveloper.GetFocus(skill));
+        Assert.Equal(unspentFocusPoints, heroDeveloper.UnspentFocusPoints);
     }
 }

--- a/source/GameInterface/Services/CharacterDevelopers/Commands/CharacterDeveloperCommands.cs
+++ b/source/GameInterface/Services/CharacterDevelopers/Commands/CharacterDeveloperCommands.cs
@@ -36,6 +36,10 @@ internal class CharacterDeveloperCommands
 
                 heroData += " Total XP: " + hero.HeroDeveloper.TotalXp + "\n";
 
+                heroData += " Unspent Focus Points: " + hero.HeroDeveloper.UnspentFocusPoints + "\n";
+
+                heroData += " Unspent Attribute Points: " + hero.HeroDeveloper.UnspentAttributePoints + "\n";
+
                 heroData += " Attributes: {";
                 foreach (CharacterAttribute attribute in hero._characterAttributes._attributes.Keys)
                 {

--- a/source/GameInterface/Services/CharacterDevelopers/Handlers/CharacterDeveloperHandler.cs
+++ b/source/GameInterface/Services/CharacterDevelopers/Handlers/CharacterDeveloperHandler.cs
@@ -151,6 +151,7 @@ namespace GameInterface.Services.CharacterDevelopers.Handlers
             {
                 string skillId = skillIds[i];
 
+                // Reject the whole request so focus changes are applied atomically.
                 if (!objectManager.TryGetObjectWithLogging<SkillObject>(skillId, out var currentSkill)) return;
 
                 int targetFocusLevel = skillFocusLevels[i];

--- a/source/GameInterface/Services/CharacterDevelopers/Handlers/CharacterDeveloperHandler.cs
+++ b/source/GameInterface/Services/CharacterDevelopers/Handlers/CharacterDeveloperHandler.cs
@@ -6,6 +6,7 @@ using GameInterface.Services.CharacterDevelopers.Messages;
 using GameInterface.Services.ObjectManager;
 using Serilog;
 using System.Collections.Generic;
+using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CharacterDevelopment;
 using TaleWorlds.Core;
 
@@ -69,14 +70,12 @@ namespace GameInterface.Services.CharacterDevelopers.Handlers
                 // Store skill ids and levels in lists for transmission over the network
                 var skillIds = new List<string>();
                 var skillFocusLevels = new List<int>();
-                var skillOrgFocusAmounts = new List<int>();
                 foreach (var skillVM in data.Skills)
                 {
                     if (!objectManager.TryGetId(skillVM.Skill, out var currentSkillId)) continue;
 
                     skillIds.Add(currentSkillId);
                     skillFocusLevels.Add(skillVM.CurrentFocusLevel);
-                    skillOrgFocusAmounts.Add(skillVM._orgFocusAmount);
                 }
 
                 // Send to server from client
@@ -86,8 +85,7 @@ namespace GameInterface.Services.CharacterDevelopers.Handlers
                     attributeIds,
                     attributeIncreases,
                     skillIds,
-                    skillFocusLevels,
-                    skillOrgFocusAmounts
+                    skillFocusLevels
                 );
                 network.SendAll(message);
             });
@@ -103,7 +101,7 @@ namespace GameInterface.Services.CharacterDevelopers.Handlers
 
                 AddPerks(data.PerkIds, heroDeveloper);
                 AddAttributes(data.AttributeIds, data.AttributeIncreases, heroDeveloper);
-                AddFocuses(data.SkillIds, data.SkillFocusLevels, data.SkillOrgFocusAmounts, heroDeveloper);
+                AddFocuses(data.SkillIds, data.SkillFocusLevels, heroDeveloper);
             });
         }
 
@@ -135,23 +133,54 @@ namespace GameInterface.Services.CharacterDevelopers.Handlers
             }
         }
 
-        private void AddFocuses(List<string> skillIds, List<int> skillFocusLevels, List<int> skillOrgFocusAmounts, HeroDeveloper heroDeveloper)
+        private void AddFocuses(List<string> skillIds, List<int> skillFocusLevels, HeroDeveloper heroDeveloper)
         {
-            if (skillIds == null) return;
+            if (skillIds == null || skillFocusLevels == null) return;
+
+            if (skillIds.Count != skillFocusLevels.Count)
+            {
+                Logger.Warning("Rejected focus changes with mismatched skill and focus counts");
+                return;
+            }
+
+            var focusChanges = new List<(SkillObject Skill, int Increase)>();
+            int requiredFocusPoints = 0;
+            int maxFocusPerSkill = Campaign.Current.Models.CharacterDevelopmentModel.MaxFocusPerSkill;
 
             for (int i = 0; i < skillIds.Count; i++)
             {
                 string skillId = skillIds[i];
 
-                if (!objectManager.TryGetObjectWithLogging<SkillObject>(skillId, out var currentSkill)) continue;
+                if (!objectManager.TryGetObjectWithLogging<SkillObject>(skillId, out var currentSkill)) return;
 
-                for (int j = 0; j < skillFocusLevels[i] - skillOrgFocusAmounts[i]; j++)
+                int targetFocusLevel = skillFocusLevels[i];
+                int focusIncrease = targetFocusLevel - heroDeveloper.GetFocus(currentSkill);
+                if (focusIncrease <= 0) continue;
+
+                if (targetFocusLevel > maxFocusPerSkill)
                 {
-                    heroDeveloper.AddFocus(currentSkill, 1);
+                    Logger.Warning("Rejected focus target {TargetFocusLevel} for {SkillId}; maximum is {MaxFocusPerSkill}",
+                        targetFocusLevel, skillId, maxFocusPerSkill);
+                    return;
                 }
 
-                // Needed to calculate remaining skill points correctly
-                skillOrgFocusAmounts[i] = skillFocusLevels[i];
+                focusChanges.Add((currentSkill, focusIncrease));
+                requiredFocusPoints += focusIncrease * heroDeveloper.GetRequiredFocusPointsToAddFocus(currentSkill);
+            }
+
+            if (requiredFocusPoints > heroDeveloper.UnspentFocusPoints)
+            {
+                Logger.Warning("Rejected focus changes requiring {RequiredFocusPoints} points; only {UnspentFocusPoints} remain",
+                    requiredFocusPoints, heroDeveloper.UnspentFocusPoints);
+                return;
+            }
+
+            foreach (var focusChange in focusChanges)
+            {
+                for (int i = 0; i < focusChange.Increase; i++)
+                {
+                    heroDeveloper.AddFocus(focusChange.Skill, 1);
+                }
             }
         }
     }

--- a/source/GameInterface/Services/CharacterDevelopers/Messages/NetworkApplyChanges.cs
+++ b/source/GameInterface/Services/CharacterDevelopers/Messages/NetworkApplyChanges.cs
@@ -25,17 +25,13 @@ internal readonly struct NetworkApplyChanges : ICommand
     [ProtoMember(6)]
     public readonly List<int> SkillFocusLevels;
 
-    [ProtoMember(7)]
-    public readonly List<int> SkillOrgFocusAmounts;
-
     public NetworkApplyChanges(
         string heroDeveloperId,
         List<string> perkIds,
         List<string> attributeIds,
         List<int> attributeIncreases,
         List<string> skillIds,
-        List<int> skillFocusLevels,
-        List<int> skillOrgFocusAmounts)
+        List<int> skillFocusLevels)
     {
         HeroDeveloperId = heroDeveloperId;
         PerkIds = perkIds;
@@ -43,6 +39,5 @@ internal readonly struct NetworkApplyChanges : ICommand
         AttributeIncreases = attributeIncreases;
         SkillIds = skillIds;
         SkillFocusLevels = skillFocusLevels;
-        SkillOrgFocusAmounts = skillOrgFocusAmounts;
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Leveling up after joining and then submitting the Character screen can spend the character's existing focus allocations again, leaving a fresh character with negative focus points.

## What is the new behavior?

Resolves #2064

Submitting the Character screen now spends only the points needed for newly selected focus levels. Reopening or repeating an unchanged submission leaves the balance alone, and an unaffordable selection leaves all focus allocations unchanged.

## Bot Changelog Entry

- Prevented focus points from becoming negative when a player levels up after joining.
