### PR TITLE
Disable managing player received damage on clients

### DIFF
--- a/deploy/ModuleData/global_strings.xml
+++ b/deploy/ModuleData/global_strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<strings>
+    <string id="str_coop_server_managed_player_received_damage" text="{=!}Managing this option is disabled on clients; the server does this." />
+    <!-- Add other custom text here in the future-->
+</strings>

--- a/source/Coop.Core/Client/Messages/NetworkGameSaveDataReceived.cs
+++ b/source/Coop.Core/Client/Messages/NetworkGameSaveDataReceived.cs
@@ -2,6 +2,7 @@
 
 using Common.Messaging;
 using GameInterface.Services.Alleys;
+using GameInterface.Services.CampaignService.Data;
 using GameInterface.Services.Caravans;
 using GameInterface.Services.Inventory.TradeSkills;
 using GameInterface.Services.MobileParties;
@@ -36,6 +37,8 @@ public record NetworkGameSaveDataReceived : IEvent
     public TradePlayerData TradePlayerData { get; }
     [ProtoMember(9)]
     public AttachmentIdMap AttachmentIdMap { get; }
+    [ProtoMember(10)]
+    public ServerOptions ServerOptions { get; }
 
     public NetworkGameSaveDataReceived(
         byte[] gameSaveData,
@@ -46,7 +49,8 @@ public record NetworkGameSaveDataReceived : IEvent
         AlleyPlayerData alleyPlayerData,
         InteractionsPlayerData interactionsPlayerData,
         TradePlayerData tradePlayerData,
-        AttachmentIdMap attachmentIdMap)
+        AttachmentIdMap attachmentIdMap,
+        ServerOptions serverOptions)
     {
         GameSaveData = gameSaveData;
         CampaignID = campaignID;
@@ -57,5 +61,6 @@ public record NetworkGameSaveDataReceived : IEvent
         InteractionsPlayerData = interactionsPlayerData;
         TradePlayerData = tradePlayerData;
         AttachmentIdMap = attachmentIdMap;
+        ServerOptions = serverOptions;
     }
 }

--- a/source/Coop.Core/Client/Services/Save/Handler/SaveDataHandler.cs
+++ b/source/Coop.Core/Client/Services/Save/Handler/SaveDataHandler.cs
@@ -1,6 +1,7 @@
 ﻿using Common.Messaging;
 using Coop.Core.Client.Messages;
 using GameInterface.Services.Alleys.Messages;
+using GameInterface.Services.CampaignService.Messages;
 using GameInterface.Services.Caravans.Messages;
 using GameInterface.Services.Inventory.TradeSkills.Messages;
 using GameInterface.Services.MobileParties.Messages;
@@ -36,6 +37,9 @@ internal class SaveDataHandler : IHandler
         // arrived and the server world has not loaded yet. It is ended once the campaign
         // is ready (see LoadingState.Handle_CampaignLoaded).
         saveDataMessage = obj.What;
+
+        // Send options on server not part of the save game to clients
+        messageBroker.Publish(this, new InitializeServerOptionsOnClient(saveDataMessage.ServerOptions));
 
         messageBroker.Publish(this, new InitializeClientCraftingData(saveDataMessage.CraftingPlayerData));
         messageBroker.Publish(this, new InitializeClientWorkshopData(saveDataMessage.WorkshopPlayerData));

--- a/source/Coop.Core/Client/Services/Save/PacketHandlers/GameSaveDataPacketHandler.cs
+++ b/source/Coop.Core/Client/Services/Save/PacketHandlers/GameSaveDataPacketHandler.cs
@@ -45,6 +45,7 @@ internal class GameSaveDataPacketHandler : IPacketHandler
             convertedPacket.AlleyPlayerData,
             convertedPacket.InteractionsPlayerData,
             convertedPacket.TradePlayerData,
-            convertedPacket.AttachmentIdMap));
+            convertedPacket.AttachmentIdMap,
+            convertedPacket.ServerOptions));
     }
 }

--- a/source/Coop.Core/Common/Network/Packets/GameSaveDataPacket.cs
+++ b/source/Coop.Core/Common/Network/Packets/GameSaveDataPacket.cs
@@ -1,5 +1,6 @@
 ﻿using Common.PacketHandlers;
 using GameInterface.Services.Alleys;
