### PR TITLE
[2280] Synchronize companion dismissal before opening the party screen

### DIFF
--- a/source/E2E.Tests/Environment/Instance/EnvironmentInstance.cs
+++ b/source/E2E.Tests/Environment/Instance/EnvironmentInstance.cs
@@ -29,6 +29,7 @@ public abstract class EnvironmentInstance : IDisposable
     /// Messages sent over the network
     /// </summary>
     public MessageCollection NetworkSentMessages => mockNetwork.NetworkSentMessages;
+    public MessageCollection NetworkSentImmediateMessages => mockNetwork.NetworkSentImmediateMessages;
 
     public ILifetimeScope Container => container;
     public IObjectManager ObjectManager => Container.Resolve<IObjectManager>();

--- a/source/E2E.Tests/Environment/Mock/MockNetworkBase.cs
+++ b/source/E2E.Tests/Environment/Mock/MockNetworkBase.cs
@@ -29,6 +29,7 @@ public abstract class MockNetworkBase : INetwork
     public NetPeer NetPeer { get; } = NetPeerExtensions.CreatePeer();
 
     public MessageCollection NetworkSentMessages { get; } = new MessageCollection();
+    public MessageCollection NetworkSentImmediateMessages { get; } = new MessageCollection();
     public PacketCollection NetworkSentPackets { get; } = new PacketCollection();
 
     public void ReceiveFromNetwork(NetPeer peer, IPacket packet) => packetManager.HandleReceive(peer, packet);
@@ -49,7 +50,11 @@ public abstract class MockNetworkBase : INetwork
 
     public void SendImmediate(NetPeer netPeer, IPacket packet) => Send(netPeer, packet);
 
