### PR TITLE
Reduce desync in sieges and large battles (hopefully always load both sides also)

### DIFF
--- a/source/Common/GameThread.cs
+++ b/source/Common/GameThread.cs
@@ -1,4 +1,4 @@
-using Common.Logging;
+﻿using Common.Logging;
 using Common.Util;
 using Serilog;
 using System;
@@ -253,17 +253,22 @@ public class GameThread : IUpdateable
         [CallerMemberName] string callerMember = null)
     {
         string label = context ?? BuildLabel(callerFile, callerMember);
-        Run(() =>
+        Run(WrapSafe(action, context), blocking, label);
+    }
+
+    /// <summary>
+    /// Queues an action for a later <see cref="Update"/> even when called from the game-loop thread.
+    /// Use this when running inline would mutate state currently being iterated by the engine.
+    /// </summary>
+    public static void EnqueueSafe(Action action, string context = null,
+        [CallerFilePath] string callerFile = null,
+        [CallerMemberName] string callerMember = null)
+    {
+        string label = context ?? BuildLabel(callerFile, callerMember);
+        lock (Instance.m_QueueLock)
         {
-            try
-            {
-                action();
-            }
-            catch (Exception e)
-            {
-                Logger.Error(e, "Failed to run action on the game thread: {Context}", context ?? "(none)");
-            }
-        }, blocking, label);
+            Instance.m_Queue.Enqueue((WrapSafe(action, context), null, label));
+        }
     }
 
     /// <summary>
@@ -321,6 +326,18 @@ public class GameThread : IUpdateable
         }
         return $"{Path.GetFileNameWithoutExtension(callerFile)}.{callerMember}";
     }
+
+    private static Action WrapSafe(Action action, string context) => () =>
+    {
+        try
+        {
+            action();
+        }
+        catch (Exception e)
+        {
+            Logger.Error(e, "Failed to run action on the game thread: {Context}", context ?? "(none)");
+        }
+    };
 
     public void MarkGameThread()
     {

--- a/source/Coop.Tests/Missions/Battles/BattleDeploymentTimeLimitWiringTests.cs
+++ b/source/Coop.Tests/Missions/Battles/BattleDeploymentTimeLimitWiringTests.cs
@@ -1,9 +1,11 @@
-using Common.Messaging;
+﻿using Common.Messaging;
 using GameInterface.Services.MapEvents;
 using Missions;
 using Missions.Battles;
 using Missions.Messages;
 using Moq;
+using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Coop.Tests.Missions.Battles;
@@ -32,6 +34,7 @@ public class BattleDeploymentTimeLimitWiringTests
     // preserving the intent of the pre-existing cases); flip to false to emulate the limit expiring while
     // reserves are still inside the spawn handler's hold.
     private bool teamSetupOver = true;
+    private readonly Queue<Action> deferredActions = new();
 
     private int nativeFinishInvocations; // every seam call, including the no-op retries while teams aren't set up
     private int nativeFinishCommits;     // seam calls that actually committed the deployment (reported Finished)
@@ -46,10 +49,18 @@ public class BattleDeploymentTimeLimitWiringTests
             messageBroker.Object,
             session.Object,
             new BattleDeploymentTimer(Limit),
-            FakeNativeFinish);
+            FakeNativeFinish,
+            deferredActions.Enqueue);
     }
 
     private void AsHost() => session.SetupGet(s => s.IsLocalHost).Returns(true);
+
+    private void TickAndRunDeferredFinish(float dt)
+    {
+        sut.Tick(dt);
+        if (deferredActions.Count > 0)
+            deferredActions.Dequeue()();
+    }
 
     // Emulates the native FinishDeployment seam. When the teams are set up it runs the fan-out reaching
     // CoopBattleController.OnDeploymentFinished (calling OnLocalDeploymentFinished() and revealing the withheld
@@ -75,7 +86,7 @@ public class BattleDeploymentTimeLimitWiringTests
         AsHost();
         sut.OnMissionReady();
 
-        sut.Tick(Limit);
+        TickAndRunDeferredFinish(Limit);
 
         Assert.Equal(1, nativeFinishInvocations);
         // The mesh announce goes out — the same NetworkBattleDeploymentFinished a manual finish sends, so
@@ -96,7 +107,7 @@ public class BattleDeploymentTimeLimitWiringTests
         // finish from ANY client — BR-024) and reveals its own troops (BR-023); it activates nothing itself.
         sut.OnMissionReady();
 
-        sut.Tick(Limit);
+        TickAndRunDeferredFinish(Limit);
 
         Assert.Equal(1, nativeFinishInvocations);
         network.Verify(n => n.SendAll(It.IsAny<NetworkBattleDeploymentFinished>()), Times.Once);
@@ -122,7 +133,7 @@ public class BattleDeploymentTimeLimitWiringTests
 
     [Fact]
     [Trait("Requirement", "BR-025")]
-    public void Expiry_FiresAtMostOnce_AcrossFurtherTicks()
+    public void Expiry_DefersAndQueuesAtMostOneFinish_AcrossFurtherTicks()
     {
         sut.OnMissionReady();
 
@@ -130,7 +141,27 @@ public class BattleDeploymentTimeLimitWiringTests
         sut.Tick(Limit);
         sut.Tick(Limit);
 
+        Assert.Equal(0, nativeFinishInvocations);
+        Assert.Single(deferredActions);
+
+        deferredActions.Dequeue()();
+
         Assert.Equal(1, nativeFinishInvocations);
+        network.Verify(n => n.SendAll(It.IsAny<NetworkBattleDeploymentFinished>()), Times.Once);
+    }
+
+    [Fact]
+    [Trait("Requirement", "BR-025")]
+    public void ManualFinishWhileAutoFinishIsQueued_CancelsTheDeferredFinish()
+    {
+        sut.OnMissionReady();
+        sut.Tick(Limit);
+        Assert.Single(deferredActions);
+
+        Assert.True(sut.OnLocalDeploymentFinished());
+        deferredActions.Dequeue()();
+
+        Assert.Equal(0, nativeFinishInvocations);
         network.Verify(n => n.SendAll(It.IsAny<NetworkBattleDeploymentFinished>()), Times.Once);
     }
 
@@ -140,7 +171,7 @@ public class BattleDeploymentTimeLimitWiringTests
     {
         AsHost();
         sut.OnMissionReady();
-        sut.Tick(Limit);
+        TickAndRunDeferredFinish(Limit);
         Assert.Equal(1, revealRequests);
 
         // A stray manual finish landing after the auto-finish (e.g. an in-flight button click): the
@@ -179,13 +210,13 @@ public class BattleDeploymentTimeLimitWiringTests
         sut.OnMissionReady();
 
         teamSetupOver = false;
-        sut.Tick(Limit); // limit reached, but reserves still spawning → Retry (no-op)
-        sut.Tick(1f);    // still spawning → Retry (no-op)
+        TickAndRunDeferredFinish(Limit); // limit reached, but reserves still spawning → Retry (no-op)
+        TickAndRunDeferredFinish(1f);    // still spawning → Retry (no-op)
         Assert.Equal(0, nativeFinishCommits);
         network.Verify(n => n.SendAll(It.IsAny<NetworkBattleDeploymentFinished>()), Times.Never);
 
         teamSetupOver = true; // the spawn hold elapsed; the teams are set up
-        sut.Tick(1f);         // now the finish commits through the same path as a manual Start Battle
+        TickAndRunDeferredFinish(1f); // now the finish commits through the same path as a manual Start Battle
         Assert.Equal(1, nativeFinishCommits);
         network.Verify(n => n.SendAll(It.IsAny<NetworkBattleDeploymentFinished>()), Times.Once);
         network.Verify(n => n.SendAll(It.IsAny<NetworkBattleActivated>()), Times.Once);

--- a/source/E2E.Tests/Services/Missions/MountedPuppetMovementTests.cs
+++ b/source/E2E.Tests/Services/Missions/MountedPuppetMovementTests.cs
@@ -341,13 +341,13 @@ public class MountedPuppetMovementTests : MissionTestEnvironment
             Assert.True(registry.TryRegisterAgent("owner", Guid.NewGuid(), remoteRider));
             Assert.True(registry.TryRegisterAgent("peer", Guid.NewGuid(), localHorse));
 
-            component.AgentMovementHandler.PollMovement(0.02f);
+            component.AgentMovementHandler.PollMovement(0.05f);
             Assert.Equal(AgentControllerType.None, localHorseMirror.Controller);
             Assert.Equal(0f, localHorseMirror.MaximumSpeedLimit);
             Assert.Equal(0, localHorseMirror.SetMaximumSpeedLimitCalls);
 
             remoteRiderMirror.IsActive = false;
-            component.AgentMovementHandler.PollMovement(0.02f);
+            component.AgentMovementHandler.PollMovement(0.05f);
             Assert.Equal(AgentControllerType.AI, localHorseMirror.Controller);
             Assert.Equal(-1f, localHorseMirror.MaximumSpeedLimit);
             Assert.Equal(1, localHorseMirror.SetMaximumSpeedLimitCalls);
@@ -357,7 +357,7 @@ public class MountedPuppetMovementTests : MissionTestEnvironment
             localHorseMirror.MaximumSpeedLimit = 0f;
             localHorseMirror.SetMaximumSpeedLimitCalls = 0;
             remoteRider.MountAgent = null;
-            component.AgentMovementHandler.PollMovement(0.02f);
+            component.AgentMovementHandler.PollMovement(0.05f);
             Assert.Equal(AgentControllerType.AI, localHorseMirror.Controller);
             Assert.Equal(-1f, localHorseMirror.MaximumSpeedLimit);
             Assert.Equal(1, localHorseMirror.SetMaximumSpeedLimitCalls);
@@ -370,7 +370,7 @@ public class MountedPuppetMovementTests : MissionTestEnvironment
             Assert.True(registry.TryRegisterAgent("peer", Guid.NewGuid(), localRider));
             Assert.True(registry.TryRegisterAgent("owner", Guid.NewGuid(), remoteHorse));
 
-            component.AgentMovementHandler.PollMovement(0.02f);
+            component.AgentMovementHandler.PollMovement(0.05f);
             Assert.Equal(AgentControllerType.AI, remoteHorseMirror.Controller);
             Assert.Equal(-1f, remoteHorseMirror.MaximumSpeedLimit);
             Assert.Equal(1, remoteHorseMirror.SetMaximumSpeedLimitCalls);
@@ -379,7 +379,7 @@ public class MountedPuppetMovementTests : MissionTestEnvironment
             remoteHorseMirror.MaximumSpeedLimit = 0f;
             remoteHorseMirror.SetMaximumSpeedLimitCalls = 0;
             remoteHorseMirror.IsActive = false;
-            component.AgentMovementHandler.PollMovement(0.02f);
+            component.AgentMovementHandler.PollMovement(0.05f);
             Assert.Equal(AgentControllerType.None, remoteHorseMirror.Controller);
             Assert.Equal(0f, remoteHorseMirror.MaximumSpeedLimit);
             Assert.Equal(0, remoteHorseMirror.SetMaximumSpeedLimitCalls);

--- a/source/E2E.Tests/Services/Missions/MovementTrafficTests.cs
+++ b/source/E2E.Tests/Services/Missions/MovementTrafficTests.cs
@@ -19,13 +19,13 @@ using AgentData = Missions.Agents.Packets.AgentData;
 
 namespace E2E.Tests.Services.Missions;
 
-/// <summary>Regression coverage for bounded movement traffic and delivery selection.</summary>
+/// <summary>Regression coverage for movement traffic and delivery selection.</summary>
 public class MovementTrafficTests : MissionTestEnvironment
 {
     public MovementTrafficTests(ITestOutputHelper output) : base(output) { }
 
     [Fact]
-    public void PollMovement_UsesTwentyHertzCadenceAndThreeAgentBatches()
+    public void PollMovement_UsesFortyHertzCadenceAndThreeAgentBatches()
     {
         using var fixture = new MissionEngineFixture();
         var peer = Clients.First();
@@ -47,18 +47,25 @@ public class MovementTrafficTests : MissionTestEnvironment
                 .Select(packet => packet.AgentIds.Length));
 
             network.NetworkSentPackets.Packets.Clear();
-            component.AgentMovementHandler.PollMovement(0.049f);
+            component.AgentMovementHandler.PollMovement(0.024f);
             Assert.Empty(network.NetworkSentPackets.GetPackets<MovementPacket>());
 
             component.AgentMovementHandler.PollMovement(0.002f);
             Assert.Equal(new[] { 3, 1 }, network.NetworkSentPackets
                 .GetPackets<MovementPacket>()
                 .Select(packet => packet.AgentIds.Length));
+
+            network.NetworkSentPackets.Packets.Clear();
+            for (int i = 0; i < 6; i++)
+                component.AgentMovementHandler.PollMovement(1f / 60f);
+            Assert.Equal(16, network.NetworkSentPackets
+                .GetPackets<MovementPacket>()
+                .Sum(packet => packet.AgentIds.Length));
         });
     }
 
     [Fact]