+using GameInterface.Services.CampaignService.Data;
 using GameInterface.Services.Caravans;
 using GameInterface.Services.Inventory.TradeSkills;
 using GameInterface.Services.MobileParties;
@@ -58,6 +59,9 @@ public readonly struct GameSaveDataPacket : IPacket
     [ProtoMember(9)]
     public readonly AttachmentIdMap AttachmentIdMap;
 
+    [ProtoMember(10)]
+    public readonly ServerOptions ServerOptions;
+
     public GameSaveDataPacket(
         byte[] gameSaveData,
         string campaignID,
@@ -67,7 +71,8 @@ public readonly struct GameSaveDataPacket : IPacket
         AlleyPlayerData alleyPlayerData,
         InteractionsPlayerData interactionsPlayerData,
         TradePlayerData tradePlayerData,
-        AttachmentIdMap attachmentIdMap)
+        AttachmentIdMap attachmentIdMap,
+        ServerOptions serverOptions)
     {
         GameSaveData = gameSaveData;
         CampaignID = campaignID;
@@ -78,5 +83,6 @@ public readonly struct GameSaveDataPacket : IPacket
         InteractionsPlayerData = interactionsPlayerData;
         TradePlayerData = tradePlayerData;
         AttachmentIdMap = attachmentIdMap;
+        ServerOptions = serverOptions;
     }
 }

--- a/source/Coop.Core/Server/Connections/ConnectionContext.cs
+++ b/source/Coop.Core/Server/Connections/ConnectionContext.cs
@@ -2,6 +2,7 @@ using Common.Messaging;
 using Common.Network;
 using Common.Network.Coalescing;
 using GameInterface.CoopSessionData;
+using GameInterface.Services.CampaignService.Interfaces;
 using GameInterface.Services.Heroes.Interaces;
 using GameInterface.Services.Heroes.Interfaces;
 using GameInterface.Services.Modules;
@@ -32,7 +33,8 @@ public class ConnectionContext
         IConnectionMessageQueue connectionMessageQueue,
         ISendCoalescer coalescer,
         IAttachmentIdMapper attachmentIdMapper,
-        IExistingPlayerSender existingPlayerSender)
+        IExistingPlayerSender existingPlayerSender,
+        IServerOptionsProvider serverOptionsProvider)
     {
         MessageBroker = messageBroker;
         Network = network;
@@ -48,6 +50,7 @@ public class ConnectionContext
         Coalescer = coalescer;
         AttachmentIdMapper = attachmentIdMapper;
         ExistingPlayerSender = existingPlayerSender;
+        ServerOptionsProvider = serverOptionsProvider;
     }
 
     public IMessageBroker MessageBroker { get; }
@@ -64,4 +67,5 @@ public class ConnectionContext
     public ISendCoalescer Coalescer { get; }
     public IAttachmentIdMapper AttachmentIdMapper { get; }
     public IExistingPlayerSender ExistingPlayerSender { get; }
+    public IServerOptionsProvider ServerOptionsProvider { get; }
 }

