### PR TITLE
Route besieger leave-menu camp writes through the server

### DIFF
--- a/source/E2E.Tests/Services/SiegeEvents/SiegeLeaveMenuTests.cs
+++ b/source/E2E.Tests/Services/SiegeEvents/SiegeLeaveMenuTests.cs
@@ -1,0 +1,265 @@
+using Common.Util;
+using Coop.Core.Client.Services.SiegeEvents.Messages;
+using Coop.Core.Server.Services.SiegeEvents.Messages;
+using E2E.Tests.Environment;
+using E2E.Tests.Environment.Instance;
+using HarmonyLib;
+using Helpers;
+using System.Reflection;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.CampaignBehaviors;
+using TaleWorlds.CampaignSystem.GameMenus;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.CampaignSystem.Siege;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace E2E.Tests.Services.SiegeEvents;
+
+/// <summary>
+/// Issue #2263: a besieging client's "Leave" clicks that funnel into a direct native camp write —
+/// <c>MenuHelper.EncounterLeaveConsequence</c> (the encounter menu's Leave, e.g. after retreating out of
+/// a siege battle) and <c>EncounterGameMenuBehavior.leave_siege_after_attack_on_consequence</c> (the
+/// post-battle "Leave the siege" option) — must round-trip the camp removal through the server. The
+/// native consequences cleared <see cref="MobileParty.BesiegerCamp"/> client-locally, which sync drops,
+/// so the party kept besieging on the server while the client walked away. Each test drives the REAL
+/// Harmony-patched method, not a hand-published message.
+/// </summary>
+public class SiegeLeaveMenuTests : IDisposable
+{
+    private E2ETestEnvironment TestEnvironment { get; }
+    private EnvironmentInstance Server => TestEnvironment.Server;
+    private IEnumerable<EnvironmentInstance> Clients => TestEnvironment.Clients;
+    private IEnumerable<EnvironmentInstance> AllEnvironmentInstances => Clients.Append(Server);
+
+    public SiegeLeaveMenuTests(ITestOutputHelper output)
+    {
+        TestEnvironment = new E2ETestEnvironment(output);
+    }
+
+    public void Dispose()
+    {
+        TestEnvironment.Dispose();
+    }
+
+    /// <summary>Construction-time world dependencies of the siege object graph (see
+    /// <c>BesiegerCampSyncTests</c>): the camp-join internals and both siege-side initializers need a
+    /// live town/scene.</summary>
+    private static List<MethodBase> SiegeCreationDisabledMethods => new()
+    {
+        AccessTools.Method(typeof(MobileParty), nameof(MobileParty.OnPartyJoinedSiegeInternal)),
+        AccessTools.Method(typeof(BesiegerCamp), nameof(BesiegerCamp.InitializeSiegeEventSide)),
+        AccessTools.Method(typeof(Settlement), nameof(Settlement.InitializeSiegeEventSide)),
+    };
+
+    /// <summary>
+    /// World dependencies hit while a leave click round-trips inline: the server-side camp cascade
+    /// (party-list removal, impairment model, siege finalize) needs a live campaign world, and the
+    /// approval's local menu exit needs a menu context. The <see cref="MobileParty.BesiegerCamp"/>
+    /// setter itself stays live so the authoritative clear and its replication are exercised.
+    /// </summary>
+    private static List<MethodBase> LeaveRoundTripDisabledMethods => new()
+    {
+        AccessTools.Method(typeof(MobileParty), nameof(MobileParty.OnPartyLeftSiegeInternal)),
+        AccessTools.Method(typeof(GameMenu), nameof(GameMenu.ExitToLast)),
+    };
+
+    [Fact]
+    public void ClientEncounterLeave_WhileBesieging_RemovesCampOnServerAndClients()
+    {
+        // Arrange
+        var leavingClient = Clients.First();
+        var (partyId, _) = SetupBesiegingPlayerParty(leavingClient);
+
+        // Act
+        leavingClient.Call(() =>
+        {
+            InvokePatchedEncounterLeave();
+        }, LeaveRoundTripDisabledMethods);
+
+        // Assert: the click was routed, not applied locally — exactly one break request named the leaver's party.
+        var request = Assert.Single(leavingClient.NetworkSentMessages.GetMessages<NetworkRequestBreakSiege>());
+        Assert.Equal(partyId, request.PartyId);
+        Assert.Empty(Clients.Last().NetworkSentMessages.GetMessages<NetworkRequestBreakSiege>());
+
+        // The server approved the request and cleared the camp authoritatively...
+        var approval = Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkBreakSiegeApproved>());
+        Assert.True(approval.Approved);
+        AssertBesiegerCamp(Server, partyId, expectCamp: false);
+
+        // ...and the cleared camp replicated to every client.
+        foreach (var client in Clients)
+        {
+            AssertBesiegerCamp(client, partyId, expectCamp: false);
+        }
+    }
+
+    [Fact]
+    public void ClientLeaveSiegeAfterAttack_WhileBesieging_RemovesCampOnServerAndClients()
+    {
+        // Arrange
+        var leavingClient = Clients.First();
+        var (partyId, _) = SetupBesiegingPlayerParty(leavingClient);
+
+        // Act
+        leavingClient.Call(() =>
+        {
+            InvokePatchedLeaveSiegeAfterAttack();
+        }, LeaveRoundTripDisabledMethods);
+
+        // Assert
+        var request = Assert.Single(leavingClient.NetworkSentMessages.GetMessages<NetworkRequestBreakSiege>());
+        Assert.Equal(partyId, request.PartyId);
+
+        var approval = Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkBreakSiegeApproved>());
+        Assert.True(approval.Approved);
+        AssertBesiegerCamp(Server, partyId, expectCamp: false);
+
+        foreach (var client in Clients)
+        {
+            AssertBesiegerCamp(client, partyId, expectCamp: false);
+        }
+    }
+
+    [Fact]
+    public void ClientEncounterLeave_WithoutBesiegerCamp_DoesNotRouteBreakSiege()
+    {
+        // Arrange: the client's main party fights no siege — a plain field-battle leave must stay native.
+        var leavingClient = Clients.First();
+        var partyId = TestEnvironment.CreateRegisteredObject<MobileParty>();
+        SetMainParty(leavingClient, partyId);
+
+        // Act: the native body is suppressed (it needs a live encounter); the coop prefix still runs first.
+        var disabledMethods = LeaveRoundTripDisabledMethods
+            .Append(AccessTools.Method(typeof(MenuHelper), nameof(MenuHelper.EncounterLeaveConsequence)))
+            .ToList();
+        leavingClient.Call(() =>
+        {
+            InvokePatchedEncounterLeave();
+        }, disabledMethods);
+
+        // Assert: no break-siege request was forwarded for a party that is not besieging.
+        Assert.Empty(leavingClient.NetworkSentMessages.GetMessages<NetworkRequestBreakSiege>());
+    }
+
+    [Fact]
+    public void ServerEncounterLeave_RunsNativeWithoutRouting()
+    {
+        // Arrange: the host player is besieging; its leave stays native (patches live) instead of routing
+        // a request nothing in the server container handles.
+        var (partyId, _) = SetupBesiegingPlayerParty(Server);
+
+        // Act: the native body is suppressed (it needs a live encounter); the coop prefix still runs first.
+        var disabledMethods = LeaveRoundTripDisabledMethods
+            .Append(AccessTools.Method(typeof(MenuHelper), nameof(MenuHelper.EncounterLeaveConsequence)))
+            .ToList();
+        Server.Call(() =>
+        {
+            InvokePatchedEncounterLeave();
+        }, disabledMethods);
+
+        // Assert: the server routed nothing — the camp write stays native (here suppressed with the body).
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkRequestBreakSiege>());
+        AssertBesiegerCamp(Server, partyId, expectCamp: true);
+    }
+
+    // ------------------------------------------------------------------
+    // Drivers
+    // ------------------------------------------------------------------
+
+    /// <summary>Invokes the real (Harmony-patched) <c>MenuHelper.EncounterLeaveConsequence</c> — the
+    /// encounter menu's Leave funnel — via reflection so the coop prefix fires exactly as it does live
+    /// (a direct call could be inlined past the detour).</summary>
+    private static void InvokePatchedEncounterLeave()
+    {
+        var method = AccessTools.Method(typeof(MenuHelper), nameof(MenuHelper.EncounterLeaveConsequence));
+        Assert.NotNull(method);
+        method.Invoke(null, Array.Empty<object>());
+    }
+
+    /// <summary>Invokes the real (Harmony-patched)
+    /// <c>EncounterGameMenuBehavior.leave_siege_after_attack_on_consequence</c> — the post-battle
+    /// "Leave the siege" menu option. Neither the prefix nor the native body reads the behavior state
+    /// or the menu args, so a constructor-skipped behavior and null args drive it faithfully.</summary>
+    private static void InvokePatchedLeaveSiegeAfterAttack()
+    {
+        var method = AccessTools.Method(typeof(EncounterGameMenuBehavior), nameof(EncounterGameMenuBehavior.leave_siege_after_attack_on_consequence));
+        Assert.NotNull(method);
+
+        var behavior = ObjectHelper.SkipConstructor<EncounterGameMenuBehavior>();
+        method.Invoke(behavior, new object[] { null });
+    }
+
+    // ------------------------------------------------------------------
+    // Setup / assertions
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Builds a synced siege (settlement, siege event, besieger camp) plus a synced player party, wires
+    /// the party into the camp on every instance, and makes it <paramref name="leavingInstance"/>'s
+    /// <see cref="MobileParty.MainParty"/>. The membership is wired by field so the world-dependent join
+    /// internals stay out of the headless harness; the leave under test then runs the real setter.
+    /// </summary>
+    private (string partyId, string siegeEventId) SetupBesiegingPlayerParty(EnvironmentInstance leavingInstance)
+    {
+        var siegeEventId = TestEnvironment.CreateRegisteredObject<SiegeEvent>(SiegeCreationDisabledMethods);
+        var partyId = TestEnvironment.CreateRegisteredObject<MobileParty>();
+
+        // The camp is registered (and replicated) as its own object by its constructor patch; resolving
+        // it by id keeps the fixture independent of the SiegeEvent.BesiegerCamp field-sync timing.
+        string? campId = null;
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<SiegeEvent>(siegeEventId, out var siegeEvent));
+            Assert.NotNull(siegeEvent.BesiegerCamp);
+            Assert.True(Server.ObjectManager.TryGetId(siegeEvent.BesiegerCamp, out campId));
+        });
+        Assert.NotNull(campId);
+
+        foreach (var instance in AllEnvironmentInstances)
+        {
+            instance.Call(() =>
+            {
+                Assert.True(instance.ObjectManager.TryGetObject<BesiegerCamp>(campId!, out var camp));
+                Assert.True(instance.ObjectManager.TryGetObject<MobileParty>(partyId, out var party));
+
+                party._besiegerCamp = camp;
+            });
+        }
+
+        SetMainParty(leavingInstance, partyId);
+
+        return (partyId, siegeEventId);
+    }
+
+    /// <summary>Makes the party the instance's <see cref="MobileParty.MainParty"/>. Runs in the
+    /// instance's static scope, where <c>Campaign.Current</c> resolves to that instance.</summary>
+    private static void SetMainParty(EnvironmentInstance instance, string partyId)
+    {
+        instance.Call(() =>
+        {
+            Assert.True(instance.ObjectManager.TryGetObject<MobileParty>(partyId, out var party));
+            Campaign.Current.MainParty = party;
+            Assert.Same(party, MobileParty.MainParty);
+        });
+    }
+
+    /// <summary>Asserts whether the party is in a besieger camp on the given instance.</summary>
+    private static void AssertBesiegerCamp(EnvironmentInstance instance, string partyId, bool expectCamp)
+    {
+        instance.Call(() =>
+        {
+            Assert.True(instance.ObjectManager.TryGetObject<MobileParty>(partyId, out var party));
+
+            if (expectCamp)
+            {
+                Assert.NotNull(party.BesiegerCamp);
+            }
+            else
+            {
+                Assert.Null(party.BesiegerCamp);
+            }
+        });
+    }
+}