-    public void PollMovement_BoundsAndRotatesLargeArmiesWhileAlwaysSendingMainAgent()
+    public void PollMovement_SendsEveryEligibleAgent()
     {
         using var fixture = new MissionEngineFixture();
         var peer = Clients.First();
@@ -78,30 +85,21 @@ public class MovementTrafficTests : MissionTestEnvironment
                 Guid agentId = Guid.NewGuid();
                 Assert.True(registry.TryRegisterAgent("peer", agentId, agent));
                 agentIds.Add(agentId);
-                if (i == 124) mock.MainAgent = agent;
             }
 
             component.AgentMovementHandler.PollMovement(0f);
-            Guid[] firstPoll = network.NetworkSentPackets
+            MovementPacket[] packets = network.NetworkSentPackets
                 .GetPackets<MovementPacket>()
-                .SelectMany(packet => packet.AgentIds)
                 .ToArray();
-            Assert.Equal(120, firstPoll.Length);
-            Assert.Equal(firstPoll.Length, firstPoll.Distinct().Count());
-            Assert.Contains(agentIds[124], firstPoll);
-            Assert.All(agentIds.Skip(119).Take(5), id => Assert.DoesNotContain(id, firstPoll));
+            Assert.Equal((agentIds.Count + 2) / 3, packets.Length);
+            Assert.All(packets, packet => Assert.InRange(packet.AgentIds.Length, 1, 3));
 
-            network.NetworkSentPackets.Packets.Clear();
-            component.AgentMovementHandler.PollMovement(0.05f);
-            Guid[] secondPoll = network.NetworkSentPackets
-                .GetPackets<MovementPacket>()
+            Guid[] sentAgents = packets
                 .SelectMany(packet => packet.AgentIds)
                 .ToArray();
-            Assert.Equal(120, secondPoll.Length);
-            Assert.Equal(secondPoll.Length, secondPoll.Distinct().Count());
-            Assert.Contains(agentIds[124], secondPoll);
-            Assert.All(agentIds.Skip(119).Take(5), id => Assert.Contains(id, secondPoll));
-            Assert.Equal(agentIds.Count, firstPoll.Concat(secondPoll).Distinct().Count());
+            Assert.Equal(agentIds.Count, sentAgents.Length);
+            Assert.Equal(sentAgents.Length, sentAgents.Distinct().Count());
+            Assert.All(agentIds, id => Assert.Contains(id, sentAgents));
         });
     }
 

--- a/source/E2E.Tests/Services/Missions/MovementTrafficTests.cs
+++ b/source/E2E.Tests/Services/Missions/MovementTrafficTests.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using System.Linq;
+using Common.Network;
+using Common.PacketHandlers;
+using Common.Serialization;
+using E2E.Tests.Environment.Mock;
+using E2E.Tests.Environment.MockEngine;
+using LiteNetLib;
+using Missions;
+using Missions.Agents;
+using Missions.Agents.Packets;
+using Missions.Services.Network;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+using Xunit;
+using Xunit.Abstractions;
+using AgentData = Missions.Agents.Packets.AgentData;
+
+namespace E2E.Tests.Services.Missions;
+
+/// <summary>Regression coverage for bounded movement traffic and delivery selection.</summary>
+public class MovementTrafficTests : MissionTestEnvironment
+{
+    public MovementTrafficTests(ITestOutputHelper output) : base(output) { }
+
+    [Fact]
+    public void PollMovement_UsesTwentyHertzCadenceAndThreeAgentBatches()
+    {
+        using var fixture = new MissionEngineFixture();
+        var peer = Clients.First();
+        SetControllerId(peer, "peer");
+
+        peer.Call(() =>
+        {
+            var mock = fixture.CreateMission(peer);
+            var registry = peer.Resolve<INetworkAgentRegistry>();
+            var component = peer.Resolve<ICoopMissionComponent>();
+            var network = Assert.IsType<MockBattleNetwork>(peer.Resolve<IBattleNetwork>());
+
+            for (int i = 0; i < 4; i++)
+                Assert.True(registry.TryRegisterAgent("peer", Guid.NewGuid(), SpawnRider(mock)));
+
+            component.AgentMovementHandler.PollMovement(0f);
+            Assert.Equal(new[] { 3, 1 }, network.NetworkSentPackets
+                .GetPackets<MovementPacket>()
+                .Select(packet => packet.AgentIds.Length));
+
+            network.NetworkSentPackets.Packets.Clear();
+            component.AgentMovementHandler.PollMovement(0.049f);
+            Assert.Empty(network.NetworkSentPackets.GetPackets<MovementPacket>());
+
+            component.AgentMovementHandler.PollMovement(0.002f);
+            Assert.Equal(new[] { 3, 1 }, network.NetworkSentPackets
+                .GetPackets<MovementPacket>()
+                .Select(packet => packet.AgentIds.Length));
+        });
+    }
+
+    [Fact]
+    public void PollMovement_BoundsAndRotatesLargeArmiesWhileAlwaysSendingMainAgent()
+    {
+        using var fixture = new MissionEngineFixture();
+        var peer = Clients.First();
+        SetControllerId(peer, "peer");
+
+        peer.Call(() =>
+        {
+            var mock = fixture.CreateMission(peer);
+            var registry = peer.Resolve<INetworkAgentRegistry>();
+            var component = peer.Resolve<ICoopMissionComponent>();
+            var network = Assert.IsType<MockBattleNetwork>(peer.Resolve<IBattleNetwork>());
+            var agentIds = new List<Guid>();
+
+            for (int i = 0; i < 125; i++)
+            {
+                Agent agent = SpawnRider(mock);
+                Guid agentId = Guid.NewGuid();
+                Assert.True(registry.TryRegisterAgent("peer", agentId, agent));
+                agentIds.Add(agentId);
+                if (i == 124) mock.MainAgent = agent;
+            }
+
+            component.AgentMovementHandler.PollMovement(0f);
+            Guid[] firstPoll = network.NetworkSentPackets
+                .GetPackets<MovementPacket>()
+                .SelectMany(packet => packet.AgentIds)
+                .ToArray();
+            Assert.Equal(120, firstPoll.Length);
+            Assert.Equal(firstPoll.Length, firstPoll.Distinct().Count());
+            Assert.Contains(agentIds[124], firstPoll);
+            Assert.All(agentIds.Skip(119).Take(5), id => Assert.DoesNotContain(id, firstPoll));
+
+            network.NetworkSentPackets.Packets.Clear();
+            component.AgentMovementHandler.PollMovement(0.05f);
+            Guid[] secondPoll = network.NetworkSentPackets
+                .GetPackets<MovementPacket>()
+                .SelectMany(packet => packet.AgentIds)
+                .ToArray();
+            Assert.Equal(120, secondPoll.Length);
+            Assert.Equal(secondPoll.Length, secondPoll.Distinct().Count());
+            Assert.Contains(agentIds[124], secondPoll);
+            Assert.All(agentIds.Skip(119).Take(5), id => Assert.Contains(id, secondPoll));
+            Assert.Equal(agentIds.Count, firstPoll.Concat(secondPoll).Distinct().Count());
+        });
+    }
+
+    [Fact]
+    public void ThreeMountedSnapshots_FitDirectAndRelayDatagrams()
+    {
+        using var fixture = new MissionEngineFixture();
+        var peer = Clients.First();
+
+        peer.Call(() =>
+        {
+            var mock = fixture.CreateMission(peer);
+            var ids = new Guid[3];
+            var riders = new AgentData[3];
+            var mounts = new AgentMountData[3];
+
+            for (int i = 0; i < ids.Length; i++)
+            {
+                var rider = SpawnRider(mock);
+                var mount = mock.SpawnMount(rider);
+                Assert.True(AgentMirror.TryGet(rider, out var riderMirror));
+                Assert.True(AgentMirror.TryGet(mount, out var mountMirror));
+                PopulateMovementState(riderMirror, i + 1);
+                PopulateMovementState(mountMirror, i + 1);
+                ids[i] = Guid.NewGuid();
+                var mountId = Guid.NewGuid();
+                riders[i] = new AgentData(rider, mountId);
+                mounts[i] = new AgentMountData(mount, mountId);
+            }
+
+            var serializer = new ProtoBufSerializer(new SerializableTypeMapper());
+            AssertFitsRelay(serializer, new MovementPacket(ids, riders));
+            AssertFitsRelay(serializer, new MountMovementPacket(ids, mounts));
+        });
+    }
+
+    [Fact]
+    public void OversizedMovement_IsDroppedInsteadOfPromotedToReliable()
+    {
+        int datagramCeiling = LiteNetP2PClient.SafeSinglePacketBytes;
+        var movement = new MovementPacket(Array.Empty<Guid>(), Array.Empty<AgentData>());
+        var mountMovement = new MountMovementPacket(Array.Empty<Guid>(), Array.Empty<AgentMountData>());
+        var ordinaryUnreliable = new TestPacket(PacketType.Test, DeliveryMethod.Unreliable);
+        var reliable = new TestPacket(PacketType.Test, DeliveryMethod.ReliableOrdered);
+
+        Assert.Equal(DeliveryMethod.Unreliable,
+            LiteNetP2PClient.SelectDeliveryMethod(movement, datagramCeiling, datagramCeiling));
+        Assert.Null(LiteNetP2PClient.SelectDeliveryMethod(movement, datagramCeiling + 1, datagramCeiling));
+        Assert.Null(LiteNetP2PClient.SelectDeliveryMethod(mountMovement, datagramCeiling + 1, datagramCeiling));
+        Assert.Equal(DeliveryMethod.ReliableUnordered,
+            LiteNetP2PClient.SelectDeliveryMethod(ordinaryUnreliable, datagramCeiling + 1, datagramCeiling));
+        Assert.Equal(DeliveryMethod.ReliableOrdered,
+            LiteNetP2PClient.SelectDeliveryMethod(reliable, datagramCeiling + 1, datagramCeiling));
+
+        Assert.Null(LiteNetP2PClient.SelectDeliveryMethod(movement, datagramCeiling - 1, 0));
+        Assert.Equal(DeliveryMethod.ReliableUnordered,
+            LiteNetP2PClient.SelectDeliveryMethod(ordinaryUnreliable, datagramCeiling - 1, 0));
+    }
+
+    private static void AssertFitsRelay(ProtoBufSerializer serializer, IPacket packet)
+    {
+        byte[] payload = serializer.Serialize(packet);
+        Assert.True(payload.Length <= LiteNetP2PClient.SafeSinglePacketBytes,
+            $"Direct payload was {payload.Length} bytes");
+
+        byte[] relay = serializer.Serialize(new RelayPacket(
+            packet.DeliveryMethod,
+            "MapEvent_Created_0000",
+            "76561198000000042",
+            payload));
+        Assert.True(relay.Length <= LiteNetP2PClient.SafeSinglePacketBytes,
+            $"Relay payload was {relay.Length} bytes");
+    }
+
+    private static Agent SpawnRider(MockMission mock)
+    {
+        return mock.SpawnAgent(
+            new AgentBuildData(Game.Current.PlayerTroop)
+                .Controller(AgentControllerType.None));
+    }
+
+    private static void PopulateMovementState(MirrorAgent mirror, int multiplier)
+    {
+        mirror.Position = new Vec3(1024.25f * multiplier, -2048.5f * multiplier, 512.75f * multiplier);
+        mirror.InputVector = new Vec2(0.75f, -0.5f);
+        mirror.LookDirection = new Vec3(-0.25f, 0.5f, 0.75f);
+        mirror.MovementDirection = new Vec2(-0.75f, 0.5f);
+        mirror.RealGlobalVelocity = new Vec3(123.25f, -456.5f, 789.75f);
+        mirror.PrimaryWieldedItemIndex = EquipmentIndex.Weapon3;
+        mirror.OffhandWieldedItemIndex = EquipmentIndex.Weapon2;
+        mirror.Action0Flags = (AnimFlags)ulong.MaxValue;
+        mirror.Action1Flags = (AnimFlags)ulong.MaxValue;
+        mirror.Action0Progress = 0.75f;
+        mirror.Action1Progress = 0.5f;
+        mirror.Action0Index = -1;
+        mirror.Action1Index = -1;
+    }
+
+    private readonly struct TestPacket : IPacket
+    {
+        public PacketType PacketType { get; }
+        public DeliveryMethod DeliveryMethod { get; }
+
+        public TestPacket(PacketType packetType, DeliveryMethod deliveryMethod)
+        {
+            PacketType = packetType;
+            DeliveryMethod = deliveryMethod;
+        }
+    }
+}

