### PR TITLE
[2261] Disable player dialogue during sieges

### DIFF
--- a/source/Coop.Core/Server/Services/Time/Handlers/CampaignTimeSyncHandler.cs
+++ b/source/Coop.Core/Server/Services/Time/Handlers/CampaignTimeSyncHandler.cs
@@ -18,7 +18,7 @@ namespace Coop.Core.Server.Services.Time.Handlers;
 /// reliable message — so the clock heartbeat stays live even while the reliable world-sync stream is
 /// congested (see the packet's remarks).
 /// </remarks>
-public class CampaignTimeSyncHandler : IHandler
+public class CampaignTimeSyncHandler : IHandler, IDisposable
 {
     private static readonly ILogger Logger = LogManager.GetLogger<CampaignTimeSyncHandler>();
 

--- a/source/E2E.Tests/Services/MapEvents/PlayerPartyInteractionFlowTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/PlayerPartyInteractionFlowTests.cs
@@ -30,6 +30,7 @@ using TaleWorlds.CampaignSystem.BarterSystem.Barterables;
 using TaleWorlds.CampaignSystem.MapEvents;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.CampaignSystem.Siege;
 using TaleWorlds.Core;
 using TaleWorlds.Core.ImageIdentifiers;
 using TaleWorlds.Library;
@@ -79,6 +80,48 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
         {
             Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(responderPartyId, out var responderParty));
             responderParty.MobileParty.IsActive = false;
+        });
+        Server.NetworkSentMessages.Clear();
+
+        RequestInteraction(client1, initiatorPartyId, responderPartyId);
+
+        var denied = Server.NetworkSentMessages.GetMessages<NetworkConversationDenied>().Single();
+        Assert.Equal(ConversationDeniedReason.PlayerUnavailable, denied.Reason);
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>());
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionState>());
+    }
+
+    [Fact]
+    public void ClientRequest_BesiegingPlayer_DeniesWithoutStartingDialog()
+    {
+        var (client1, _, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(responderPartyId, out var responderParty));
+            responderParty.MobileParty._besiegerCamp = ObjectHelper.SkipConstructor<BesiegerCamp>();
+        });
+        Server.NetworkSentMessages.Clear();
+
+        RequestInteraction(client1, initiatorPartyId, responderPartyId);
+
+        var denied = Server.NetworkSentMessages.GetMessages<NetworkConversationDenied>().Single();
+        Assert.Equal(ConversationDeniedReason.PlayerUnavailable, denied.Reason);
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>());
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionState>());
+    }
+
+    [Fact]
+    public void ClientRequest_PlayerDefendingBesiegedSettlement_DeniesWithoutStartingDialog()
+    {
+        var (client1, _, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(initiatorPartyId, out var initiatorParty));
+            var settlement = ObjectHelper.SkipConstructor<Settlement>();
+            settlement.SiegeEvent = ObjectHelper.SkipConstructor<SiegeEvent>();
+            initiatorParty.MobileParty._currentSettlement = settlement;
         });
         Server.NetworkSentMessages.Clear();
 

--- a/source/GameInterface/Services/MapEvents/Handlers/ConversationRequestHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/ConversationRequestHandler.cs
@@ -250,6 +250,16 @@ internal class ConversationRequestHandler : IHandler
                 request.AttackerId, request.DefenderId);
             return true;
         }
+
+        if (attackerIsPlayer && defenderIsPlayer &&
+            (IsInSiege(attacker.MobileParty) || IsInSiege(defender.MobileParty)))
+        {
+            Logger.Debug(
+                "Rejecting PvP conversation: a player is participating in a siege. AttackerId={AttackerId}, DefenderId={DefenderId}",
+                request.AttackerId, request.DefenderId);
+            network.Send(requestingPeer, new NetworkConversationDenied(ConversationDeniedReason.PlayerUnavailable));
+            return false;
+        }
         
         // PvP: two human players are allowed to open the encounter so they can fight each other. Neither side is AI,
         // so there is nothing to hold; the defending player is shown a "hold on" popup instead.
@@ -409,6 +419,9 @@ internal class ConversationRequestHandler : IHandler
     /// <paramref name="allowedPartnerId"/> (so the same pair re-requesting is still allowed).</summary>
     private bool IsConversingWithOther(string partyId, string allowedPartnerId)
         => conversationPartyTracker.TryGetPvpPartner(partyId, out var partner) && partner != allowedPartnerId;
+
+    private static bool IsInSiege(MobileParty party)
+        => party.BesiegerCamp != null || party.CurrentSettlement?.IsUnderSiege == true;
 
     /// <summary>
     /// [Server] Ends the given attacker's PvP interaction (the attacker left before any battle), telling the


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Players can start a player-to-player conversation with another player while either party is participating in a siege.

## What is the new behavior?

Resolves #2261

Player-to-player conversation requests are now refused while either player is besieging a settlement or defending inside one, and dialogue becomes available again after the player leaves the siege.

## Bot Changelog Entry

- Player dialogue is now unavailable while either player is participating in a siege.
