### PR TITLE
[2151] Fix the Clan screen for workshop owners

### DIFF
--- a/source/E2E.Tests/Services/Workshops/WorkshopPurchaseConversationTests.cs
+++ b/source/E2E.Tests/Services/Workshops/WorkshopPurchaseConversationTests.cs
@@ -9,6 +9,11 @@ using GameInterface.Services.Entity;
 using GameInterface.Services.Heroes.Messages;
 using GameInterface.Services.Players;
 using GameInterface.Services.Players.Data;
+using GameInterface.Services.Workshops.Commands;
+using GameInterface.Services.Workshops.Interfaces;
+using HarmonyLib;
+using WarehouseOwnerChanged = GameInterface.Services.Workshops.Messages.ChangeWorkshopOwner;
+using WarehouseOwnerChangedEvent = GameInterface.Services.Workshops.Messages.WorkshopOwnerChanged;
 using System.Collections.Generic;
 using System.Linq;
 using TaleWorlds.CampaignSystem;
@@ -27,6 +32,9 @@ public class WorkshopPurchaseConversationTests : IDisposable
     private const string BuyerControllerId = "WorkshopBuyer";
     private const int WorkshopCapital = 1000;
     private const int WorkshopCost = 400;
+    private static Workshop expectedDispatchedWorkshop;
+    private static Hero expectedDispatchedOldOwner;
+    private static int observedOwnerChangeDispatches;
 
     private E2ETestEnvironment TestEnvironment { get; }
     private EnvironmentInstance Server => TestEnvironment.Server;
@@ -73,6 +81,72 @@ public class WorkshopPurchaseConversationTests : IDisposable
 
         AssertClanWorkshopDataReadyForClanMenu(client, state);
         Assert.Single(Server.NetworkSentMessages.GetMessages<RefreshWorkshopsList>());
+    }
+
+    [Fact]
+    public void DebugOwnerChange_ServerPreparesClientWarehouseDataForClanMenu()
+    {
+        var client = Clients.First();
+        var state = CreatePurchaseState(workshopOwnedByBuyer: false, buyerGold: 1000, sellerGold: 0);
+        var harmony = new Harmony("e2e.workshops.debug-owner-change");
+        Workshop serverWorkshop = null;
+        Hero serverOldOwner = null;
+
+        try
+        {
+            Server.Call(() =>
+            {
+                Assert.True(Server.ObjectManager.TryGetObject<Workshop>(state.WorkshopId, out serverWorkshop));
+                Assert.True(Server.ObjectManager.TryGetObject<Hero>(state.BuyerId, out var buyer));
+
+                serverOldOwner = serverWorkshop.Owner;
+                expectedDispatchedWorkshop = serverWorkshop;
+                expectedDispatchedOldOwner = serverOldOwner;
+                observedOwnerChangeDispatches = 0;
+                Server.Resolve<ISessionWorkshopPlayerDataInterface>().AddPlayerKeys(state.BuyerId);
+
+                harmony.Patch(
+                    AccessTools.Method(typeof(CampaignEventDispatcher), nameof(CampaignEventDispatcher.OnWorkshopOwnerChanged)),
+                    prefix: new HarmonyMethod(typeof(WorkshopPurchaseConversationTests), nameof(ObserveOwnerChangeDispatch)));
+
+                WorkshopDebugCommand.ApplyOwnerChange(serverWorkshop, buyer);
+            });
+
+            Assert.Equal(1, observedOwnerChangeDispatches);
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmony.Id);
+            expectedDispatchedWorkshop = null;
+            expectedDispatchedOldOwner = null;
+        }
+
+        Server.Call(() =>
+        {
+            // The E2E harness does not register campaign behavior events. Publish the patched
+            // behavior event separately after proving the action reached CampaignEventDispatcher.
+            var workshopsBehavior = Campaign.Current.GetCampaignBehavior<WorkshopsCampaignBehavior>();
+            MessageBroker.Instance.Publish(
+                workshopsBehavior,
+                new WarehouseOwnerChangedEvent(serverWorkshop, serverOldOwner));
+        });
+
+        AssertWorkshopOwnedByBuyer(Server, state, expectedBuyerGold: 1000, expectedSellerGold: 0);
+        Assert.Single(Server.NetworkSentMessages.GetMessages<WarehouseOwnerChanged>());
+        foreach (var environmentClient in Clients)
+        {
+            AssertWorkshopOwnedByBuyer(environmentClient, state, expectedBuyerGold: 1000, expectedSellerGold: 0);
+        }
+
+        AssertClanWorkshopDataReadyForClanMenu(client, state);
+    }
+
+    private static void ObserveOwnerChangeDispatch(Workshop workshop, Hero oldOwner)
+    {
+        if (workshop == expectedDispatchedWorkshop && oldOwner == expectedDispatchedOldOwner)
+        {
+            observedOwnerChangeDispatches++;
+        }
     }
 
     [Fact]