--- a/source/GameInterface.Tests/Services/MapEvents/HitRewardHandlerTests.cs
+++ b/source/GameInterface.Tests/Services/MapEvents/HitRewardHandlerTests.cs
@@ -1,0 +1,53 @@
+﻿using Common;
+using Common.Messaging;
+using Common.Network;
+using GameInterface.Services.MapEvents.Handlers;
+using GameInterface.Services.MapEvents.Messages;
+using GameInterface.Services.ObjectManager;
+using Moq;
+using System;
+using System.Runtime.CompilerServices;
+using TaleWorlds.Core;
+using TaleWorlds.MountAndBlade;
+using Xunit;
+
+namespace GameInterface.Tests.Services.MapEvents;
+
+public class HitRewardHandlerTests
+{
+    static HitRewardHandlerTests()
+    {
+        RuntimeHelpers.RunModuleConstructor(typeof(Coop.Tests.Mocks.TestNetwork).Module.ModuleHandle);
+    }
+
+    [Fact]
+    public void NetworkScoreboardUpdate_WithoutMission_SkipsObjectResolution()
+    {
+        Assert.Null(Mission.Current);
+
+        Action<MessagePayload<NetworkUpdateScoreboardAfterUpgrades>>? subscriber = null;
+        var messageBroker = new Mock<IMessageBroker>();
+        messageBroker
+            .Setup(b => b.Subscribe(It.IsAny<Action<MessagePayload<NetworkUpdateScoreboardAfterUpgrades>>>()!))
+            .Callback<Action<MessagePayload<NetworkUpdateScoreboardAfterUpgrades>>>(handler => subscriber = handler);
+        var objectManager = new Mock<IObjectManager>();
+
+        using var handler = new HitRewardHandler(
+            messageBroker.Object,
+            objectManager.Object,
+            new Mock<INetwork>().Object);
+
+        Assert.NotNull(subscriber);
+        subscriber(new MessagePayload<NetworkUpdateScoreboardAfterUpgrades>(
+            this,
+            new NetworkUpdateScoreboardAfterUpgrades(
+                "map-event",
+                "character",
+                "party",
+                BattleSideEnum.Attacker,
+                1)));
+        GameThread.Run(() => { }, blocking: true);
+
+        objectManager.VerifyNoOtherCalls();
+    }
+}

--- a/source/GameInterface.Tests/Utils/GameThreadPumpTests.cs
+++ b/source/GameInterface.Tests/Utils/GameThreadPumpTests.cs
@@ -39,6 +39,22 @@ public class GameThreadPumpTests
     }
 
     [Fact]
+    public void EnqueueSafe_CalledOnTheGameLoopThread_RunsOnALaterUpdate()
+    {
+        using var executed = new ManualResetEventSlim(false);
+        bool ranInline = true;
+
+        GameThread.Run(() =>
+        {
+            GameThread.EnqueueSafe(executed.Set);
+            ranInline = executed.IsSet;
+        }, blocking: true);
+
+        Assert.False(ranInline);
+        Assert.True(executed.Wait(TimeSpan.FromSeconds(5)), "the deferred action was not drained");
+    }
+
+    [Fact]
     public void WaitWhilePumping_ThrowsWhenCalledOffTheGameLoopThread()
     {
         // The xUnit worker thread is not the game-loop thread, so it can't pump; the wait refuses to run.

--- a/source/GameInterface/Services/MapEvents/Commands/BattleTeamKillCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/BattleTeamKillCommands.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.Core;
 using TaleWorlds.InputSystem;
+using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.GauntletUI.Mission.Singleplayer;
 using static TaleWorlds.Library.CommandLineFunctionality;
@@ -59,7 +60,7 @@ Finishes the current battle deployment through the native deployment handler.";
 @"Usage:
   coop.debug.mapevent.toggle_scoreboard
 
-Holds or releases the configured scoreboard binding through the native input path.";
+Holds or releases the native scoreboard input without requiring window focus.";
 
     [CommandLineArgumentFunction("toggle_scoreboard", "coop.debug.mapevent")]
     public static string ToggleScoreboard(List<string> args)
@@ -76,22 +77,16 @@ Holds or releases the configured scoreboard binding through the native input pat
         if (scoreboard?.DataSource == null)
             return "Failed: no battle scoreboard UI.";
 
-        var scoreboardHold = mission.GetMissionBehavior<ScoreboardHoldBehavior>();
-        if (scoreboardHold == null)
+        if (mission.InputManager is ScoreboardInputContext scoreboardInput)
         {
-            var holdShow = HotKeyManager.GetCategory(ScoreboardHotKeyCategory.CategoryId)
-                ?.GetHotKey(ScoreboardHotKeyCategory.HoldShow);
-            var key = holdShow?.Keys.FirstOrDefault(candidate => candidate.IsKeyboardInput || candidate.IsMouseButtonInput);
-            if (key == null)
-                return "Failed: the scoreboard has no configured keyboard or mouse binding.";
-
-            mission.AddMissionBehavior(new ScoreboardHoldBehavior(key.InputKey));
-            Input.PressKey(key.InputKey);
-            return $"Holding the configured scoreboard binding ({key.InputKey}).";
+            mission.InputManager = scoreboardInput.Inner;
+            return "Released the native scoreboard input.";
         }
+        if (mission.InputManager == null)
+            return "Failed: no mission input context.";
 
-        mission.RemoveMissionBehavior(scoreboardHold);
-        return "Released the configured scoreboard binding.";
+        mission.InputManager = new ScoreboardInputContext(mission.InputManager);
+        return "Holding the native scoreboard input.";
     }
 
     private const string ScoreboardStateUsage =
