### PR TITLE
Fix manual build expiration timestamp

### DIFF
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -152,7 +152,8 @@ jobs:
 
           archive_bytes=$(stat -c %s "artifact/$FILE_NAME")
           archive_sha256=$(sha256sum "artifact/$FILE_NAME" | cut -d' ' -f1)
-          expires_at=$(date -u -d '+24 hours' +%Y-%m-%dT%H:%M:%SZ)
+          now=$(date +%s)
+          expires_at=$(date -u -d "@$((now + 86400))" +%Y-%m-%dT%H:%M:%SZ)
           r2_key="manual/$BUILD_ID/client/Coop.7z"
           printf '{"kind":"manual-build","buildId":"%s","fileName":"%s","headSha":"%s","serverSha":"%s","expiresAt":"%s","serverInput":{"bucket":"%s","key":"%s","bytes":%s,"sha256":"%s"}}\n' \
             "$BUILD_ID" "$FILE_NAME" "$HEAD_SHA" "$SERVER_SHA" "$expires_at" \


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] CI related changes

## What is the current behavior?

Manual builds fail while calculating their 24-hour expiration because the build container uses BusyBox `date`, which does not accept GNU relative-date syntax.

## What is the new behavior?

Calculate the expiration from the current Unix timestamp using syntax supported by the workflow container.

## Bot Changelog Entry


## Other information