-    public void SendImmediate(NetPeer netPeer, IMessage message) => Send(netPeer, message);
+    public void SendImmediate(NetPeer netPeer, IMessage message)
+    {
+        NetworkSentImmediateMessages.Add(message);
+        Send(netPeer, message);
+    }
 
     public void SendAll(IPacket packet)
     {

--- a/source/E2E.Tests/Services/Companions/CompanionDismissalSyncTests.cs
+++ b/source/E2E.Tests/Services/Companions/CompanionDismissalSyncTests.cs
@@ -1,0 +1,268 @@
+﻿using Common.Messaging;
+using Common.Network;
+using Common.Util;
+using E2E.Tests.Environment;
+using E2E.Tests.Environment.Instance;
+using E2E.Tests.Util;
+using GameInterface.Services.Companions.Messages;
+using GameInterface.Services.MapEvents.Interfaces;
+using GameInterface.Services.TroopRosters.Messages;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Actions;
+using TaleWorlds.CampaignSystem.Encounters;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.Localization;
+using Xunit.Abstractions;
+
+namespace E2E.Tests.Services.Companions;
+
+public class CompanionDismissalSyncTests : IDisposable
+{
+    private static readonly System.Reflection.MethodBase CreateObituaryMethod =
+        AccessTools.Method(typeof(KillCharacterAction), "CreateObituary");
+
+    private readonly E2ETestEnvironment testEnvironment;
+    private EnvironmentInstance Server => testEnvironment.Server;
+    private IReadOnlyList<EnvironmentInstance> Clients => testEnvironment.Clients.ToList();
+
+    public CompanionDismissalSyncTests(ITestOutputHelper output)
+    {
+        testEnvironment = new E2ETestEnvironment(output);
+    }
+
+    [Theory]
+    [InlineData(1, 0)]
+    [InlineData(6, 1)]
+    public void CompanionFired_RemovesEveryCopyBeforeRequesterCompletion(
+        int initialCount, int woundedCount)
+    {
+        var context = CreateCompanion(initialCount, woundedCount, includeParty: true);
+        var requester = Clients[0];
+        CompanionDismissalCompleted? completion = null;
+        int? countAtCompletion = null;
+        int completionCount = 0;
+
+        requester.Resolve<IMessageBroker>().Subscribe<CompanionDismissalCompleted>(payload =>
+        {
+            completion = payload.What;
+            completionCount++;
+            countAtCompletion = GetTroopCount(requester, context.PartyId, context.CharacterId);
+        });
+
+        Server.NetworkSentMessages.Clear();
+        requester.Call(() =>
+            {
+                Assert.True(requester.ObjectManager.TryGetObject<Hero>(context.HeroId, out var companion));
+                requester.Resolve<IMessageBroker>().Publish(this, new CompanionFired(companion));
+            },
+            new[] { CreateObituaryMethod });
+        testEnvironment.FlushCoalescer();
+
+        Assert.NotNull(completion);
+        Assert.True(completion.Value.Success, completion.Value.Error);
+        Assert.Equal(context.HeroId, completion.Value.OneToOneConversationHeroId);
+        Assert.Equal(0, countAtCompletion);
+        Assert.Equal(0, GetTroopCount(Server, context.PartyId, context.CharacterId));
+        foreach (var client in Clients)
+        {
+            Assert.Equal(0, GetTroopCount(client, context.PartyId, context.CharacterId));
+        }
+
+        var orderedTail = Server.NetworkSentMessages
+            .Where(message => message is NetworkTroopRosterSetNumber
+                or NetworkTroopRosterRemoveZeroCounts
+                or FireCompanionCompleted)
+            .TakeLast(3)
+            .ToArray();
+        Assert.IsType<NetworkTroopRosterSetNumber>(orderedTail[0]);
+        Assert.IsType<NetworkTroopRosterRemoveZeroCounts>(orderedTail[1]);
+        Assert.IsType<FireCompanionCompleted>(orderedTail[2]);
+
+        Server.Resolve<INetwork>().Send(requester.NetPeer,
+            new FireCompanionCompleted(completion.Value.RequestId, context.HeroId, true, null));
+        Assert.Equal(1, completionCount);
+
+        foreach (var otherClient in Clients.Skip(1))
+        {
+            Assert.Empty(otherClient.InternalMessages.OfType<FireCompanionCompleted>());
+        }
+    }
+
+    [Fact]
+    public void BareDismissalEncounter_BeginUpdateYieldsWithoutFinishing()
+    {
+        var requester = Clients[0];
+        requester.Call(() =>
+        {
+            var encounter = ObjectHelper.SkipConstructor<PlayerEncounter>();
+            Campaign.Current.PlayerEncounter = encounter;
+
+            new PlayerEncounterInterface().UpdateInternalAfterBattle(encounter);
+
+            Assert.Same(encounter, PlayerEncounter.Current);
+            Assert.True(encounter._stateHandled);
+            Assert.False(PlayerEncounter.LeaveEncounter);
+            Campaign.Current.PlayerEncounter = null;
+        });
+    }
+
+    [Fact]
+    public void CompanionFired_WithoutOwningClan_ReturnsLocalTerminalFailure()
+    {
+        string heroId = null;
+        Server.Call(() =>
+        {
+            var companion = GameObjectCreator.CreateInitializedObject<Hero>();
+            var companionName = new TextObject("Unowned Dismissal Test Companion");
+            companion.SetName(companionName, companionName);
+            Assert.True(Server.ObjectManager.TryGetId(companion, out heroId));
+        });
+        testEnvironment.FlushCoalescer();
+
+        var requester = Clients[0];
+        CompanionDismissalCompleted? completion = null;
+        requester.Resolve<IMessageBroker>().Subscribe<CompanionDismissalCompleted>(payload => completion = payload.What);
+
+        requester.Call(() =>
+        {
+            Assert.True(requester.ObjectManager.TryGetObject<Hero>(heroId, out var companion));
+            requester.Resolve<IMessageBroker>().Publish(this, new CompanionFired(companion));
+        });
+
+        Assert.NotNull(completion);
+        Assert.False(completion.Value.Success);
+        Assert.Equal(heroId, completion.Value.OneToOneConversationHeroId);
+        Assert.Contains("no owning clan", completion.Value.Error);
+        Assert.Empty(Server.InternalMessages.OfType<FireCompanion>());
+    }
+
+    [Fact]
+    public void FireCompanion_WithStaleOwnership_ReturnsFailureWithoutMutatingCompanion()
+    {
+        var context = CreateCompanion(1, 0, includeParty: true);
+        string staleClanId = null;
+        Server.Call(() =>
+        {
+            var staleClan = GameObjectCreator.CreateInitializedObject<Clan>();
+            Assert.True(Server.ObjectManager.TryGetId(staleClan, out staleClanId));
+        });
+        testEnvironment.FlushCoalescer();
+
+        var requester = Clients[0];
+        string requestId = Guid.NewGuid().ToString("N");
+        requester.Call(() => requester.Resolve<INetwork>().SendAll(new FireCompanion(
+            requestId, context.HeroId, staleClanId, context.PartyId)));
+
+        var completion = requester.InternalMessages.OfType<FireCompanionCompleted>()
+            .Single(message => message.RequestId == requestId);
+        Assert.False(completion.Success);
+        Assert.Contains("clan changed", completion.Error);
+        Assert.Equal(1, GetTroopCount(Server, context.PartyId, context.CharacterId));
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(context.HeroId, out var companion));
+            Assert.True(Server.ObjectManager.TryGetObject<Clan>(context.ClanId, out var clan));
+            Assert.Same(clan, companion.CompanionOf);
+        });
+    }
+
+    [Fact]
+    public void CompanionFired_WithoutParty_CompletesSuccessfully()
+    {
+        var context = CreateCompanion(0, 0, includeParty: false);
+        var requester = Clients[0];
+        CompanionDismissalCompleted? completion = null;
+        requester.Resolve<IMessageBroker>().Subscribe<CompanionDismissalCompleted>(payload => completion = payload.What);
+
+        requester.Call(() =>
+            {
+                Assert.True(requester.ObjectManager.TryGetObject<Hero>(context.HeroId, out var companion));
+                requester.Resolve<IMessageBroker>().Publish(this, new CompanionFired(companion));
+            },
+            new[] { CreateObituaryMethod });
+
+        Assert.NotNull(completion);
+        Assert.True(completion.Value.Success, completion.Value.Error);
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(context.HeroId, out var companion));
+            Assert.Null(companion.CompanionOf);
+        });
+    }
+
+    [Fact]
+    public void CompanionFired_WhenPostRemovalActionThrows_ReturnsTerminalFailureAfterCorrection()
+    {
+        var context = CreateCompanion(1, 0, includeParty: true);
+        var requester = Clients[0];
+        CompanionDismissalCompleted? completion = null;
+        requester.Resolve<IMessageBroker>().Subscribe<CompanionDismissalCompleted>(payload => completion = payload.What);
+
+        // The stripped E2E campaign intentionally has no encyclopedia pages, so vanilla obituary
+        // creation throws after RemoveCompanionAction. This exercises the handler's terminal-error path.
+        requester.Call(() =>
+        {
+            Assert.True(requester.ObjectManager.TryGetObject<Hero>(context.HeroId, out var companion));
+            requester.Resolve<IMessageBroker>().Publish(this, new CompanionFired(companion));
+        });
+
+        Assert.NotNull(completion);
+        Assert.False(completion.Value.Success);
+        Assert.NotEmpty(completion.Value.Error);
+        Assert.Equal(0, GetTroopCount(Server, context.PartyId, context.CharacterId));
+        foreach (var client in Clients)
+        {
+            Assert.Equal(0, GetTroopCount(client, context.PartyId, context.CharacterId));
+        }
+    }
+
+    private CompanionContext CreateCompanion(int initialCount, int woundedCount, bool includeParty)
+    {
+        string partyId = null;
+        string clanId = null;
+        string heroId = null;
+        string characterId = null;
+
+        Server.Call(() =>
+        {
+            var clan = GameObjectCreator.CreateInitializedObject<Clan>();
+            var companion = GameObjectCreator.CreateInitializedObject<Hero>();
+            MobileParty party = null;
+
+            var companionName = new TextObject("Dismissal Test Companion");
+            companion.SetName(companionName, companionName);
+
+            AddCompanionAction.Apply(clan, companion);
+            if (includeParty)
+            {
+                party = GameObjectCreator.CreateInitializedObject<MobileParty>();
+                AddHeroToPartyAction.Apply(companion, party, true);
+                int currentCount = party.MemberRoster.GetTroopCount(companion.CharacterObject);
+                party.MemberRoster.AddToCounts(companion.CharacterObject, initialCount - currentCount);
+                int companionIndex = party.MemberRoster.FindIndexOfTroop(companion.CharacterObject);
+                party.MemberRoster.SetElementWoundedNumber(companionIndex, woundedCount);
+                Assert.True(Server.ObjectManager.TryGetId(party, out partyId));
+            }
+
+            Assert.True(Server.ObjectManager.TryGetId(clan, out clanId));
+            Assert.True(Server.ObjectManager.TryGetId(companion, out heroId));
+            Assert.True(Server.ObjectManager.TryGetId(companion.CharacterObject, out characterId));
+        });
+        testEnvironment.FlushCoalescer();
+
+        return new CompanionContext(partyId, clanId, heroId, characterId);
+    }
+
+    private static int GetTroopCount(EnvironmentInstance instance, string partyId, string characterId)
+    {
+        Assert.True(instance.ObjectManager.TryGetObject<MobileParty>(partyId, out var party));
+        Assert.True(instance.ObjectManager.TryGetObject<CharacterObject>(characterId, out var character));
+        return party.MemberRoster.GetTroopCount(character);
+    }
+
+    private readonly record struct CompanionContext(
+        string PartyId, string ClanId, string HeroId, string CharacterId);
+
+    public void Dispose() => testEnvironment.Dispose();
+}

--- a/source/E2E.Tests/Services/Companions/CompanionDismissalSyncTests.cs
+++ b/source/E2E.Tests/Services/Companions/CompanionDismissalSyncTests.cs
@@ -1,5 +1,6 @@
 ﻿using Common.Messaging;
 using Common.Network;
+using Common.Network.Coalescing;
 using Common.Util;
 using E2E.Tests.Environment;
 using E2E.Tests.Environment.Instance;
@@ -57,6 +58,7 @@ public class CompanionDismissalSyncTests : IDisposable
                 requester.Resolve<IMessageBroker>().Publish(this, new CompanionFired(companion));
             },
             new[] { CreateObituaryMethod });
+        Assert.False(Server.Resolve<ISendCoalescer>().HasPending);
         testEnvironment.FlushCoalescer();
 
         Assert.NotNull(completion);

--- a/source/E2E.Tests/Services/Companions/CompanionDismissalSyncTests.cs
+++ b/source/E2E.Tests/Services/Companions/CompanionDismissalSyncTests.cs
@@ -80,6 +80,7 @@ public class CompanionDismissalSyncTests : IDisposable
         Assert.IsType<NetworkTroopRosterSetNumber>(orderedTail[0]);
         Assert.IsType<NetworkTroopRosterRemoveZeroCounts>(orderedTail[1]);
         Assert.IsType<FireCompanionCompleted>(orderedTail[2]);