--- a/source/Coop.Core/Server/Connections/ConnectionLogic.cs
+++ b/source/Coop.Core/Server/Connections/ConnectionLogic.cs
@@ -66,7 +66,7 @@ public class ConnectionLogic : IConnectionLogic
         {
             [typeof(ResolveCharacterState)] = () => new ResolveCharacterState(this, context.MessageBroker, context.Network, context.ModuleValidator, context.PlayerManager, context.ObjectManager, context.ModuleInfoProvider, context.ExistingPlayerSender),
             [typeof(CreateCharacterState)] = () => new CreateCharacterState(this, context.ObjectManager, context.MessageBroker, context.Network, context.HeroInterface, context.PlayerManager, context.ExistingPlayerSender),
-            [typeof(TransferSaveState)] = () => new TransferSaveState(this, context.Network, context.CoopSessionProvider, context.SaveInterface, context.TimeControlInterface, context.ConnectionMessageQueue, context.Coalescer, context.AttachmentIdMapper),
+            [typeof(TransferSaveState)] = () => new TransferSaveState(this, context.Network, context.CoopSessionProvider, context.SaveInterface, context.TimeControlInterface, context.ConnectionMessageQueue, context.Coalescer, context.AttachmentIdMapper, context.ServerOptionsProvider),
             [typeof(LoadingState)] = () => new LoadingState(this, context.MessageBroker),
             [typeof(CampaignState)] = () => new CampaignState(this, context.MessageBroker),
             [typeof(MissionState)] = () => new MissionState(this, context.MessageBroker),

--- a/source/Coop.Core/Server/Connections/States/TransferSaveState.cs
+++ b/source/Coop.Core/Server/Connections/States/TransferSaveState.cs
@@ -4,6 +4,7 @@ using Common.Network;
 using Common.Network.Coalescing;
 using Coop.Core.Common.Network.Packets;
 using GameInterface.CoopSessionData;
+using GameInterface.Services.CampaignService.Interfaces;
 using GameInterface.Services.Heroes.Enum;
 using GameInterface.Services.Heroes.Interaces;
 using GameInterface.Services.Heroes.Interfaces;
@@ -29,7 +30,8 @@ public class TransferSaveState : ConnectionStateBase
         ITimeControlInterface timeControlInterface,
         IConnectionMessageQueue connectionMessageQueue,
         ISendCoalescer coalescer,
-        IAttachmentIdMapper attachmentIdMapper)
+        IAttachmentIdMapper attachmentIdMapper,
+        IServerOptionsProvider serverOptionsProvider)
         : base(connectionLogic)
     {
         GameThread.Run(() =>
@@ -71,7 +73,8 @@ public class TransferSaveState : ConnectionStateBase
                 coopSessionProvider.CoopSession?.AlleyPlayerData,
                 coopSessionProvider.CoopSession?.InteractionsPlayerData,
                 coopSessionProvider.CoopSession?.TradePlayerData,
-                attachmentIdMapper.BuildServerMap());
+                attachmentIdMapper.BuildServerMap(),
+                serverOptionsProvider.GetServerOptions());
 
             // Start holding this peer's broadcasts now that the snapshot has been taken. The whole save
             // runs in a blocking GameThread.Run call issued from the network thread, so the poller is

--- a/source/Coop.Tests/Client/States/ReceivingSavedDataStateTests.cs
+++ b/source/Coop.Tests/Client/States/ReceivingSavedDataStateTests.cs
@@ -16,6 +16,7 @@ using System;
 using Xunit;
 using Xunit.Abstractions;
 using GameInterface.Services.Inventory.TradeSkills;
+using GameInterface.Services.CampaignService.Data;
 
 namespace Coop.Tests.Client.States
 {
@@ -37,7 +38,7 @@ namespace Coop.Tests.Client.States
         }
 
         private static NetworkGameSaveDataReceived SaveData(byte[] data, string campaignId) =>
-            new NetworkGameSaveDataReceived(data, campaignId, new CraftingPlayerData(new(), new(), new()), new WorkshopPlayerData(new()), new CaravansPlayerData(new(), new()), new AlleyPlayerData(new()), new InteractionsPlayerData(new(), new(), new(), new()), new TradePlayerData(new()), new AttachmentIdMap(new()));
+            new NetworkGameSaveDataReceived(data, campaignId, new CraftingPlayerData(new(), new(), new()), new WorkshopPlayerData(new()), new CaravansPlayerData(new(), new()), new AlleyPlayerData(new()), new InteractionsPlayerData(new(), new(), new(), new()), new TradePlayerData(new()), new AttachmentIdMap(new()), new ServerOptions(new()));
 
         [Fact]
         public void StateEntered_Shows_LoadingProgressMessage()

--- a/source/Coop.Tests/TestComponentBase.cs
+++ b/source/Coop.Tests/TestComponentBase.cs
@@ -35,6 +35,7 @@ using Serilog;
 using System;
 using Xunit.Abstractions;
 using IGameInterface = GameInterface.IGameInterface;
+using GameInterface.Services.CampaignService.Interfaces;
 
 namespace Coop.Tests;
 
@@ -116,6 +117,7 @@ internal abstract class TestComponentBase
         RegisterMock<IRaidAiInterventionConfigInterface>(builder);
         RegisterMock<ITacticalUnitSymbolsConfigInterface>(builder);
         RegisterMock<IVillageHostileActionInterface>(builder);