@@ -149,20 +144,46 @@ Lists the player parties and party rows currently loaded by the battle scoreboar
         return names.Length == 0 ? "<none>" : string.Join(", ", names);
     }
 
-    private sealed class ScoreboardHoldBehavior : MissionLogic
+    private sealed class ScoreboardInputContext : IInputContext
     {
-        private readonly InputKey inputKey;
+        public IInputContext Inner { get; }
 
-        public ScoreboardHoldBehavior(InputKey inputKey)
+        public ScoreboardInputContext(IInputContext inner)
         {
-            this.inputKey = inputKey;
+            Inner = inner;
         }
 
-        public override void OnMissionTick(float dt)
-        {
-            base.OnMissionTick(dt);
-            Input.PressKey(inputKey);
-        }
+        public int GetPointerX() => Inner.GetPointerX();
+        public int GetPointerY() => Inner.GetPointerY();
+        public System.Numerics.Vector2 GetPointerPosition() => Inner.GetPointerPosition();
+        public bool IsGameKeyDown(int gameKey) => Inner.IsGameKeyDown(gameKey);
+        public bool IsGameKeyDownImmediate(int gameKey) => Inner.IsGameKeyDownImmediate(gameKey);
+        public bool IsGameKeyPressed(int gameKey) => Inner.IsGameKeyPressed(gameKey);
+        public bool IsGameKeyReleased(int gameKey) => Inner.IsGameKeyReleased(gameKey);
+        public float GetGameKeyAxis(string gameAxisKey) => Inner.GetGameKeyAxis(gameAxisKey);
+        public bool IsHotKeyDown(string hotKey) =>
+            hotKey == ScoreboardHotKeyCategory.HoldShow || Inner.IsHotKeyDown(hotKey);
+        public bool IsHotKeyReleased(string hotKey) => Inner.IsHotKeyReleased(hotKey);
+        public bool IsHotKeyPressed(string hotKey) => Inner.IsHotKeyPressed(hotKey);
+        public bool IsHotKeyDoublePressed(string hotKey) => Inner.IsHotKeyDoublePressed(hotKey);
+        public Vec2 GetKeyState(InputKey key) => Inner.GetKeyState(key);
+        public bool IsKeyDown(InputKey key) => Inner.IsKeyDown(key);
+        public bool IsKeyPressed(InputKey key) => Inner.IsKeyPressed(key);
+        public bool IsKeyReleased(InputKey key) => Inner.IsKeyReleased(key);
+        public float GetMouseMoveX() => Inner.GetMouseMoveX();
+        public float GetMouseMoveY() => Inner.GetMouseMoveY();
+        public bool GetIsMouseActive() => Inner.GetIsMouseActive();
+        public Vec2 GetMousePositionPixel() => Inner.GetMousePositionPixel();
+        public float GetDeltaMouseScroll() => Inner.GetDeltaMouseScroll();
+        public bool GetIsControllerConnected() => Inner.GetIsControllerConnected();
+        public Vec2 GetMousePositionRanged() => Inner.GetMousePositionRanged();
+        public float GetMouseSensitivity() => Inner.GetMouseSensitivity();
+        public bool IsControlDown() => Inner.IsControlDown();
+        public bool IsShiftDown() => Inner.IsShiftDown();
+        public bool IsAltDown() => Inner.IsAltDown();
+        public Vec2 GetControllerRightStickState() => Inner.GetControllerRightStickState();
+        public Vec2 GetControllerLeftStickState() => Inner.GetControllerLeftStickState();
+        public InputKey[] GetClickKeys() => Inner.GetClickKeys();
     }
 
     private const string LeaveBattleUsage =

--- a/source/GameInterface/Services/MapEvents/Commands/BattleTeamKillCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/BattleTeamKillCommands.cs
@@ -1,24 +1,190 @@
 ﻿using Common.Logging;
+using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Utils.Commands;
 using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.Core;
+using TaleWorlds.InputSystem;
 using TaleWorlds.MountAndBlade;
+using TaleWorlds.MountAndBlade.GauntletUI.Mission.Singleplayer;
 using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.MapEvents.Commands;
 
 /// <summary>
-/// Battle-outcome test commands: kill one enemy, the whole enemy team, or the local player team in the current
-/// battle mission. Run the direct kill commands on the battle-authority client because it owns the AI/enemy
+/// Battle fixture commands for deployment, scoreboard inspection, mission exit, and combat outcomes. Run the
+/// direct kill commands on the battle-authority client because it owns the AI/enemy
 /// agents, so each kill goes through the coop death path: <c>Agent.Die</c>, the mission death callback,
 /// the death broadcast, and the server-roster casualty, exactly like <c>coop.debug.mapevent.kms</c>.
 /// </summary>
 internal class BattleTeamKillCommands
 {
     public static readonly ILogger Logger = LogManager.GetLogger<BattleTeamKillCommands>();
+
+    private const string FinishDeploymentUsage =
+@"Usage:
+  coop.debug.mapevent.finish_deployment
+
+Finishes the current battle deployment through the native deployment handler.";
+
+    [CommandLineArgumentFunction("finish_deployment", "coop.debug.mapevent")]
+    public static string FinishDeployment(List<string> args)
+    {
+        var ctx = new CommandContext("finish_deployment", FinishDeploymentUsage, args);
+        if (!ctx.RequireArgCount(0, out var error))
+            return error;
+
+        var mission = Mission.Current;
+        if (mission is null)
+            return "Failed: no active mission.";
+
+        var deploymentController = mission.GetMissionBehavior<DeploymentMissionController>();
+        if (deploymentController == null)
+            return "No active deployment.";
+        if (!deploymentController.TeamSetupOver)
+            return "Failed: deployment team setup is not complete.";
+
+        var deploymentHandler = mission.GetMissionBehavior<DeploymentHandler>();
+        if (deploymentHandler == null)
+            return "Failed: no deployment handler.";
+
+        deploymentHandler.FinishDeployment();
+        return "Finished the current deployment.";
+    }
+
+    private const string ToggleScoreboardUsage =
+@"Usage:
+  coop.debug.mapevent.toggle_scoreboard
+
+Holds or releases the configured scoreboard binding through the native input path.";
+
+    [CommandLineArgumentFunction("toggle_scoreboard", "coop.debug.mapevent")]
+    public static string ToggleScoreboard(List<string> args)
+    {
+        var ctx = new CommandContext("toggle_scoreboard", ToggleScoreboardUsage, args);
+        if (!ctx.RequireArgCount(0, out var error))
+            return error;
+
+        var mission = Mission.Current;
+        if (mission is null)
+            return "Failed: no active mission.";
+
+        var scoreboard = mission.GetMissionBehavior<MissionGauntletBattleScore>();
+        if (scoreboard?.DataSource == null)
+            return "Failed: no battle scoreboard UI.";
+
+        var scoreboardHold = mission.GetMissionBehavior<ScoreboardHoldBehavior>();
+        if (scoreboardHold == null)
+        {
+            var holdShow = HotKeyManager.GetCategory(ScoreboardHotKeyCategory.CategoryId)
+                ?.GetHotKey(ScoreboardHotKeyCategory.HoldShow);
+            var key = holdShow?.Keys.FirstOrDefault(candidate => candidate.IsKeyboardInput || candidate.IsMouseButtonInput);
+            if (key == null)
+                return "Failed: the scoreboard has no configured keyboard or mouse binding.";
+
+            mission.AddMissionBehavior(new ScoreboardHoldBehavior(key.InputKey));
+            Input.PressKey(key.InputKey);
+            return $"Holding the configured scoreboard binding ({key.InputKey}).";
+        }
+
+        mission.RemoveMissionBehavior(scoreboardHold);
+        return "Released the configured scoreboard binding.";
+    }
+
+    private const string ScoreboardStateUsage =
+@"Usage:
+  coop.debug.mapevent.scoreboard_state
+
+Lists the player parties and party rows currently loaded by the battle scoreboard.";
+
+    [CommandLineArgumentFunction("scoreboard_state", "coop.debug.mapevent")]
+    public static string ScoreboardState(List<string> args)
+    {
+        var ctx = new CommandContext("scoreboard_state", ScoreboardStateUsage, args);
+        if (!ctx.RequireArgCount(0, out var error))
+            return error;
+
+        var mission = Mission.Current;
+        if (mission is null)
+            return "Failed: no active mission.";
+
+        var scoreboard = mission.GetMissionBehavior<MissionGauntletBattleScore>();
+        var dataSource = scoreboard?.DataSource;
+        if (dataSource == null)
+            return "Failed: no battle scoreboard UI.";
+
+        var mapEvent = MobileParty.MainParty?.MapEvent;
+        if (mapEvent == null)
+            return "Failed: the main party has no current map event.";
+
+        var expectedParties = mapEvent.InvolvedParties
+            .Where(party => party != null)
+            .Distinct()
+            .ToArray();
+        var expectedPlayerParties = expectedParties
+            .Where(party => party.MobileParty?.IsPlayerParty() == true)
+            .ToArray();
+        if (expectedPlayerParties.Length == 0)
+            return "Failed: the current map event has no registered player parties.";
+        var scoreboardParties = dataSource.Attackers.Parties
+            .Concat(dataSource.Defenders.Parties)
+            .Select(party => party.BattleCombatant)
+            .OfType<PartyBase>()
+            .Distinct()
+            .ToArray();
+        var missingPlayerParties = expectedPlayerParties.Except(scoreboardParties).ToArray();
+
+        return $"Visible: {dataSource.ShowScoreboard}; " +
+               $"Expected player parties ({expectedPlayerParties.Length}): {FormatPartyNames(expectedPlayerParties)}; " +
+               $"Scoreboard parties ({scoreboardParties.Length}): {FormatPartyNames(scoreboardParties)}; " +
+               $"Missing player parties ({missingPlayerParties.Length}): {FormatPartyNames(missingPlayerParties)}";
+    }
+
+    private static string FormatPartyNames(IEnumerable<PartyBase> parties)
+    {
+        var names = parties.Select(party => party.Name?.ToString() ?? "<unnamed>").ToArray();
+        return names.Length == 0 ? "<none>" : string.Join(", ", names);
+    }
+
+    private sealed class ScoreboardHoldBehavior : MissionLogic
+    {
+        private readonly InputKey inputKey;
+
+        public ScoreboardHoldBehavior(InputKey inputKey)
+        {
+            this.inputKey = inputKey;
+        }
+
+        public override void OnMissionTick(float dt)
+        {
+            base.OnMissionTick(dt);
+            Input.PressKey(inputKey);
+        }
+    }
+
+    private const string LeaveBattleUsage =
+@"Usage:
+  coop.debug.mapevent.leave_battle
+
+Leaves the current battle through the native mission lifecycle.";
+
+    [CommandLineArgumentFunction("leave_battle", "coop.debug.mapevent")]
+    public static string LeaveBattle(List<string> args)
+    {
+        var ctx = new CommandContext("leave_battle", LeaveBattleUsage, args);
+        if (!ctx.RequireArgCount(0, out var error))
+            return error;
+
+        var mission = Mission.Current;
+        if (mission is null)
+            return "Failed: no active mission.";
+
+        mission.EndMission();
+        return "Left the current battle mission.";
+    }
 
     private const string KillEnemyUsage =
 @"Usage:

--- a/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
@@ -2,6 +2,7 @@
 using Common;
 using Common.Logging;
 using GameInterface.Services.MobileParties.Extensions;
+using GameInterface.Services.MapEvents.Handlers;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
 using Serilog;
@@ -39,6 +40,47 @@ public class MapEventDebugCommands
         if (ContainerProvider.TryGetContainer(out var container) == false) return false;
 
         return container.TryResolve(out objectManager);
+    }
+
+    /// <summary>
+    /// Starts the current battle through the normal client/server mission-start gate.
+    /// </summary>
+    [CommandLineArgumentFunction("start_attack_mission", "coop.debug.mapevent")]
+    public static string StartAttackMission(List<string> args)
+    {
+        if (ModInformation.IsServer)
+        {
+            return "Run this command on a client";
+        }
+
+        if (args.Count != 0)
+        {
+            return "Usage: coop.debug.mapevent.start_attack_mission";
+        }
+
+        var mainParty = MobileParty.MainParty;
+        var mapEvent = mainParty?.MapEvent;
+        if (mapEvent == null)
+        {
+            return "The main party has no replicated map event";
+        }
+
+        if (!TryGetObjectManager(out var objectManager)
+            || !objectManager.TryGetId(mapEvent, out var mapEventId)
+            || !objectManager.TryGetId(mainParty, out var partyId))
+        {
+            return "Unable to resolve the current battle ids";
+        }
+
+        var coordinator = BattleStartCoordinator.Instance;
+        if (coordinator == null)
+        {
+            return "Battle start coordinator is unavailable";
+        }
+
+        return coordinator.RequestBlocking(BattleStartMode.Mission, mapEventId, partyId)
+            ? $"Starting attack mission for {mapEventId}"
+            : $"Server rejected attack mission for {mapEventId}";
     }
 
     // coop.debug.mapevent.start_looter

