### PR TITLE
[2166] Prevent dead players from fast-forwarding battles

### DIFF
--- a/source/GameInterface/Services/UI/Patches/DeadPlayerFastForwardPatch.cs
+++ b/source/GameInterface/Services/UI/Patches/DeadPlayerFastForwardPatch.cs
@@ -1,6 +1,7 @@
 ﻿using GameInterface.Services.MapEvents;
 using HarmonyLib;
 using SandBox.ViewModelCollection;
+using TaleWorlds.Library;
 
 namespace GameInterface.Services.UI.Patches;
 
@@ -17,6 +18,8 @@ internal static class DeadPlayerFastForwardPatch
             return true;
 
         __instance.IsFastForwarding = false;
+        InformationManager.DisplayMessage(new InformationMessage(
+            "Fast forwarding is disabled during cooperative battles."));
         return false;
     }
 }

--- a/source/GameInterface/Services/UI/Patches/DeadPlayerFastForwardPatch.cs
+++ b/source/GameInterface/Services/UI/Patches/DeadPlayerFastForwardPatch.cs
@@ -1,0 +1,22 @@
+﻿using GameInterface.Services.MapEvents;
+using HarmonyLib;
+using SandBox.ViewModelCollection;
+
+namespace GameInterface.Services.UI.Patches;
+
+/// <summary>
+/// Keeps the native dead-player scoreboard from fast-forwarding live coop battles.
+/// </summary>
+[HarmonyPatch(typeof(SPScoreboardVM), nameof(SPScoreboardVM.ExecuteFastForwardAction))]
+internal static class DeadPlayerFastForwardPatch
+{
+    [HarmonyPrefix]
+    private static bool PreventCoopBattleFastForward(SPScoreboardVM __instance)
+    {
+        if (!BattleSpawnGate.IsCoopBattleActive || __instance.IsSimulation)
+            return true;
+
+        __instance.IsFastForwarding = false;
+        return false;
+    }
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Pressing F after dying during an active battle can fast-forward combat for every player, making movement and actions appear sped up and potentially increasing rubberbanding.

## What is the new behavior?

Resolves #2166

Pressing F after dying during an active battle no longer changes the battle speed. Combat continues at normal speed for every player, while simulated battles retain their existing fast-forward behavior.

## Bot Changelog Entry

- Dead players can no longer fast-forward active battles.
