### PR TITLE
[2149] Keep encyclopedia pages responsive

### DIFF
--- a/source/GameInterface.Tests/Services/UI/ConnectedPlayerCountServiceTests.cs
+++ b/source/GameInterface.Tests/Services/UI/ConnectedPlayerCountServiceTests.cs
@@ -40,26 +40,4 @@ public class ConnectedPlayerCountServiceTests
         Assert.Equal(formattedTitle, service.FormatEncyclopediaTitle(formattedTitle));
     }
 
-    [Fact]
-    public void FormatEncyclopediaTitle_WhenCountChanges_ReplacesPreviousCount()
-    {
-        var service = new ConnectedPlayerCountService();
-        service.UpdateConnectedPlayers(3);
-        var formattedTitle = service.FormatEncyclopediaTitle("Encyclopedia");
-
-        service.UpdateConnectedPlayers(4);
-
-        Assert.Equal("Encyclopedia (4 online)", service.FormatEncyclopediaTitle(formattedTitle));
-    }
-
-    [Fact]
-    public void FormatEncyclopediaTitle_PreservesParenthesesInBaseTitle()
-    {
-        var service = new ConnectedPlayerCountService();
-        service.UpdateConnectedPlayers(3);
-
-        Assert.Equal(
-            "Encyclopedia (Calradia) (3 online)",
-            service.FormatEncyclopediaTitle("Encyclopedia (Calradia)"));
-    }
 }

--- a/source/GameInterface.Tests/Services/UI/ConnectedPlayerCountServiceTests.cs
+++ b/source/GameInterface.Tests/Services/UI/ConnectedPlayerCountServiceTests.cs
@@ -29,4 +29,37 @@ public class ConnectedPlayerCountServiceTests
 
         Assert.Equal("Encyclopedia (3 online)", service.FormatEncyclopediaTitle("Encyclopedia"));
     }
+
+    [Fact]
+    public void FormatEncyclopediaTitle_WhenFormattedTitleIsReapplied_DoesNotAppendAgain()
+    {
+        var service = new ConnectedPlayerCountService();
+        service.UpdateConnectedPlayers(3);
+        var formattedTitle = service.FormatEncyclopediaTitle("Encyclopedia");
+
+        Assert.Equal(formattedTitle, service.FormatEncyclopediaTitle(formattedTitle));
+    }
+
+    [Fact]
+    public void FormatEncyclopediaTitle_WhenCountChanges_ReplacesPreviousCount()
+    {
+        var service = new ConnectedPlayerCountService();
+        service.UpdateConnectedPlayers(3);
+        var formattedTitle = service.FormatEncyclopediaTitle("Encyclopedia");
+
+        service.UpdateConnectedPlayers(4);
+
+        Assert.Equal("Encyclopedia (4 online)", service.FormatEncyclopediaTitle(formattedTitle));
+    }
+
+    [Fact]
+    public void FormatEncyclopediaTitle_PreservesParenthesesInBaseTitle()
+    {
+        var service = new ConnectedPlayerCountService();
+        service.UpdateConnectedPlayers(3);
+
+        Assert.Equal(
+            "Encyclopedia (Calradia) (3 online)",
+            service.FormatEncyclopediaTitle("Encyclopedia (Calradia)"));
+    }
 }

--- a/source/GameInterface.Tests/Services/UI/ConnectedPlayerCountServiceTests.cs
+++ b/source/GameInterface.Tests/Services/UI/ConnectedPlayerCountServiceTests.cs
@@ -39,5 +39,4 @@ public class ConnectedPlayerCountServiceTests
 
         Assert.Equal(formattedTitle, service.FormatEncyclopediaTitle(formattedTitle));
     }
-
 }

--- a/source/GameInterface/Services/UI/ConnectedPlayerCountService.cs
+++ b/source/GameInterface/Services/UI/ConnectedPlayerCountService.cs
@@ -10,15 +10,12 @@ public interface IConnectedPlayerCountService : IGameAbstraction
     int ConnectedPlayers { get; }
     event Action ConnectedPlayersChanged;
     void UpdateConnectedPlayers(int connectedPlayers);