--- a/source/GameInterface/Services/MapEvents/Handlers/HitRewardHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/HitRewardHandler.cs
@@ -228,6 +228,9 @@ public class HitRewardHandler : IHandler
 
         GameThread.RunSafe(() =>
         {
+            var mission = Mission.Current;
+            if (mission == null) return;
+
             if (!objectManager.TryGetObjectWithLogging<MapEvent>(data.MapEventId, out var mapEvent)) return;
             if (!objectManager.TryGetObjectWithLogging<CharacterObject>(data.AffectorCharacterId, out var affectorCharacter)) return;
             if (!objectManager.TryGetObjectWithLogging<PartyBase>(data.AffectorPartyId, out var affectorParty)) return;
@@ -235,10 +238,10 @@ public class HitRewardHandler : IHandler
             // Skip update if the client is not in this map event
             if (MapEvent.PlayerMapEvent != mapEvent) return;
 
-            BattleObserverMissionLogic battleObserverMissionLogic = Mission.Current.GetMissionBehavior<BattleObserverMissionLogic>();
+            BattleObserverMissionLogic battleObserverMissionLogic = mission.GetMissionBehavior<BattleObserverMissionLogic>();
             if ((battleObserverMissionLogic?.BattleObserver) == null) return;
 
-            TroopUpgradeTracker troopUpgradeTracker = MapEvent.PlayerMapEvent.TroopUpgradeTracker;
+            TroopUpgradeTracker troopUpgradeTracker = mapEvent.TroopUpgradeTracker;
             if (affectorCharacter.IsHero)
             {
                 Hero heroObject = affectorCharacter.HeroObject;

--- a/source/GameInterface/Services/Settlements/Patches/SettlementVisualSiegePatches.cs
+++ b/source/GameInterface/Services/Settlements/Patches/SettlementVisualSiegePatches.cs
@@ -4,7 +4,6 @@ using HarmonyLib;
 using SandBox.View.Map.Visuals;
 using Serilog;
 using System.Collections.Concurrent;
-using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Core;
 using static TaleWorlds.CampaignSystem.Siege.SiegeEvent;
@@ -16,7 +15,7 @@ namespace GameInterface.Services.Settlements.Patches;
 /// its NRE escapes to Game.OnTick, so one hole in the replicated siege graph freezes campaign time and
 /// menus every frame. Heals a deployed ranged engine missing its bombardment state, dirties the visual
 /// when a cached entity's backing slot is gone (the sequential refresh rebuilds the caches), skips
-/// the tick when the graph is unreadable, and skips the icon rebuild while the siege graph is still
+/// the tick when the graph is unreadable, and skips the visual refresh while the siege graph is still
 /// replicating.
 /// </summary>
 [HarmonyPatch]
@@ -27,16 +26,15 @@ internal class SettlementVisualSiegePatches
     // Tick runs in a TWParallel.For worker, so log terminal states once per settlement, not per frame.
     private static readonly ConcurrentDictionary<string, byte> loggedSkips = new ConcurrentDictionary<string, byte>();
 
-    // The rebuild derefs both siege sides' engine containers; during the SiegeEvent constructor's
-    // replication window the event exists before its camp and containers do. Skip the rebuild —
-    // the next visual-dirty re-runs it against the completed graph.
-    [HarmonyPatch(typeof(SettlementVisual), nameof(SettlementVisual.AddSiegeIconComponents))]
+    // RefreshPartyIcon clears the dirty flag before dereferencing both siege sides, so skip the whole refresh
+    // while the separately replicated camp and containers are incomplete. Vanilla then retries next frame.
+    [HarmonyPatch(typeof(SettlementVisual), nameof(SettlementVisual.RefreshPartyIcon))]
     [HarmonyPrefix]
-    private static bool AddSiegeIconComponentsPrefix(PartyBase party)
+    private static bool RefreshPartyIconPrefix(SettlementVisual __instance)
     {
         if (ModInformation.IsServer) return true;
 
-        var siegeEvent = party?.Settlement?.SiegeEvent;
+        var siegeEvent = __instance.MapEntity?.Settlement?.SiegeEvent;
         if (siegeEvent == null) return true;
 
         return siegeEvent.BesiegerCamp != null

--- a/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
+++ b/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
@@ -3,6 +3,7 @@ using Common;
 using Common.Logging;
 using GameInterface.Services.MapEvents;
 using GameInterface.Services.MobileParties.Extensions;
+using GameInterface.Services.MobileParties.Patches;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
 using GameInterface.Services.SiegeEvents.Interfaces;
@@ -25,6 +26,35 @@ namespace GameInterface.Services.SiegeEvents.Commands;
 public class SiegeDebugCommand
 {
     private static readonly ILogger Logger = LogManager.GetLogger<SiegeDebugCommand>();
+
+    [CommandLineArgumentFunction("leave_settlement", "coop.debug.siege")]
+    public static string LeaveSettlement(List<string> args)
+    {
+        if (args.Count != 0)
+        {
+            return "Usage: coop.debug.siege.leave_settlement";
+        }
+
+        if (ModInformation.IsServer)
+        {
+            return "This command can only be used by a client";
+        }
+
+        var party = MobileParty.MainParty;
+        if (party == null)
+        {
+            return "The local player party is unavailable";
+        }
+
+        if (party.CurrentSettlement == null)
+        {
+            return "The local player party is not in a settlement encounter";
+        }
+
+        var settlementName = party.CurrentSettlement.Name;
+        PlayerLeaveSettlementPatch.RequestLeave();
+        return $"Requested that the local player party leave {settlementName}";
+    }
 
     // coop.debug.siege.start
     /// <summary>

--- a/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
+++ b/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
@@ -217,6 +217,88 @@ public class SiegeDebugCommand
             string.Join(Environment.NewLine, joined);
     }
 
+    [CommandLineArgumentFunction("stage_machines", "coop.debug.siege")]
+    public static string StageMachines(List<string> args)
+    {
+        if (args.Count != 1)
+        {
+            return "Usage: coop.debug.siege.stage_machines <settlementId>";
+        }
+
+        if (ModInformation.IsClient)
+        {
+            return "This command can only be used by the server";
+        }
+
+        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)
+            || !ContainerProvider.TryResolve<ISiegeEventInterface>(out var siegeEventInterface))
+        {
+            return "Unable to resolve siege fixture services";
+        }
+
+        if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
+        {
+            return $"Settlement with id {args[0]} not found";
+        }
+
+        var siegeEvent = settlement.SiegeEvent;
+        if (siegeEvent?.BesiegerCamp == null)
+        {
+            return $"{settlement.Name} is not under siege";
+        }
+
+        var attacker = siegeEvent.GetSiegeEventSide(BattleSideEnum.Attacker);
+        if (!attacker.SiegeEngines.SiegePreparations.IsConstructed)
+        {
+            attacker.SiegeEngines.SiegePreparations.SetProgress(1f);
+            siegeEvent.CreateSiegeObject(attacker.SiegeEngines.SiegePreparations, attacker);
+        }
+
+        var machines = new[]
+        {
+            (Side: BattleSideEnum.Attacker, Type: DefaultSiegeEngineTypes.Ram, Index: 0),
+            (Side: BattleSideEnum.Attacker, Type: DefaultSiegeEngineTypes.Onager, Index: 0),
+            (Side: BattleSideEnum.Defender, Type: DefaultSiegeEngineTypes.Ballista, Index: 0),
+        };
+        var staged = new List<string>();
+        foreach (var machine in machines)
+        {
+            siegeEventInterface.DeploySiegeEngine(siegeEvent, machine.Side, machine.Type, machine.Index);
+            var side = siegeEvent.GetSiegeEventSide(machine.Side);
+            var slots = machine.Type.IsRanged
+                ? side.SiegeEngines.DeployedRangedSiegeEngines
+                : side.SiegeEngines.DeployedMeleeSiegeEngines;
+            var progress = machine.Index < slots.Length ? slots[machine.Index] : null;
+            if (progress?.SiegeEngine != machine.Type)
+            {
+                return $"Failed to stage {machine.Type.StringId} for {machine.Side}";
+            }
+
+            bool needsSiegeObject = !progress.IsConstructed
+                || (machine.Type.IsRanged && progress.RangedSiegeEngine == null);
+            if (!progress.IsConstructed)
+            {
+                progress.SetProgress(1f);
+            }
+            if (progress.IsBeingRedeployed)
+            {
+                progress.SetRedeploymentProgress(1f);
+            }
+            if (needsSiegeObject)
+            {
+                siegeEvent.CreateSiegeObject(progress, side);
+            }
+            if (!progress.IsActive)
+            {
+                return $"Failed to activate {machine.Type.StringId} for {machine.Side}";
+            }
+
+            staged.Add($"{machine.Side}:{machine.Type.StringId}[{machine.Index}]");
+        }
+
+        return $"Staged {staged.Count} constructed siege engines at {settlement.Name}: {string.Join(", ", staged)}";
+    }
+
     /// <summary>
     /// Starts the wall assault for an existing AI-led siege. Server only; the resulting map event uses the
     /// same authoritative action as campaign AI.
@@ -484,9 +566,13 @@ public class SiegeDebugCommand
                     .Where(weapon => weapon != null)
                     .ToArray() ?? Array.Empty<TaleWorlds.MountAndBlade.SynchedMissionObject>();
                 var deployedWeapon = deploymentPoint.DeployedWeapon;
+                var deployedWeaponType = deployedWeapon == null
+                    ? "none"
+                    : TaleWorlds.MountAndBlade.Missions.MissionSiegeWeaponsController.GetWeaponType(deployedWeapon)?.Name
+                        ?? deployedWeapon.GetType().Name;
                 lines.Add($"point   {deploymentPoint.Id.Id:D5} {deploymentPoint.Side,-16}" +
                     $" disabled={(deploymentPoint.IsDisabled ? 1 : 0)} deployed={(deploymentPoint.IsDeployed ? 1 : 0)}" +
-                    $" weapon={deployedWeapon?.GetType().Name ?? "none"}" +
+                    $" weapon={deployedWeaponType}" +
                     $" weaponId={(deployedWeapon != null ? deployedWeapon.Id.Id.ToString("D5") : "none")}" +
                     $" weaponVisible={(deployedWeapon?.GameEntity.IsVisibleIncludeParents() == true ? 1 : 0)}" +
                     $" variants={variants.Length} variantsVisible={variants.Count(weapon => weapon.GameEntity.IsVisibleIncludeParents())}");

--- a/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
+++ b/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
@@ -4,6 +4,8 @@ using Common.Logging;
 using GameInterface.Services.MapEvents;
 using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Players;
+using GameInterface.Services.SiegeEvents.Interfaces;
 using Serilog;
 using System;
 using System.Collections.Generic;
@@ -13,6 +15,7 @@ using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.Core;
 using static TaleWorlds.Library.CommandLineFunctionality;
 
 using GameInterface.Services.SiegeEngines;
@@ -92,6 +95,96 @@ public class SiegeDebugCommand
         Campaign.Current.SiegeEventManager.StartSiegeEvent(settlement, besieger);
 
         return $"{besieger.Name} ({besieger.StringId}) is now besieging {settlement.Name}";
+    }
+
+    /// <summary>
+    /// Joins every connected player party to an active siege on the authoritative server.
+    /// </summary>
+    [CommandLineArgumentFunction("join_players", "coop.debug.siege")]
+    public static string JoinPlayers(List<string> args)
+    {
+        if (args.Count != 2 || !int.TryParse(args[1], out int expectedPlayerCount) || expectedPlayerCount < 1)
+        {
+            return "Usage: coop.debug.siege.join_players <settlementId> <expectedPlayerCount>";
+        }
+
+        if (ModInformation.IsClient)
+        {
+            return "This command can only be used by the server";
+        }
+
+        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)
+            || !ContainerProvider.TryResolve<IPlayerManager>(out var playerManager)
+            || !ContainerProvider.TryResolve<ISiegeEventInterface>(out var siegeEventInterface))
+        {
+            return "Unable to resolve siege fixture services";
+        }
+
+        if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
+        {
+            return $"Settlement with id {args[0]} not found";
+        }
+
+        var camp = settlement.SiegeEvent?.BesiegerCamp;
+        if (camp == null)
+        {
+            return $"{settlement.Name} is not under siege";
+        }
+
+        var connectedPlayers = playerManager.Players.Where(playerManager.IsConnected).ToArray();
+        if (connectedPlayers.Length != expectedPlayerCount)
+        {
+            return $"Expected {expectedPlayerCount} connected players, found {connectedPlayers.Length}";
+        }
+
+        var parties = new List<(string ControllerId, string PartyId, MobileParty Party)>();
+        foreach (var player in connectedPlayers)
+        {
+            if (!objectManager.TryGetObjectWithLogging<MobileParty>(player.MobilePartyId, out var party))
+            {
+                return $"Unable to resolve player party {player.MobilePartyId}";
+            }
+
+            if (!party.IsActive || party.MapEvent != null || party.BesiegerCamp != null || party.CurrentSettlement != null)
+            {
+                return $"Player {player.ControllerId} is not clean for the fixture: " +
+                    $"active={party.IsActive} mapEvent={party.MapEvent != null} " +
+                    $"besiegerCamp={party.BesiegerCamp != null} settlement={party.CurrentSettlement?.StringId ?? "none"}";
+            }
+
+            if (!settlement.SiegeEvent.CanPartyJoinSide(party.Party, BattleSideEnum.Attacker))
+            {
+                return $"Player {player.ControllerId} cannot join the attacking side at {settlement.Name}";
+            }
+
+            parties.Add((player.ControllerId, player.MobilePartyId, party));
+        }
+
+        for (int i = 0; i < parties.Count; i++)
+        {
+            for (int j = i + 1; j < parties.Count; j++)
+            {
+                if (parties[i].Party.MapFaction.IsAtWarWith(parties[j].Party.MapFaction))
+                {
+                    return $"Players {parties[i].ControllerId} and {parties[j].ControllerId} cannot join the same siege side";
+                }
+            }
+        }
+
+        var joined = new List<string>();
+        foreach (var item in parties)
+        {
+            siegeEventInterface.JoinSiegeCamp(item.Party, settlement);
+            if (item.Party.BesiegerCamp != camp)
+            {
+                return $"Failed to join player {item.ControllerId} to the siege";
+            }
+
+            joined.Add($"{item.ControllerId}:{item.PartyId}");
+        }
+
+        return $"Joined {joined.Count} connected player parties to the siege of {settlement.Name}:\n" +
+            string.Join(Environment.NewLine, joined);
     }
 
     /// <summary>
