### PR TITLE
Restore siege state and menu when rejoining as a besieger

### DIFF
--- a/source/GameInterface/Services/Heroes/Interfaces/HeroInterface.cs
+++ b/source/GameInterface/Services/Heroes/Interfaces/HeroInterface.cs
@@ -137,15 +137,17 @@ internal class HeroInterface : IHeroInterface
             LeaveSettlementActionPatches.SuppressForPlayerSwitch = false;
         }
 
-        if (playerParty.CurrentSettlement != null)
+        if (playerParty.CurrentSettlement != null || playerParty.BesiegerCamp != null)
         {
             // Queued so it runs after the campaign state is entered; the headless server's save
-            // carries no player encounter or menu state for this hero.
+            // carries no player encounter, menu, or player-siege state for this hero. Covers both
+            // a party reloaded inside a settlement and one besieging a settlement, which would
+            // otherwise sit at the siege camp with no menu (soft lock).
             GameThread.RunSafe(() =>
             {
                 if (ContainerProvider.TryResolve<ISiegeEventInterface>(out var siegeEventInterface))
                 {
-                    siegeEventInterface.RestoreReloadedPlayerInSettlement();
+                    siegeEventInterface.RestoreReloadedPlayer();
                 }
             });
         }

--- a/source/GameInterface/Services/SiegeEvents/Interfaces/SiegeEventInterface.cs
+++ b/source/GameInterface/Services/SiegeEvents/Interfaces/SiegeEventInterface.cs
@@ -103,11 +103,12 @@ public interface ISiegeEventInterface : IGameAbstraction
     void PromptSiegeDefenderVictory(Settlement settlement);
 
     /// <summary>
-    /// [Game thread] Rebuilds the local in-settlement state for a player whose reloaded party is
-    /// inside a settlement: the encounter the headless server's save doesn't carry, and the siege
-    /// menus when the settlement is besieged.
+    /// [Game thread] Rebuilds the local state the transferred host save doesn't carry for a
+    /// reloaded player: the encounter (and siege menus) when its party is inside a settlement,
+    /// or the player siege and its preparation menu when the party is besieging one — without
+    /// which a rejoining besieger soft-locks at the camp with no menu.
     /// </summary>
-    void RestoreReloadedPlayerInSettlement();
+    void RestoreReloadedPlayer();
 
     /// <summary>
     /// Establishes the besieging player's encounter for a starting wall assault by adopting the replicated
@@ -154,8 +155,8 @@ public interface ISiegeEventInterface : IGameAbstraction
 internal class SiegeEventInterface : ISiegeEventInterface, IDisposable
 {
     private static readonly ILogger Logger = LogManager.GetLogger<SiegeEventInterface>();
-    private bool reloadSettlementRestorePending;
-    private bool reloadSettlementRestoreSubscribed;
+    private bool reloadRestorePending;
+    private bool reloadRestoreSubscribed;
     private Settlement localAftermathChoiceSettlement;
     private Settlement localAftermathNarrationSettlement;
 
@@ -266,24 +267,82 @@ internal class SiegeEventInterface : ISiegeEventInterface, IDisposable
             .ToArray();
     }
 
-    public void RestoreReloadedPlayerInSettlement()
+    public void RestoreReloadedPlayer()
     {
         // The queued restore can land before the map state is active. GameThread.RunSafe executes inline
         // when called from the game thread, so using it as a retry recurses immediately. Arm one campaign-
         // tick listener instead; campaign ticks resume only after the map state becomes active.
         if (!(GameStateManager.Current?.ActiveState is TaleWorlds.CampaignSystem.GameState.MapState))
         {
-            reloadSettlementRestorePending = true;
-            if (!reloadSettlementRestoreSubscribed)
+            reloadRestorePending = true;
+            if (!reloadRestoreSubscribed)
             {
-                reloadSettlementRestoreSubscribed = true;
-                CampaignEvents.TickEvent.AddNonSerializedListener(this, RetryReloadedPlayerSettlementRestore);
+                reloadRestoreSubscribed = true;
+                CampaignEvents.TickEvent.AddNonSerializedListener(this, RetryReloadedPlayerRestore);
             }
             return;
         }
 
-        ClearReloadedPlayerSettlementRetry();
+        ClearReloadedPlayerRestoreRetry();
 
+        // Vanilla's generic-state menu ranks the besieger camp above settlement presence
+        // (DefaultEncounterGameMenuModel.GetGenericStateMenu); the siege entry/join flows also
+        // leave the settlement first, so the two states are mutually exclusive in practice.
+        if (MobileParty.MainParty?.BesiegerCamp != null)
+        {
+            RestoreReloadedPlayerBesieging();
+            return;
+        }
+
+        RestoreReloadedPlayerInSettlement();
+    }
+
+    private void RestoreReloadedPlayerBesieging()
+    {
+        var party = MobileParty.MainParty;
+        var settlement = party.BesiegerCamp.SiegeEvent?.BesiegedSettlement;
+        if (settlement?.Party == null) return;
+
+        // The headless server's save carries no player-siege state for this hero: vanilla only
+        // reopens the siege menu from its own save's menu id (MapStateData.GameMenuId) and derives
+        // PlayerSiege from MainParty, so after the character switch nothing re-drives the map-side
+        // siege activation or the menu. Re-run the live entry (see StartLocalPlayerSiegePreparation).
+        using (new AllowedThread())
+        {
+            PlayerSiege.StartPlayerSiege(BattleSideEnum.Attacker, isSimulation: false, settlement);
+        }
+
+        if (party.MapEvent != null)
+        {
+            // A wall assault is still live: adopt the replicated event as the player encounter
+            // (it seats the encounter menus) instead of parking on the preparation menu.
+            if (party.MapEvent.IsSiegeAssault && settlement.Party.MapEvent == party.MapEvent)
+            {
+                PromptSiegeAssault(party, settlement);
+            }
+            else
+            {
+                Logger.Warning("Skipped the reloaded besieger's siege menu at {Settlement}: the party is in an unexpected map event", settlement.StringId);
+            }
+            return;
+        }
+
+        // The menu vanilla's generic-state model picks for a besieging main party.
+        using (new AllowedThread())
+        {
+            if (Campaign.Current.CurrentMenuContext == null)
+            {
+                GameMenu.ActivateGameMenu("menu_siege_strategies");
+            }
+            else
+            {
+                GameMenu.SwitchToMenu("menu_siege_strategies");
+            }
+        }
+    }
+
+    private void RestoreReloadedPlayerInSettlement()
+    {
         var settlement = MobileParty.MainParty?.CurrentSettlement;
         if (settlement?.Party == null) return;
 
@@ -622,27 +681,27 @@ internal class SiegeEventInterface : ISiegeEventInterface, IDisposable
         return localAftermathNarrationSettlement == settlement;
     }
 