+        Assert.Single(Server.NetworkSentImmediateMessages.OfType<FireCompanionCompleted>());
 
         Server.Resolve<INetwork>().Send(requester.NetPeer,
             new FireCompanionCompleted(completion.Value.RequestId, context.HeroId, true, null));

--- a/source/GameInterface/Services/Companions/Commands/CompanionsCommands.cs
+++ b/source/GameInterface/Services/Companions/Commands/CompanionsCommands.cs
@@ -1,10 +1,25 @@
 ﻿using Autofac;
+using Common;
+using Common.Messaging;
 using Common.Logging;
+using GameInterface.Services.Companions.Messages;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Players;
+using GameInterface.Services.Players.Data;
+using GameInterface.Utils.Commands;
 using Serilog;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Actions;
+using TaleWorlds.CampaignSystem.CampaignBehaviors;
+using TaleWorlds.CampaignSystem.Conversation;
+using TaleWorlds.CampaignSystem.Encounters;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.Localization;
+using Helpers;
 using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Companions.Commands;
@@ -12,6 +27,9 @@ namespace GameInterface.Services.Companions.Commands;
 internal class CompanionsCommands
 {
     private static readonly ILogger Logger = LogManager.GetLogger<CompanionsCommands>();
+    private static CompanionDismissalFixture pendingDismissalFixture;
+    private static CompanionDismissalCompleted? lastDismissalCompletion;
+    private static DismissalEncounterObservation lastDismissalEncounterObservation;
 
     /// <summary>
     /// Attempts to get the ObjectManager
@@ -45,5 +63,401 @@ internal class CompanionsCommands
             return result;
         }
         return "Hero not found.";