@@ -357,9 +450,16 @@ public class SiegeDebugCommand
             }
             else if (missionObject is TaleWorlds.MountAndBlade.DeploymentPoint deploymentPoint)
             {
+                var variants = deploymentPoint._weapons?
+                    .Where(weapon => weapon != null)
+                    .ToArray() ?? Array.Empty<TaleWorlds.MountAndBlade.SynchedMissionObject>();
+                var deployedWeapon = deploymentPoint.DeployedWeapon;
                 lines.Add($"point   {deploymentPoint.Id.Id:D5} {deploymentPoint.Side,-16}" +
                     $" disabled={(deploymentPoint.IsDisabled ? 1 : 0)} deployed={(deploymentPoint.IsDeployed ? 1 : 0)}" +
-                    $" weapon={deploymentPoint.DeployedWeapon?.GetType().Name ?? "none"} deployable={deploymentPoint.DeployableWeapons.Count()}");
+                    $" weapon={deployedWeapon?.GetType().Name ?? "none"}" +
+                    $" weaponId={(deployedWeapon != null ? deployedWeapon.Id.Id.ToString("D5") : "none")}" +
+                    $" weaponVisible={(deployedWeapon?.GameEntity.IsVisibleIncludeParents() == true ? 1 : 0)}" +
+                    $" variants={variants.Length} variantsVisible={variants.Count(weapon => weapon.GameEntity.IsVisibleIncludeParents())}");
             }
         }
 