+        RegisterMock<IServerOptionsProvider>(builder);
 
         // ISaveInterface is consumed by TransferSaveState's constructor, which packages a save the
         // moment the state is entered. Give it a non-null default so simply entering the state does

--- a/source/GameInterface/Services/CampaignService/Data/ServerOptions.cs
+++ b/source/GameInterface/Services/CampaignService/Data/ServerOptions.cs
@@ -1,0 +1,19 @@
+﻿using ProtoBuf;
+
+namespace GameInterface.Services.CampaignService.Data;
+
+/// <summary>
+/// Options configured outside of the campaign options that are not transferred as part of the save game.
+/// Add other options that should only be managed by the server to this data structure.
+/// </summary>
+[ProtoContract(SkipConstructor = true)]
+public class ServerOptions
+{
+    [ProtoMember(1)]
+    public readonly int PlayerReceivedDamage;
+
+    public ServerOptions(int playerReceivedDamage)
+    {
+        PlayerReceivedDamage = playerReceivedDamage;
+    }
+}

--- a/source/GameInterface/Services/CampaignService/Handlers/UpdateCampaignOptionsHandler.cs
+++ b/source/GameInterface/Services/CampaignService/Handlers/UpdateCampaignOptionsHandler.cs
@@ -5,6 +5,7 @@ using Common.Network;
 using GameInterface.Services.CampaignService.Messages;
 using Serilog;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.MountAndBlade;
 
 namespace GameInterface.Services.CampaignService.Handlers;
 
@@ -24,12 +25,18 @@ internal class UpdateCampaignOptionsHandler : IHandler
 
         messageBroker.Subscribe<UpdateCampaignOptions>(Handle_UpdateCampaignOptions);
         messageBroker.Subscribe<NetworkUpdateCampaignOptions>(Handle_NetworkUpdateCampaignOptions);
+
+        messageBroker.Subscribe<UpdateOtherOptions>(Handle_UpdateOtherOptions);
+        messageBroker.Subscribe<NetworkUpdateOtherOptions>(Handle_NetworkUpdateOtherOptions);
     }
 
     public void Dispose()
     {
         messageBroker.Unsubscribe<UpdateCampaignOptions>(Handle_UpdateCampaignOptions);
         messageBroker.Unsubscribe<NetworkUpdateCampaignOptions>(Handle_NetworkUpdateCampaignOptions);
+
+        messageBroker.Unsubscribe<UpdateOtherOptions>(Handle_UpdateOtherOptions);
+        messageBroker.Unsubscribe<NetworkUpdateOtherOptions>(Handle_NetworkUpdateOtherOptions);
     }
 
     private void Handle_UpdateCampaignOptions(MessagePayload<UpdateCampaignOptions> obj)
@@ -70,6 +77,27 @@ internal class UpdateCampaignOptionsHandler : IHandler
             CampaignOptions.ClanMemberDeathChance = newOptions.ClanMemberDeathChance;
             CampaignOptions.IsIronmanMode = newOptions.IsIronmanMode;
             CampaignOptions.BattleDeath = newOptions.BattleDeath;
+        });
+    }
+
+    private void Handle_UpdateOtherOptions(MessagePayload<UpdateOtherOptions> obj)
+    {
+        GameThread.RunSafe(() =>
+        {
+            var message = new NetworkUpdateOtherOptions(
+                BannerlordConfig.PlayerReceivedDamageDifficulty
+            );
+            network.SendAll(message);
+        });
+    }
+
+    private void Handle_NetworkUpdateOtherOptions(MessagePayload<NetworkUpdateOtherOptions> obj)
+    {
+        var newOptions = obj.What;
+
+        GameThread.RunSafe(() =>
+        {
+            BannerlordConfig.PlayerReceivedDamageDifficulty = newOptions.PlayerReceivedDamageDifficulty;
         });
     }
 }

--- a/source/GameInterface/Services/CampaignService/Handlers/UpdateCampaignOptionsHandler.cs
+++ b/source/GameInterface/Services/CampaignService/Handlers/UpdateCampaignOptionsHandler.cs
@@ -2,6 +2,7 @@
 using Common.Logging;
 using Common.Messaging;
 using Common.Network;