--- a/source/GameInterface/Services/SiegeEvents/Patches/SiegeEntryFlowPatches.cs
+++ b/source/GameInterface/Services/SiegeEvents/Patches/SiegeEntryFlowPatches.cs
@@ -7,6 +7,7 @@ using GameInterface.Services.Armies.Patches;
 using GameInterface.Services.MobileParties.Patches;
 using GameInterface.Services.SiegeEvents.Messages;
 using HarmonyLib;
+using Helpers;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
 using TaleWorlds.CampaignSystem.GameMenus;
 using TaleWorlds.CampaignSystem.Party;
@@ -101,6 +102,11 @@ internal class SiegeEntryFlowPatches
     {
         if (CallOriginalPolicy.IsOriginalAllowed()) return true;
 
+        // The host must run native directly: BreakSiegeAttempted only has a handler in the client
+        // container, and the running server's sync policy never allows the original, so without this
+        // bail the host's own leave click published into the void and its camp never cleared.
+        if (ModInformation.IsServer) return true;
+
         MessageBroker.Instance.Publish(null, new BreakSiegeAttempted(MobileParty.MainParty));
         return false;
     }
@@ -121,6 +127,39 @@ internal class SiegeEntryFlowPatches
 
         MessageBroker.Instance.Publish(null, new BreakSiegeAttempted(MobileParty.MainParty));
         MobileParty.MainParty.Army = null;
