### PR TITLE
Reduce CI test time by sharding them

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,9 @@
 # corrupted by line-ending conversion.
 * text=auto eol=crlf
 
+# Shell scripts must keep LF line endings so POSIX shells can execute them.
+*.sh text eol=lf
+
 # Binary files: never apply text/line-ending conversion (it would corrupt them).
 *.png  binary
 *.jpg  binary

--- a/.github/scripts/run-e2e-local-docker.sh
+++ b/.github/scripts/run-e2e-local-docker.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+docker_image=${E2E_IMAGE:-garrettluskey/bannerlordcoop:latest}
+shard_count=${E2E_SHARDS:-8}
+run_id="bannerlordcoop-e2e-$(date +%s)-$$"
+seed_container="${run_id}-seed"
+local_image="${run_id}:workspace"
+status_dir=$(mktemp -d)
+container_names=()
+
+cleanup() {
+    for container_name in "${container_names[@]}"; do
+        docker rm --force "$container_name" >/dev/null 2>&1 || true
+    done
+    docker rm --force "$seed_container" >/dev/null 2>&1 || true
+    docker image rm "$local_image" >/dev/null 2>&1 || true
+    rm -rf "$status_dir"
+}
+trap cleanup EXIT INT TERM
+
+case "$shard_count" in
+    ''|*[!0-9]*|0)
+        echo "E2E_SHARDS must be a positive integer: $shard_count" >&2
+        exit 1
+        ;;
+esac
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "docker is required" >&2
+    exit 1
+fi
+if ! docker image inspect "$docker_image" >/dev/null 2>&1; then
+    echo "Docker image $docker_image is not available locally" >&2
+    echo "Pull it first with: docker pull $docker_image" >&2
+    exit 1
+fi
+
+echo "preparing one Docker test workspace from $docker_image"
+docker create --name "$seed_container" "$docker_image" /bin/sh -c 'sleep infinity' >/dev/null
+docker start "$seed_container" >/dev/null
+docker exec "$seed_container" /bin/sh -c 'mkdir -p /workspace'
+docker cp "$repo_root/source" "$seed_container:/workspace/source"
+docker cp "$repo_root/deploy" "$seed_container:/workspace/deploy"
+docker cp "$repo_root/.github/scripts/run-e2e-shard.sh" "$seed_container:/workspace/run-e2e-shard.sh"
+docker exec "$seed_container" /bin/sh -eu -c '
+    find /workspace/source -type d \( -name bin -o -name obj \) -prune -exec rm -rf {} +
+    ln -s /home/mb2 /workspace/mb2
+    dotnet build /workspace/source/CoopTests.slnf -c Release
+'
+docker commit "$seed_container" "$local_image" >/dev/null
+docker rm --force "$seed_container" >/dev/null
+
+echo "running $shard_count Docker E2E shards"
+for ((shard_index = 0; shard_index < shard_count; shard_index++)); do
+    container_name="${run_id}-${shard_index}"
+    container_names+=("$container_name")
+    docker run --rm --name "$container_name" "$local_image" /bin/sh -eu -c \
+        "cd /workspace/source && sh /workspace/run-e2e-shard.sh $shard_index $shard_count" \
+        >"$status_dir/$shard_index.log" 2>&1 &
+    echo "$!" > "$status_dir/$shard_index.pid"
+done
+
+failed=0
+for ((shard_index = 0; shard_index < shard_count; shard_index++)); do
+    if ! wait "$(<"$status_dir/$shard_index.pid")"; then
+        failed=1
+    fi
+    sed "s/^/[e2e $shard_index] /" "$status_dir/$shard_index.log"
+done
+
+if ((failed)); then
+    echo "one or more local Docker E2E shards failed" >&2
+    exit 1
+fi
+
+echo "all local Docker E2E shards passed"

--- a/.github/scripts/run-e2e-shard.sh
+++ b/.github/scripts/run-e2e-shard.sh
@@ -1,23 +1,36 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
-set -euo pipefail
+set -eu
 
 shard_index=${1:?missing shard index}
 shard_count=${2:?missing shard count}
 dotnet_cmd=${DOTNET:-dotnet}
 