+    }
+
+    [CommandLineArgumentFunction("dismissal_fixture_setup", "coop.debug.companions")]
+    public static string DismissalFixtureSetupCommand(List<string> args)
+    {
+        const string usage = "Usage: coop.debug.companions.dismissal_fixture_setup <controllerId>";
+        var context = new CommandContext("dismissal_fixture_setup", usage, args);
+        if (!context.RequireServer(out var error)) return error;
+        if (!context.RequireArgCount(1, out error)) return error;
+        if (pendingDismissalFixture != null) return "A companion-dismissal fixture is already active.";
+
+        if (!TryResolvePlayer(args[0], out var playerManager, out var objectManager, out var player,
+            out var playerHero, out var playerClan, out var playerParty, out error))
+            return "Failed to set up companion-dismissal fixture: " + error;
+
+        var template = Hero.AllAliveHeroes.FirstOrDefault(hero => hero.IsWanderer && hero != playerHero);
+        if (template == null)
+            return "Failed to set up companion-dismissal fixture: no living wanderer template is available.";
+
+        int originalMemberCount = playerParty.MemberRoster.TotalManCount;
+        int originalCompanionCount = playerClan.Companions.Count();
+        var dismissed = CreateFixtureCompanion(template, playerHero.HomeSettlement, "Issue 2280 Dismissed");
+        var replacement = CreateFixtureCompanion(template, playerHero.HomeSettlement, "Issue 2280 Replacement");
+
+        if (!objectManager.TryGetIdWithLogging(dismissed, out var dismissedHeroId) ||
+            !objectManager.TryGetIdWithLogging(replacement, out var replacementHeroId))
+            return "Failed to set up companion-dismissal fixture: generated heroes were not registered.";
+
+        AddCompanionAction.Apply(playerClan, dismissed);
+        AddHeroToPartyAction.Apply(dismissed, playerParty, true);
+
+        pendingDismissalFixture = new CompanionDismissalFixture(
+            player.ControllerId,
+            player.HeroId,
+            player.ClanId,
+            player.MobilePartyId,
+            dismissed,
+            dismissedHeroId,
+            replacement,
+            replacementHeroId,
+            originalMemberCount,
+            originalCompanionCount);
+
+        return $"FIXTURE_READY controller={player.ControllerId} hero={player.HeroId} " +
+            $"clan={player.ClanId} party={player.MobilePartyId} " +
+            $"dismissedHero={dismissedHeroId} replacementHero={replacementHeroId} " +
+            $"dismissedCount={playerParty.MemberRoster.GetTroopCount(dismissed.CharacterObject)}";
+    }
+
+    [CommandLineArgumentFunction("dismissal_fixture_prepare_dismiss", "coop.debug.companions")]
+    public static string DismissalFixturePrepareDismissCommand(List<string> args)
+    {
+        const string usage = "Usage: coop.debug.companions.dismissal_fixture_prepare_dismiss <controllerId> <initialCopies>";
+        var context = new CommandContext("dismissal_fixture_prepare_dismiss", usage, args);
+        if (!context.RequireServer(out var error)) return error;
+        if (!context.RequireArgCount(2, out error)) return error;
+        if (!int.TryParse(args[1], out var initialCopies) || initialCopies < 1)
+            return usage;
+        if (!TryGetFixture(args[0], out var fixture, out error)) return error;
+        if (!TryResolvePlayer(args[0], out _, out _, out _, out _, out _, out var party, out error))
+            return "Failed to prepare fixture dismissal: " + error;
+
+        int current = party.MemberRoster.GetTroopCount(fixture.Dismissed.CharacterObject);
+        if (current < 1)
+            return "Failed to prepare fixture dismissal: the companion is not in the player party.";
+        if (current != initialCopies)
+        {
+            party.MemberRoster.AddToCounts(fixture.Dismissed.CharacterObject, initialCopies - current);
+        }
+
+        return $"DISMISSAL_PREPARED hero={fixture.DismissedHeroId} requestedCopies={initialCopies} " +
+            $"count={party.MemberRoster.GetTroopCount(fixture.Dismissed.CharacterObject)}";
+    }
+
+    [CommandLineArgumentFunction("dismissal_fixture_trigger_consequence", "coop.debug.companions")]
+    public static string DismissalFixtureTriggerConsequenceCommand(List<string> args)
+    {
+        const string usage = "Usage: coop.debug.companions.dismissal_fixture_trigger_consequence <dismissedHeroId>";
+        if (!ModInformation.IsClient) return "Command can only be run on a client.";
+        if (args.Count != 1) return usage;
+        if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
+        if (!objectManager.TryGetObject(args[0], out Hero dismissed)) return $"Hero '{args[0]}' not found.";
+        if (PlayerEncounter.Current != null) return "A player encounter is already active.";
+        if (Campaign.Current.ConversationManager.IsConversationInProgress)
+            return "A conversation is already active.";
+
+        var behavior = Campaign.Current.GetCampaignBehavior<CompanionRolesCampaignBehavior>();
+        if (behavior == null) return "CompanionRolesCampaignBehavior is unavailable.";
+
+        lastDismissalCompletion = null;
+        lastDismissalEncounterObservation = new DismissalEncounterObservation();
+        Action<MessagePayload<CompanionDismissalCompleted>> completionHandler = null;
+        completionHandler = payload =>
+        {
+            if (payload.What.OneToOneConversationHeroId != args[0]) return;
+            lastDismissalCompletion = payload.What;
+            lastDismissalEncounterObservation.EncounterActiveAtCompletion = PlayerEncounter.Current != null;
+            lastDismissalEncounterObservation.LeaveAtCompletion =
+                PlayerEncounter.Current != null && PlayerEncounter.LeaveEncounter;
+            MessageBroker.Instance.Unsubscribe(completionHandler);
+        };
+        MessageBroker.Instance.Subscribe(completionHandler);
+
+        try
+        {
+            PlayerEncounter.Start();
+            Campaign.Current.CurrentConversationContext = ConversationContext.PartyEncounter;
+            CampaignMapConversation.OpenConversation(
+                new ConversationCharacterData(CharacterObject.PlayerCharacter, PartyBase.MainParty, noHorse: true),
+                new ConversationCharacterData(dismissed.CharacterObject, PartyBase.MainParty, noHorse: true));
+
+            lastDismissalEncounterObservation.EncounterActiveAtTrigger = PlayerEncounter.Current != null;
+            lastDismissalEncounterObservation.LeaveBeforeConsequence = PlayerEncounter.LeaveEncounter;
+            lastDismissalEncounterObservation.ConversationHeroMatched = Hero.OneToOneConversationHero == dismissed;
+            if (!lastDismissalEncounterObservation.ConversationHeroMatched)
+                throw new InvalidOperationException("The live conversation did not select the dismissed companion.");
+
+            behavior.companion_fire_on_consequence();
+            lastDismissalEncounterObservation.LeaveAfterConsequence =
+                PlayerEncounter.Current != null && PlayerEncounter.LeaveEncounter;
+
+            // The real farewell line ends at close_window after running this consequence. Close the synthetic
+            // map conversation too, while leaving its encounter held until the correlated acknowledgement.
+            Campaign.Current.ConversationManager.EndConversation();
+
+            return $"DISMISSAL_CONSEQUENCE_TRIGGERED hero={args[0]} " +
+                $"encounterActive={lastDismissalEncounterObservation.EncounterActiveAtTrigger} " +
+                $"conversationHeroMatched={lastDismissalEncounterObservation.ConversationHeroMatched} " +
+                $"leaveBefore={lastDismissalEncounterObservation.LeaveBeforeConsequence} " +
+                $"leaveAfter={lastDismissalEncounterObservation.LeaveAfterConsequence}";
+        }
+        catch (Exception exception)
+        {
+            MessageBroker.Instance.Unsubscribe(completionHandler);
+            if (Campaign.Current.ConversationManager.IsConversationInProgress)
+                Campaign.Current.ConversationManager.EndConversation();
+            Campaign.Current.PlayerEncounter = null;
+            return "Failed to trigger the live dismissal consequence: " + exception.Message;
+        }
+    }
+
+    [CommandLineArgumentFunction("dismissal_fixture_completion", "coop.debug.companions")]
+    public static string DismissalFixtureCompletionCommand(List<string> args)
+    {
+        const string usage = "Usage: coop.debug.companions.dismissal_fixture_completion <dismissedHeroId>";
+        if (!ModInformation.IsClient) return "Command can only be run on a client.";
+        if (args.Count != 1) return usage;
+        if (lastDismissalCompletion == null ||
+            lastDismissalCompletion.Value.OneToOneConversationHeroId != args[0])
+            return $"DISMISSAL_PENDING hero={args[0]}";
+
+        var completion = lastDismissalCompletion.Value;
+        var observation = lastDismissalEncounterObservation;
+        return $"DISMISSAL_COMPLETED hero={args[0]} request={completion.RequestId} " +
+            $"success={completion.Success} error={completion.Error ?? "none"} " +
+            $"encounterAtTrigger={observation?.EncounterActiveAtTrigger} " +
+            $"conversationHeroMatched={observation?.ConversationHeroMatched} " +
+            $"leaveBefore={observation?.LeaveBeforeConsequence} " +
+            $"leaveAfterConsequence={observation?.LeaveAfterConsequence} " +
+            $"encounterAtCompletion={observation?.EncounterActiveAtCompletion} " +
+            $"leaveAtCompletion={observation?.LeaveAtCompletion}";
+    }
+
+    [CommandLineArgumentFunction("dismissal_fixture_release_encounter", "coop.debug.companions")]
+    public static string DismissalFixtureReleaseEncounterCommand(List<string> args)
+    {
+        const string usage = "Usage: coop.debug.companions.dismissal_fixture_release_encounter <dismissedHeroId>";
+        if (!ModInformation.IsClient) return "Command can only be run on a client.";
+        if (args.Count != 1) return usage;
+        if (lastDismissalCompletion == null ||
+            lastDismissalCompletion.Value.OneToOneConversationHeroId != args[0])
+            return $"Dismissal completion for hero '{args[0]}' has not arrived.";
+        if (lastDismissalEncounterObservation?.LeaveAtCompletion != true)
+            return "The dismissal encounter was not released by the correlated completion.";
+
+        bool wasActive = PlayerEncounter.Current != null;
+        Campaign.Current.PlayerEncounter = null;
+        return $"DISMISSAL_ENCOUNTER_RELEASED hero={args[0]} wasActive={wasActive} leaveAcknowledged=True";
+    }
+
+    [CommandLineArgumentFunction("dismissal_fixture_request_replacement", "coop.debug.companions")]
+    public static string DismissalFixtureRequestReplacementCommand(List<string> args)
+    {
+        const string usage = "Usage: coop.debug.companions.dismissal_fixture_request_replacement <replacementHeroId>";
+        if (!ModInformation.IsClient) return "Command can only be run on a client.";
+        if (args.Count != 1) return usage;
+        if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
+        if (!objectManager.TryGetObject(args[0], out Hero replacement)) return $"Hero '{args[0]}' not found.";
+        if (Hero.MainHero?.Clan == null || MobileParty.MainParty == null)
+            return "The local player hero, clan, or main party is unavailable.";
+
+        MessageBroker.Instance.Publish(null,
+            new CompanionHired(Hero.MainHero, replacement, 0, Hero.MainHero.Clan, MobileParty.MainParty));
+        return $"REPLACEMENT_REQUESTED hero={args[0]}";
+    }
+
+    [CommandLineArgumentFunction("dismissal_fixture_state", "coop.debug.companions")]
+    public static string DismissalFixtureStateCommand(List<string> args)
+    {
+        const string usage = "Usage: coop.debug.companions.dismissal_fixture_state <partyId> <dismissedHeroId> <replacementHeroId>";
+        if (args.Count != 3) return usage;
+        if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
+        if (!objectManager.TryGetObject(args[0], out MobileParty party)) return $"Party '{args[0]}' not found.";
+        if (!objectManager.TryGetObject(args[1], out Hero dismissed)) return $"Hero '{args[1]}' not found.";
+        if (!objectManager.TryGetObject(args[2], out Hero replacement)) return $"Hero '{args[2]}' not found.";
+
+        return "COMPANION_STATE " + FormatHeroState("dismissed", party, dismissed) + " " +
+            FormatHeroState("replacement", party, replacement);
+    }
+
+    [CommandLineArgumentFunction("dismissal_fixture_restore", "coop.debug.companions")]
+    public static string DismissalFixtureRestoreCommand(List<string> args)
+    {
+        const string usage = "Usage: coop.debug.companions.dismissal_fixture_restore <controllerId>";
+        var context = new CommandContext("dismissal_fixture_restore", usage, args);
+        if (!context.RequireServer(out var error)) return error;
+        if (!context.RequireArgCount(1, out error)) return error;
+        if (!TryGetFixture(args[0], out var fixture, out error)) return error;
+        if (!TryResolvePlayer(args[0], out var playerManager, out var objectManager,
+            out _, out _, out var clan, out var party, out error))
+            return "Failed to restore companion-dismissal fixture: " + error;
+        if (!playerManager.TryGetPeer(args[0], out var peer))
+            return $"Failed to restore companion-dismissal fixture: player '{args[0]}' is not connected.";
+
+        if (fixture.Dismissed.CompanionOf != null)
+        {
+            MessageBroker.Instance.Publish(peer, CreateCleanupDismissalRequest(
+                objectManager, fixture.Dismissed, fixture.DismissedHeroId));
+        }
+        if (fixture.Replacement.CompanionOf != null)
+        {
+            MessageBroker.Instance.Publish(peer, CreateCleanupDismissalRequest(
+                objectManager, fixture.Replacement, fixture.ReplacementHeroId));
+        }
+
+        int dismissedCount = party.MemberRoster.GetTroopCount(fixture.Dismissed.CharacterObject);
+        int replacementCount = party.MemberRoster.GetTroopCount(fixture.Replacement.CharacterObject);
+        int memberCount = party.MemberRoster.TotalManCount;
+        int companionCount = clan.Companions.Count();
+        if (dismissedCount != 0 || replacementCount != 0 ||
+            memberCount != fixture.OriginalMemberCount || companionCount != fixture.OriginalCompanionCount)
+        {
+            return $"RESTORE_FAILED dismissed={dismissedCount} replacement={replacementCount} " +
+                $"members={memberCount}/{fixture.OriginalMemberCount} companions={companionCount}/{fixture.OriginalCompanionCount}";
+        }
+
+        pendingDismissalFixture = null;
+        return $"FIXTURE_RESTORED party={fixture.PlayerPartyId} dismissed=0 replacement=0 " +
+            $"members={memberCount} companions={companionCount}";
+    }
+
+    [CommandLineArgumentFunction("open_party_screen", "coop.debug.companions")]
+    public static string OpenPartyScreenCommand(List<string> args)
+    {
+        if (!ModInformation.IsClient) return "Command can only be run on a client.";
+        if (args.Count != 0) return "Usage: coop.debug.companions.open_party_screen";
+        if (Hero.MainHero?.PartyBelongedTo == null) return "The local player hero has no party.";
+
+        PartyScreenHelper.OpenScreenAsNormal();
+        return "PARTY_SCREEN_OPENED";
+    }
+
+    [CommandLineArgumentFunction("close_party_screen", "coop.debug.companions")]
+    public static string ClosePartyScreenCommand(List<string> args)
+    {
+        if (!ModInformation.IsClient) return "Command can only be run on a client.";
+        if (args.Count != 0) return "Usage: coop.debug.companions.close_party_screen";
+
+        PartyScreenHelper.CloseScreen(true, true);
+        return "PARTY_SCREEN_CLOSED";
+    }
+
+    private static Hero CreateFixtureCompanion(Hero template,
+        TaleWorlds.CampaignSystem.Settlements.Settlement homeSettlement, string name)
+    {
+        var hero = HeroCreator.CreateSpecialHero(template.CharacterObject, homeSettlement, age: 30);
+        var heroName = new TextObject(name);
+        hero.SetName(heroName, heroName);
+        hero.SetNewOccupation(Occupation.Wanderer);
+        return hero;
+    }
+
+    private static FireCompanion CreateCleanupDismissalRequest(
+        IObjectManager objectManager, Hero companion, string heroId)
+    {
+        if (!objectManager.TryGetIdWithLogging(companion.CompanionOf, out var clanId))
+            throw new InvalidOperationException($"Could not resolve the owning clan for fixture hero '{heroId}'.");
+
+        string partyId = null;
+        if (companion.PartyBelongedTo != null &&
+            !objectManager.TryGetIdWithLogging(companion.PartyBelongedTo, out partyId))
+            throw new InvalidOperationException($"Could not resolve the party for fixture hero '{heroId}'.");
+
+        return new FireCompanion(Guid.NewGuid().ToString("N"), heroId, clanId, partyId);
+    }
+
+    private static bool TryResolvePlayer(
+        string controllerId,
+        out IPlayerManager playerManager,
+        out IObjectManager objectManager,
+        out Player player,
+        out Hero hero,
+        out Clan clan,
+        out MobileParty party,
+        out string error)
+    {
+        playerManager = null;
+        objectManager = null;
+        player = null;
+        hero = null;
+        clan = null;
+        party = null;
+        error = null;
+
+        if (!ContainerProvider.TryResolve(out playerManager) || !ContainerProvider.TryResolve(out objectManager))
+        {
+            error = "could not resolve player services.";
+            return false;
+        }
+        if (!playerManager.TryGetPlayer(controllerId, out player))
+        {
+            error = $"no registered player has controller id '{controllerId}'.";
+            return false;
+        }
+        if (!objectManager.TryGetObject(player.HeroId, out hero) ||
+            !objectManager.TryGetObject(player.ClanId, out clan) ||
+            !objectManager.TryGetObject(player.MobilePartyId, out party))
+        {
+            error = $"player '{controllerId}' has unresolved hero, clan, or party objects.";
+            return false;
+        }
+        return true;
+    }
+
+    private static bool TryGetFixture(string controllerId, out CompanionDismissalFixture fixture, out string error)
+    {
+        fixture = pendingDismissalFixture;
+        if (fixture == null)
+        {
+            error = "No companion-dismissal fixture is active.";
+            return false;
+        }
+        if (fixture.ControllerId != controllerId)
+        {
+            error = $"The active companion-dismissal fixture belongs to '{fixture.ControllerId}'.";
+            return false;
+        }
+        error = null;
+        return true;
+    }
+
+    private static string FormatHeroState(string label, MobileParty party, Hero hero)
+    {
+        return $"{label}.id={hero.StringId} {label}.count={party.MemberRoster.GetTroopCount(hero.CharacterObject)} " +
+            $"{label}.state={hero.HeroState} {label}.companion={(hero.CompanionOf?.StringId ?? "none")} " +
+            $"{label}.party={(hero.PartyBelongedTo?.StringId ?? "none")}";
+    }
+
+    private sealed class CompanionDismissalFixture
+    {
+        public string ControllerId { get; }
+        public string PlayerHeroId { get; }
+        public string PlayerClanId { get; }
+        public string PlayerPartyId { get; }
+        public Hero Dismissed { get; }
+        public string DismissedHeroId { get; }
+        public Hero Replacement { get; }
+        public string ReplacementHeroId { get; }
+        public int OriginalMemberCount { get; }
+        public int OriginalCompanionCount { get; }
+
+        public CompanionDismissalFixture(string controllerId, string playerHeroId, string playerClanId,
+            string playerPartyId, Hero dismissed, string dismissedHeroId, Hero replacement,
+            string replacementHeroId, int originalMemberCount, int originalCompanionCount)
+        {
+            ControllerId = controllerId;
+            PlayerHeroId = playerHeroId;
+            PlayerClanId = playerClanId;
+            PlayerPartyId = playerPartyId;
+            Dismissed = dismissed;
+            DismissedHeroId = dismissedHeroId;
+            Replacement = replacement;
+            ReplacementHeroId = replacementHeroId;
+            OriginalMemberCount = originalMemberCount;
+            OriginalCompanionCount = originalCompanionCount;
+        }
+    }
+
+    private sealed class DismissalEncounterObservation
+    {
+        public bool EncounterActiveAtTrigger { get; set; }
+        public bool ConversationHeroMatched { get; set; }
+        public bool LeaveBeforeConsequence { get; set; }
+        public bool LeaveAfterConsequence { get; set; }
+        public bool EncounterActiveAtCompletion { get; set; }
+        public bool LeaveAtCompletion { get; set; }
     }
 }