+        return false;
+    }
+
+    // A besieger's encounter-menu "Leave..." (the menu a player lands on after retreating out of a siege
+    // battle) funnels into MenuHelper.EncounterLeaveConsequence, which finishes the encounter and clears
+    // MainParty.BesiegerCamp directly — a client-local write the server never sees, so the party stayed in
+    // the camp and the siege map event there (issue #2263). Route the camp write through the server; the
+    // approval runs the local encounter finish. Patching the MenuHelper funnel (not the menu consequence)
+    // also keeps vanilla's "abandon the siege?" confirmation, whose Yes callback lands here too.
+    [HarmonyPatch(typeof(MenuHelper), nameof(MenuHelper.EncounterLeaveConsequence))]
+    [HarmonyPrefix]
+    private static bool EncounterLeaveConsequencePrefix()
+    {
+        if (CallOriginalPolicy.IsOriginalAllowed()) return true;
+        if (ModInformation.IsServer) return true;
+        if (MobileParty.MainParty.BesiegerCamp == null) return true;
+
+        MessageBroker.Instance.Publish(null, new BreakSiegeAttempted(MobileParty.MainParty));
+        return false;
+    }
+
+    // The post-battle "Leave the siege" option (continue_siege_after_attack menu) writes the camp directly
+    // instead of calling LeaveSiege, so the LeaveSiege reroute never fires for it. Same split as above:
+    // the server owns the camp write, the approval closes the menu.
+    [HarmonyPatch(typeof(EncounterGameMenuBehavior), nameof(EncounterGameMenuBehavior.leave_siege_after_attack_on_consequence))]
+    [HarmonyPrefix]
+    private static bool LeaveSiegeAfterAttackPrefix()
+    {
+        if (CallOriginalPolicy.IsOriginalAllowed()) return true;
+        if (ModInformation.IsServer) return true;
+        if (MobileParty.MainParty.BesiegerCamp == null) return true;
+
+        MessageBroker.Instance.Publish(null, new BreakSiegeAttempted(MobileParty.MainParty));
         return false;
     }
 }