--- a/source/GameInterface.Tests/Services/Workshops/WorkshopDebugCommandTests.cs
+++ b/source/GameInterface.Tests/Services/Workshops/WorkshopDebugCommandTests.cs
@@ -1,0 +1,25 @@
+﻿using Common.Util;
+using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Workshops.Commands;
+using Moq;
+using TaleWorlds.CampaignSystem;
+using Xunit;
+
+namespace GameInterface.Tests.Services.Workshops;
+
+public class WorkshopDebugCommandTests
+{
+    [Fact]
+    public void ResolveHero_RegistryId_ReturnsRegisteredPlayerHero()
+    {
+        Hero playerHero = ObjectHelper.SkipConstructor<Hero>();
+        var objectManager = new Mock<IObjectManager>();
+        objectManager
+            .Setup(manager => manager.TryGetObject<Hero>("Hero_Player2863", out playerHero))
+            .Returns(true);
+
+        Hero result = WorkshopDebugCommand.ResolveHero("Hero_Player2863", objectManager.Object);
+
+        Assert.Same(playerHero, result);
+    }
+}

--- a/source/GameInterface.Tests/Services/Workshops/WorkshopsCampaignBehaviorInitializationHandlerTests.cs
+++ b/source/GameInterface.Tests/Services/Workshops/WorkshopsCampaignBehaviorInitializationHandlerTests.cs
@@ -1,0 +1,87 @@
+﻿using Common.Util;
+using GameInterface.Services.Workshops.Handlers;
+using System.Collections.Generic;
+using System.Reflection;
+using TaleWorlds.CampaignSystem.Roster;
+using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.CampaignSystem.Settlements.Workshops;
+using Xunit;
+
+namespace GameInterface.Tests.Services.Workshops;
+
+public class WorkshopsCampaignBehaviorInitializationHandlerTests
+{
+    [Fact]
+    public void AddMissingOwnedWorkshopRosters_NoSavedRoster_AddsEmptyRosterForWorkshopSettlement()
+    {
+        Settlement settlement = ObjectHelper.SkipConstructor<Settlement>();
+        Workshop workshop = ObjectHelper.SkipConstructor<Workshop>();
+        typeof(Workshop).GetField("_settlement", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(workshop, settlement);
+        var warehouseRosters = new Dictionary<Settlement, ItemRoster>();
+
+        WorkshopsCampaignBehaviorInitializationHandler.AddMissingOwnedWorkshopRosters(
+            warehouseRosters,
+            new[] { workshop });
+
+        ItemRoster roster = Assert.Contains(settlement, warehouseRosters);
+        Assert.Empty(roster);
+    }
+
+    [Fact]
+    public void CreateWarehouseRosterSlots_NoSavedRosters_UsesMinimumCapacity()
+    {
+        var warehouseRosters = new Dictionary<Settlement, ItemRoster>();
+
+        KeyValuePair<Settlement, ItemRoster>[] result =
+            WorkshopsCampaignBehaviorInitializationHandler.CreateWarehouseRosterSlots(warehouseRosters, 4);
+
+        Assert.Equal(4, result.Length);
+        Assert.All(result, slot =>
+        {
+            Assert.Null(slot.Key);
+            Assert.Null(slot.Value);
+        });
+    }
+
+    [Fact]
+    public void CreateWarehouseRosterSlots_SavedRosters_PreservesEntriesAndUnusedCapacity()
+    {
+        Settlement settlement = ObjectHelper.SkipConstructor<Settlement>();
+        var itemRoster = new ItemRoster();
+        var warehouseRosters = new Dictionary<Settlement, ItemRoster>
+        {
+            [settlement] = itemRoster,
+        };
+
+        KeyValuePair<Settlement, ItemRoster>[] result =
+            WorkshopsCampaignBehaviorInitializationHandler.CreateWarehouseRosterSlots(warehouseRosters, 3);
+
+        Assert.Equal(3, result.Length);
+        Assert.Same(settlement, result[0].Key);
+        Assert.Same(itemRoster, result[0].Value);
+        Assert.Null(result[1].Key);
+        Assert.Null(result[1].Value);
+    }
+
+    [Fact]
+    public void CreateWarehouseRosterSlots_MoreRostersThanMinimum_PreservesEveryEntry()
+    {
+        Settlement firstSettlement = ObjectHelper.SkipConstructor<Settlement>();
+        Settlement secondSettlement = ObjectHelper.SkipConstructor<Settlement>();
+        var firstRoster = new ItemRoster();
+        var secondRoster = new ItemRoster();
+        var warehouseRosters = new Dictionary<Settlement, ItemRoster>
+        {
+            [firstSettlement] = firstRoster,
+            [secondSettlement] = secondRoster,
+        };
+
+        KeyValuePair<Settlement, ItemRoster>[] result =
+            WorkshopsCampaignBehaviorInitializationHandler.CreateWarehouseRosterSlots(warehouseRosters, 1);
+
+        Assert.Equal(2, result.Length);
+        Assert.Contains(result, slot => slot.Key == firstSettlement && slot.Value == firstRoster);
+        Assert.Contains(result, slot => slot.Key == secondSettlement && slot.Value == secondRoster);
+    }
+}

--- a/source/GameInterface/Services/Workshops/Commands/WorkshopDebugCommand.cs
+++ b/source/GameInterface/Services/Workshops/Commands/WorkshopDebugCommand.cs
@@ -1,6 +1,7 @@
 ﻿using Autofac;
 using Common;
 using GameInterface.CoopSessionData;
+using GameInterface.Services.Actions.Patches;
 using GameInterface.Services.ObjectManager;
 using System.Collections.Generic;
 using System.Text;
@@ -34,6 +35,26 @@ namespace GameInterface.Services.Workshops.Commands
                 }
             }
             return null;
