### PR TITLE
[2044] Allow Space to unpause from campaign menus

### DIFF
--- a/source/GameInterface/Services/Time/Patches/TimePatches.cs
+++ b/source/GameInterface/Services/Time/Patches/TimePatches.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Reflection.Emit;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Encounters;
+using TaleWorlds.CampaignSystem.GameMenus;
 using TaleWorlds.CampaignSystem.ViewModelCollection.Map.MapBar;
 
 namespace GameInterface.Services.Heroes.Patches;
@@ -157,6 +158,8 @@ internal class AllowTimeControlFromHotKeysPatches
         var revoke = AccessTools.Method(typeof(AllowedThread), nameof(AllowedThread.RevokeThisThread));
 
         var setTime = AccessTools.Method(typeof(Campaign), nameof(Campaign.SetTimeSpeed));
+        var isWaitActive = AccessTools.PropertyGetter(typeof(GameMenu), nameof(GameMenu.IsWaitActive));
+        var allowTimeControlInMenu = AccessTools.Method(typeof(AllowTimeControlFromHotKeysPatches), nameof(AllowTimeControlInMenu));
 
         foreach (var instr in instructions)
         {
@@ -167,12 +170,21 @@ internal class AllowTimeControlFromHotKeysPatches
                 yield return instr;
                 yield return new CodeInstruction(OpCodes.Call, revoke);
             }
+            else if (instr.Calls(isWaitActive))
+            {
+                // Co-op pauses when everyone is occupied, so menus must still let a player resume time.
+                instr.opcode = OpCodes.Call;
+                instr.operand = allowTimeControlInMenu;
+                yield return instr;
+            }
             else
             {
                 yield return instr;
             }
         }
     }
+
+    private static bool AllowTimeControlInMenu(GameMenu _) => true;
 }
 
 [HarmonyPatch(typeof(PlayerEncounter), nameof(PlayerEncounter.Finish))]


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Pressing Space after entering or leaving a battle instance does not resume campaign time while the encounter menu is open.

## What is the new behavior?

Resolves #2044

Pressing Space now toggles campaign time from encounter and other campaign menus, while existing loading and map-event speed restrictions still apply.

## Bot Changelog Entry

- Allow Space to resume campaign time from campaign menus