+using GameInterface.Services.CampaignService.Data;
 using GameInterface.Services.CampaignService.Messages;
 using Serilog;
 using TaleWorlds.CampaignSystem;
@@ -28,6 +29,8 @@ internal class UpdateCampaignOptionsHandler : IHandler
 
         messageBroker.Subscribe<UpdateOtherOptions>(Handle_UpdateOtherOptions);
         messageBroker.Subscribe<NetworkUpdateOtherOptions>(Handle_NetworkUpdateOtherOptions);
+
+        messageBroker.Subscribe<InitializeServerOptionsOnClient>(Handle_InitializeServerOptionsOnClient);
     }
 
     public void Dispose()
@@ -37,6 +40,8 @@ internal class UpdateCampaignOptionsHandler : IHandler
 
         messageBroker.Unsubscribe<UpdateOtherOptions>(Handle_UpdateOtherOptions);
         messageBroker.Unsubscribe<NetworkUpdateOtherOptions>(Handle_NetworkUpdateOtherOptions);
+
+        messageBroker.Unsubscribe<InitializeServerOptionsOnClient>(Handle_InitializeServerOptionsOnClient);
     }
 
     private void Handle_UpdateCampaignOptions(MessagePayload<UpdateCampaignOptions> obj)
@@ -82,22 +87,30 @@ internal class UpdateCampaignOptionsHandler : IHandler
 
     private void Handle_UpdateOtherOptions(MessagePayload<UpdateOtherOptions> obj)
     {
-        GameThread.RunSafe(() =>
-        {
-            var message = new NetworkUpdateOtherOptions(
-                BannerlordConfig.PlayerReceivedDamageDifficulty
-            );
-            network.SendAll(message);
-        });
+        // Add other server options as needed
+        var message = new NetworkUpdateOtherOptions(new(
+            BannerlordConfig.PlayerReceivedDamageDifficulty
+        ));
+        network.SendAll(message);
     }
 
     private void Handle_NetworkUpdateOtherOptions(MessagePayload<NetworkUpdateOtherOptions> obj)
     {
-        var newOptions = obj.What;
+        var newOptions = obj.What.ServerOptions;
+        UpdateOtherOptions(newOptions);
+    }
 
+    private void Handle_InitializeServerOptionsOnClient(MessagePayload<InitializeServerOptionsOnClient> obj)
+    {
+        var newOptions = obj.What.ServerOptions;
+        UpdateOtherOptions(newOptions);
+    }
+
+    private void UpdateOtherOptions(ServerOptions newOptions)
+    {
         GameThread.RunSafe(() =>
         {
-            BannerlordConfig.PlayerReceivedDamageDifficulty = newOptions.PlayerReceivedDamageDifficulty;
+            BannerlordConfig.PlayerReceivedDamageDifficulty = newOptions.PlayerReceivedDamage;
         });
     }
 }

--- a/source/GameInterface/Services/CampaignService/Handlers/UpdateCampaignOptionsHandler.cs
+++ b/source/GameInterface/Services/CampaignService/Handlers/UpdateCampaignOptionsHandler.cs
@@ -3,6 +3,7 @@ using Common.Logging;
 using Common.Messaging;
 using Common.Network;
 using GameInterface.Services.CampaignService.Data;
+using GameInterface.Services.CampaignService.Interfaces;
 using GameInterface.Services.CampaignService.Messages;
 using Serilog;
 using TaleWorlds.CampaignSystem;
@@ -16,14 +17,16 @@ internal class UpdateCampaignOptionsHandler : IHandler
 
     private readonly IMessageBroker messageBroker;
     private readonly INetwork network;
