### PR TITLE
Let the Steam lobby password prompt reopen after canceling

### DIFF
--- a/source/Common/Network/Session/Messages/SessionJoinAbandoned.cs
+++ b/source/Common/Network/Session/Messages/SessionJoinAbandoned.cs
@@ -1,0 +1,11 @@
+using Common.Messaging;
+
+namespace Common.Network.Session.Messages;
+
+/// <summary>
+/// The user abandoned a discovery-initiated join before it produced a session
+/// (e.g. canceled the server password prompt).
+/// </summary>
+public record SessionJoinAbandoned : IEvent
+{
+}

--- a/source/Coop.Core/CoopartiveMultiplayerExperience.cs
+++ b/source/Coop.Core/CoopartiveMultiplayerExperience.cs
@@ -279,7 +279,14 @@ namespace Coop.Core
                     joinInfo.Password = password ?? string.Empty;
                     StartResolvedJoin(joinInfo);
                 },
-                () => passwordInquiryPending = false,
+                () =>
+                {
+                    passwordInquiryPending = false;
+                    // The join keeps its Steam lobby membership alive while this prompt is
+                    // open; abandoning tells the join listener to leave, so a later Join
+                    // click starts a fresh attempt instead of no-oping on the stale membership.
+                    messageBroker.Publish(this, new SessionJoinAbandoned());
+                },
                 shouldInputBeObfuscated: true,
                 textCondition: password =>
                 {

--- a/source/Coop.Steam/SteamJoinListener.cs
+++ b/source/Coop.Steam/SteamJoinListener.cs
@@ -189,35 +189,47 @@ public class SteamJoinListener : IDisposable, ISteamLobbyMembership
 
     private void ResolveJoinInfo(ulong lobbyId)
     {
-        bool decoded = LobbyDataCodec.TryDecode(key => lobbyApi.GetLobbyData(lobbyId, key), out var info, out var error);
+        try
+        {
+            bool decoded = LobbyDataCodec.TryDecode(key => lobbyApi.GetLobbyData(lobbyId, key), out var info, out var error);
 
-        // A standalone server advertises its own game-server identity to tunnel to; otherwise the
-        // lobby owner runs the tunnel. Either is only readable while still a member of the lobby.
-        if (decoded && info.HasServerSteamId)
-        {
-            info.HostSteamId = info.ServerSteamId;
-        }
-        else if (decoded && info.Version >= SessionJoinInfo.MinTunnelVersion)
-        {
-            info.HostSteamId = lobbyApi.GetLobbyOwner(lobbyId);
-        }
+            // A standalone server advertises its own game-server identity to tunnel to; otherwise the
+            // lobby owner runs the tunnel. Either is only readable while still a member of the lobby.
+            if (decoded && info.HasServerSteamId)
+            {
+                info.HostSteamId = info.ServerSteamId;
+            }
+            else if (decoded && info.Version >= SessionJoinInfo.MinTunnelVersion)
+            {
+                info.HostSteamId = lobbyApi.GetLobbyOwner(lobbyId);
+            }
 
-        if (!decoded)
+            if (!decoded)
+            {
+                LeaveActiveLobby();
+                messageBroker.Publish(this, new SessionJoinFailed(error));
+                return;
+            }
+
+            if (!info.HasAddress && !info.HasHostSteamId)
+            {
+                LeaveActiveLobby();
+                messageBroker.Publish(this, new SessionJoinFailed(
+                    "The host has not set a public address on their co-op screen, so this session cannot be joined yet"));
+                return;
+            }
+
+            messageBroker.Publish(this, new SessionJoinInfoResolved(info));
+        }
+        catch (Exception ex)
         {
+            // GetLobbyData/GetLobbyOwner can throw; both callers (OnLobbyEntered and the
+            // rejoin-while-still-member path) rely on this releasing the membership and
+            // reporting the failure instead of stranding the join silently in the lobby.
             LeaveActiveLobby();
-            messageBroker.Publish(this, new SessionJoinFailed(error));
-            return;
+            Logger.Error(ex, "Failed to read Steam lobby {LobbyId}", lobbyId.ToString());
+            messageBroker.Publish(this, new SessionJoinFailed("Could not read the Steam lobby"));
         }
-
-        if (!info.HasAddress && !info.HasHostSteamId)
-        {
-            LeaveActiveLobby();
-            messageBroker.Publish(this, new SessionJoinFailed(
-                "The host has not set a public address on their co-op screen, so this session cannot be joined yet"));
-            return;
-        }
-
-        messageBroker.Publish(this, new SessionJoinInfoResolved(info));
     }
 
     public void LeaveSessionLobby()

--- a/source/Coop.Steam/SteamJoinListener.cs
+++ b/source/Coop.Steam/SteamJoinListener.cs
@@ -39,6 +39,7 @@ public class SteamJoinListener : IDisposable, ISteamLobbyMembership
         lobbyApi.ConnectStringReceived += OnConnectStringReceived;
 
         messageBroker.Subscribe<JoinSteamLobby>(Handle);
+        messageBroker.Subscribe<SessionJoinAbandoned>(Handle);
     }
 
     /// <summary>