+        }
+
+        internal static Hero ResolveHero(string heroId, IObjectManager objectManager)
+        {
+            if (objectManager.TryGetObject<Hero>(heroId, out var registeredHero))
+            {
+                return registeredHero;
+            }
+
+            return Hero.FindFirst(hero => hero.StringId == heroId || hero.Name?.ToString() == heroId);
+        }
+
+        internal static void ApplyOwnerChange(Workshop workshop, Hero newOwner)
+        {
+            ChangeOwnerOfWorkshopActionPatches.ApplyInternalOverride(
+                workshop,
+                newOwner,
+                workshop.WorkshopType,
+                1000,
+                0);
         }
 
         [CommandLineArgumentFunction("set_workshop_custom_name", "coop.debug.workshop")]
@@ -78,7 +99,7 @@ namespace GameInterface.Services.Workshops.Commands
             // Expect three arguments: settlement name, workshop type, and new owner (hero ID or name)
             if (args.Count != 3)
             {
-                return "Usage: coop.debug.workshop.set_owner <settlementName> <workshopType> <newOwnerId>";
+                return "Usage: coop.debug.workshop.set_workshop_owner <settlementName> <workshopType> <newOwnerId>";
             }
 
             string settlementName = args[0];
@@ -107,14 +128,20 @@ namespace GameInterface.Services.Workshops.Commands
             }
 
             // Find the new owner (Hero) by ID or name