--- a/source/Missions/Agents/Handlers/AgentMovementHandler.cs
+++ b/source/Missions/Agents/Handlers/AgentMovementHandler.cs
@@ -37,17 +37,13 @@ public class AgentMovementHandler : IAgentMovementHandler
 {
     private static readonly ILogger Logger = LogManager.GetLogger<AgentMovementHandler>();
 
-    // Max agents per movement packet. The host has authority over every AI troop, so its batch can be
-    // dozens of agents — one packet for all of them overflows the unreliable MTU ceiling (LiteNetLib
-    // throws TooBigPacketException on oversized non-fragmentable sends). The MTU can stay near its ~1 KB floor
-    // (no negotiation up over P2P), and a mounted/well-equipped agent can run a few hundred bytes, so keep the
-    // chunk small enough that the common case fits one unreliable packet; the send path promotes any chunk that
-    // still overflows to a fragmentable reliable channel.
-    private const int MaxAgentsPerMovementPacket = 4;
+    // Movement is strictly droppable, so keep even mounted snapshots below the 1 KB unreliable ceiling.
+    private const int MaxAgentsPerMovementPacket = 3;
+    // Two 1,000-agent rotations fit inside the interpolator's one-second expiry window.
+    private const int MaxAgentsPerMovementPoll = 120;
 
-    // Keep the old movement-send ceiling after moving capture onto the game thread. High-FPS clients can tick
-    // faster than the old poller, and sending every frame would raise battle bandwidth.
-    private const float MovementPollingIntervalSeconds = 0.01f;
+    // Twenty updates per second keeps movement smooth without saturating battle meshes.
+    private const float MovementPollingIntervalSeconds = 0.05f;
 
     private readonly IPacketManager packetManager;
     private readonly IBattleNetwork client;
@@ -74,6 +70,7 @@ public class AgentMovementHandler : IAgentMovementHandler
     // guards against a second call (the GC finalizer, or the DI scope also disposing this transient handler).
     private bool _disposed;
     private float movementPollElapsed = MovementPollingIntervalSeconds;
+    private int nextMovementAgentIndex;
 
     public AgentMovementHandler(
         IBattleNetwork client,
@@ -134,8 +131,7 @@ public class AgentMovementHandler : IAgentMovementHandler
 
     public PacketType PacketType => PacketType.Movement;
 
-    // Broadcast the movement of every agent the local node currently has authority over: its own party,
-    // plus any party it has assumed control of as host.
+    // Broadcast a fair slice of locally authoritative agents, always including the local main agent.
     public void PollMovement(float dt)
     {
         if (_disposed || Mission.Current == null) return;
@@ -144,27 +140,33 @@ public class AgentMovementHandler : IAgentMovementHandler
         if (movementPollElapsed < MovementPollingIntervalSeconds) return;
         movementPollElapsed = 0f;
 
-        // Collect every agent we have authority over, then broadcast them in MTU-safe chunks. One packet
-        // per agent floods the mesh and the receiver's game-thread queue at battle scale (the GameThread
-        // lockup); one packet for ALL of them overflows the unreliable MTU ceiling. The single registry pass
-        // partitions the two movement streams: troops as AgentData, masterless registered horses as
-        // standalone AgentMountData (a ridden horse's pose rides inside its rider's AgentData instead).
-        var ids = new List<Guid>();
-        var data = new List<AgentData>();
-        List<Guid> mountIds = null;
-        List<AgentMountData> mountData = null;
+        var candidates = new List<CoopAgentInfo>();
+        CoopAgentInfo mainAgentInfo = null;
+        Agent mainAgent = Mission.Current.MainAgent;
 
         foreach (var agentInfo in agentRegistry.GetAgents(controllerIdProvider.ControllerId))
         {
             Agent agent = agentInfo.Agent;
             // Skip agents whose native object is already gone (dead/removed but not yet deregistered):
-            // building the snapshot calls into the agent (GetCurrentActionType, etc.), which throws an
-            // AccessViolationException on a freed agent. Mirrors the IsActive() guard on the apply path.
+            // building the snapshot calls into the agent, which can access-violate after native teardown.
             if (agent == null || agent.Mission == null || !agent.IsActive()) continue;
 
             EnsureLocallyDrivenMountController(agent);
             if (!ShouldBroadcastMovement(agent)) continue;
 
+            candidates.Add(agentInfo);
+            if (ReferenceEquals(agent, mainAgent)) mainAgentInfo = agentInfo;
+        }
+
+        IReadOnlyList<CoopAgentInfo> selectedAgents = SelectMovementAgents(candidates, mainAgentInfo);
+        var ids = new List<Guid>();
+        var data = new List<AgentData>();
+        List<Guid> mountIds = null;
+        List<AgentMountData> mountData = null;
+
+        foreach (var agentInfo in selectedAgents)
+        {
+            Agent agent = agentInfo.Agent;
             if (agent.IsMount)
             {
                 (mountIds ??= new List<Guid>()).Add(agentInfo.AgentId);
@@ -198,6 +200,30 @@ public class AgentMovementHandler : IAgentMovementHandler
             mountData.CopyTo(start, dataChunk, 0, count);
             client.SendAll(new MountMovementPacket(idChunk, dataChunk));
         }
+    }
+
+    private IReadOnlyList<CoopAgentInfo> SelectMovementAgents(
+        List<CoopAgentInfo> candidates,
+        CoopAgentInfo mainAgentInfo)
+    {
+        if (candidates.Count == 0) return Array.Empty<CoopAgentInfo>();
+        if (candidates.Count <= MaxAgentsPerMovementPoll) return candidates;
+
+        var selected = new List<CoopAgentInfo>(MaxAgentsPerMovementPoll);
+        if (mainAgentInfo != null) selected.Add(mainAgentInfo);
+
+        int start = nextMovementAgentIndex % candidates.Count;
+        int scanned = 0;
+        while (selected.Count < MaxAgentsPerMovementPoll && scanned < candidates.Count)
+        {
+            CoopAgentInfo candidate = candidates[(start + scanned) % candidates.Count];
+            scanned++;
+            if (ReferenceEquals(candidate, mainAgentInfo)) continue;
+            selected.Add(candidate);
+        }
+
+        nextMovementAgentIndex = (start + scanned) % candidates.Count;
+        return selected;
     }
 
     public void HandlePacket(NetPeer peer, IPacket packet)

--- a/source/Missions/Agents/Handlers/AgentMovementHandler.cs
+++ b/source/Missions/Agents/Handlers/AgentMovementHandler.cs
@@ -39,11 +39,9 @@ public class AgentMovementHandler : IAgentMovementHandler
 
     // Movement is strictly droppable, so keep even mounted snapshots below the 1 KB unreliable ceiling.
     private const int MaxAgentsPerMovementPacket = 3;
-    // Two 1,000-agent rotations fit inside the interpolator's one-second expiry window.
-    private const int MaxAgentsPerMovementPoll = 120;
 
-    // Twenty updates per second keeps movement smooth without saturating battle meshes.
-    private const float MovementPollingIntervalSeconds = 0.05f;
+    // Forty updates per second keeps locally authoritative agents responsive.
+    private const float MovementPollingIntervalSeconds = 0.025f;
 
     private readonly IPacketManager packetManager;
     private readonly IBattleNetwork client;
@@ -70,7 +68,6 @@ public class AgentMovementHandler : IAgentMovementHandler
     // guards against a second call (the GC finalizer, or the DI scope also disposing this transient handler).
     private bool _disposed;
     private float movementPollElapsed = MovementPollingIntervalSeconds;
-    private int nextMovementAgentIndex;
 
     public AgentMovementHandler(
         IBattleNetwork client,
@@ -131,18 +128,19 @@ public class AgentMovementHandler : IAgentMovementHandler
 
     public PacketType PacketType => PacketType.Movement;
 
-    // Broadcast a fair slice of locally authoritative agents, always including the local main agent.
+    // Broadcast every locally authoritative agent.
     public void PollMovement(float dt)
     {
         if (_disposed || Mission.Current == null) return;
 
         movementPollElapsed += dt;
         if (movementPollElapsed < MovementPollingIntervalSeconds) return;
-        movementPollElapsed = 0f;
+        movementPollElapsed %= MovementPollingIntervalSeconds;
 
-        var candidates = new List<CoopAgentInfo>();
-        CoopAgentInfo mainAgentInfo = null;
-        Agent mainAgent = Mission.Current.MainAgent;
+        var ids = new List<Guid>();
+        var data = new List<AgentData>();
+        List<Guid> mountIds = null;
+        List<AgentMountData> mountData = null;
 
         foreach (var agentInfo in agentRegistry.GetAgents(controllerIdProvider.ControllerId))
         {
@@ -154,19 +152,6 @@ public class AgentMovementHandler : IAgentMovementHandler
             EnsureLocallyDrivenMountController(agent);
             if (!ShouldBroadcastMovement(agent)) continue;
 
-            candidates.Add(agentInfo);
-            if (ReferenceEquals(agent, mainAgent)) mainAgentInfo = agentInfo;
-        }
-
-        IReadOnlyList<CoopAgentInfo> selectedAgents = SelectMovementAgents(candidates, mainAgentInfo);
-        var ids = new List<Guid>();
-        var data = new List<AgentData>();
-        List<Guid> mountIds = null;
-        List<AgentMountData> mountData = null;
-
-        foreach (var agentInfo in selectedAgents)
-        {
-            Agent agent = agentInfo.Agent;
             if (agent.IsMount)
             {
                 (mountIds ??= new List<Guid>()).Add(agentInfo.AgentId);
@@ -200,30 +185,6 @@ public class AgentMovementHandler : IAgentMovementHandler
             mountData.CopyTo(start, dataChunk, 0, count);
             client.SendAll(new MountMovementPacket(idChunk, dataChunk));
         }
-    }
-
-    private IReadOnlyList<CoopAgentInfo> SelectMovementAgents(
-        List<CoopAgentInfo> candidates,
-        CoopAgentInfo mainAgentInfo)
-    {
-        if (candidates.Count == 0) return Array.Empty<CoopAgentInfo>();
-        if (candidates.Count <= MaxAgentsPerMovementPoll) return candidates;
-
-        var selected = new List<CoopAgentInfo>(MaxAgentsPerMovementPoll);
-        if (mainAgentInfo != null) selected.Add(mainAgentInfo);
-
-        int start = nextMovementAgentIndex % candidates.Count;
-        int scanned = 0;
-        while (selected.Count < MaxAgentsPerMovementPoll && scanned < candidates.Count)
-        {
-            CoopAgentInfo candidate = candidates[(start + scanned) % candidates.Count];
-            scanned++;
-            if (ReferenceEquals(candidate, mainAgentInfo)) continue;
-            selected.Add(candidate);
-        }
-
-        nextMovementAgentIndex = (start + scanned) % candidates.Count;
-        return selected;
     }
 
     public void HandlePacket(NetPeer peer, IPacket packet)

--- a/source/Missions/Agents/Packets/MovementPacket.cs
+++ b/source/Missions/Agents/Packets/MovementPacket.cs
@@ -1,4 +1,4 @@
-using Common.PacketHandlers;
+﻿using Common.PacketHandlers;
 using LiteNetLib;
 using ProtoBuf;
 using System;
@@ -7,9 +7,7 @@ using TaleWorlds.MountAndBlade;
 namespace Missions.Agents.Packets
 {
     /// <summary>
-    /// A batch of agent movement snapshots for one poll tick: one packet carrying every agent the sender
-    /// currently has authority over, instead of one packet per agent. At battle scale (dozens of agents at
-    /// ~100 Hz) per-agent packets flood the mesh and the receiver's game-thread queue.
+    /// A small batch of agent movement snapshots for one poll tick.
     /// </summary>
     [ProtoContract]
     public readonly struct MovementPacket : IPacket

--- a/source/Missions/Battles/BattleDebugCommands.cs
+++ b/source/Missions/Battles/BattleDebugCommands.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using TaleWorlds.MountAndBlade;
+using static TaleWorlds.Library.CommandLineFunctionality;
+
+namespace Missions.Battles;
+
+/// <summary>Reports state needed to verify co-op battle synchronization.</summary>
+internal class BattleDebugCommands
+{
+    [CommandLineArgumentFunction("state", "coop.debug.battle")]
+    public static string State(List<string> args)
+    {
+        if (args.Count != 0)
+        {
+            return "Usage: coop.debug.battle.state";
+        }
+
+        var mission = Mission.Current;
+        var controller = mission?.GetMissionBehavior<CoopBattleController>();
+        if (mission == null || controller == null)
+        {
+            return "No active coop battle mission";
+        }
+
+        bool deploymentReady = mission.GetMissionBehavior<DeploymentMissionController>()?.TeamSetupOver == true;
+        int activeAgents = mission.Agents.Count(agent => agent.IsActive());
+
+        return $"instance={controller.Session.InstanceId} host={controller.Session.IsLocalHost} " +
+            $"activated={controller.Deployment.IsActivated} committed={controller.Deployment.IsCommitted} " +
+            $"deploymentReady={deploymentReady} mainAgent={Agent.Main != null} activeAgents={activeAgents}";
+    }
+}

--- a/source/Missions/Battles/BattleDeploymentCoordinator.cs
+++ b/source/Missions/Battles/BattleDeploymentCoordinator.cs
@@ -1,4 +1,4 @@
-using Common;
+﻿using Common;
 using Common.Logging;
 using Common.Messaging;
 using GameInterface.Services.MapEvents;
@@ -82,10 +82,12 @@ public class BattleDeploymentCoordinator : IBattleDeploymentCoordinator
     // the timer only disarms on a terminal outcome — see BR-025 retry semantics in Tick.
     private readonly IBattleDeploymentTimer deploymentTimer;
     private readonly Func<DeploymentAutoFinishResult> finishNativeDeployment;
+    private readonly Action<Action> enqueueDeferred;
 
     // BR-025: logged once when the limit first expires, so the per-tick retry loop (while reserves are still
     // spawning) does not spam the log until the finish actually commits.
     private bool autoFinishRequested;
+    private bool autoFinishPending;
 
     // Requirement #4 "hidden everywhere until deployed": own-party spawns are withheld from peers until the
     // local deployment commit (spawned locally so they can be placed, but not replicated); this latch is the
@@ -102,13 +104,16 @@ public class BattleDeploymentCoordinator : IBattleDeploymentCoordinator
         IMessageBroker messageBroker,
         IBattleSession session,
         IBattleDeploymentTimer deploymentTimer = null,
-        Func<DeploymentAutoFinishResult> finishNativeDeployment = null)
+        Func<DeploymentAutoFinishResult> finishNativeDeployment = null,
+        Action<Action> enqueueDeferred = null)
     {
         this.network = network;
         this.messageBroker = messageBroker;
         this.session = session;
         this.deploymentTimer = deploymentTimer ?? new BattleDeploymentTimer();
         this.finishNativeDeployment = finishNativeDeployment ?? FinishNativeDeployment;
+        this.enqueueDeferred = enqueueDeferred
+            ?? (action => GameThread.EnqueueSafe(action, context: "BattleDeploymentCoordinator.AutoFinishDeployment"));
 
         // Clients announce when they finish deploying; the host releases the NPC AI on the first announcement
         // from any client and broadcasts that the battle is live (so a migrated host knows to release the NPCs
@@ -119,6 +124,7 @@ public class BattleDeploymentCoordinator : IBattleDeploymentCoordinator
 
     public void Dispose()
     {
+        autoFinishPending = false;
         messageBroker.Unsubscribe<NetworkBattleDeploymentFinished>(Handle_NetworkBattleDeploymentFinished);
         messageBroker.Unsubscribe<NetworkBattleActivated>(Handle_NetworkBattleActivated);
     }
@@ -138,6 +144,7 @@ public class BattleDeploymentCoordinator : IBattleDeploymentCoordinator
         // The deployment finished (manually, or via this very gate's expiry) — the time limit no longer
         // applies (BR-025). Disarming here also covers the native auto-finish paths (e.g. a leaderless
         // rejoiner skipping the Order of Battle), which reach us through the same behavior fan-out.
+        autoFinishPending = false;
         deploymentTimer.OnDeploymentFinished();
 
         // Announce it to the battle mesh so the host releases the NPC AI on the first finish from ANY client.
@@ -190,7 +197,7 @@ public class BattleDeploymentCoordinator : IBattleDeploymentCoordinator
     // The seam's outcome feeds straight back to the timer, which disarms only on a terminal (non-Retry) result.
     public void Tick(float dt)
     {
-        if (!deploymentTimer.Tick(dt)) return;
+        if (autoFinishPending || !deploymentTimer.Tick(dt)) return;
 
         if (!autoFinishRequested)
         {
@@ -198,6 +205,17 @@ public class BattleDeploymentCoordinator : IBattleDeploymentCoordinator
             Logger.Information("[BattleSync] Deployment time limit expired — auto-finishing the local deployment (BR-025)");
         }
 
+        // Native finish removes both deployment behaviors. Defer it until Mission.OnTick has finished
+        // reverse-indexing MissionBehaviors, otherwise the shortened list makes its next index invalid.
+        autoFinishPending = true;
+        enqueueDeferred(FinishDeferredDeployment);
+    }
+
+    private void FinishDeferredDeployment()
+    {
+        if (!autoFinishPending) return;
+
+        autoFinishPending = false;
         DeploymentAutoFinishResult result = finishNativeDeployment();
         deploymentTimer.OnAutoFinishResult(result);
     }

--- a/source/Missions/CoopMissionController.cs
+++ b/source/Missions/CoopMissionController.cs
@@ -53,7 +53,7 @@ public abstract class CoopMissionController : MissionBehavior, IDisposable
         coopMissionComponent.AgentMovementHandler.PollMovement(dt);
 
         // Smoothly reconcile received puppets toward their owners' last-reported positions every frame; the
-        // per-packet correction was bound to the bursty ~10ms poll cadence and looked stepped. Subclasses that
+        // per-packet correction was bound to the bursty movement-poll cadence and looked stepped. Subclasses that
         // override OnMissionTick call base (CoopBattleController does), and CoopLocationsController does not
         // override it, so this runs for both battle and location missions.
         coopMissionComponent.AgentMovementHandler.Interpolator.Tick(dt);

--- a/source/Missions/Services/Network/LiteNetP2PClient.cs
+++ b/source/Missions/Services/Network/LiteNetP2PClient.cs
@@ -599,29 +599,38 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
         relayNetwork.SendAll(new RelayPacket(packet.DeliveryMethod, instanceId, controllerId, payload));
     }
 
-    // A conservative ceiling for a single non-fragmentable (Unreliable/Sequenced) send. netPeer
-    // .GetMaxSinglePacketSize() can read OPTIMISTICALLY high — it cleared a movement batch the send then
-    // rejected at ~1 KB (TooBigPacketException), which the Poller swallowed so movement silently stopped and
-    // every puppet froze. Capping the promote threshold here keeps the pre-check honest on links whose real
-    // single-packet limit sits near the minimum MTU; genuinely-smaller MTUs still win via the Math.Min below.
-    private const int SafeSinglePacketBytes = 1000;
+    // Peer-reported MTUs can be optimistic, so cap nonfragmentable sends at a conservative ceiling.
+    internal const int SafeSinglePacketBytes = 1000;
+
+    internal static DeliveryMethod? SelectDeliveryMethod(
+        IPacket packet,
+        int serializedLength,
+        int maxSinglePacketSize)
+    {
+        DeliveryMethod method = packet.DeliveryMethod;
+        bool fragmentable = method == DeliveryMethod.ReliableOrdered || method == DeliveryMethod.ReliableUnordered;
+        if (fragmentable || serializedLength <= Math.Min(maxSinglePacketSize, SafeSinglePacketBytes))
+        {
+            return method;
+        }
+
+        return IsMovementPacket(packet) ? null : DeliveryMethod.ReliableUnordered;
+    }
+
+    private static bool IsMovementPacket(IPacket packet) =>
+        packet.PacketType == PacketType.Movement || packet.PacketType == PacketType.MountMovement;
 
     public void Send(NetPeer netPeer, IPacket packet)
     {
         byte[] data = serializer.Serialize(packet);
-        var method = packet.DeliveryMethod;
+        DeliveryMethod? selectedMethod = SelectDeliveryMethod(
+            packet,
+            data.Length,
+            netPeer.GetMaxSinglePacketSize(packet.DeliveryMethod));
+        if (!selectedMethod.HasValue) return;
 
-        // Unreliable/Sequenced channels can't fragment: an oversized payload makes netPeer.Send throw
-        // TooBigPacketException, which the Poller swallows (e.g. movement then silently stops). When a
-        // packet exceeds the peer's single-packet limit, promote it to a fragmentable reliable channel so
-        // LiteNetLib splits it instead of throwing. Senders chunk to keep the common case unreliable; this is
-        // the backstop for whatever still overflows (small early MTU, fat all-cavalry batches, spawn bursts).
+        DeliveryMethod method = selectedMethod.Value;
         bool fragmentable = method == DeliveryMethod.ReliableOrdered || method == DeliveryMethod.ReliableUnordered;
-        if (!fragmentable && data.Length > Math.Min(netPeer.GetMaxSinglePacketSize(method), SafeSinglePacketBytes))
-        {
-            method = DeliveryMethod.ReliableUnordered;
-            fragmentable = true;
-        }
 
         try
         {
@@ -629,9 +638,9 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
         }
         catch (TooBigPacketException) when (!fragmentable)
         {
-            // The size estimate still under-shot the peer's real cap — deliver via the fragmentable reliable
-            // channel rather than letting the Poller swallow the throw and drop the packet entirely.
-            netPeer.Send(data, DeliveryMethod.ReliableUnordered);
+            DeliveryMethod? retryMethod = SelectDeliveryMethod(packet, data.Length, 0);
+            if (retryMethod.HasValue)
+                netPeer.Send(data, retryMethod.Value);
         }
     }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Large sieges can load players into an incomplete battle where scoreboards omit other players and deployed siege engines are invisible or arrive much later.

## What is the new behavior?

Large sieges now load every player and deployed siege engine promptly into the same battle, with matching scoreboards and siege-machine visibility for all players.

## Bot Changelog Entry

- Larger battles should now keep players, scoreboards, and deployed siege engines synchronized between players.