-if ((shard_index < 0 || shard_index >= shard_count)); then
+case "$shard_index" in
+    ''|*[!0-9]*)
+        echo "shard index must be a non-negative integer: $shard_index" >&2
+        exit 1
+        ;;
+esac
+case "$shard_count" in
+    ''|*[!0-9]*|0)
+        echo "shard count must be a positive integer: $shard_count" >&2
+        exit 1
+        ;;
+esac
+if [ "$shard_index" -ge "$shard_count" ]; then
     echo "shard index must be between 0 and $((shard_count - 1)): $shard_index" >&2
     exit 1
 fi
 
-start_seconds=$SECONDS
+start_seconds=$(date +%s)
 test_project="E2E.Tests/E2E.Tests.csproj"
 # E2E tests generate AutoSync source files, so every shard must run in its own
 # GitHub workspace. Do not run multiple shards concurrently from one checkout.
 test_list=$(mktemp)
 method_counts=$(mktemp)
-trap 'rm -f "$test_list" "$method_counts"' EXIT
+assignments=$(mktemp)
+trap 'rm -f "$test_list" "$method_counts" "$assignments"' 0 1 2 3 15
 
 "$dotnet_cmd" test "$test_project" \
     -c Release \
@@ -27,7 +40,7 @@ trap 'rm -f "$test_list" "$method_counts"' EXIT
     --verbosity quiet 2>&1 \
     | awk '/^    E2E\.Tests\./ { sub(/^    /, ""); print }' > "$test_list"
 
-if [[ ! -s "$test_list" ]]; then
+if [ ! -s "$test_list" ]; then
     echo "test discovery returned no E2E tests" >&2
     exit 1
 fi
@@ -57,42 +70,47 @@ awk 'BEGIN { invalid = 0 }
         for (method_name in counts) print method_name "\t" counts[method_name]
     }' \
     "$test_list" \
-    | sort -t $'\t' -k2,2nr -k1,1 > "$method_counts"
+    | sort -t "$(printf '\t')" -k2,2nr -k1,1 > "$method_counts"
 
-declare -a shard_loads
-declare -a shard_filters
-for ((i = 0; i < shard_count; i++)); do
-    shard_loads[i]=0
-    shard_filters[i]=""
-done
+awk -F "$(printf '\t')" -v shard_count="$shard_count" '
+    BEGIN {
+        for (i = 0; i < shard_count; i++)
+            loads[i] = 0
+    }
+    {
+        target = 0
+        for (i = 1; i < shard_count; i++) {
+            if (loads[i] < loads[target])
+                target = i
+        }
+        if (filters[target] != "")
+            filters[target] = filters[target] "|"
+        filters[target] = filters[target] "FullyQualifiedName~" $1
+        loads[target] += $2
+    }
+    END {
+        for (i = 0; i < shard_count; i++)
+            print i "\t" loads[i] "\t" filters[i]
+    }' "$method_counts" > "$assignments"
 
-while IFS=$'\t' read -r method_name test_count; do
-    target_shard=0
-    for ((i = 1; i < shard_count; i++)); do
-        if ((shard_loads[i] < shard_loads[target_shard])); then
-            target_shard=$i
-        fi
-    done
+assignment=$(awk -F "$(printf '\t')" -v shard_index="$shard_index" \
+    '$1 == shard_index { print; found = 1 } END { if (!found) exit 1 }' "$assignments")
+case "$assignment" in
+    "")
+        echo "shard $shard_index has no assigned E2E tests" >&2
+        exit 1
+        ;;
+esac
 
-    if [[ -n "${shard_filters[target_shard]}" ]]; then
-        shard_filters[target_shard]+="|"
-    fi
-    shard_filters[target_shard]+="FullyQualifiedName~$method_name"
-    shard_loads[target_shard]=$((shard_loads[target_shard] + test_count))
-done < "$method_counts"
-
-if [[ -z "${shard_filters[shard_index]}" ]]; then
-    echo "shard $shard_index has no assigned E2E tests" >&2
-    exit 1
-fi
-
-echo "running E2E shard $shard_index/$shard_count with ${shard_loads[shard_index]} discovered test cases"
+assigned_case_count=$(printf '%s\n' "$assignment" | cut -f2)
+shard_filter=$(printf '%s\n' "$assignment" | cut -f3-)
+echo "running E2E shard $shard_index/$shard_count with $assigned_case_count discovered test cases"
 "$dotnet_cmd" test "$test_project" \
     -c Release \
     --no-build \
     --no-restore \
-    --filter "${shard_filters[shard_index]}" \
+    --filter "$shard_filter" \
     --consoleLoggerParameters:ErrorsOnly
 