-            Hero newOwner = Hero.FindFirst(h => h.StringId == newOwnerId || h.Name.ToString() == newOwnerId);
-            if (newOwner == null)
+            if (!TryGetObjectManager(out var objectManager))
             {
-                return $"Hero with ID or Name: '{newOwnerId}' not found";
+                return "Unable to resolve ObjectManager";
             }
 
-            // Use the existing Workshop method to change the owner
-            workshop.ChangeOwnerOfWorkshop(newOwner, workshop.WorkshopType, 1000);
+            Hero newOwner = ResolveHero(newOwnerId, objectManager);
+            if (newOwner == null)
+            {
+                return $"Hero with ID or Name: '{newOwnerId}' not found (use the registry id from coop.debug.alley.my_hero_id on the owning client)";
+            }
+
+            // Use the same action path as normal workshop purchases so ownership-dependent
+            // campaign behavior and client warehouse data are updated too.
+            ApplyOwnerChange(workshop, newOwner);
 
             return $"Workshop owner has been changed to: {newOwner.Name} with the type {workshop.WorkshopType} and with a capital of {workshop.Capital}";
         }

--- a/source/GameInterface/Services/Workshops/Handlers/WorkshopWarehouseHandler.cs
+++ b/source/GameInterface/Services/Workshops/Handlers/WorkshopWarehouseHandler.cs
@@ -125,6 +125,10 @@ internal class WorkshopWarehouseHandler : IHandler
                 using (new AllowedThread())
                 {
                     workshopsBehavior.EnsureBehaviorDataSize();
+                    if (workshopsBehavior.GetDataOfWorkshop(workshop) == null)
+                    {
+                        workshopsBehavior.AddNewWorkshopData(workshop);
+                    }
                     workshopsBehavior.AddNewWarehouseDataIfNeeded(workshop.Settlement);
                 }
                 return;

--- a/source/GameInterface/Services/Workshops/Handlers/WorkshopsCampaignBehaviorInitializationHandler.cs
+++ b/source/GameInterface/Services/Workshops/Handlers/WorkshopsCampaignBehaviorInitializationHandler.cs
@@ -9,11 +9,12 @@ using GameInterface.Services.Workshops.Interfaces;
 using GameInterface.Services.Workshops.Messages;
 using Serilog;
 using System.Collections.Generic;
-using System.Linq;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
 using TaleWorlds.CampaignSystem.Roster;
 using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.CampaignSystem.Settlements.Workshops;
+using TaleWorlds.Core;
 
 namespace GameInterface.Services.Workshops.Handlers
 {
@@ -57,11 +58,12 @@ namespace GameInterface.Services.Workshops.Handlers
         // Need to load workshop data when the hero changes for the player
         private void Handle(MessagePayload<PlayerHeroChanged> obj)
         {
-            if (!objectManager.TryGetIdWithLogging(obj.What.NewHero, out string playerHeroId)) return;
+            Hero playerHero = obj.What.NewHero;
+            if (!objectManager.TryGetIdWithLogging(playerHero, out string playerHeroId)) return;
 
             WorkshopsCampaignBehavior workshopsCampaignBehavior = Campaign.Current.GetCampaignBehavior<WorkshopsCampaignBehavior>();
 
-            workshopsCampaignBehavior._warehouseRosterPerSettlement = GetWarehouseRosterPerSettlement(playerHeroId).ToArray();
+            workshopsCampaignBehavior._warehouseRosterPerSettlement = GetWarehouseRosterPerSettlement(playerHeroId, playerHero);
 
             network.SendAll(new NetworkInitializeServerWorkshopDataKeys(playerHeroId));
         }
@@ -71,7 +73,7 @@ namespace GameInterface.Services.Workshops.Handlers
             sessionWorkshopPlayerDataInterface.AddPlayerKeys(obj.What.PlayerHeroId);
         }
 
-        private Dictionary<Settlement, ItemRoster> GetWarehouseRosterPerSettlement(string playerHeroId)
+        private KeyValuePair<Settlement, ItemRoster>[] GetWarehouseRosterPerSettlement(string playerHeroId, Hero playerHero)
         {
             Dictionary<Settlement, ItemRoster> warehouseRosterPerSettlement = new();
             int maxWorkshopCount = 0;
@@ -83,27 +85,64 @@ namespace GameInterface.Services.Workshops.Handlers
                     maxWorkshopCount = Campaign.Current.Models.WorkshopModel.MaximumWorkshopsPlayerCanHave;
                 }
 