--- a/source/GameInterface/Services/Companions/Commands/CompanionsCommands.cs
+++ b/source/GameInterface/Services/Companions/Commands/CompanionsCommands.cs
@@ -30,6 +30,7 @@ internal class CompanionsCommands
     private static CompanionDismissalFixture pendingDismissalFixture;
     private static CompanionDismissalCompleted? lastDismissalCompletion;
     private static DismissalEncounterObservation lastDismissalEncounterObservation;
+    private static Action<MessagePayload<CompanionDismissalCompleted>> dismissalCompletionHandler;
 
     /// <summary>
     /// Attempts to get the ObjectManager
@@ -154,17 +155,21 @@ internal class CompanionsCommands
 
         lastDismissalCompletion = null;
         lastDismissalEncounterObservation = new DismissalEncounterObservation();
-        Action<MessagePayload<CompanionDismissalCompleted>> completionHandler = null;
-        completionHandler = payload =>
+        if (dismissalCompletionHandler != null)
+        {
+            MessageBroker.Instance.Unsubscribe(dismissalCompletionHandler);
+        }
+        dismissalCompletionHandler = payload =>
         {
             if (payload.What.OneToOneConversationHeroId != args[0]) return;
             lastDismissalCompletion = payload.What;
             lastDismissalEncounterObservation.EncounterActiveAtCompletion = PlayerEncounter.Current != null;
             lastDismissalEncounterObservation.LeaveAtCompletion =
                 PlayerEncounter.Current != null && PlayerEncounter.LeaveEncounter;
-            MessageBroker.Instance.Unsubscribe(completionHandler);
+            MessageBroker.Instance.Unsubscribe(dismissalCompletionHandler);
+            dismissalCompletionHandler = null;
         };