+    private readonly IServerOptionsProvider serverOptionsProvider;
 
     public UpdateCampaignOptionsHandler(
         IMessageBroker messageBroker,
-        INetwork network)
+        INetwork network,
+        IServerOptionsProvider serverOptionsProvider)
     {
         this.messageBroker = messageBroker;
         this.network = network;
-
+        this.serverOptionsProvider = serverOptionsProvider;
         messageBroker.Subscribe<UpdateCampaignOptions>(Handle_UpdateCampaignOptions);
         messageBroker.Subscribe<NetworkUpdateCampaignOptions>(Handle_NetworkUpdateCampaignOptions);
 
@@ -87,30 +90,34 @@ internal class UpdateCampaignOptionsHandler : IHandler
 
     private void Handle_UpdateOtherOptions(MessagePayload<UpdateOtherOptions> obj)
     {
-        // Add other server options as needed
-        var message = new NetworkUpdateOtherOptions(new(
-            BannerlordConfig.PlayerReceivedDamageDifficulty
-        ));
-        network.SendAll(message);
+        GameThread.RunSafe(() =>
+        {
+            var message = new NetworkUpdateOtherOptions(serverOptionsProvider.GetServerOptions());
+            network.SendAll(message);
+        });  
     }
 
     private void Handle_NetworkUpdateOtherOptions(MessagePayload<NetworkUpdateOtherOptions> obj)
     {
-        var newOptions = obj.What.ServerOptions;
-        UpdateOtherOptions(newOptions);
+        GameThread.RunSafe(() =>
+        {
+            var newOptions = obj.What.ServerOptions;
+            UpdateOtherOptions(newOptions);
+        });
     }
 
     private void Handle_InitializeServerOptionsOnClient(MessagePayload<InitializeServerOptionsOnClient> obj)
     {
-        var newOptions = obj.What.ServerOptions;
-        UpdateOtherOptions(newOptions);
+        GameThread.RunSafe(() =>
+        {
+            var newOptions = obj.What.ServerOptions;
+            UpdateOtherOptions(newOptions);
+        });
     }
 
     private void UpdateOtherOptions(ServerOptions newOptions)
     {
-        GameThread.RunSafe(() =>
-        {
-            BannerlordConfig.PlayerReceivedDamageDifficulty = newOptions.PlayerReceivedDamage;
-        });
+        // Add other server options as needed
+        BannerlordConfig.PlayerReceivedDamageDifficulty = newOptions.PlayerReceivedDamage;
     }
 }

--- a/source/GameInterface/Services/CampaignService/Interfaces/ServerOptionsProvider.cs
+++ b/source/GameInterface/Services/CampaignService/Interfaces/ServerOptionsProvider.cs
@@ -1,0 +1,21 @@
+﻿using GameInterface.Services.CampaignService.Data;
+using TaleWorlds.MountAndBlade;
+
+namespace GameInterface.Services.CampaignService.Interfaces;
+
+public interface IServerOptionsProvider : IGameAbstraction
+{
+    ServerOptions GetServerOptions();
+}
+
+public class ServerOptionsProvider : IServerOptionsProvider
+{
+    public ServerOptions GetServerOptions()
+    {
+        // Expand with other options as needed
+        var serverOptions = new ServerOptions(
+            BannerlordConfig.PlayerReceivedDamageDifficulty);
+
+        return serverOptions;
+    }
+}

--- a/source/GameInterface/Services/CampaignService/Messages/InitializeServerOptionsOnClient.cs
+++ b/source/GameInterface/Services/CampaignService/Messages/InitializeServerOptionsOnClient.cs
@@ -1,0 +1,14 @@
+﻿using Common.Messaging;
+using GameInterface.Services.CampaignService.Data;
+
+namespace GameInterface.Services.CampaignService.Messages;
+
+public class InitializeServerOptionsOnClient : IEvent
+{
+    public readonly ServerOptions ServerOptions;
+
+    public InitializeServerOptionsOnClient(ServerOptions serverOptions)
+    {
+        ServerOptions = serverOptions;
+    }
+}

--- a/source/GameInterface/Services/CampaignService/Messages/UpdateOtherOptions.cs
+++ b/source/GameInterface/Services/CampaignService/Messages/UpdateOtherOptions.cs
@@ -1,4 +1,5 @@
 ﻿using Common.Messaging;
+using GameInterface.Services.CampaignService.Data;
 using ProtoBuf;
 
 namespace GameInterface.Services.CampaignService.Messages;