-                // Null and key check for players without existing workshop data
-                if (workshopPlayerData?.PlayerWarehouseRosterPerSettlement?.ContainsKey(playerHeroId) != true) return;
-
-                foreach (var settlementRoster in workshopPlayerData.PlayerWarehouseRosterPerSettlement[playerHeroId])
+                if (workshopPlayerData?.PlayerWarehouseRosterPerSettlement?.TryGetValue(playerHeroId, out var savedRosters) == true && savedRosters != null)
                 {
-                    if (settlementRoster.Key == null)
-                        continue;
-
-                    if (!objectManager.TryGetObjectWithLogging<Settlement>(settlementRoster.Key, out var settlement)) continue;
-
-                    var itemRoster = new ItemRoster();
-                    foreach (var elementData in settlementRoster.Value)
+                    foreach (var settlementRoster in savedRosters)
                     {
-                        itemRoster.Add(sessionWorkshopPlayerDataInterface.GetItemRosterElementFromData(elementData));
-                    }
+                        if (settlementRoster.Key == null || settlementRoster.Value == null)
+                            continue;
 
-                    warehouseRosterPerSettlement[settlement] = itemRoster;
+                        if (!objectManager.TryGetObjectWithLogging<Settlement>(settlementRoster.Key, out var settlement)) continue;
+
+                        var itemRoster = new ItemRoster();
+                        foreach (var elementData in settlementRoster.Value)
+                        {
+                            ItemRosterElement rosterElement = sessionWorkshopPlayerDataInterface.GetItemRosterElementFromData(elementData);
+                            if (rosterElement.EquipmentElement.Item == null) continue;
+
+                            itemRoster.Add(rosterElement);
+                        }
+
+                        warehouseRosterPerSettlement[settlement] = itemRoster;
+                    }
                 }
+
+                AddMissingOwnedWorkshopRosters(warehouseRosterPerSettlement, playerHero.OwnedWorkshops);
             }, blocking: true);
 
-            return warehouseRosterPerSettlement;
+            return CreateWarehouseRosterSlots(warehouseRosterPerSettlement, maxWorkshopCount);
+        }
+
+        internal static void AddMissingOwnedWorkshopRosters(
+            IDictionary<Settlement, ItemRoster> warehouseRosters,
+            IEnumerable<Workshop> ownedWorkshops)
+        {
+            foreach (var workshop in ownedWorkshops)
+            {
+                Settlement settlement = workshop?.Settlement;
+                if (settlement != null && !warehouseRosters.ContainsKey(settlement))
+                {
+                    warehouseRosters[settlement] = new ItemRoster();
+                }
+            }
+        }
+
+        internal static KeyValuePair<Settlement, ItemRoster>[] CreateWarehouseRosterSlots(
+            IReadOnlyCollection<KeyValuePair<Settlement, ItemRoster>> warehouseRosters,
+            int minimumCapacity)
+        {
+            int capacity = warehouseRosters.Count > minimumCapacity
+                ? warehouseRosters.Count
+                : minimumCapacity;
+            var rosterSlots = new KeyValuePair<Settlement, ItemRoster>[capacity];
+            int index = 0;
+
+            foreach (var warehouseRoster in warehouseRosters)
+            {
+                rosterSlots[index++] = warehouseRoster;
+            }
+
+            return rosterSlots;
         }
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Opening Clan after the player's hero acquires a workshop can leave only a black background instead of loading the Clan interface, particularly when that workshop settlement has no saved warehouse inventory.

## What is the new behavior?

Resolves #2151

Opening Clan after acquiring a workshop now loads the complete Clan interface and Income tab, including for newly acquired workshops that do not yet have warehouse inventory.

## Bot Changelog Entry

- Fixed the Clan screen appearing black for players who own workshops.