-elapsed_seconds=$((SECONDS - start_seconds))
+elapsed_seconds=$(( $(date +%s) - start_seconds ))
 echo "E2E shard $shard_index completed in ${elapsed_seconds}s"

--- a/.github/scripts/run-e2e-shard.sh
+++ b/.github/scripts/run-e2e-shard.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+shard_index=${1:?missing shard index}
+shard_count=${2:?missing shard count}
+dotnet_cmd=${DOTNET:-dotnet}
+
+if ((shard_index < 0 || shard_index >= shard_count)); then
+    echo "shard index must be between 0 and $((shard_count - 1)): $shard_index" >&2
+    exit 1
+fi
+
+start_seconds=$SECONDS
+test_project="E2E.Tests/E2E.Tests.csproj"
+# E2E tests generate AutoSync source files, so every shard must run in its own
+# GitHub workspace. Do not run multiple shards concurrently from one checkout.
+test_list=$(mktemp)
+method_counts=$(mktemp)
+trap 'rm -f "$test_list" "$method_counts"' EXIT
+
+"$dotnet_cmd" test "$test_project" \
+    -c Release \
+    --no-build \
+    --no-restore \
+    --list-tests \
+    --verbosity quiet 2>&1 \
+    | awk '/^    E2E\.Tests\./ { sub(/^    /, ""); print }' > "$test_list"
+
+if [[ ! -s "$test_list" ]]; then
+    echo "test discovery returned no E2E tests" >&2
+    exit 1
+fi
+
+awk 'BEGIN { invalid = 0 }
+    {
+        sub(/\r$/, "")
+        field_count = split($0, fields, "[.]")
+        method_name = ""
+        for (i = 3; i < field_count; i++) {
+            if (fields[i] ~ /Tests?$/ && fields[i + 1] ~ /^[A-Za-z_]/) {
+                for (j = 1; j <= i + 1; j++)
+                    method_name = method_name (j == 1 ? "" : ".") fields[j]
+                break
+            }
+        }
+        if (method_name == "") {
+            print "unable to determine test method: " $0 > "/dev/stderr"
+            invalid = 1
+        } else {
+            sub(/\(.*/, "", method_name)
+            counts[method_name]++
+        }
+    }
+    END {
+        if (invalid) exit 1
+        for (method_name in counts) print method_name "\t" counts[method_name]
+    }' \
+    "$test_list" \
+    | sort -t $'\t' -k2,2nr -k1,1 > "$method_counts"
+
+declare -a shard_loads
+declare -a shard_filters
+for ((i = 0; i < shard_count; i++)); do
+    shard_loads[i]=0
+    shard_filters[i]=""
+done
+
+while IFS=$'\t' read -r method_name test_count; do
+    target_shard=0
+    for ((i = 1; i < shard_count; i++)); do
+        if ((shard_loads[i] < shard_loads[target_shard])); then
+            target_shard=$i
+        fi
+    done
+
+    if [[ -n "${shard_filters[target_shard]}" ]]; then
+        shard_filters[target_shard]+="|"
+    fi
+    shard_filters[target_shard]+="FullyQualifiedName~$method_name"
+    shard_loads[target_shard]=$((shard_loads[target_shard] + test_count))
+done < "$method_counts"
+
+if [[ -z "${shard_filters[shard_index]}" ]]; then
+    echo "shard $shard_index has no assigned E2E tests" >&2
+    exit 1
+fi
+
+echo "running E2E shard $shard_index/$shard_count with ${shard_loads[shard_index]} discovered test cases"
+"$dotnet_cmd" test "$test_project" \
+    -c Release \
+    --no-build \
+    --no-restore \
+    --filter "${shard_filters[shard_index]}" \
+    --consoleLoggerParameters:ErrorsOnly
+
+elapsed_seconds=$((SECONDS - start_seconds))
+echo "E2E shard $shard_index completed in ${elapsed_seconds}s"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -83,10 +83,52 @@ jobs:
 
       # Restore recreates the NuGet assets (obj/) that --no-build project evaluation needs;
       # the binaries under bin/ come from the build job's artifact, so nothing is recompiled.
-      - name: Restore
+      - name: Restore Test Assets
         working-directory: source
         run: dotnet restore CoopTests.slnf
 
       - name: Run Unit Tests
         working-directory: source
-        run: dotnet test CoopTests.slnf -c Release --no-build --consoleLoggerParameters:ErrorsOnly
+        run: dotnet test CoopUnitTests.slnf -c Release --no-build --no-restore --consoleLoggerParameters:ErrorsOnly
+
+  e2e:
+    name: E2E Tests (${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63]
+
+    container:
+      image: garrettluskey/bannerlordcoop:latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Link Game Assemblies Folder
+        run: ln -s /home/mb2 mb2
+
+      - name: Cache NuGet Packages
+        uses: actions/cache@v6
+        with:
+          path: ${{ github.workspace }}/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('source/**/*.csproj') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
+      - name: Download Build Output
+        uses: actions/download-artifact@v8
+        with:
+          name: build-output
+          path: source
+
+      - name: Restore Test Assets
+        working-directory: source
+        run: dotnet restore CoopTests.slnf
+
+      - name: Run E2E Test Shard
+        working-directory: source
+        run: bash ../.github/scripts/run-e2e-shard.sh "${{ matrix.shard }}" 64

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -99,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
 
     container:
       image: garrettluskey/bannerlordcoop:latest
@@ -131,4 +131,4 @@ jobs:
 
       - name: Run E2E Test Shard
         working-directory: source
-        run: sh ../.github/scripts/run-e2e-shard.sh "${{ matrix.shard }}" 24
+        run: sh ../.github/scripts/run-e2e-shard.sh "${{ matrix.shard }}" 8

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -99,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
 
     container:
       image: garrettluskey/bannerlordcoop:latest
@@ -131,4 +131,4 @@ jobs:
 
       - name: Run E2E Test Shard
         working-directory: source
-        run: sh ../.github/scripts/run-e2e-shard.sh "${{ matrix.shard }}" 64
+        run: sh ../.github/scripts/run-e2e-shard.sh "${{ matrix.shard }}" 24

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -131,4 +131,4 @@ jobs:
 
       - name: Run E2E Test Shard
         working-directory: source
-        run: bash ../.github/scripts/run-e2e-shard.sh "${{ matrix.shard }}" 64
+        run: sh ../.github/scripts/run-e2e-shard.sh "${{ matrix.shard }}" 64

--- a/source/Coop.Tests/Server/Services/Time/CampaignTimeSyncHandlerTests.cs
+++ b/source/Coop.Tests/Server/Services/Time/CampaignTimeSyncHandlerTests.cs
@@ -5,7 +5,6 @@ using GameInterface.Services.Time.Interfaces;
 using Moq;
 using System;
 using System.Threading;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Coop.Tests.Server.Services.Time;
@@ -38,22 +37,32 @@ public class CampaignTimeSyncHandlerTests
 
         Assert.True(sendStarted.Wait(TimeSpan.FromSeconds(5)));
 
-        var disposeTask = Task.Run(() =>
+        Exception disposeException = null;
+        var disposeThread = new Thread(() =>
         {
-            disposeStarted.Set();
-            handler.Dispose();
+            try
+            {
+                disposeStarted.Set();
+                handler.Dispose();
+            }
+            catch (Exception ex)
+            {
+                disposeException = ex;
+            }
         });
+        disposeThread.Start();
 
         try
         {
             Assert.True(disposeStarted.Wait(TimeSpan.FromSeconds(5)));
-            Assert.False(disposeTask.Wait(TimeSpan.FromMilliseconds(250)));
+            Assert.False(disposeThread.Join(TimeSpan.FromMilliseconds(250)));
         }
         finally
         {
             releaseSend.Set();
+            Assert.True(disposeThread.Join(TimeSpan.FromSeconds(5)));
         }
 
-        Assert.True(disposeTask.Wait(TimeSpan.FromSeconds(5)));
+        Assert.Null(disposeException);
     }
 }

--- a/source/CoopUnitTests.slnf
+++ b/source/CoopUnitTests.slnf
@@ -1,0 +1,11 @@
+{
+  "solution": {
+    "path": "Coop.sln",
+    "projects": [
+      "Common.Tests\\Common.Tests.csproj",
+      "Coop.Tests\\Coop.Tests.csproj",
+      "Coop.IntegrationTests\\Coop.IntegrationTests.csproj",
+      "GameInterface.Tests\\GameInterface.Tests.csproj"
+    ]
+  }
+}


### PR DESCRIPTION
Split the E2E suite across 64 isolated jobs and run the non-E2E tests from a focused solution filter.

The E2E launcher uses POSIX sh because the CI container does not include bash.

Also fixed flaky test