@@ -9,11 +10,10 @@ public readonly struct UpdateOtherOptions : IEvent { }
 internal readonly struct NetworkUpdateOtherOptions : ICommand
 {
     [ProtoMember(1)]
-    public readonly int PlayerReceivedDamageDifficulty;
+    public readonly ServerOptions ServerOptions;
 
-    public NetworkUpdateOtherOptions(
-        int playerReceivedDamageDifficulty)
+    public NetworkUpdateOtherOptions(ServerOptions serverOptions)
     {
-        PlayerReceivedDamageDifficulty = playerReceivedDamageDifficulty;
+        ServerOptions = serverOptions;
     }
 }

--- a/source/GameInterface/Services/CampaignService/Messages/UpdateOtherOptions.cs
+++ b/source/GameInterface/Services/CampaignService/Messages/UpdateOtherOptions.cs
@@ -1,0 +1,19 @@
+﻿using Common.Messaging;
+using ProtoBuf;
+
+namespace GameInterface.Services.CampaignService.Messages;
+
+public readonly struct UpdateOtherOptions : IEvent { }
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkUpdateOtherOptions : ICommand
+{
+    [ProtoMember(1)]
+    public readonly int PlayerReceivedDamageDifficulty;
+
+    public NetworkUpdateOtherOptions(
+        int playerReceivedDamageDifficulty)
+    {
+        PlayerReceivedDamageDifficulty = playerReceivedDamageDifficulty;
+    }
+}

--- a/source/GameInterface/Services/CampaignService/Patches/UpdateCampaignOptionsPatch.cs
+++ b/source/GameInterface/Services/CampaignService/Patches/UpdateCampaignOptionsPatch.cs
@@ -3,6 +3,7 @@ using Common.Messaging;
 using GameInterface.Services.CampaignService.Messages;
 using HarmonyLib;
 using SandBox.View.Map;
+using TaleWorlds.MountAndBlade;
 
 namespace GameInterface.Services.CampaignService.Patches;
 
@@ -20,5 +21,19 @@ internal class UpdateCampaignOptionsPatch
 
         var message = new UpdateCampaignOptions();
         MessageBroker.Instance.Publish(__instance, message);
+    }
+}
+
+[HarmonyPatch(typeof(ManagedOptions))]
+internal class UpdateOtherOptionsPatch
+{
+    [HarmonyPatch(nameof(ManagedOptions.SetConfig))]
+    [HarmonyPostfix]
+    public static void SetConfigPostfix()
+    {
+        if (ModInformation.IsClient) return;
+
+        var message = new UpdateOtherOptions();
+        MessageBroker.Instance.Publish(null, message);
     }
 }

--- a/source/GameInterface/Services/CampaignService/Patches/UpdateCampaignOptionsPatch.cs
+++ b/source/GameInterface/Services/CampaignService/Patches/UpdateCampaignOptionsPatch.cs
@@ -4,6 +4,7 @@ using GameInterface.Services.CampaignService.Messages;
 using HarmonyLib;
 using SandBox.View.Map;
 using TaleWorlds.MountAndBlade;
+using TaleWorlds.MountAndBlade.ViewModelCollection.GameOptions;
 
 namespace GameInterface.Services.CampaignService.Patches;
 
@@ -24,12 +25,12 @@ internal class UpdateCampaignOptionsPatch
     }
 }
 