-    private void RetryReloadedPlayerSettlementRestore(float dt)
+    private void RetryReloadedPlayerRestore(float dt)
     {
-        if (!reloadSettlementRestorePending) return;
+        if (!reloadRestorePending) return;
         if (!(GameStateManager.Current?.ActiveState is TaleWorlds.CampaignSystem.GameState.MapState)) return;
 
-        ClearReloadedPlayerSettlementRetry();
-        RestoreReloadedPlayerInSettlement();
+        ClearReloadedPlayerRestoreRetry();
+        RestoreReloadedPlayer();
     }
 
-    private void ClearReloadedPlayerSettlementRetry()
+    private void ClearReloadedPlayerRestoreRetry()
     {
-        reloadSettlementRestorePending = false;
-        if (!reloadSettlementRestoreSubscribed) return;
+        reloadRestorePending = false;
+        if (!reloadRestoreSubscribed) return;
 
-        reloadSettlementRestoreSubscribed = false;
+        reloadRestoreSubscribed = false;
         CampaignEvents.TickEvent.ClearListeners(this);
     }
 
     public void Dispose()
     {
-        ClearReloadedPlayerSettlementRetry();
+        ClearReloadedPlayerRestoreRetry();
         SiegeCaptureMenuHoldPatch.Release(localAftermathChoiceSettlement);
         localAftermathChoiceSettlement = null;
         localAftermathNarrationSettlement = null;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?

Leaving and rejoining while besieging a settlement soft-locks the player: the party is still attached to the besieger camp (so it can't move), but no menu opens.

`HeroInterface.SwitchToPlayer` only rebuilds local state when the reloaded party is *inside* a settlement (`CurrentSettlement != null`). A besieger has `CurrentSettlement == null` and `BesiegerCamp != null`, so nothing runs. Vanilla can't self-heal this either: `PlayerSiege` holds no saved state (`PlayerSiegeEvent`/`PlayerSide` are computed from `MainParty`), and a normal load only reopens the siege menu from the save's own `MapStateData.GameMenuId` — which the transferred host save doesn't carry for the rejoiner's hero. A besieging attacker in the preparation phase natively has no `PlayerEncounter` at all, so the missing pieces are the player-siege activation and the menu, not an encounter.

## What is the new behavior?

Resolves #2262

- `SwitchToPlayer` now queues the reload restore when the party is in a settlement **or** has a besieger camp.
- The restore entry (renamed `RestoreReloadedPlayer`) dispatches on live party state, keeping the existing MapState gate + campaign-tick retry:
  - **Besieger camp:** re-runs the live siege entry (`PlayerSiege.StartPlayerSiege(Attacker)` — safe to re-fire, `MapScreen.OnPlayerSiegeActivated` is empty in this game version) and lands on `menu_siege_strategies`, the menu vanilla's `GetGenericStateMenu` picks for a besieging main party. If the wall assault is still live and the party is in it, it instead adopts the replicated event via the existing `PromptSiegeAssault`.
  - **In settlement:** unchanged existing behavior.
- A besieger stuck in a non-assault map event logs a warning and deliberately skips the menu: opening the wait menu there would tick-switch into the `encounter` menu, whose init derefs a null `PlayerEncounter`.

## Bot Changelog Entry

- Rejoining the server while besieging a settlement now reopens the siege menu instead of soft-locking on the map

## Other information

- No new classes; the interface doc on `ISiegeEventInterface.RestoreReloadedPlayer` was updated.
- No automated tests added: the restore is game-runtime code (menus, `MapState`, `PlayerSiege`), same as the existing in-settlement restore and the other `Prompt*` methods, and the E2E harness has no MapState/menu simulation. Existing coverage passes: 4/4 E2E `SiegeEvent*` tests, 13/13 GameInterface siege/encounter unit tests.
- Manual check (2 clients): besiege a town → disconnect → rejoin → siege strategies menu opens and Leave/assault options work; rejoin during a live wall assault lands on the encounter menu instead.
- Known gaps of the same class, out of scope here: rejoin mid *field* battle and rejoin as an army follower have no restore branch yet.