-        MessageBroker.Instance.Subscribe(completionHandler);
+        MessageBroker.Instance.Subscribe(dismissalCompletionHandler);
 
         try
         {
@@ -196,7 +201,8 @@ internal class CompanionsCommands
         }
         catch (Exception exception)
         {
-            MessageBroker.Instance.Unsubscribe(completionHandler);
+            MessageBroker.Instance.Unsubscribe(dismissalCompletionHandler);
+            dismissalCompletionHandler = null;
             if (Campaign.Current.ConversationManager.IsConversationInProgress)
                 Campaign.Current.ConversationManager.EndConversation();
             Campaign.Current.PlayerEncounter = null;

--- a/source/GameInterface/Services/Companions/Handlers/CompanionRolesHandler.cs
+++ b/source/GameInterface/Services/Companions/Handlers/CompanionRolesHandler.cs
@@ -188,7 +188,6 @@ internal class CompanionRolesHandler : IHandler
         }
     }
 
-
     private void Handle_FireCompanion(MessagePayload<FireCompanion> obj)
     {
         var data = obj.What;

--- a/source/GameInterface/Services/Companions/Handlers/CompanionRolesHandler.cs
+++ b/source/GameInterface/Services/Companions/Handlers/CompanionRolesHandler.cs
@@ -2,6 +2,7 @@
 using Common.Logging;
 using Common.Messaging;
 using Common.Network;
+using Common.Network.Coalescing;
 using GameInterface.Services.Companions.Messages;
 using GameInterface.Services.Heroes.Patches;
 using GameInterface.Services.ObjectManager;
@@ -30,17 +31,20 @@ internal class CompanionRolesHandler : IHandler
     private readonly IMessageBroker messageBroker;
     private readonly IObjectManager objectManager;
     private readonly INetwork network;
+    private readonly ISendCoalescer sendCoalescer;
     private string pendingFireCompanionRequestId;
     private string pendingFireCompanionHeroId;
 
     public CompanionRolesHandler(
         IMessageBroker messageBroker,
         IObjectManager objectManager,
-        INetwork network)
+        INetwork network,
+        ISendCoalescer sendCoalescer = null)
     {
         this.messageBroker = messageBroker;
         this.objectManager = objectManager;
         this.network = network;
+        this.sendCoalescer = sendCoalescer;
 
         messageBroker.Subscribe<ClanNameSelectionDone>(Handle_ClanNameSelectionDone);
         messageBroker.Subscribe<DoClanNameSelection>(Handle_DoClanNameSelection);
@@ -246,8 +250,10 @@ internal class CompanionRolesHandler : IHandler
                     if (memberRoster != null)
                     {
                         ReconcileDismissedCompanionRoster(memberRoster, oneToOneConversationHero.CharacterObject,
-                            memberRosterId, characterId, network);
+                            memberRosterId, characterId, network, sendCoalescer);
                     }
+                    else
+                        sendCoalescer?.Flush(network);
                 }
 
                 success = true;
@@ -309,7 +315,7 @@ internal class CompanionRolesHandler : IHandler
     }
 
     internal static void ReconcileDismissedCompanionRoster(TroopRoster memberRoster, CharacterObject character,
-        string memberRosterId, string characterId, INetwork network)
+        string memberRosterId, string characterId, INetwork network, ISendCoalescer sendCoalescer = null)
     {
         int index = memberRoster.FindIndexOfTroop(character);
         if (index >= 0)
@@ -323,6 +329,11 @@ internal class CompanionRolesHandler : IHandler
         }
 
         memberRoster.RemoveZeroCounts();
+
+        // Flush the ordinary coalesced deltas before the absolute correction and correlated completion.
+        // All of them share the reliable ordered stream, so the client cannot observe the acknowledgement
+        // while a stale roster delta from this dismissal is still pending for the next server tick.
+        sendCoalescer?.Flush(network);
 
         // Send an absolute correction after the ordinary deltas. This is idempotent and repairs clients
         // that entered the dismissal with duplicate companion counts.

--- a/source/GameInterface/Services/Companions/Handlers/CompanionRolesHandler.cs
+++ b/source/GameInterface/Services/Companions/Handlers/CompanionRolesHandler.cs
@@ -5,17 +5,21 @@ using Common.Network;
 using GameInterface.Services.Companions.Messages;
 using GameInterface.Services.Heroes.Patches;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.TroopRosters.Messages;
+using LiteNetLib;
 using Serilog;
 using System;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
+using TaleWorlds.CampaignSystem.Encounters;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Party.PartyComponents;
 using TaleWorlds.CampaignSystem.Roster;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Core;
 using TaleWorlds.Localization;
+using static GameInterface.Services.ObjectManager.ObjectManager;
 
 namespace GameInterface.Services.Companions.Handlers;
 
@@ -26,6 +30,8 @@ internal class CompanionRolesHandler : IHandler
     private readonly IMessageBroker messageBroker;
     private readonly IObjectManager objectManager;
     private readonly INetwork network;
