### PR TITLE
Fix campaign join synchronization

### DIFF
--- a/source/Coop.Tests/Server/Services/Time/CampaignTimeSyncHandlerTests.cs
+++ b/source/Coop.Tests/Server/Services/Time/CampaignTimeSyncHandlerTests.cs
@@ -1,9 +1,12 @@
 ﻿using Common.Network;
 using Common.PacketHandlers;
+using Coop.Core.Server.Connections;
 using Coop.Core.Server.Services.Time.Handlers;
 using GameInterface.Services.Time.Interfaces;
+using LiteNetLib;
 using Moq;
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -21,7 +24,7 @@ public class CampaignTimeSyncHandlerTests
 
         var network = new Mock<INetwork>();
         network
-            .Setup(n => n.SendAll(It.IsAny<IPacket>()))
+            .Setup(n => n.Send(It.IsAny<NetPeer>(), It.IsAny<IPacket>()))
             .Callback(() =>
             {
                 sendStarted.Set();
@@ -34,7 +37,19 @@ public class CampaignTimeSyncHandlerTests
             .Setup(m => m.TryGetCurrentTicks(out currentTicks))
             .Returns(true);
 
-        var handler = new CampaignTimeSyncHandler(network.Object, mapTimeTracker.Object);
+        var connection = new Mock<IConnectionLogic>();
+        IEnumerable<IConnectionLogic> connections = new[] { connection.Object };
+        var connectionCollection = new Mock<IConnectionCollection>();
+        connectionCollection
+            .Setup(c => c.GetEnumerator())
+            .Returns(() => connections.GetEnumerator());
+        var connectionMessageQueue = new Mock<IConnectionMessageQueue>();
+
+        var handler = new CampaignTimeSyncHandler(
+            network.Object,
+            mapTimeTracker.Object,
+            connectionCollection.Object,
+            connectionMessageQueue.Object);
 
         Assert.True(sendStarted.Wait(TimeSpan.FromSeconds(5)));
 

--- a/source/GameInterface.Tests/Services/MobileParties/MobilePartyBehaviorSnapshotTests.cs
+++ b/source/GameInterface.Tests/Services/MobileParties/MobilePartyBehaviorSnapshotTests.cs
@@ -1,0 +1,63 @@
+﻿using Common.Util;
+using GameInterface.Services.MobileParties.Data;
+using GameInterface.Services.ObjectManager;
+using Moq;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.Library;
+using Xunit;
+
+namespace GameInterface.Tests.Services.MobileParties;
+
+public class MobilePartyBehaviorSnapshotTests
+{
+    [Fact]
+    public void TryCreate_RegisteredMoveTarget_PreservesPartyNavigation()
+    {
+        var party = CreateParty();
+        var moveTarget = ObjectHelper.SkipConstructor<MobileParty>();
+        party.MoveTargetParty = moveTarget;
+
+        var objectManager = new Mock<IObjectManager>();
+        string partyId = "MobileParty_Created_1";
+        string moveTargetId = "MobileParty_Created_2";
+        objectManager.Setup(m => m.TryGetId(party, out partyId)).Returns(true);
+        objectManager.Setup(m => m.TryGetId(moveTarget, out moveTargetId)).Returns(true);
+
+        var snapshot = new MobilePartyBehaviorSnapshot(objectManager.Object);
+
+        Assert.True(snapshot.TryCreate(party, out PartyBehaviorUpdateData data));
+        Assert.Equal(MoveModeType.Party, data.PartyMoveMode);
+        Assert.Equal("Created_2", data.MoveTargetPartyId);
+    }
+
+    [Fact]
+    public void TryCreate_RemovedMoveTarget_UsesLastTargetPoint()
+    {
+        var party = CreateParty();
+        var removedMoveTarget = ObjectHelper.SkipConstructor<MobileParty>();
+        party.MoveTargetParty = removedMoveTarget;
+
+        var objectManager = new Mock<IObjectManager>();
+        string partyId = "MobileParty_Created_1";
+        string missingId = null!;
+        objectManager.Setup(m => m.TryGetId(party, out partyId)).Returns(true);
+        objectManager.Setup(m => m.TryGetId(removedMoveTarget, out missingId)).Returns(false);
+
+        var snapshot = new MobilePartyBehaviorSnapshot(objectManager.Object);
+
+        Assert.True(snapshot.TryCreate(party, out PartyBehaviorUpdateData data));
+        Assert.Equal(MoveModeType.Point, data.PartyMoveMode);
+        Assert.Null(data.MoveTargetPartyId);
+        Assert.Equal(party.MoveTargetPoint, data.MoveTargetPoint);
+    }
+
+    private static MobileParty CreateParty()
+    {
+        var party = ObjectHelper.SkipConstructor<MobileParty>();
+        party.Ai = new MobilePartyAi(party);
+        party.PartyMoveMode = MoveModeType.Party;
+        party.MoveTargetPoint = new CampaignVec2(new Vec2(10f, 20f), isOnLand: true);
+        return party;
+    }
+}

--- a/source/GameInterface.Tests/Services/MobileParties/MobilePartyBehaviorSnapshotTests.cs
+++ b/source/GameInterface.Tests/Services/MobileParties/MobilePartyBehaviorSnapshotTests.cs
@@ -36,6 +36,7 @@ public class MobilePartyBehaviorSnapshotTests
     {
         var party = CreateParty();
         var removedMoveTarget = ObjectHelper.SkipConstructor<MobileParty>();
+        removedMoveTarget.Position = new CampaignVec2(new Vec2(30f, 40f), isOnLand: true);
         party.MoveTargetParty = removedMoveTarget;
 
         var objectManager = new Mock<IObjectManager>();
@@ -49,7 +50,7 @@ public class MobilePartyBehaviorSnapshotTests
         Assert.True(snapshot.TryCreate(party, out PartyBehaviorUpdateData data));
         Assert.Equal(MoveModeType.Point, data.PartyMoveMode);
         Assert.Null(data.MoveTargetPartyId);
-        Assert.Equal(party.MoveTargetPoint, data.MoveTargetPoint);
+        Assert.Equal(removedMoveTarget.Position, data.MoveTargetPoint);
     }
 
     private static MobileParty CreateParty()

--- a/source/GameInterface/Services/MobileParties/Data/MobilePartyBehaviorSnapshot.cs
+++ b/source/GameInterface/Services/MobileParties/Data/MobilePartyBehaviorSnapshot.cs
@@ -48,11 +48,17 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
             return false;
 
         MoveModeType partyMoveMode = party.PartyMoveMode;
-        if (!TryGetCompactId(party.MoveTargetParty, out string moveTargetPartyId))
+        CampaignVec2 moveTargetPoint = party.MoveTargetPoint;
+        MobileParty moveTargetParty = party.MoveTargetParty;
+        if (!TryGetCompactId(moveTargetParty, out string moveTargetPartyId))
         {
             // A removed movement target cannot exist on clients, so preserve its last destination.
             moveTargetPartyId = null;
-            if (partyMoveMode == MoveModeType.Party) partyMoveMode = MoveModeType.Point;
+            if (partyMoveMode == MoveModeType.Party)
+            {
+                partyMoveMode = MoveModeType.Point;
+                moveTargetPoint = moveTargetParty.Position;
+            }
         }
 
         data = new PartyBehaviorUpdateData(
@@ -67,7 +73,7 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
         {
             TargetPartyId = targetPartyId,
             TargetSettlementId = targetSettlementId,
-            MoveTargetPoint = party.MoveTargetPoint,
+            MoveTargetPoint = moveTargetPoint,
             IsTargetingPort = party.IsTargetingPort,
             PartyMoveMode = partyMoveMode,
             MoveTargetPartyId = moveTargetPartyId,

--- a/source/GameInterface/Services/MobileParties/Data/MobilePartyBehaviorSnapshot.cs
+++ b/source/GameInterface/Services/MobileParties/Data/MobilePartyBehaviorSnapshot.cs
@@ -44,9 +44,17 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
                 out string interactablePointId,
                 out bool isInteractableAnchor) ||
             !TryGetCompactId(party.TargetParty, out string targetPartyId) ||
-            !TryGetCompactId(party.TargetSettlement, out string targetSettlementId) ||
-            !TryGetCompactId(party.MoveTargetParty, out string moveTargetPartyId))
+            !TryGetCompactId(party.TargetSettlement, out string targetSettlementId))
             return false;
+
+        MoveModeType partyMoveMode = party.PartyMoveMode;
+        if (!TryGetCompactId(party.MoveTargetParty, out string moveTargetPartyId))
+        {
+            // A removed movement target cannot exist on clients, so preserve its last destination.
+            moveTargetPartyId = null;
+            if (partyMoveMode == MoveModeType.Party) partyMoveMode = MoveModeType.Point;
+        }
+
         data = new PartyBehaviorUpdateData(
             partyId,
             party.ShortTermBehavior,
@@ -61,7 +69,7 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
             TargetSettlementId = targetSettlementId,
             MoveTargetPoint = party.MoveTargetPoint,
             IsTargetingPort = party.IsTargetingPort,
-            PartyMoveMode = party.PartyMoveMode,
+            PartyMoveMode = partyMoveMode,
             MoveTargetPartyId = moveTargetPartyId,
             IsInteractableAnchor = isInteractableAnchor,
             IsCurrentlyAtSea = party.IsCurrentlyAtSea,


### PR DESCRIPTION
## PR Checklist

- [ ] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

The campaign time sync test still constructs the handler with its pre-merge dependencies. A removed mobile party can also remain as another party's movement target, which prevents the server from capturing a complete join baseline and leaves clients at `Finishing synchronization`.

## What is the new behavior?

The time sync test now uses the current per-connection broadcast dependencies. Stale movement targets fall back to their last target point so the complete mobile-party baseline can be sent to joining clients.

## Bot Changelog Entry

- Fixed clients getting stuck at `Finishing synchronization` when a removed party remained as an AI movement target.