@@ -64,6 +65,13 @@ public class SteamJoinListener : IDisposable, ISteamLobbyMembership
         OnLobbyJoinRequested(payload.What.LobbyId);
     }
 
+    private void Handle(MessagePayload<SessionJoinAbandoned> payload)
+    {
+        // Keeping the membership would hold one of the host's lobby slots and make the
+        // next join request for the same lobby a no-op; give it up so retries start fresh.
+        LeaveSessionLobby();
+    }
+
     private void OnConnectStringReceived(string connectString)
     {
         if (!TryParseConnectLobby(connectString, out var lobbyId)) return;
@@ -83,7 +91,19 @@ public class SteamJoinListener : IDisposable, ISteamLobbyMembership
 
     private void BeginLobbyJoin(ulong lobbyId, bool resolveJoinInfo)
     {
-        if (lobbyId == 0 || activeLobbyId == lobbyId) return;
+        if (lobbyId == 0) return;
+
+        if (activeLobbyId == lobbyId)
+        {
+            // Still a member from an earlier attempt whose join never produced a session
+            // (e.g. an abandoned password prompt). The lobby data is readable while a
+            // member, so restart the attempt from the resolve step instead of no-oping.
+            if (resolveJoinInfo)
+            {
+                ResolveJoinInfo(lobbyId);
+            }
+            return;
+        }
 
         // A second JoinLobby would silently unregister the first pending call result.
         if (joinInFlight)
@@ -256,6 +276,7 @@ public class SteamJoinListener : IDisposable, ISteamLobbyMembership
     {
         LeaveSessionLobby();
         messageBroker.Unsubscribe<JoinSteamLobby>(Handle);
+        messageBroker.Unsubscribe<SessionJoinAbandoned>(Handle);
         lobbyApi.LobbyJoinRequested -= OnLobbyJoinRequested;
         lobbyApi.ConnectStringReceived -= OnConnectStringReceived;
     }

--- a/source/Coop.Tests/Steam/FakeSteamLobbyApi.cs
+++ b/source/Coop.Tests/Steam/FakeSteamLobbyApi.cs
@@ -27,6 +27,7 @@ namespace Coop.Tests.Steam
         public bool ThrowOnListRequest;
         public bool ThrowOnFriendLobbyRequest;
         public bool ThrowOnLobbyDataRequest;
+        public bool ThrowOnGetLobbyData;
 
         public readonly List<ulong> LeftLobbies = new List<ulong>();
         public readonly List<ulong> InviteDialogsOpened = new List<ulong>();
@@ -149,6 +150,8 @@ namespace Coop.Tests.Steam
 
         public string GetLobbyData(ulong lobbyId, string key)
         {
+            if (ThrowOnGetLobbyData) throw new InvalidOperationException("scripted get-lobby-data failure");
+
             if (LobbyData.TryGetValue(lobbyId, out var data) && data.TryGetValue(key, out var value)) return value;
 
             return string.Empty;

--- a/source/Coop.Tests/Steam/SteamJoinListenerTests.cs
+++ b/source/Coop.Tests/Steam/SteamJoinListenerTests.cs
@@ -141,6 +141,23 @@ namespace Coop.Tests.Steam
         }
 
         [Fact]
+        public void RejoinRequestWhileStillMember_ReadThrows_LeavesLobbyAndReportsFailure()
+        {
+            SetupLobby(42);
+            api.RaiseLobbyJoinRequested(42);
+            Assert.True(listener.IsInLobby);
+
+            // A lobby read throwing on the re-resolve must not strand the join in the lobby:
+            // release the membership and surface the failure, same as the OnLobbyEntered path.
+            api.ThrowOnGetLobbyData = true;
+            api.RaiseLobbyJoinRequested(42);
+
+            Assert.False(listener.IsInLobby);
+            Assert.Contains(42UL, api.LeftLobbies);
+            Assert.Single(failed);
+        }
+
+        [Fact]
         public void ConnectString_JoinsReferencedLobby()
         {
             SetupLobby(42);

--- a/source/Coop.Tests/Steam/SteamJoinListenerTests.cs
+++ b/source/Coop.Tests/Steam/SteamJoinListenerTests.cs
@@ -108,6 +108,39 @@ namespace Coop.Tests.Steam
         }
 
         [Fact]
+        public void AbandonedJoin_LeavesLobbyAndAllowsRejoin()
+        {
+            SetupLobby(42);
+            api.RaiseLobbyJoinRequested(42);
+
+            // Canceling the password prompt abandons the attempt without a session.
+            messageBroker.Publish(this, new SessionJoinAbandoned());
+
+            Assert.False(listener.IsInLobby);
+            Assert.Contains(42UL, api.LeftLobbies);
+
+            api.RaiseLobbyJoinRequested(42);
+
+            Assert.Equal(2, resolved.Count);
+            Assert.True(listener.IsInLobby);
+            Assert.Empty(failed);
+        }
+
+        [Fact]
+        public void RejoinRequestWhileStillMember_ResolvesAgain()
+        {
+            SetupLobby(42);
+
+            api.RaiseLobbyJoinRequested(42);
+            api.RaiseLobbyJoinRequested(42);
+
+            Assert.Equal(2, resolved.Count);
+            Assert.Empty(failed);
+            Assert.True(listener.IsInLobby);
+            Assert.DoesNotContain(42UL, api.LeftLobbies);
+        }
+
+        [Fact]
         public void ConnectString_JoinsReferencedLobby()
         {
             SetupLobby(42);


### PR DESCRIPTION
Fixes #2238

## Root cause

Clicking Join on a password-protected server makes `SteamJoinListener` join the Steam lobby first (membership is required to read the lobby's connection data), and only then does the password prompt open. Canceling the prompt only reset the inquiry flag — nothing left the lobby. Every later Join click on the same server then hit `BeginLobbyJoin`'s already-in-this-lobby early return and silently did nothing, so the prompt could never be opened again. Joining a *different* server still worked, which matches the video in the issue. Side effect: the canceled player kept holding one of the host's limited lobby member slots.

## Fix

- New `SessionJoinAbandoned` message, published when the password prompt is canceled.
- `SteamJoinListener` handles it by leaving the lobby (via the existing `LeaveSessionLobby` path, which already covers the join-in-flight and own-advertised-lobby cases), so the next Join starts a fresh attempt and the ghost member slot is released.
- Safety net: a join request for a lobby the player is somehow still a member of now re-resolves the join info instead of returning silently, so the Join button can never permanently dead-end on stale membership (e.g. any other abandoned-attempt path).

## Testing

- New tests: `AbandonedJoin_LeavesLobbyAndAllowsRejoin` (cancel -> leave -> rejoin loop) and `RejoinRequestWhileStillMember_ResolvesAgain` (re-resolve safety net).
- Full Coop.Tests suite green: 446 passed / 0 failed / 1 pre-existing skip; E2E.Tests compiles clean (nothing in it touches these types).