+    private string pendingFireCompanionRequestId;
+    private string pendingFireCompanionHeroId;
 
     public CompanionRolesHandler(
         IMessageBroker messageBroker,
@@ -40,6 +46,7 @@ internal class CompanionRolesHandler : IHandler
         messageBroker.Subscribe<DoClanNameSelection>(Handle_DoClanNameSelection);
         messageBroker.Subscribe<CompanionFired>(Handle_CompanionFired);
         messageBroker.Subscribe<FireCompanion>(Handle_FireCompanion);
+        messageBroker.Subscribe<FireCompanionCompleted>(Handle_FireCompanionCompleted);
         messageBroker.Subscribe<CompanionRejoinAfterEmprisonment>(Handle_CompanionRejoinAfterEmprisonment);
         messageBroker.Subscribe<DoCompanionRejoinAfterEmprisonment>(Handle_DoCompanionRejoinAfterEmprisonment);
         messageBroker.Subscribe<CompanionJoinedPartyByRescue>(Handle_CompanionJoinedPartyByRescue);
@@ -56,6 +63,7 @@ internal class CompanionRolesHandler : IHandler
         messageBroker.Unsubscribe<DoClanNameSelection>(Handle_DoClanNameSelection);
         messageBroker.Unsubscribe<CompanionFired>(Handle_CompanionFired);
         messageBroker.Unsubscribe<FireCompanion>(Handle_FireCompanion);
+        messageBroker.Unsubscribe<FireCompanionCompleted>(Handle_FireCompanionCompleted);
         messageBroker.Unsubscribe<CompanionRejoinAfterEmprisonment>(Handle_CompanionRejoinAfterEmprisonment);
         messageBroker.Unsubscribe<DoCompanionRejoinAfterEmprisonment>(Handle_DoCompanionRejoinAfterEmprisonment);
         messageBroker.Unsubscribe<CompanionJoinedPartyByRescue>(Handle_CompanionJoinedPartyByRescue);
@@ -141,31 +149,187 @@ internal class CompanionRolesHandler : IHandler
 
     private void Handle_CompanionFired(MessagePayload<CompanionFired> obj)
     {
-        if (!objectManager.TryGetIdWithLogging(obj.What.OneToOneConversationHero, out var oneToOneConversationHeroId)) return;
+        if (pendingFireCompanionRequestId != null)
+        {
+            logger.Warning("Ignored a second companion dismissal while request {RequestId} is pending",
+                pendingFireCompanionRequestId);
+            return;
+        }
 
-        var message = new FireCompanion(oneToOneConversationHeroId);
+        var requestId = Guid.NewGuid().ToString("N");
+        pendingFireCompanionRequestId = requestId;
+        pendingFireCompanionHeroId = null;
 
-        network.SendAll(message);
+        try
+        {
+            if (!objectManager.TryGetIdWithLogging(obj.What.OneToOneConversationHero,
+                out var oneToOneConversationHeroId))
+                throw new InvalidOperationException("The companion being dismissed could not be resolved.");
+
+            pendingFireCompanionHeroId = oneToOneConversationHeroId;
+            if (obj.What.OneToOneConversationHero.CompanionOf == null)
+                throw new InvalidOperationException("The companion has no owning clan.");
+            if (!objectManager.TryGetIdWithLogging(obj.What.OneToOneConversationHero.CompanionOf,
+                out var expectedClanId))
+                throw new InvalidOperationException("The companion's owning clan could not be resolved.");
+
+            string expectedPartyId = null;
+            if (obj.What.OneToOneConversationHero.PartyBelongedTo != null &&
+                !objectManager.TryGetIdWithLogging(obj.What.OneToOneConversationHero.PartyBelongedTo,
+                    out expectedPartyId))
+                throw new InvalidOperationException("The companion's party could not be resolved.");
+
+            network.SendAll(new FireCompanion(requestId, oneToOneConversationHeroId,
+                expectedClanId, expectedPartyId));
+        }
+        catch (Exception exception)
+        {
+            CompletePendingFireCompanion(requestId, pendingFireCompanionHeroId, false, exception.Message);
+        }
     }
+
 
     private void Handle_FireCompanion(MessagePayload<FireCompanion> obj)
     {
         var data = obj.What;
+        var requester = obj.Who as NetPeer;
 
-        GameThread.Run(() =>
+        if (requester == null)
         {
+            logger.Error("Rejected {Message} without a requesting peer", nameof(FireCompanion));
+            return;
+        }
+
+        GameThread.RunSafe(() =>
+        {
+            bool success = false;
+            string error = null;
             try
             {
-                if (!objectManager.TryGetObjectWithLogging<Hero>(data.OneToOneConversationHeroId, out var oneToOneConversationHero)) return;
+                if (string.IsNullOrWhiteSpace(data.RequestId))
+                    throw new InvalidOperationException("The dismissal request has no correlation id.");
+                if (!objectManager.TryGetObjectWithLogging<Hero>(data.OneToOneConversationHeroId,
+                    out var oneToOneConversationHero))
+                    throw new InvalidOperationException("The requested companion could not be resolved.");
+                if (oneToOneConversationHero.CompanionOf == null ||
+                    !objectManager.TryGetIdWithLogging(oneToOneConversationHero.CompanionOf, out var currentClanId) ||
+                    currentClanId != data.ExpectedClanId)
+                    throw new InvalidOperationException("The companion's owning clan changed before dismissal.");
+
+                string currentPartyId = null;
+                if (oneToOneConversationHero.PartyBelongedTo != null &&
+                    !objectManager.TryGetIdWithLogging(oneToOneConversationHero.PartyBelongedTo, out currentPartyId))
+                    throw new InvalidOperationException("The companion's current party could not be resolved.");
+                if (currentPartyId != data.ExpectedPartyId)
+                    throw new InvalidOperationException("The companion's party changed before dismissal.");
+
+                TroopRoster memberRoster = oneToOneConversationHero.PartyBelongedTo?.MemberRoster;
+                string memberRosterId = null;
+                string characterId = null;
+                if (memberRoster != null)
+                {
+                    if (!objectManager.TryGetIdWithLogging(memberRoster, out memberRosterId) ||
+                        !objectManager.TryGetIdWithLogging(oneToOneConversationHero.CharacterObject, out characterId))
+                        throw new InvalidOperationException("The companion's party roster could not be resolved.");
+                    memberRosterId = Compact(memberRosterId, typeof(TroopRoster));
+                    characterId = Compact(characterId, typeof(CharacterObject));
+                }
 
                 RemoveCompanionAction.ApplyByFire(oneToOneConversationHero.CompanionOf, oneToOneConversationHero);
-                KillCharacterAction.ApplyByRemove(oneToOneConversationHero, false, true);
+                try
+                {
+                    KillCharacterAction.ApplyByRemove(oneToOneConversationHero, false, true);
+                }
+                finally
+                {
+                    // Once RemoveCompanionAction clears CompanionOf, a retry cannot rediscover the old party.
+                    // Always finish the captured roster correction, even if the follow-up removal throws.
+                    if (memberRoster != null)
+                    {
+                        ReconcileDismissedCompanionRoster(memberRoster, oneToOneConversationHero.CharacterObject,
+                            memberRosterId, characterId, network);
+                    }
+                }
+
+                success = true;
             }
-            catch (Exception e)
+            catch (Exception exception)
             {
-                logger.Error(e, "Failed to apply {Message}", nameof(FireCompanion));
+                error = exception.Message;
+                logger.Error(exception, "Failed companion dismissal request {RequestId} for {HeroId}",
+                    data.RequestId, data.OneToOneConversationHeroId);
             }
-        });
+            finally
+            {
+                SendCompletion(requester, data.RequestId, data.OneToOneConversationHeroId, success, error);
+            }
+        }, context: nameof(FireCompanion));
+    }
+
+    private void Handle_FireCompanionCompleted(MessagePayload<FireCompanionCompleted> obj)
+    {
+        var data = obj.What;
+
+        // Roster corrections and this acknowledgement share the reliable ordered stream. Deferring all of
+        // them to the game thread preserves that FIFO before the player can open the party screen.
+        GameThread.RunSafe(() =>
+        {
+            CompletePendingFireCompanion(data.RequestId, data.OneToOneConversationHeroId,
+                data.Success, data.Error);
+        }, context: nameof(FireCompanionCompleted));
+    }
+
+    private void CompletePendingFireCompanion(string requestId, string heroId, bool success, string error)
+    {
+        if (requestId != pendingFireCompanionRequestId || heroId != pendingFireCompanionHeroId)
+        {
+            logger.Warning("Ignored unmatched companion dismissal completion {RequestId} for {HeroId}",
+                requestId, heroId);
+            return;
+        }
+
+        pendingFireCompanionRequestId = null;
+        pendingFireCompanionHeroId = null;
+
+        if (PlayerEncounter.Current != null)
+        {
+            PlayerEncounter.LeaveEncounter = true;
+        }
+
+        if (!success)
+        {
+            logger.Error("Companion dismissal request {RequestId} failed: {Error}", requestId, error);
+        }
+
+        messageBroker.Publish(this, new CompanionDismissalCompleted(requestId, heroId, success, error));
+    }
+
+    private void SendCompletion(NetPeer requester, string requestId, string heroId, bool success, string error)
+    {
+        network.Send(requester, new FireCompanionCompleted(requestId, heroId, success, error));
+    }
+
+    internal static void ReconcileDismissedCompanionRoster(TroopRoster memberRoster, CharacterObject character,
+        string memberRosterId, string characterId, INetwork network)
+    {
+        int index = memberRoster.FindIndexOfTroop(character);
+        if (index >= 0)
+        {
+            var element = memberRoster.GetElementCopyAtIndex(index);
+            if (element.Number != 0 || element.WoundedNumber != 0)
+            {
+                memberRoster.AddToCounts(character, -element.Number, false, -element.WoundedNumber,
+                    0, true);
+            }
+        }
+
+        memberRoster.RemoveZeroCounts();
+
+        // Send an absolute correction after the ordinary deltas. This is idempotent and repairs clients
+        // that entered the dismissal with duplicate companion counts.
+        network.SendAll(new NetworkTroopRosterSetWoundedNumber(memberRosterId, characterId, 0));
+        network.SendAll(new NetworkTroopRosterSetNumber(memberRosterId, characterId, 0));
+        network.SendAll(new NetworkTroopRosterRemoveZeroCounts(memberRosterId));
     }
 
     private void Handle_CompanionRejoinAfterEmprisonment(MessagePayload<CompanionRejoinAfterEmprisonment> obj)