### PR DESCRIPTION
Fixes #2263

## Root cause

The attached client log pins it: right after the client left the siege battle mission and clicked Leave, autosync logged

```
ERR AutoSync.MobileParty_BesiegerCamp_PropertySetPrefix] Client updated managed MobileParty.BesiegerCamp
ERR AutoSync.MobileParty_DynamicPatches] Client updated managed _besiegerCampResetStarted
ERR AutoSync.MobileParty_DynamicPatches] Client updated managed _isDisorganized
ERR AutoSync.MobileParty_EventPositionAdder_PropertySetPrefix] Client updated managed MobileParty.EventPositionAdder
```

— the full native `BesiegerCamp = null` cascade ran **client-locally**. The encounter menu's Leave for a besieger funnels into `MenuHelper.EncounterLeaveConsequence`, which finishes the encounter and clears `MobileParty.MainParty.BesiegerCamp` directly. That path was never rerouted (the coop `EncounterLeavePrefix` deliberately falls through for sieges, and `SiegeEntryFlowPatches` only intercepts `SiegeEventCampaignBehavior.LeaveSiege`), and the autosync property prefix only error-logs unauthorized client writes — it does not forward them. So the client freed itself locally while the server still had the party in the besieger camp and the siege's map event (the tent in the server screenshot).