-[HarmonyPatch(typeof(ManagedOptions))]
-internal class UpdateOtherOptionsPatch
+[HarmonyPatch(typeof(OptionsVM))]
+internal class ApplyChangedOptionsPatch
 {
-    [HarmonyPatch(nameof(ManagedOptions.SetConfig))]
+    [HarmonyPatch(nameof(OptionsVM.ApplyChangedOptions))]
     [HarmonyPostfix]
-    public static void SetConfigPostfix()
+    public static void ApplyChangedOptionsPostfix()
     {
         if (ModInformation.IsClient) return;
 

--- a/source/GameInterface/Services/GameMenus/Patches/DisableCampaignOptionsOnClients.cs
+++ b/source/GameInterface/Services/GameMenus/Patches/DisableCampaignOptionsOnClients.cs
@@ -2,8 +2,10 @@
 using HarmonyLib;
 using System;
 using TaleWorlds.CampaignSystem.ViewModelCollection;
+using TaleWorlds.Localization;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.Options.ManagedOptions;
+using TaleWorlds.MountAndBlade.ViewModelCollection.GameOptions;
 
 namespace GameInterface.Services.GameMenus.Patches;
 
@@ -38,7 +40,25 @@ internal class DisableManagingOtherOptionsOnClients
         var type = __instance.Type;
         if (ModInformation.IsClient && type == ManagedOptions.ManagedOptionsType.PlayerReceivedDamageDifficulty)
         {
-            __result = new("Managing this option is disabled on clients; the host does this.", true);
+            __result = new("str_coop_server_managed_player_received_damage", true);
+            return false;
+        }
+
+        return true;
+    }
+}
+
+[HarmonyPatch(typeof(GenericOptionDataVM))]
+internal class DisableResetToDefaultOnClients
+{
+    [HarmonyPatch(nameof(GenericOptionDataVM.ResetToDefault))]
+    [HarmonyPrefix]
+    public static bool ResetToDefaultPrefix(GenericOptionDataVM __instance)
+    {
+        var optionType = __instance.Option.GetOptionType();
+
+        if (ModInformation.IsClient && optionType is ManagedOptions.ManagedOptionsType.PlayerReceivedDamageDifficulty)
+        {
             return false;
         }
 

--- a/source/GameInterface/Services/GameMenus/Patches/DisableCampaignOptionsOnClients.cs
+++ b/source/GameInterface/Services/GameMenus/Patches/DisableCampaignOptionsOnClients.cs
@@ -1,6 +1,9 @@
 ﻿using Common;
 using HarmonyLib;
+using System;
 using TaleWorlds.CampaignSystem.ViewModelCollection;
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.MountAndBlade.Options.ManagedOptions;
 
 namespace GameInterface.Services.GameMenus.Patches;
 
@@ -18,6 +21,24 @@ internal class DisableManagingCampaignOptionsOnClients
         if (ModInformation.IsClient)
         {
             __result = new(true, "Managing campaign options is disabled on clients; the host does this.", -1f);
+            return false;
+        }
+
+        return true;
+    }
+}
+
+[HarmonyPatch(typeof(ManagedOptionData))]
+internal class DisableManagingOtherOptionsOnClients
+{
+    [HarmonyPatch(nameof(ManagedOptionData.GetIsDisabledAndReasonID))]
+    [HarmonyPrefix]
+    public static bool GetIsDisabledAndReasonWithIDPrefix(ManagedOptionData __instance, ref ValueTuple<string, bool> __result)
+    {
+        var type = __instance.Type;
+        if (ModInformation.IsClient && type == ManagedOptions.ManagedOptionsType.PlayerReceivedDamageDifficulty)
+        {
+            __result = new("Managing this option is disabled on clients; the host does this.", true);
             return false;
         }
 

--- a/source/GameInterface/Services/GameMenus/Patches/DisableCampaignOptionsOnClients.cs
+++ b/source/GameInterface/Services/GameMenus/Patches/DisableCampaignOptionsOnClients.cs
@@ -49,11 +49,29 @@ internal class DisableManagingOtherOptionsOnClients
 }
 
 [HarmonyPatch(typeof(GenericOptionDataVM))]
-internal class DisableResetToDefaultOnClients
+internal class DisableResetToDefaultGenericOptionsOnClients
 {
     [HarmonyPatch(nameof(GenericOptionDataVM.ResetToDefault))]
     [HarmonyPrefix]
     public static bool ResetToDefaultPrefix(GenericOptionDataVM __instance)
+    {
+        var optionType = __instance.Option.GetOptionType();
+
+        if (ModInformation.IsClient && optionType is ManagedOptions.ManagedOptionsType.PlayerReceivedDamageDifficulty)
+        {
+            return false;
+        }
+
+        return true;
+    }
+}
+
+[HarmonyPatch(typeof(StringOptionDataVM))]
+internal class DisableResetToDefaultStringOptionsOnClients
+{
+    [HarmonyPatch(nameof(StringOptionDataVM.ResetData))]
+    [HarmonyPrefix]
+    public static bool ResetDataPrefix(StringOptionDataVM __instance)
     {
         var optionType = __instance.Option.GetOptionType();
 


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #2260
<!-- Describe functionality added. Add images or videos to show how it works if applies -->

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Now only the server can manage player received damage.