--- a/source/GameInterface/Services/Companions/Handlers/CompanionRolesHandler.cs
+++ b/source/GameInterface/Services/Companions/Handlers/CompanionRolesHandler.cs
@@ -185,6 +185,8 @@ internal class CompanionRolesHandler : IHandler
 
             network.SendAll(new FireCompanion(requestId, oneToOneConversationHeroId,
                 expectedClanId, expectedPartyId));
+            logger.Information("Sent companion dismissal request {RequestId} for {HeroId}",
+                requestId, oneToOneConversationHeroId);
         }
         catch (Exception exception)
         {
@@ -274,6 +276,10 @@ internal class CompanionRolesHandler : IHandler
     private void Handle_FireCompanionCompleted(MessagePayload<FireCompanionCompleted> obj)
     {
         var data = obj.What;
+        logger.Information(
+            "Received companion dismissal completion {RequestId} for {HeroId}; pending request {PendingRequestId} for {PendingHeroId}; game-thread queue {QueueDepth}",
+            data.RequestId, data.OneToOneConversationHeroId, pendingFireCompanionRequestId,
+            pendingFireCompanionHeroId, GameThread.Instance.QueueLength);
 
         // Roster corrections and this acknowledgement share the reliable ordered stream. Deferring all of
         // them to the game thread preserves that FIFO before the player can open the party screen.
@@ -311,7 +317,14 @@ internal class CompanionRolesHandler : IHandler
 
     private void SendCompletion(NetPeer requester, string requestId, string heroId, bool success, string error)
     {
-        network.Send(requester, new FireCompanionCompleted(requestId, heroId, success, error));
+        logger.Information(
+            "Sending immediate companion dismissal completion {RequestId} for {HeroId} to peer {PeerId}; success {Success}",
+            requestId, heroId, requester.Id, success);
+
+        // SendImmediate first flushes every message already buffered for this peer and then writes the
+        // completion directly on the same reliable ordered stream. The acknowledgement therefore cannot
+        // remain in the network aggregation buffer after the roster corrections it confirms.
+        network.SendImmediate(requester, new FireCompanionCompleted(requestId, heroId, success, error));
     }
 
     internal static void ReconcileDismissedCompanionRoster(TroopRoster memberRoster, CharacterObject character,

--- a/source/GameInterface/Services/Companions/Messages/NetworkCompanionRolesMessages.cs
+++ b/source/GameInterface/Services/Companions/Messages/NetworkCompanionRolesMessages.cs
@@ -40,11 +40,66 @@ internal readonly struct DoClanNameSelection : ICommand
 public readonly struct FireCompanion : IEvent
 {
     [ProtoMember(1)]
+    public readonly string RequestId;
+
+    [ProtoMember(2)]
     public readonly string OneToOneConversationHeroId;
 
-    public FireCompanion(string oneToOneConversationHeroId)
+    [ProtoMember(3)]
+    public readonly string ExpectedClanId;
+
+    [ProtoMember(4)]
+    public readonly string ExpectedPartyId;
+
+    public FireCompanion(string requestId, string oneToOneConversationHeroId,
+        string expectedClanId, string expectedPartyId)
     {
+        RequestId = requestId;
         OneToOneConversationHeroId = oneToOneConversationHeroId;
+        ExpectedClanId = expectedClanId;
+        ExpectedPartyId = expectedPartyId;
+    }
+}
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct FireCompanionCompleted : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string RequestId;
+
+    [ProtoMember(2)]
+    public readonly string OneToOneConversationHeroId;
+
+    [ProtoMember(3)]
+    public readonly bool Success;
+
+    [ProtoMember(4)]
+    public readonly string Error;
+
+    public FireCompanionCompleted(string requestId, string oneToOneConversationHeroId,
+        bool success, string error)
+    {
+        RequestId = requestId;
+        OneToOneConversationHeroId = oneToOneConversationHeroId;
+        Success = success;
+        Error = error;
+    }
+}
+
+internal readonly struct CompanionDismissalCompleted : IEvent
+{
+    public readonly string RequestId;
+    public readonly string OneToOneConversationHeroId;
+    public readonly bool Success;
+    public readonly string Error;
+
+    public CompanionDismissalCompleted(string requestId, string oneToOneConversationHeroId,
+        bool success, string error)
+    {
+        RequestId = requestId;
+        OneToOneConversationHeroId = oneToOneConversationHeroId;
+        Success = success;
+        Error = error;
     }
 }
 

--- a/source/GameInterface/Services/Companions/Patches/CompanionRolesPatches.cs
+++ b/source/GameInterface/Services/Companions/Patches/CompanionRolesPatches.cs
@@ -54,11 +54,6 @@ internal class CompanionRolesPatches
         var message = new CompanionFired(Hero.OneToOneConversationHero);
         MessageBroker.Instance.Publish(__instance, message);
 
-        if (PlayerEncounter.Current != null)
-        {
-            PlayerEncounter.LeaveEncounter = true;
-        }
-
         return false;
     }
 

--- a/source/GameInterface/Services/MapEvents/Interfaces/PlayerEncounterInterface.cs
+++ b/source/GameInterface/Services/MapEvents/Interfaces/PlayerEncounterInterface.cs
@@ -62,6 +62,9 @@ public class PlayerEncounterInterface : IPlayerEncounterInterface
                         EndPlayerEncounter(playerEncounter);
                         break;
                     default:
+                        // Begin/Wait and any future states are not after-battle work. Yield until the
+                        // next campaign tick instead of spinning forever when no player map event exists.
+                        playerEncounter._stateHandled = true;
                         break;
                 }
             }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Kicking a companion and immediately hiring a replacement can leave the dismissed companion in the Party screen, sometimes duplicated several times, while further conversation only offers to leave.

## What is the new behavior?

Resolves #2280

Kicking a companion now keeps the farewell encounter active until dismissal completes, removes every copy before the Party screen can reopen, and allows a replacement to join without restoring the dismissed companion.

## Bot Changelog Entry

- Fixed dismissed companions remaining or appearing multiple times in the player party after hiring a replacement.