-    string FormatEncyclopediaTitle(string baseTitle);
+    string FormatEncyclopediaTitle(string title);
 }
 
 /// <inheritdoc cref="IConnectedPlayerCountService"/>
 public class ConnectedPlayerCountService : IConnectedPlayerCountService
 {
-    private const string CountSuffixStart = " (";
-    private const string CountSuffixEnd = " online)";
-
     public int ConnectedPlayers { get; private set; }
     public event Action ConnectedPlayersChanged;
 
@@ -31,25 +28,9 @@ public class ConnectedPlayerCountService : IConnectedPlayerCountService
         ConnectedPlayersChanged?.Invoke();
     }
 
-    public string FormatEncyclopediaTitle(string baseTitle)
+    public string FormatEncyclopediaTitle(string title)
     {
-        string normalizedTitle = RemoveConnectedPlayerCount(baseTitle);
-        return $"{normalizedTitle} ({ConnectedPlayers} online)";
-    }
-
-    private static string RemoveConnectedPlayerCount(string title)
-    {
-        if (string.IsNullOrEmpty(title) || !title.EndsWith(CountSuffixEnd, StringComparison.Ordinal))
-            return title;
-
-        int suffixStart = title.LastIndexOf(CountSuffixStart, StringComparison.Ordinal);
-        if (suffixStart < 0) return title;
-
-        int countStart = suffixStart + CountSuffixStart.Length;
-        int countLength = title.Length - CountSuffixEnd.Length - countStart;
-        if (countLength <= 0 || !int.TryParse(title.Substring(countStart, countLength), out _))
-            return title;
-
-        return title.Substring(0, suffixStart);
+        string suffix = $" ({ConnectedPlayers} online)";
+        return title.EndsWith(suffix, StringComparison.Ordinal) ? title : title + suffix;
     }
 }

--- a/source/GameInterface/Services/UI/ConnectedPlayerCountService.cs
+++ b/source/GameInterface/Services/UI/ConnectedPlayerCountService.cs
@@ -16,6 +16,9 @@ public interface IConnectedPlayerCountService : IGameAbstraction
 /// <inheritdoc cref="IConnectedPlayerCountService"/>
 public class ConnectedPlayerCountService : IConnectedPlayerCountService
 {
+    private const string CountSuffixStart = " (";
+    private const string CountSuffixEnd = " online)";
+
     public int ConnectedPlayers { get; private set; }
     public event Action ConnectedPlayersChanged;
 
@@ -30,6 +33,23 @@ public class ConnectedPlayerCountService : IConnectedPlayerCountService
 
     public string FormatEncyclopediaTitle(string baseTitle)
     {
-        return $"{baseTitle} ({ConnectedPlayers} online)";
+        string normalizedTitle = RemoveConnectedPlayerCount(baseTitle);
+        return $"{normalizedTitle} ({ConnectedPlayers} online)";
+    }
+
+    private static string RemoveConnectedPlayerCount(string title)
+    {
+        if (string.IsNullOrEmpty(title) || !title.EndsWith(CountSuffixEnd, StringComparison.Ordinal))
+            return title;
+
+        int suffixStart = title.LastIndexOf(CountSuffixStart, StringComparison.Ordinal);
+        if (suffixStart < 0) return title;
+
+        int countStart = suffixStart + CountSuffixStart.Length;
+        int countLength = title.Length - CountSuffixEnd.Length - countStart;
+        if (countLength <= 0 || !int.TryParse(title.Substring(countStart, countLength), out _))
+            return title;
+
+        return title.Substring(0, suffixStart);
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Opening an encyclopedia page can make the interface stop responding after the online player count appears in the page title. Buttons cannot be clicked and Esc does not close the page.

## What is the new behavior?

Resolves #2149

Encyclopedia page titles now keep a single current online player count, so the page remains responsive and buttons and Esc continue to work.

## Bot Changelog Entry

- Fixed encyclopedia pages becoming unresponsive while showing the online player count.