The post-battle `continue_siege_after_attack` menu's "Leave the siege" option (`leave_siege_after_attack_on_consequence`) writes the camp directly the same way — its sibling "Leave Army" option was already patched in `ArmyDialogPatches`, this one was missed.

## Fix

Two new client prefixes in `SiegeEntryFlowPatches` publish `BreakSiegeAttempted` instead of running the native camp write, round-tripping the removal through the existing `NetworkRequestBreakSiege` → `ServerSiegeEntryHandler.HandleBreak` → `BreakSiege` flow (server clears the camp with patches live, so the cascade and the `NetworkBreakSiegeApproved` continuation replicate as usual):

- `MenuHelper.EncounterLeaveConsequence` — patched at the funnel so vanilla's "abandon the siege?" confirmation (whose Yes callback also lands there) keeps working.
- `EncounterGameMenuBehavior.leave_siege_after_attack_on_consequence`.

Also fixed a latent host-side hole in `LeaveSiegePrefix`: `CallOriginalPolicy.IsOriginalAllowed()` is false on a running server, so the host's own leave click published `BreakSiegeAttempted` into the server container — which has no handler for it — and did nothing. The prefix now bails to native on the server like the rest of the file.

## Tests

New `SiegeLeaveMenuTests` (E2E) drive the real Harmony-patched methods, mirroring `BattleSurrenderTests`:

- client encounter-menu Leave while besieging → exactly one `NetworkRequestBreakSiege` naming the party, server clears the camp, `NetworkBreakSiegeApproved(true)`, and the cleared camp replicates to every client
- same for the post-battle "Leave the siege" option
- a client without a besieger camp routes nothing (field battles stay native)
- the server invocation routes nothing (host stays native)

`SiegeEvents`/`BesiegerCamps`/`SiegeStrategies`/`MobilePartyPropertyTests` (17) and the full `Services.MapEvents` suite (140) pass.

## Known remaining direct writers (out of scope)

Other native paths still clear `BesiegerCamp` client-locally and can be routed the same way if they surface: `game_menu_encounter_leave_your_soldiers_behind_accept_on_consequence` (try-to-get-away, already tracked as unsynced), `PlayerEncounter.DoPlayerDefeat` (defeat converges via the captivity flow), the `join_encounter` leave lambda, `break_in_leave_consequence`, and `SafePassageBarterable`.
