### PR TITLE
[2309] Optimize field battle network traffic (should fix issue where NPCs in a field battle are afk for nonhost clients)

### DIFF
--- a/source/Common/PacketHandlers/IPacket.cs
+++ b/source/Common/PacketHandlers/IPacket.cs
@@ -20,7 +20,9 @@ namespace Common.PacketHandlers
         AgentAction,
         MountMovement,
         AggregateMessage,
-        CampaignTime
+        CampaignTime,
+        AgentEquipment,
+        CompressedMovement
     }
 
     public interface IPacket

--- a/source/Coop.IntegrationTests/Missions/MissionDisconnectDetectionTests.cs
+++ b/source/Coop.IntegrationTests/Missions/MissionDisconnectDetectionTests.cs
@@ -150,6 +150,7 @@ public class MissionDisconnectDetectionTests
         var packetManager = new Mock<IPacketManager>();
         var controllerIdProvider = new Mock<IControllerIdProvider>();
         var steamBridge = new Mock<ISteamMissionBridge>();
+        var movementPacketCompressor = new Mock<IMovementPacketCompressor>();
 
         var client = new LiteNetP2PClient(
             config.Object,
@@ -159,7 +160,8 @@ public class MissionDisconnectDetectionTests
             messageBroker.Object,
             packetManager.Object,
             controllerIdProvider.Object,
-            steamBridge.Object);
+            steamBridge.Object,
+            movementPacketCompressor.Object);
 
         var droppedPeer = CreatePeer(new IPEndPoint(IPAddress.Loopback, 55001), 1);
 

--- a/source/Coop.Steam/ISteamTunnelTransport.cs
+++ b/source/Coop.Steam/ISteamTunnelTransport.cs
@@ -31,7 +31,7 @@ public static class SteamTunnel
     /// Effective send-rate floor. This Steam build stays near its minimum while saturated, so the
     /// elevated floor keeps large join saves from taking minutes.
     /// </summary>
-    public const int SendRateMinBytesPerSecond = 2 * 1024 * 1024;
+    public const int SendRateMinBytesPerSecond = 4 * 1024 * 1024;
 
     /// <summary>Ceiling for Steam's send pacing, headroom above the floor.</summary>
     public const int SendRateMaxBytesPerSecond = 20 * 1024 * 1024;

--- a/source/Coop.Tests/Steam/SteamNetworkingTunnelTransportBaseTests.cs
+++ b/source/Coop.Tests/Steam/SteamNetworkingTunnelTransportBaseTests.cs
@@ -1,4 +1,4 @@
-using Coop.Steam;
+﻿using Coop.Steam;
 using Moq;
 using Serilog;
 using Steamworks;
@@ -11,6 +11,12 @@ namespace Coop.Tests.Steam
 {
     public class SteamNetworkingTunnelTransportBaseTests
     {
+        [Fact]
+        public void SendRateFloor_IsFourMiBPerSecond()
+        {
+            Assert.Equal(4 * 1024 * 1024, SteamTunnel.SendRateMinBytesPerSecond);
+        }
+
         [Fact]
         public void ClosedSubscriberThrows_StillClosesAndForgetsConnection()
         {

--- a/source/E2E.Tests/Services/Missions/BattleMountIdentityTests.cs
+++ b/source/E2E.Tests/Services/Missions/BattleMountIdentityTests.cs
@@ -420,6 +420,54 @@ public class BattleMountIdentityTests : MissionTestEnvironment
         });
     }
 
+    [Fact]
+    public void JoinerReplay_CarriesTakenMountsSeparateMovementIdentity()
+    {
+        using var fixture = new MissionEngineFixture();
+        var owner = Clients.First();
+        var joiner = Clients.Skip(1).First();
+        SetControllerId(owner, "owner");
+        SetControllerId(joiner, "joiner");
+
+        var characterId = CreateRegisteredObject<CharacterObject>();
+        var riderId = Guid.NewGuid();
+        var mountId = Guid.NewGuid();
+
+        owner.Call(() =>
+        {
+            var mock = fixture.CreateMission(owner);
+            mock.SpawnMounted = true;
+            var controller = owner.Resolve<CoopBattleController>();
+            var registry = owner.Resolve<INetworkAgentRegistry>();
+
+            Assert.True(owner.ObjectManager.TryGetObject<CharacterObject>(characterId, out var character));
+            var rider = mock.SpawnAgent(new AgentBuildData(character).Controller(AgentControllerType.AI));
+            var mount = rider.MountAgent;
+            Assert.NotNull(mount);
+
+            Assert.True(registry.TryRegisterAgent(
+                "owner", "rider-origin", "rider-origin:epoch-1",
+                riderId, 21, rider));
+            Assert.True(registry.TryRegisterAgent(
+                "owner", "mount-origin", "mount-origin:epoch-4",
+                mountId, 9, mount));
+
+            owner.Resolve<IMessageBroker>().Publish(this, new NetworkMissionPeerEntered("joiner", null));
+
+            var record = joiner.InternalMessages.GetMessages<NetworkSpawnBattleAgents>().Last().Agents.Single();
+            Assert.Equal(riderId, record.AgentId);
+            Assert.Equal("rider-origin", record.OriginalOwnerControllerId);
+            Assert.Equal("rider-origin:epoch-1", record.MovementScopeId);
+            Assert.Equal((ushort)21, record.MovementId);
+            Assert.Equal(mountId, record.MountAgentId);
+            Assert.Equal("mount-origin", record.MountOriginalOwnerControllerId);
+            Assert.Equal("mount-origin:epoch-4", record.MountMovementScopeId);
+            Assert.Equal((ushort)9, record.MountMovementId);
+
+            GC.KeepAlive(controller);
+        });
+    }
+
     /// <summary>The owner broadcasts a registered horse's OWN movement only while nothing rides it — a ridden
     /// horse's pose travels in its rider's MountData, but a masterless one has no other driver.</summary>
     [Fact]

--- a/source/E2E.Tests/Services/Missions/MovementTrafficTests.cs
+++ b/source/E2E.Tests/Services/Missions/MovementTrafficTests.cs
@@ -22,7 +22,12 @@ namespace E2E.Tests.Services.Missions;
 /// <summary>Regression coverage for movement traffic and delivery selection.</summary>
 public class MovementTrafficTests : MissionTestEnvironment
 {
-    public MovementTrafficTests(ITestOutputHelper output) : base(output) { }
+    private readonly ITestOutputHelper output;
+
+    public MovementTrafficTests(ITestOutputHelper output) : base(output)
+    {
+        this.output = output;
+    }
 
     [Fact]
     public void PollMovement_UsesFortyHertzCadenceAndThreeAgentBatches()
@@ -39,7 +44,8 @@ public class MovementTrafficTests : MissionTestEnvironment
             var network = Assert.IsType<MockBattleNetwork>(peer.Resolve<IBattleNetwork>());
 
             for (int i = 0; i < 4; i++)
-                Assert.True(registry.TryRegisterAgent("peer", Guid.NewGuid(), SpawnRider(mock)));
+                Assert.True(registry.TryRegisterAgent(
+                    "peer", Guid.NewGuid(), (ushort)(i + 1), SpawnRider(mock)));
 
             component.AgentMovementHandler.PollMovement(0f);
             Assert.Equal(new[] { 3, 1 }, network.NetworkSentPackets
@@ -77,30 +83,147 @@ public class MovementTrafficTests : MissionTestEnvironment
             var registry = peer.Resolve<INetworkAgentRegistry>();
             var component = peer.Resolve<ICoopMissionComponent>();
             var network = Assert.IsType<MockBattleNetwork>(peer.Resolve<IBattleNetwork>());
-            var agentIds = new List<Guid>();
+            var movementIds = new List<ushort>();
 
             for (int i = 0; i < 125; i++)
             {
                 Agent agent = SpawnRider(mock);
                 Guid agentId = Guid.NewGuid();
-                Assert.True(registry.TryRegisterAgent("peer", agentId, agent));
-                agentIds.Add(agentId);
+                ushort movementId = (ushort)(i + 1);
+                Assert.True(registry.TryRegisterAgent(
+                    "peer", agentId, movementId, agent));
+                movementIds.Add(movementId);
             }
 
             component.AgentMovementHandler.PollMovement(0f);
             MovementPacket[] packets = network.NetworkSentPackets
                 .GetPackets<MovementPacket>()
                 .ToArray();
-            Assert.Equal((agentIds.Count + 2) / 3, packets.Length);
+            Assert.Equal((movementIds.Count + 2) / 3, packets.Length);
             Assert.All(packets, packet => Assert.InRange(packet.AgentIds.Length, 1, 3));
 
-            Guid[] sentAgents = packets
+            ushort[] sentAgents = packets
                 .SelectMany(packet => packet.AgentIds)
                 .ToArray();
-            Assert.Equal(agentIds.Count, sentAgents.Length);
+            Assert.Equal(movementIds.Count, sentAgents.Length);
             Assert.Equal(sentAgents.Length, sentAgents.Distinct().Count());
-            Assert.All(agentIds, id => Assert.Contains(id, sentAgents));
+            Assert.All(movementIds, id => Assert.Contains(id, sentAgents));
         });
+    }
+
+    [Fact]
+    public void PollMovement_SeedsSpawnEquipmentAndOnlySendsChanges()
+    {
+        using var fixture = new MissionEngineFixture();
+        var peer = Clients.First();
+        SetControllerId(peer, "peer");
+
+        peer.Call(() =>
+        {
+            var mock = fixture.CreateMission(peer);
+            var registry = peer.Resolve<INetworkAgentRegistry>();
+            var component = peer.Resolve<ICoopMissionComponent>();
+            var network = Assert.IsType<MockBattleNetwork>(peer.Resolve<IBattleNetwork>());
+            Agent agent = SpawnRider(mock);
+            Assert.True(AgentMirror.TryGet(agent, out var mirror));
+            Assert.True(registry.TryRegisterAgent(
+                "peer", Guid.NewGuid(), 1, agent));
+
+            component.AgentMovementHandler.PollMovement(0f);
+            Assert.Empty(
+                network.NetworkSentPackets.GetPackets<AgentEquipmentPacket>());
+
+            network.NetworkSentPackets.Packets.Clear();
+            component.AgentMovementHandler.PollMovement(0.025f);
+            Assert.Empty(
+                network.NetworkSentPackets.GetPackets<AgentEquipmentPacket>());
+
+            mirror.PrimaryWieldedItemIndex = EquipmentIndex.Weapon2;
+            component.AgentMovementHandler.PollMovement(0.025f);
+            var changed = Assert.Single(
+                network.NetworkSentPackets.GetPackets<AgentEquipmentPacket>());
+            Assert.Equal("peer", changed.IdentityScopeId);
+            Assert.Equal(new ushort[] { 1 }, changed.AgentIds);
+        });
+    }
+
+    [Fact]
+    public void PollMovement_SendsInitialEquipmentForLegacyGuidAgents()
+    {
+        using var fixture = new MissionEngineFixture();
+        var peer = Clients.First();
+        SetControllerId(peer, "peer");
+
+        peer.Call(() =>
+        {
+            var mock = fixture.CreateMission(peer);
+            var registry = peer.Resolve<INetworkAgentRegistry>();
+            var component = peer.Resolve<ICoopMissionComponent>();
+            var network = Assert.IsType<MockBattleNetwork>(peer.Resolve<IBattleNetwork>());
+            Guid agentId = Guid.NewGuid();
+            Assert.True(registry.TryRegisterAgent("peer", agentId, SpawnRider(mock)));
+
+            component.AgentMovementHandler.PollMovement(0f);
+
+            var initial = Assert.Single(
+                network.NetworkSentPackets.GetPackets<AgentEquipmentPacket>());
+            Assert.Equal(new[] { agentId }, initial.AgentGuids);
+        });
+    }
+
+    [Fact]
+    public void Lz4MovementCompression_RoundTripsRepresentativeThreeAgentPacket()
+    {
+        using var fixture = new MissionEngineFixture();
+        var peer = Clients.First();
+
+        peer.Call(() =>
+        {
+            var mock = fixture.CreateMission(peer);
+            var agents = new AgentData[3];
+            for (int i = 0; i < agents.Length; i++)
+            {
+                Agent rider = SpawnRider(mock);
+                Assert.True(AgentMirror.TryGet(rider, out var mirror));
+                PopulateMovementState(mirror, i + 1);
+                agents[i] = new AgentData(rider);
+            }
+
+            var serializer = new ProtoBufSerializer(new SerializableTypeMapper());
+            var compressor = new MovementPacketCompressor(serializer);
+            var movement = new MovementPacket(
+                "76561198000000042",
+                new ushort[] { 1, 2, 3 },
+                agents);
+
+            byte[] original = serializer.Serialize(movement);
+            byte[] wire = compressor.Serialize(movement);
+            output.WriteLine(
+                $"Three-agent movement packet: {original.Length} bytes compact, {wire.Length} bytes LZ4");
+
+            Assert.Equal(wire.Length, compressor.GetSerializedLength(movement));
+            Assert.True(wire.Length < original.Length,
+                $"LZ4 envelope was {wire.Length} bytes for {original.Length} input bytes");
+            IPacket envelope = serializer.Deserialize<IPacket>(wire);
+            Assert.IsType<CompressedMovementPacket>(envelope);
+            Assert.True(compressor.TryRestore(envelope, out var restored));
+
+            var roundTripped = Assert.IsType<MovementPacket>(restored);
+            Assert.Equal(movement.IdentityScopeId, roundTripped.IdentityScopeId);
+            Assert.Equal(movement.AgentIds, roundTripped.AgentIds);
+            Assert.Equal(movement.Agents.Length, roundTripped.Agents.Length);
+            Assert.True(wire.Length <= LiteNetP2PClient.SafeSinglePacketBytes);
+        });
+    }
+
+    [Fact]
+    public void Lz4MovementCompression_RejectsCorruptEnvelope()
+    {
+        var serializer = new ProtoBufSerializer(new SerializableTypeMapper());
+        var compressor = new MovementPacketCompressor(serializer);
+        var corrupt = new CompressedMovementPacket(512, new byte[] { 1, 2, 3 });
+
+        Assert.False(compressor.TryRestore(corrupt, out _));
     }
 
     [Fact]
@@ -112,7 +235,7 @@ public class MovementTrafficTests : MissionTestEnvironment
         peer.Call(() =>
         {
             var mock = fixture.CreateMission(peer);
-            var ids = new Guid[3];
+            var ids = new ushort[3];
             var riders = new AgentData[3];
             var mounts = new AgentMountData[3];
 
@@ -124,15 +247,18 @@ public class MovementTrafficTests : MissionTestEnvironment
                 Assert.True(AgentMirror.TryGet(mount, out var mountMirror));
                 PopulateMovementState(riderMirror, i + 1);
                 PopulateMovementState(mountMirror, i + 1);
-                ids[i] = Guid.NewGuid();
-                var mountId = Guid.NewGuid();
+                ids[i] = (ushort)(i + 1);
+                ushort mountId = (ushort)(i + 101);
                 riders[i] = new AgentData(rider, mountId);
                 mounts[i] = new AgentMountData(mount, mountId);
             }
 
             var serializer = new ProtoBufSerializer(new SerializableTypeMapper());
-            AssertFitsRelay(serializer, new MovementPacket(ids, riders));
-            AssertFitsRelay(serializer, new MountMovementPacket(ids, mounts));
+            var compressor = new MovementPacketCompressor(serializer);
+            AssertFitsRelay(serializer, compressor,
+                new MovementPacket("76561198000000042", ids, riders));
+            AssertFitsRelay(serializer, compressor,
+                new MountMovementPacket("76561198000000042", ids, mounts));
         });
     }
 
@@ -159,9 +285,12 @@ public class MovementTrafficTests : MissionTestEnvironment
             LiteNetP2PClient.SelectDeliveryMethod(ordinaryUnreliable, datagramCeiling - 1, 0));
     }
 
-    private static void AssertFitsRelay(ProtoBufSerializer serializer, IPacket packet)
+    private static void AssertFitsRelay(
+        ProtoBufSerializer serializer,
+        MovementPacketCompressor compressor,
+        IPacket packet)
     {
-        byte[] payload = serializer.Serialize(packet);
+        byte[] payload = compressor.Serialize(packet);
         Assert.True(payload.Length <= LiteNetP2PClient.SafeSinglePacketBytes,
             $"Direct payload was {payload.Length} bytes");
 

--- a/source/E2E.Tests/Services/Missions/MovementTrafficTests.cs
+++ b/source/E2E.Tests/Services/Missions/MovementTrafficTests.cs
@@ -201,7 +201,6 @@ public class MovementTrafficTests : MissionTestEnvironment
             output.WriteLine(
                 $"Three-agent movement packet: {original.Length} bytes compact, {wire.Length} bytes LZ4");
 
-            Assert.Equal(wire.Length, compressor.GetSerializedLength(movement));
             Assert.True(wire.Length < original.Length,
                 $"LZ4 envelope was {wire.Length} bytes for {original.Length} input bytes");
             IPacket envelope = serializer.Deserialize<IPacket>(wire);

--- a/source/E2E.Tests/Services/Missions/NetworkAgentRegistryTests.cs
+++ b/source/E2E.Tests/Services/Missions/NetworkAgentRegistryTests.cs
@@ -1,4 +1,4 @@
-using Common.Util;
+﻿using Common.Util;
 using GameInterface.Services.Entity;
 using Missions;
 using Moq;
@@ -92,5 +92,63 @@ public class NetworkAgentRegistryTests
         var registry = NewRegistry(localControllerId: "me");
 
         Assert.False(registry.TryTransferAuthority("me", Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void CompactMovementIdentity_StaysInMovementScopeAfterTransfer()
+    {
+        var registry = NewRegistry(localControllerId: "successor");
+        var agent = ObjectHelper.SkipConstructor<Agent>();
+        Guid agentId = Guid.NewGuid();
+
+        Assert.True(registry.TryRegisterAgent("host", agentId, 42, agent));
+        Assert.True(registry.TryTransferAuthority("successor", agentId));
+
+        Assert.True(registry.TryGetAgentInfo("host", 42, out var resolved));
+        Assert.Same(agent, resolved.Agent);
+        Assert.Equal("host", resolved.OriginalOwner);
+        Assert.Equal("host", resolved.MovementScopeId);
+        Assert.Equal("successor", resolved.CurrentAuthority);
+    }
+
+    [Fact]
+    public void CompactMovementIdentity_IsUniqueWithinMovementScope()
+    {
+        var registry = NewRegistry(localControllerId: "me");
+
+        Assert.True(registry.TryRegisterAgent(
+            "host", "host", "host:epoch-1", Guid.NewGuid(), 7,
+            ObjectHelper.SkipConstructor<Agent>()));
+        Assert.False(registry.TryRegisterAgent(
+            "host", "host", "host:epoch-1", Guid.NewGuid(), 7,
+            ObjectHelper.SkipConstructor<Agent>()));
+        Assert.True(registry.TryRegisterAgent(
+            "host", "host", "host:epoch-2", Guid.NewGuid(), 7,
+            ObjectHelper.SkipConstructor<Agent>()));
+    }
+
+    [Fact]
+    public void CatchUpRegistration_PreservesSeparateRiderAndMountMovementScopes()
+    {
+        var registry = NewRegistry(localControllerId: "observer");
+        var rider = ObjectHelper.SkipConstructor<Agent>();
+        var mount = ObjectHelper.SkipConstructor<Agent>();
+
+        Assert.True(registry.TryRegisterAgent(
+            "successor", "rider-origin", "rider-origin:epoch-1",
+            Guid.NewGuid(), 11, rider));
+        Assert.True(registry.TryRegisterAgent(
+            "successor", "mount-origin", "mount-origin:epoch-4",
+            Guid.NewGuid(), 9, mount));
+
+        Assert.True(registry.TryGetAgentInfo("rider-origin:epoch-1", 11, out var resolvedRider));
+        Assert.Same(rider, resolvedRider.Agent);
+        Assert.Equal("rider-origin", resolvedRider.OriginalOwner);
+        Assert.Equal("successor", resolvedRider.CurrentAuthority);
+
+        Assert.True(registry.TryGetAgentInfo("mount-origin:epoch-4", 9, out var resolvedMount));
+        Assert.Same(mount, resolvedMount.Agent);
+        Assert.Equal("mount-origin", resolvedMount.OriginalOwner);
+        Assert.Equal("successor", resolvedMount.CurrentAuthority);
     }
 }

--- a/source/GameInterface/Services/MapEvents/Commands/BattleTeamKillCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/BattleTeamKillCommands.cs
@@ -409,33 +409,6 @@ coop battle LOSS.";
         return $"Killed {killed} agent(s) on the local player team.";
     }
 
-    private const string RouteEnemyTeamUsage =
-@"Usage:
-  coop.debug.mapevent.route_enemy_team
-
-Orders every live enemy-team AI agent to retreat from the current battle.";
-
-    [CommandLineArgumentFunction("route_enemy_team", "coop.debug.mapevent")]
-    public static string RouteEnemyTeam(List<string> args)
-    {
-        var ctx = new CommandContext("route_enemy_team", RouteEnemyTeamUsage, args);
-        if (!ctx.RequireArgCount(0, out var error))
-            return error;
-
-        if (!TryGetEnemyAgents(out var agents, out var failure))
-            return failure;
-
-        int routed = 0;
-        foreach (var agent in agents)
-        {
-            if (!agent.IsAIControlled) continue;
-            agent.Retreat(agent.GetRetreatPos());
-            routed++;
-        }
-
-        return $"Ordered {routed} enemy agent(s) to retreat.";
-    }
-
     /// <summary>Live agents on any team hostile to the player (host) team.</summary>
     private static bool TryGetEnemyAgents(out List<Agent> agents, out string failure)
     {

--- a/source/GameInterface/Services/MapEvents/Commands/BattleTeamKillCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/BattleTeamKillCommands.cs
@@ -409,6 +409,33 @@ coop battle LOSS.";
         return $"Killed {killed} agent(s) on the local player team.";
     }
 
+    private const string RouteEnemyTeamUsage =
+@"Usage:
+  coop.debug.mapevent.route_enemy_team
+
+Orders every live enemy-team AI agent to retreat from the current battle.";
+
+    [CommandLineArgumentFunction("route_enemy_team", "coop.debug.mapevent")]
+    public static string RouteEnemyTeam(List<string> args)
+    {
+        var ctx = new CommandContext("route_enemy_team", RouteEnemyTeamUsage, args);
+        if (!ctx.RequireArgCount(0, out var error))
+            return error;
+
+        if (!TryGetEnemyAgents(out var agents, out var failure))
+            return failure;
+
+        int routed = 0;
+        foreach (var agent in agents)
+        {
+            if (!agent.IsAIControlled) continue;
+            agent.Retreat(agent.GetRetreatPos());
+            routed++;
+        }
+
+        return $"Ordered {routed} enemy agent(s) to retreat.";
+    }
+
     /// <summary>Live agents on any team hostile to the player (host) team.</summary>
     private static bool TryGetEnemyAgents(out List<Agent> agents, out string failure)
     {

--- a/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
+++ b/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
@@ -2,11 +2,8 @@
 using Common;
 using Common.Logging;
 using Common.Messaging;
-using GameInterface.Registry.Auto;
 using GameInterface.Services.MapEvents;
-using GameInterface.Services.MapEvents.Messages.Leave;
 using GameInterface.Services.MobileParties.Extensions;
-using GameInterface.Services.MobileParties.Messages.Behavior;
 using GameInterface.Services.MobileParties.Patches;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Party.Commands;
@@ -22,9 +19,7 @@ using System.Linq;
 using System.Text;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Actions;
-using TaleWorlds.CampaignSystem.MapEvents;
 using TaleWorlds.CampaignSystem.Party;
-using TaleWorlds.CampaignSystem.Roster;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Core;
 using static TaleWorlds.CampaignSystem.Army;
@@ -36,34 +31,6 @@ namespace GameInterface.Services.SiegeEvents.Commands;
 public class SiegeDebugCommand
 {
     private static readonly ILogger Logger = LogManager.GetLogger<SiegeDebugCommand>();
-    private static ArmyReliefFixture armyReliefFixture;
-
-    private sealed class ArmyReliefFixture
-    {
-        public string ControllerId;
-        public Settlement Settlement;
-        public MobileParty PlayerParty;
-        public Army ReliefArmy;
-        public MapEvent MapEvent;
-        public IFaction PlayerFaction;
-        public IFaction DefenderFaction;
-        public bool WasAtWar;
-        public PartyFixtureState[] Parties;
-        public bool RequiresRecoveryMessages;
-        public bool RecoveryFinalizedPublished;
-        public bool RecoveryDestroyedPublished;
-    }
-
-    private sealed class PartyFixtureState
-    {
-        public PartyBase Party;
-        public MobileParty MobileParty;
-        public CampaignVec2 Position;
-        public float RecentEventsMorale;
-        public TroopRosterElement[] Members;
-        public TroopRosterElement[] Prisoners;
-        public Dictionary<Hero, int> HeroHitPoints;
-    }
 
     /// <summary>
     /// Creates a player-led siege and sends a multi-party defending army to interrupt it. Server only.
@@ -85,12 +52,6 @@ public class SiegeDebugCommand
         if (args.Count == 3 && (!int.TryParse(args[2], out armyPartyCount) || armyPartyCount < 2))
         {
             return "armyPartyCount must be at least 2";
-        }
-
-        if (armyReliefFixture != null)
-        {
-            return $"Army relief fixture already active for {armyReliefFixture.ControllerId} at " +
-                $"{armyReliefFixture.Settlement.Name}";
         }
 
         if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)
@@ -130,6 +91,11 @@ public class SiegeDebugCommand
             return $"{playerParty.Name} has no map faction";
         }
 
+        if (!playerParty.MapFaction.IsAtWarWith(settlement.MapFaction))
+        {
+            DeclareWarAction.ApplyByDefault(playerParty.MapFaction, settlement.MapFaction);
+        }
+
         var defenders = MobileParty.AllLordParties
             .Where(party => party.IsActive && !party.IsPlayerParty()
                 && party.MapFaction == settlement.MapFaction && party.LeaderHero != null
@@ -145,73 +111,37 @@ public class SiegeDebugCommand
             return $"Only found {defenders.Count} available {settlement.MapFaction.Name} lord parties; need {armyPartyCount}";
         }
 
-        var fixtureParties = new List<PartyBase> { settlement.Party };
-        fixtureParties.AddRange(defenders.Select(party => party.Party));
-        foreach (var connectedPlayer in playerManager.Players.Where(playerManager.IsConnected))
+        siegeEventInterface.StartSiegeEvent(playerParty, settlement);
+        foreach (var otherPlayer in playerManager.Players)
         {
-            if (objectManager.TryGetObject<MobileParty>(connectedPlayer.MobilePartyId, out var connectedParty))
-                fixtureParties.Add(connectedParty.Party);
+            if (otherPlayer.ControllerId == player.ControllerId || !playerManager.IsConnected(otherPlayer)) continue;
+            if (!objectManager.TryGetObjectWithLogging<MobileParty>(otherPlayer.MobilePartyId, out var otherParty)) continue;
+            if (otherParty.MapEvent != null || otherParty.BesiegerCamp != null) continue;
+            if (settlement.SiegeEvent?.CanPartyJoinSide(otherParty.Party, BattleSideEnum.Attacker) != true) continue;
+
+            siegeEventInterface.JoinSiegeCamp(otherParty, settlement);
         }
 
-        var fixture = new ArmyReliefFixture
+        var armyLeader = defenders[0];
+        kingdom.CreateArmy(armyLeader.LeaderHero, settlement, ArmyTypes.Defender);
+        var army = armyLeader.Army;
+        if (army == null)
         {
-            ControllerId = args[0],
-            Settlement = settlement,
-            PlayerParty = playerParty,
-            PlayerFaction = playerParty.MapFaction,
-            DefenderFaction = settlement.MapFaction,
-            WasAtWar = playerParty.MapFaction.IsAtWarWith(settlement.MapFaction),
-            Parties = fixtureParties.Distinct().Select(CapturePartyState).ToArray(),
-        };
-        armyReliefFixture = fixture;
-
-        if (!fixture.WasAtWar)
-        {
-            DeclareWarAction.ApplyByDefault(playerParty.MapFaction, settlement.MapFaction);
+            return $"Failed to create a relief army led by {armyLeader.Name}";
         }
 
-        try
+        armyLeader.Position = playerParty.Position;
+        foreach (var defender in defenders.Skip(1))
         {
-            siegeEventInterface.StartSiegeEvent(playerParty, settlement);
-            foreach (var otherPlayer in playerManager.Players)
-            {
-                if (otherPlayer.ControllerId == player.ControllerId || !playerManager.IsConnected(otherPlayer)) continue;
-                if (!objectManager.TryGetObjectWithLogging<MobileParty>(otherPlayer.MobilePartyId, out var otherParty)) continue;
-                if (otherParty.MapEvent != null || otherParty.BesiegerCamp != null) continue;
-                if (settlement.SiegeEvent?.CanPartyJoinSide(otherParty.Party, BattleSideEnum.Attacker) != true) continue;
-
-                siegeEventInterface.JoinSiegeCamp(otherParty, settlement);
-            }
-
-            var armyLeader = defenders[0];
-            kingdom.CreateArmy(armyLeader.LeaderHero, settlement, ArmyTypes.Defender);
-            var army = armyLeader.Army;
-            if (army == null)
-            {
-                throw new InvalidOperationException($"Failed to create a relief army led by {armyLeader.Name}");
-            }
-
-            fixture.ReliefArmy = army;
-            armyLeader.Position = playerParty.Position;
-            foreach (var defender in defenders.Skip(1))
-            {
-                defender.Position = playerParty.Position;
-                defender.Army = army;
-                army.AddPartyToMergedParties(defender);
-            }
-
-            StartBattleAction.Apply(armyLeader.Party, playerParty.Party);
-            fixture.MapEvent = playerParty.MapEvent;
-
-            return $"Started {settlement.Name} siege relief: {army.Name} with {army.Parties.Count} parties is attacking " +
-                $"{playerParty.Name}; connected friendly player parties joined the siege";
+            defender.Position = playerParty.Position;
+            defender.Army = army;
+            army.AddPartyToMergedParties(defender);
         }
-        catch (Exception e)
-        {
-            Logger.Error(e, "Failed to create the army relief fixture");
-            return $"Army relief fixture setup failed: {e.Message}. Run coop.debug.siege.army_relief_restore " +
-                $"{args[0]} {args[1]} after leaving any active mission.";
-        }
+
+        StartBattleAction.Apply(armyLeader.Party, playerParty.Party);
+
+        return $"Started {settlement.Name} siege relief: {army.Name} with {army.Parties.Count} parties is attacking " +
+            $"{playerParty.Name}; connected friendly player parties joined the siege";
     }
 
     [CommandLineArgumentFunction("army_relief_state", "coop.debug.siege")]
@@ -241,225 +171,10 @@ public class SiegeDebugCommand
             ? 0
             : mapEvent.InvolvedParties.Count(party => party.MobileParty?.Army == reliefArmy);
         bool reliefEncounterActive = mapEvent != null && reliefArmy != null;
-        bool fixtureMapEventFinalized = armyReliefFixture?.MapEvent?.IsFinalized == true;
         return $"siege={siegeActive} playerBesieger={playerBesieger} " +
             $"reliefArmyParties={involvedReliefParties} reliefArmyMembers={reliefArmy?.Parties.Count ?? 0} " +
             $"reliefEncounter={reliefEncounterActive} " +
-            $"playerMapEvent={mapEvent != null} fixtureActive={armyReliefFixture != null} " +
-            $"fixtureMapEventFinalized={fixtureMapEventFinalized}";
-    }
-
-    [CommandLineArgumentFunction("army_relief_restore", "coop.debug.siege")]
-    public static string RestoreArmyRelief(List<string> args)
-    {
-        if (ModInformation.IsClient)
-        {
-            return "This command can only be used by the server";
-        }
-
-        if (args.Count < 2 || args.Count > 3 || (args.Count == 3 && args[2] != "force"))
-        {
-            return "Usage: coop.debug.siege.army_relief_restore <controllerId> <settlementId> [force]";
-        }
-
-        var fixture = armyReliefFixture;
-        if (fixture == null || fixture.ControllerId != args[0] ||
-            fixture.Settlement.StringId != args[1])
-        {
-            return $"No active army relief fixture exists for {args[0]} at {args[1]}";
-        }
-
-        if (fixture.MapEvent != null && !fixture.MapEvent.IsFinalized)
-        {
-            if (args.Count != 3)
-            {
-                return "Army relief fixture is still in an active map event; leave the battle on both clients first";
-            }
-        }
-
-        if (!ContainerProvider.TryResolve<ISiegeEventInterface>(out var siegeEventInterface))
-        {
-            return "Unable to resolve SiegeEventInterface";
-        }
-
-        try
-        {
-            if (fixture.MapEvent != null && !fixture.MapEvent.IsFinalized)
-            {
-                try
-                {
-                    fixture.MapEvent.FinalizeEvent();
-                }
-                catch
-                {
-                    fixture.RequiresRecoveryMessages = fixture.MapEvent.IsFinalized;
-                    throw;
-                }
-            }
-            RecoverPartiallyFinalizedMapEvent(fixture);
-
-            if (fixture.PlayerParty.BesiegerCamp != null &&
-                fixture.Settlement.SiegeEvent != null)
-            {
-                siegeEventInterface.BreakSiege(fixture.PlayerParty);
-            }
-
-            if (fixture.ReliefArmy != null &&
-                fixture.ReliefArmy.Parties.Any(party => party.Army == fixture.ReliefArmy))
-            {
-                DisbandArmyAction.ApplyByObjectiveFinished(fixture.ReliefArmy);
-            }
-
-            foreach (var party in fixture.Parties)
-                RestorePartyState(party);
-
-            if (!fixture.WasAtWar &&
-                fixture.PlayerFaction.IsAtWarWith(fixture.DefenderFaction))
-            {
-                MakePeaceAction.Apply(fixture.PlayerFaction, fixture.DefenderFaction);
-            }
-
-            armyReliefFixture = null;
-            return $"Restored army relief fixture for {args[0]} at {fixture.Settlement.Name}: " +
-                $"parties={fixture.Parties.Length} siege={fixture.Settlement.SiegeEvent != null} " +
-                $"war={fixture.PlayerFaction.IsAtWarWith(fixture.DefenderFaction)}";
-        }
-        catch (Exception e)
-        {
-            Logger.Error(e, "Failed to restore the army relief fixture");
-            return $"Army relief fixture restore failed: {e.Message}. The fixture remains active for one retry.";
-        }
-    }
-
-    private static void RecoverPartiallyFinalizedMapEvent(ArmyReliefFixture fixture)
-    {
-        if (fixture.MapEvent == null)
-            return;
-
-        var attachedParties = GetAttachedParties(fixture);
-        bool hasAttachedParties = attachedParties.Length > 0 ||
-            fixture.MapEvent.AttackerSide?.Parties.Count > 0 ||
-            fixture.MapEvent.DefenderSide?.Parties.Count > 0;
-        if (hasAttachedParties)
-        {
-            fixture.RequiresRecoveryMessages = true;
-            foreach (var party in attachedParties)
-            {
-                if (party?._mapEventSide?.MapEvent != fixture.MapEvent)
-                    continue;
-
-                party._mapEventSide = null;
-                if (party.MobileParty != null)
-                    party.MobileParty.EventPositionAdder = TaleWorlds.Library.Vec2.Zero;
-                party.SetVisualAsDirty();
-            }
-
-            fixture.MapEvent.AttackerSide?.Clear();
-            fixture.MapEvent.DefenderSide?.Clear();
-            if (GetAttachedParties(fixture).Length > 0 ||
-                fixture.MapEvent.AttackerSide?.Parties.Count > 0 ||
-                fixture.MapEvent.DefenderSide?.Parties.Count > 0)
-            {
-                throw new InvalidOperationException("The partially finalized army relief fixture still has attached parties");
-            }
-        }
-
-        if (!fixture.RequiresRecoveryMessages)
-            return;
-
-        if (!fixture.RecoveryFinalizedPublished)
-        {
-            MessageBroker.Instance.Publish(fixture.MapEvent, new MapEventFinalized(fixture.MapEvent));
-            fixture.RecoveryFinalizedPublished = true;
-        }
-        if (!fixture.RecoveryDestroyedPublished)
-        {
-            MessageBroker.Instance.Publish(fixture.MapEvent, new InstanceDestroyed<MapEvent>(fixture.MapEvent));
-            fixture.RecoveryDestroyedPublished = true;
-        }
-    }
-
-    private static PartyBase[] GetAttachedParties(ArmyReliefFixture fixture)
-    {
-        var sideParties = fixture.MapEvent._sides
-            .Where(side => side != null)
-            .SelectMany(side => side.Parties ?? Enumerable.Empty<MapEventParty>())
-            .Select(mapEventParty => mapEventParty.Party);
-        return sideParties
-            .Concat(fixture.Parties.Select(state => state.Party))
-            .Where(party => party?._mapEventSide?.MapEvent == fixture.MapEvent)
-            .Distinct()
-            .ToArray();
-    }
-
-    private static PartyFixtureState CapturePartyState(PartyBase party)
-    {
-        var heroHitPoints = party.MemberRoster.GetTroopRoster()
-            .Concat(party.PrisonRoster.GetTroopRoster())
-            .Select(element => element.Character?.HeroObject)
-            .Where(hero => hero != null)
-            .Distinct()
-            .ToDictionary(hero => hero, hero => hero.HitPoints);
-
-        return new PartyFixtureState
-        {
-            Party = party,
-            MobileParty = party.MobileParty,
-            Position = party.MobileParty?.Position ?? default,
-            RecentEventsMorale = party.MobileParty?.RecentEventsMorale ?? 0,
-            Members = party.MemberRoster.GetTroopRoster().ToArray(),
-            Prisoners = party.PrisonRoster.GetTroopRoster().ToArray(),
-            HeroHitPoints = heroHitPoints,
-        };
-    }
-
-    private static void RestorePartyState(PartyFixtureState state)
-    {
-        if (state.MobileParty != null && !state.MobileParty.IsActive)
-        {
-            throw new InvalidOperationException(
-                $"Fixture party {state.MobileParty.StringId} was destroyed and cannot be restored safely");
-        }
-
-        RestoreRoster(state.Party.MemberRoster, state.Members);
-        RestoreRoster(state.Party.PrisonRoster, state.Prisoners);
-        foreach (var hitPoints in state.HeroHitPoints)
-            hitPoints.Key.HitPoints = hitPoints.Value;
-
-        if (state.MobileParty == null) return;
-
-        state.MobileParty.RecentEventsMorale = state.RecentEventsMorale;
-        state.MobileParty.Position = state.Position;
-        state.MobileParty.SetMoveModeHold();
-        state.MobileParty.ResetNavigationToHold();
-        MessageBroker.Instance.Publish(
-            typeof(SiegeDebugCommand),
-            new PartyBehaviorChangeAttempted(
-                state.MobileParty,
-                forcePosition: true,
-                isCurrentlyAtSea: state.MobileParty.IsCurrentlyAtSea,
-                resetMovementToHold: true));
-    }
-
-    private static void RestoreRoster(TroopRoster roster, TroopRosterElement[] snapshot)
-    {
-        for (int i = roster.Count - 1; i >= 0; i--)
-        {
-            var element = roster.GetElementCopyAtIndex(i);
-            roster.AddToCountsAtIndex(
-                i, -element.Number, -element.WoundedNumber, 0, false);
-        }
-
-        foreach (var element in snapshot)
-        {
-            roster.AddToCounts(
-                element.Character,
-                element.Number,
-                false,
-                element.WoundedNumber,
-                element.Xp,
-                true);
-        }
+            $"playerMapEvent={mapEvent != null}";
     }
 
     [CommandLineArgumentFunction("request_besiege", "coop.debug.siege")]

--- a/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
+++ b/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
@@ -4,6 +4,7 @@ using Common.Logging;
 using Common.Messaging;
 using GameInterface.Services.MapEvents;
 using GameInterface.Services.MobileParties.Extensions;
+using GameInterface.Services.MobileParties.Messages.Behavior;
 using GameInterface.Services.MobileParties.Patches;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Party.Commands;
@@ -19,7 +20,9 @@ using System.Linq;
 using System.Text;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Actions;
+using TaleWorlds.CampaignSystem.MapEvents;
 using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Roster;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Core;
 using static TaleWorlds.CampaignSystem.Army;
@@ -31,6 +34,31 @@ namespace GameInterface.Services.SiegeEvents.Commands;
 public class SiegeDebugCommand
 {
     private static readonly ILogger Logger = LogManager.GetLogger<SiegeDebugCommand>();
+    private static ArmyReliefFixture armyReliefFixture;
+
+    private sealed class ArmyReliefFixture
+    {
+        public string ControllerId;
+        public Settlement Settlement;
+        public MobileParty PlayerParty;
+        public Army ReliefArmy;
+        public MapEvent MapEvent;
+        public IFaction PlayerFaction;
+        public IFaction DefenderFaction;
+        public bool WasAtWar;
+        public PartyFixtureState[] Parties;
+    }
+
+    private sealed class PartyFixtureState
+    {
+        public PartyBase Party;
+        public MobileParty MobileParty;
+        public CampaignVec2 Position;
+        public float RecentEventsMorale;
+        public TroopRosterElement[] Members;
+        public TroopRosterElement[] Prisoners;
+        public Dictionary<Hero, int> HeroHitPoints;
+    }
 
     /// <summary>
     /// Creates a player-led siege and sends a multi-party defending army to interrupt it. Server only.
@@ -52,6 +80,12 @@ public class SiegeDebugCommand
         if (args.Count == 3 && (!int.TryParse(args[2], out armyPartyCount) || armyPartyCount < 2))
         {
             return "armyPartyCount must be at least 2";
+        }
+
+        if (armyReliefFixture != null)
+        {
+            return $"Army relief fixture already active for {armyReliefFixture.ControllerId} at " +
+                $"{armyReliefFixture.Settlement.Name}";
         }
 
         if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)
@@ -91,11 +125,6 @@ public class SiegeDebugCommand
             return $"{playerParty.Name} has no map faction";
         }
 
-        if (!playerParty.MapFaction.IsAtWarWith(settlement.MapFaction))
-        {
-            DeclareWarAction.ApplyByDefault(playerParty.MapFaction, settlement.MapFaction);
-        }
-
         var defenders = MobileParty.AllLordParties
             .Where(party => party.IsActive && !party.IsPlayerParty()
                 && party.MapFaction == settlement.MapFaction && party.LeaderHero != null
@@ -111,37 +140,73 @@ public class SiegeDebugCommand
             return $"Only found {defenders.Count} available {settlement.MapFaction.Name} lord parties; need {armyPartyCount}";
         }
 
-        siegeEventInterface.StartSiegeEvent(playerParty, settlement);
-        foreach (var otherPlayer in playerManager.Players)
+        var fixtureParties = new List<PartyBase> { settlement.Party };
+        fixtureParties.AddRange(defenders.Select(party => party.Party));
+        foreach (var connectedPlayer in playerManager.Players.Where(playerManager.IsConnected))
         {
-            if (otherPlayer.ControllerId == player.ControllerId || !playerManager.IsConnected(otherPlayer)) continue;
-            if (!objectManager.TryGetObjectWithLogging<MobileParty>(otherPlayer.MobilePartyId, out var otherParty)) continue;
-            if (otherParty.MapEvent != null || otherParty.BesiegerCamp != null) continue;
-            if (settlement.SiegeEvent?.CanPartyJoinSide(otherParty.Party, BattleSideEnum.Attacker) != true) continue;
-
-            siegeEventInterface.JoinSiegeCamp(otherParty, settlement);
+            if (objectManager.TryGetObject<MobileParty>(connectedPlayer.MobilePartyId, out var connectedParty))
+                fixtureParties.Add(connectedParty.Party);
         }
 
-        var armyLeader = defenders[0];
-        kingdom.CreateArmy(armyLeader.LeaderHero, settlement, ArmyTypes.Defender);
-        var army = armyLeader.Army;
-        if (army == null)
+        var fixture = new ArmyReliefFixture
         {
-            return $"Failed to create a relief army led by {armyLeader.Name}";
+            ControllerId = args[0],
+            Settlement = settlement,
+            PlayerParty = playerParty,
+            PlayerFaction = playerParty.MapFaction,
+            DefenderFaction = settlement.MapFaction,
+            WasAtWar = playerParty.MapFaction.IsAtWarWith(settlement.MapFaction),
+            Parties = fixtureParties.Distinct().Select(CapturePartyState).ToArray(),
+        };
+        armyReliefFixture = fixture;
+
+        if (!fixture.WasAtWar)
+        {
+            DeclareWarAction.ApplyByDefault(playerParty.MapFaction, settlement.MapFaction);
         }
 
-        armyLeader.Position = playerParty.Position;
-        foreach (var defender in defenders.Skip(1))
+        try
         {
-            defender.Position = playerParty.Position;
-            defender.Army = army;
-            army.AddPartyToMergedParties(defender);
+            siegeEventInterface.StartSiegeEvent(playerParty, settlement);
+            foreach (var otherPlayer in playerManager.Players)
+            {
+                if (otherPlayer.ControllerId == player.ControllerId || !playerManager.IsConnected(otherPlayer)) continue;
+                if (!objectManager.TryGetObjectWithLogging<MobileParty>(otherPlayer.MobilePartyId, out var otherParty)) continue;
+                if (otherParty.MapEvent != null || otherParty.BesiegerCamp != null) continue;
+                if (settlement.SiegeEvent?.CanPartyJoinSide(otherParty.Party, BattleSideEnum.Attacker) != true) continue;
+
+                siegeEventInterface.JoinSiegeCamp(otherParty, settlement);
+            }
+
+            var armyLeader = defenders[0];
+            kingdom.CreateArmy(armyLeader.LeaderHero, settlement, ArmyTypes.Defender);
+            var army = armyLeader.Army;
+            if (army == null)
+            {
+                throw new InvalidOperationException($"Failed to create a relief army led by {armyLeader.Name}");
+            }
+
+            fixture.ReliefArmy = army;
+            armyLeader.Position = playerParty.Position;
+            foreach (var defender in defenders.Skip(1))
+            {
+                defender.Position = playerParty.Position;
+                defender.Army = army;
+                army.AddPartyToMergedParties(defender);
+            }
+
+            StartBattleAction.Apply(armyLeader.Party, playerParty.Party);
+            fixture.MapEvent = playerParty.MapEvent;
+
+            return $"Started {settlement.Name} siege relief: {army.Name} with {army.Parties.Count} parties is attacking " +
+                $"{playerParty.Name}; connected friendly player parties joined the siege";
         }
-
-        StartBattleAction.Apply(armyLeader.Party, playerParty.Party);
-
-        return $"Started {settlement.Name} siege relief: {army.Name} with {army.Parties.Count} parties is attacking " +
-            $"{playerParty.Name}; connected friendly player parties joined the siege";
+        catch (Exception e)
+        {
+            Logger.Error(e, "Failed to create the army relief fixture");
+            return $"Army relief fixture setup failed: {e.Message}. Run coop.debug.siege.army_relief_restore " +
+                $"{args[0]} {args[1]} after leaving any active mission.";
+        }
     }
 
     [CommandLineArgumentFunction("army_relief_state", "coop.debug.siege")]
@@ -174,7 +239,142 @@ public class SiegeDebugCommand
         return $"siege={siegeActive} playerBesieger={playerBesieger} " +
             $"reliefArmyParties={involvedReliefParties} reliefArmyMembers={reliefArmy?.Parties.Count ?? 0} " +
             $"reliefEncounter={reliefEncounterActive} " +
-            $"playerMapEvent={mapEvent != null}";
+            $"playerMapEvent={mapEvent != null} fixtureActive={armyReliefFixture != null}";
+    }
+
+    [CommandLineArgumentFunction("army_relief_restore", "coop.debug.siege")]
+    public static string RestoreArmyRelief(List<string> args)
+    {
+        if (ModInformation.IsClient)
+        {
+            return "This command can only be used by the server";
+        }
+
+        if (args.Count != 2)
+        {
+            return "Usage: coop.debug.siege.army_relief_restore <controllerId> <settlementId>";
+        }
+
+        var fixture = armyReliefFixture;
+        if (fixture == null || fixture.ControllerId != args[0] ||
+            fixture.Settlement.StringId != args[1])
+        {
+            return $"No active army relief fixture exists for {args[0]} at {args[1]}";
+        }
+
+        if (fixture.MapEvent != null && !fixture.MapEvent.IsFinalized)
+        {
+            return "Army relief fixture is still in an active map event; leave the battle on both clients first";
+        }
+
+        if (!ContainerProvider.TryResolve<ISiegeEventInterface>(out var siegeEventInterface))
+        {
+            return "Unable to resolve SiegeEventInterface";
+        }
+
+        try
+        {
+            if (fixture.PlayerParty.BesiegerCamp != null &&
+                fixture.Settlement.SiegeEvent != null)
+            {
+                siegeEventInterface.BreakSiege(fixture.PlayerParty);
+            }
+
+            if (fixture.ReliefArmy != null &&
+                fixture.ReliefArmy.Parties.Any(party => party.Army == fixture.ReliefArmy))
+            {
+                DisbandArmyAction.ApplyByObjectiveFinished(fixture.ReliefArmy);
+            }
+
+            foreach (var party in fixture.Parties)
+                RestorePartyState(party);
+
+            if (!fixture.WasAtWar &&
+                fixture.PlayerFaction.IsAtWarWith(fixture.DefenderFaction))
+            {
+                MakePeaceAction.Apply(fixture.PlayerFaction, fixture.DefenderFaction);
+            }
+
+            armyReliefFixture = null;
+            return $"Restored army relief fixture for {args[0]} at {fixture.Settlement.Name}: " +
+                $"parties={fixture.Parties.Length} siege={fixture.Settlement.SiegeEvent != null} " +
+                $"war={fixture.PlayerFaction.IsAtWarWith(fixture.DefenderFaction)}";
+        }
+        catch (Exception e)
+        {
+            Logger.Error(e, "Failed to restore the army relief fixture");
+            return $"Army relief fixture restore failed: {e.Message}. The fixture remains active for one retry.";
+        }
+    }
+
+    private static PartyFixtureState CapturePartyState(PartyBase party)
+    {
+        var heroHitPoints = party.MemberRoster.GetTroopRoster()
+            .Concat(party.PrisonRoster.GetTroopRoster())
+            .Select(element => element.Character?.HeroObject)
+            .Where(hero => hero != null)
+            .Distinct()
+            .ToDictionary(hero => hero, hero => hero.HitPoints);
+
+        return new PartyFixtureState
+        {
+            Party = party,
+            MobileParty = party.MobileParty,
+            Position = party.MobileParty?.Position ?? default,
+            RecentEventsMorale = party.MobileParty?.RecentEventsMorale ?? 0,
+            Members = party.MemberRoster.GetTroopRoster().ToArray(),
+            Prisoners = party.PrisonRoster.GetTroopRoster().ToArray(),
+            HeroHitPoints = heroHitPoints,
+        };
+    }
+
+    private static void RestorePartyState(PartyFixtureState state)
+    {
+        if (state.MobileParty != null && !state.MobileParty.IsActive)
+        {
+            throw new InvalidOperationException(
+                $"Fixture party {state.MobileParty.StringId} was destroyed and cannot be restored safely");
+        }
+
+        RestoreRoster(state.Party.MemberRoster, state.Members);
+        RestoreRoster(state.Party.PrisonRoster, state.Prisoners);
+        foreach (var hitPoints in state.HeroHitPoints)
+            hitPoints.Key.HitPoints = hitPoints.Value;
+
+        if (state.MobileParty == null) return;
+
+        state.MobileParty.RecentEventsMorale = state.RecentEventsMorale;
+        state.MobileParty.Position = state.Position;
+        state.MobileParty.SetMoveModeHold();
+        state.MobileParty.ResetNavigationToHold();
+        MessageBroker.Instance.Publish(
+            typeof(SiegeDebugCommand),
+            new PartyBehaviorChangeAttempted(
+                state.MobileParty,
+                forcePosition: true,
+                isCurrentlyAtSea: state.MobileParty.IsCurrentlyAtSea,
+                resetMovementToHold: true));
+    }
+
+    private static void RestoreRoster(TroopRoster roster, TroopRosterElement[] snapshot)
+    {
+        for (int i = roster.Count - 1; i >= 0; i--)
+        {
+            var element = roster.GetElementCopyAtIndex(i);
+            roster.AddToCountsAtIndex(
+                i, -element.Number, -element.WoundedNumber, 0, false);
+        }
+
+        foreach (var element in snapshot)
+        {
+            roster.AddToCounts(
+                element.Character,
+                element.Number,
+                false,
+                element.WoundedNumber,
+                element.Xp,
+                true);
+        }
     }
 
     [CommandLineArgumentFunction("request_besiege", "coop.debug.siege")]

--- a/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
+++ b/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
@@ -2,7 +2,9 @@
 using Common;
 using Common.Logging;
 using Common.Messaging;
+using GameInterface.Registry.Auto;
 using GameInterface.Services.MapEvents;
+using GameInterface.Services.MapEvents.Messages.Leave;
 using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Services.MobileParties.Messages.Behavior;
 using GameInterface.Services.MobileParties.Patches;
@@ -47,6 +49,9 @@ public class SiegeDebugCommand
         public IFaction DefenderFaction;
         public bool WasAtWar;
         public PartyFixtureState[] Parties;
+        public bool RequiresRecoveryMessages;
+        public bool RecoveryFinalizedPublished;
+        public bool RecoveryDestroyedPublished;
     }
 
     private sealed class PartyFixtureState
@@ -236,10 +241,12 @@ public class SiegeDebugCommand
             ? 0
             : mapEvent.InvolvedParties.Count(party => party.MobileParty?.Army == reliefArmy);
         bool reliefEncounterActive = mapEvent != null && reliefArmy != null;
+        bool fixtureMapEventFinalized = armyReliefFixture?.MapEvent?.IsFinalized == true;
         return $"siege={siegeActive} playerBesieger={playerBesieger} " +
             $"reliefArmyParties={involvedReliefParties} reliefArmyMembers={reliefArmy?.Parties.Count ?? 0} " +
             $"reliefEncounter={reliefEncounterActive} " +
-            $"playerMapEvent={mapEvent != null} fixtureActive={armyReliefFixture != null}";
+            $"playerMapEvent={mapEvent != null} fixtureActive={armyReliefFixture != null} " +
+            $"fixtureMapEventFinalized={fixtureMapEventFinalized}";
     }
 
     [CommandLineArgumentFunction("army_relief_restore", "coop.debug.siege")]
@@ -250,9 +257,9 @@ public class SiegeDebugCommand
             return "This command can only be used by the server";
         }
 
-        if (args.Count != 2)
+        if (args.Count < 2 || args.Count > 3 || (args.Count == 3 && args[2] != "force"))
         {
-            return "Usage: coop.debug.siege.army_relief_restore <controllerId> <settlementId>";
+            return "Usage: coop.debug.siege.army_relief_restore <controllerId> <settlementId> [force]";
         }
 
         var fixture = armyReliefFixture;
@@ -264,7 +271,10 @@ public class SiegeDebugCommand
 
         if (fixture.MapEvent != null && !fixture.MapEvent.IsFinalized)
         {
-            return "Army relief fixture is still in an active map event; leave the battle on both clients first";
+            if (args.Count != 3)
+            {
+                return "Army relief fixture is still in an active map event; leave the battle on both clients first";
+            }
         }
 
         if (!ContainerProvider.TryResolve<ISiegeEventInterface>(out var siegeEventInterface))
@@ -274,6 +284,20 @@ public class SiegeDebugCommand
 
         try
         {
+            if (fixture.MapEvent != null && !fixture.MapEvent.IsFinalized)
+            {
+                try
+                {
+                    fixture.MapEvent.FinalizeEvent();
+                }
+                catch
+                {
+                    fixture.RequiresRecoveryMessages = fixture.MapEvent.IsFinalized;
+                    throw;
+                }
+            }
+            RecoverPartiallyFinalizedMapEvent(fixture);
+
             if (fixture.PlayerParty.BesiegerCamp != null &&
                 fixture.Settlement.SiegeEvent != null)
             {
@@ -305,6 +329,67 @@ public class SiegeDebugCommand
             Logger.Error(e, "Failed to restore the army relief fixture");
             return $"Army relief fixture restore failed: {e.Message}. The fixture remains active for one retry.";
         }
+    }
+
+    private static void RecoverPartiallyFinalizedMapEvent(ArmyReliefFixture fixture)
+    {
+        if (fixture.MapEvent == null)
+            return;
+
+        var attachedParties = GetAttachedParties(fixture);
+        bool hasAttachedParties = attachedParties.Length > 0 ||
+            fixture.MapEvent.AttackerSide?.Parties.Count > 0 ||
+            fixture.MapEvent.DefenderSide?.Parties.Count > 0;
+        if (hasAttachedParties)
+        {
+            fixture.RequiresRecoveryMessages = true;
+            foreach (var party in attachedParties)
+            {
+                if (party?._mapEventSide?.MapEvent != fixture.MapEvent)
+                    continue;
+
+                party._mapEventSide = null;
+                if (party.MobileParty != null)
+                    party.MobileParty.EventPositionAdder = TaleWorlds.Library.Vec2.Zero;
+                party.SetVisualAsDirty();
+            }
+
+            fixture.MapEvent.AttackerSide?.Clear();
+            fixture.MapEvent.DefenderSide?.Clear();
+            if (GetAttachedParties(fixture).Length > 0 ||
+                fixture.MapEvent.AttackerSide?.Parties.Count > 0 ||
+                fixture.MapEvent.DefenderSide?.Parties.Count > 0)
+            {
+                throw new InvalidOperationException("The partially finalized army relief fixture still has attached parties");
+            }
+        }
+
+        if (!fixture.RequiresRecoveryMessages)
+            return;
+
+        if (!fixture.RecoveryFinalizedPublished)
+        {
+            MessageBroker.Instance.Publish(fixture.MapEvent, new MapEventFinalized(fixture.MapEvent));
+            fixture.RecoveryFinalizedPublished = true;
+        }
+        if (!fixture.RecoveryDestroyedPublished)
+        {
+            MessageBroker.Instance.Publish(fixture.MapEvent, new InstanceDestroyed<MapEvent>(fixture.MapEvent));
+            fixture.RecoveryDestroyedPublished = true;
+        }
+    }
+
+    private static PartyBase[] GetAttachedParties(ArmyReliefFixture fixture)
+    {
+        var sideParties = fixture.MapEvent._sides
+            .Where(side => side != null)
+            .SelectMany(side => side.Parties ?? Enumerable.Empty<MapEventParty>())
+            .Select(mapEventParty => mapEventParty.Party);
+        return sideParties
+            .Concat(fixture.Parties.Select(state => state.Party))
+            .Where(party => party?._mapEventSide?.MapEvent == fixture.MapEvent)
+            .Distinct()
+            .ToArray();
     }
 
     private static PartyFixtureState CapturePartyState(PartyBase party)

--- a/source/Missions/Agents/Handlers/AgentEquipmentApplier.cs
+++ b/source/Missions/Agents/Handlers/AgentEquipmentApplier.cs
@@ -1,0 +1,66 @@
+﻿using Common;
+using Common.PacketHandlers;
+using Common.Util;
+using LiteNetLib;
+using Missions.Agents.Packets;
+using TaleWorlds.MountAndBlade;
+
+namespace Missions.Agents.Handlers;
+
+public interface IAgentEquipmentApplier : IPacketHandler
+{
+}
+
+public class AgentEquipmentApplier : IAgentEquipmentApplier
+{
+    private readonly INetworkAgentRegistry agentRegistry;
+
+    public AgentEquipmentApplier(INetworkAgentRegistry agentRegistry)
+    {
+        this.agentRegistry = agentRegistry;
+    }
+
+    public PacketType PacketType => PacketType.AgentEquipment;
+
+    public void Dispose()
+    {
+    }
+
+    public void HandlePacket(NetPeer peer, IPacket packet)
+    {
+        var equipment = (AgentEquipmentPacket)packet;
+        int idCount = equipment.AgentIds?.Length ?? equipment.AgentGuids?.Length ?? 0;
+        if (idCount == 0 || equipment.Equipment == null ||
+            equipment.Equipment.Length != idCount)
+        {
+            return;
+        }
+
+        GameThread.RunSafe(() =>
+        {
+            if (Mission.Current == null) return;
+
+            using (new AllowedThread())
+            {
+                for (int i = 0; i < idCount; i++)
+                {
+                    bool found = equipment.AgentIds != null
+                        ? agentRegistry.TryGetAgentInfo(
+                            equipment.IdentityScopeId, equipment.AgentIds[i], out var compactInfo)
+                        : agentRegistry.TryGetAgentInfo(
+                            equipment.AgentGuids[i], out compactInfo);
+                    if (!found) continue;
+
+                    Agent agent = compactInfo.Agent;
+                    if (agent == null || agent.Mission != Mission.Current ||
+                        !agent.IsActive() || agentRegistry.IsLocallyControlled(agent))
+                    {
+                        continue;
+                    }
+
+                    equipment.Equipment[i].Apply(agent);
+                }
+            }
+        });
+    }
+}

--- a/source/Missions/Agents/Handlers/AgentMovementHandler.cs
+++ b/source/Missions/Agents/Handlers/AgentMovementHandler.cs
@@ -9,7 +9,6 @@ using LiteNetLib;
 using Missions.Agents;
 using Missions.Agents.Packets;
 using Missions.Messages;
-using Missions.Services.Network;
 using Serilog;
 using System;
 using System.Collections.Generic;
@@ -43,8 +42,6 @@ public class AgentMovementHandler : IAgentMovementHandler
 
     // Forty updates per second keeps locally authoritative agents responsive.
     private const float MovementPollingIntervalSeconds = 0.025f;
-    private const float PayloadProfileIntervalSeconds = 5f;
-    private const int MaxProfileAgents = 64;
 
     private readonly IPacketManager packetManager;
     private readonly IBattleNetwork client;
@@ -52,7 +49,6 @@ public class AgentMovementHandler : IAgentMovementHandler
     private readonly INetworkAgentRegistry agentRegistry;
     private readonly IControllerIdProvider controllerIdProvider;
     private readonly IAgentEquipmentApplier equipmentApplier;
-    private readonly IMovementPacketCompressor movementPacketCompressor;
     private readonly Dictionary<Guid, AgentEquipmentData> lastEquipment = new Dictionary<Guid, AgentEquipmentData>();
 
     // A puppet's horse, remembered when its owner dismounts, so a later re-mount can put it back on the
@@ -74,7 +70,6 @@ public class AgentMovementHandler : IAgentMovementHandler
     // guards against a second call (the GC finalizer, or the DI scope also disposing this transient handler).
     private bool _disposed;
     private float movementPollElapsed = MovementPollingIntervalSeconds;
-    private float payloadProfileElapsed;
 
     public AgentMovementHandler(
         IBattleNetwork client,
@@ -82,8 +77,7 @@ public class AgentMovementHandler : IAgentMovementHandler
         IMessageBroker messageBroker,
         INetworkAgentRegistry agentRegistry,
         IControllerIdProvider controllerIdProvider,
-        IAgentEquipmentApplier equipmentApplier,
-        IMovementPacketCompressor movementPacketCompressor)
+        IAgentEquipmentApplier equipmentApplier)
     {
         Logger.Verbose("Creating {handlerType}", typeof(AgentMovementHandler));
 
@@ -93,7 +87,6 @@ public class AgentMovementHandler : IAgentMovementHandler
         this.agentRegistry = agentRegistry;
         this.controllerIdProvider = controllerIdProvider;
         this.equipmentApplier = equipmentApplier;
-        this.movementPacketCompressor = movementPacketCompressor;
 
         // Server-mediated membership. A peer entering is the cue to clear any STALE party it left behind
         // on a missed disconnect (so its rejoin re-spawns clean); a leave/disconnect releases its party.
@@ -169,7 +162,6 @@ public class AgentMovementHandler : IAgentMovementHandler
         if (_disposed || Mission.Current == null) return;
 
         movementPollElapsed += dt;
-        payloadProfileElapsed += dt;
         if (movementPollElapsed < MovementPollingIntervalSeconds) return;
         movementPollElapsed %= MovementPollingIntervalSeconds;
 
@@ -243,121 +235,10 @@ public class AgentMovementHandler : IAgentMovementHandler
 
         SendEquipment(equipmentGroups.Values);
         SendEquipment(legacyEquipment);
-        if (payloadProfileElapsed >= PayloadProfileIntervalSeconds)
-        {
-            payloadProfileElapsed %= PayloadProfileIntervalSeconds;
-            ProfileActualPayloadCapacity(
-                FindLargestBatch(movementGroups.Values, legacyMovement));
-            ProfileActualPayloadCapacity(
-                FindLargestBatch(mountGroups.Values, legacyMountMovement));
-        }
         SendMovement(movementGroups.Values);
         SendMovement(legacyMovement);
         SendMountMovement(mountGroups.Values);
         SendMountMovement(legacyMountMovement);
-    }
-
-    private static MovementBatch<T> FindLargestBatch<T>(
-        IEnumerable<MovementBatch<T>> batches,
-        MovementBatch<T> legacyBatch)
-    {
-        MovementBatch<T> largest = legacyBatch;
-        foreach (var batch in batches)
-        {
-            if (largest == null || batch.Data.Count > largest.Data.Count)
-                largest = batch;
-        }
-        return largest;
-    }
-
-    private void ProfileActualPayloadCapacity(MovementBatch<AgentData> batch)
-    {
-        if (batch == null || batch.Data.Count == 0) return;
-
-        ProfileActualPayloadCapacity(
-            "agents",
-            batch,
-            count =>
-            {
-                var data = new AgentData[count];
-                batch.Data.CopyTo(0, data, 0, count);
-                if (batch.IdentityScopeId == null)
-                {
-                    var ids = new Guid[count];
-                    batch.CanonicalIds.CopyTo(0, ids, 0, count);
-                    return new MovementPacket(ids, data);
-                }
-
-                var compactIds = new ushort[count];
-                batch.CompactIds.CopyTo(0, compactIds, 0, count);
-                return new MovementPacket(batch.IdentityScopeId, compactIds, data);
-            });
-    }
-
-    private void ProfileActualPayloadCapacity(MovementBatch<AgentMountData> batch)
-    {
-        if (batch == null || batch.Data.Count == 0) return;
-
-        ProfileActualPayloadCapacity(
-            "mounts",
-            batch,
-            count =>
-            {
-                var data = new AgentMountData[count];
-                batch.Data.CopyTo(0, data, 0, count);
-                if (batch.IdentityScopeId == null)
-                {
-                    var ids = new Guid[count];
-                    batch.CanonicalIds.CopyTo(0, ids, 0, count);
-                    return new MountMovementPacket(ids, data);
-                }
-
-                var compactIds = new ushort[count];
-                batch.CompactIds.CopyTo(0, compactIds, 0, count);
-                return new MountMovementPacket(batch.IdentityScopeId, compactIds, data);
-            });
-    }
-
-    private void ProfileActualPayloadCapacity<T>(
-        string payloadName,
-        MovementBatch<T> batch,
-        Func<int, IPacket> createPacket)
-    {
-        int sampleCount = Math.Min(batch.Data.Count, MaxProfileAgents);
-        int maxSafeAgents = 0;
-        int overCeilingStreak = 0;
-        bool foundOverCeiling = false;
-        var sizes = new List<string>();
-
-        for (int count = 1; count <= sampleCount; count++)
-        {
-            int wireBytes = movementPacketCompressor.GetSerializedLength(
-                createPacket(count));
-            sizes.Add($"{count}:{wireBytes}");
-            if (wireBytes <= LiteNetP2PClient.SafeSinglePacketBytes)
-            {
-                maxSafeAgents = count;
-                overCeilingStreak = 0;
-            }
-            else
-            {
-                foundOverCeiling = true;
-                overCeilingStreak++;
-                if (overCeilingStreak >= 3)
-                    break;
-            }
-        }
-
-        bool isLowerBound = maxSafeAgents > 0 && !foundOverCeiling;
-        Logger.Information(
-            "[BattleTraffic] Actual {PayloadName} capacity: scope={IdentityScopeId}, " +
-            "wireBytes={WireBytes}, maxSafeAgents={MaxSafeAgents}{LowerBound}, ceiling={Ceiling}",
-            payloadName,
-            batch.IdentityScopeId ?? "legacy-guid",
-            string.Join(",", sizes),
-            maxSafeAgents,
-            isLowerBound ? "+" : string.Empty,
-            LiteNetP2PClient.SafeSinglePacketBytes);
     }
 
     private static void AddToBatch<T>(

--- a/source/Missions/Agents/Handlers/AgentMovementHandler.cs
+++ b/source/Missions/Agents/Handlers/AgentMovementHandler.cs
@@ -9,6 +9,7 @@ using LiteNetLib;
 using Missions.Agents;
 using Missions.Agents.Packets;
 using Missions.Messages;
+using Missions.Services.Network;
 using Serilog;
 using System;
 using System.Collections.Generic;
@@ -42,12 +43,17 @@ public class AgentMovementHandler : IAgentMovementHandler
 
     // Forty updates per second keeps locally authoritative agents responsive.
     private const float MovementPollingIntervalSeconds = 0.025f;
+    private const float PayloadProfileIntervalSeconds = 5f;
+    private const int MaxProfileAgents = 64;
 
     private readonly IPacketManager packetManager;
     private readonly IBattleNetwork client;
     private readonly IMessageBroker messageBroker;
     private readonly INetworkAgentRegistry agentRegistry;
     private readonly IControllerIdProvider controllerIdProvider;
+    private readonly IAgentEquipmentApplier equipmentApplier;
+    private readonly IMovementPacketCompressor movementPacketCompressor;
+    private readonly Dictionary<Guid, AgentEquipmentData> lastEquipment = new Dictionary<Guid, AgentEquipmentData>();
 
     // A puppet's horse, remembered when its owner dismounts, so a later re-mount can put it back on the
     // same one. Touched only on the game thread (inside HandlePacket's apply), so no lock; per-mission
@@ -68,13 +74,16 @@ public class AgentMovementHandler : IAgentMovementHandler
     // guards against a second call (the GC finalizer, or the DI scope also disposing this transient handler).
     private bool _disposed;
     private float movementPollElapsed = MovementPollingIntervalSeconds;
+    private float payloadProfileElapsed;
 
     public AgentMovementHandler(
         IBattleNetwork client,
         IPacketManager packetManager,
         IMessageBroker messageBroker,
         INetworkAgentRegistry agentRegistry,
-        IControllerIdProvider controllerIdProvider)
+        IControllerIdProvider controllerIdProvider,
+        IAgentEquipmentApplier equipmentApplier,
+        IMovementPacketCompressor movementPacketCompressor)
     {
         Logger.Verbose("Creating {handlerType}", typeof(AgentMovementHandler));
 
@@ -83,6 +92,8 @@ public class AgentMovementHandler : IAgentMovementHandler
         this.messageBroker = messageBroker;
         this.agentRegistry = agentRegistry;
         this.controllerIdProvider = controllerIdProvider;
+        this.equipmentApplier = equipmentApplier;
+        this.movementPacketCompressor = movementPacketCompressor;
 
         // Server-mediated membership. A peer entering is the cue to clear any STALE party it left behind
         // on a missed disconnect (so its rejoin re-spawns clean); a leave/disconnect releases its party.
@@ -91,6 +102,7 @@ public class AgentMovementHandler : IAgentMovementHandler
         this.messageBroker.Subscribe<MissionPeerDisconnected>(Handle_PeerDisconnected);
 
         this.packetManager.RegisterPacketHandler(this);
+        this.packetManager.RegisterPacketHandler(equipmentApplier);
 
         _mountMovementApplier = new MountMovementApplier(agentRegistry, _interpolator);
         this.packetManager.RegisterPacketHandler(_mountMovementApplier);
@@ -118,6 +130,7 @@ public class AgentMovementHandler : IAgentMovementHandler
 
         packetManager.RemovePacketHandler(this);
         packetManager.RemovePacketHandler(_mountMovementApplier);
+        packetManager.RemovePacketHandler(equipmentApplier);
         messageBroker.Unsubscribe<NetworkMissionPeerEntered>(Handle_PeerEntered);
         messageBroker.Unsubscribe<MissionPeerLeft>(Handle_PeerLeft);
         messageBroker.Unsubscribe<MissionPeerDisconnected>(Handle_PeerDisconnected);
@@ -128,19 +141,44 @@ public class AgentMovementHandler : IAgentMovementHandler
 
     public PacketType PacketType => PacketType.Movement;
 
+    private sealed class MovementBatch<T>
+    {
+        public readonly string IdentityScopeId;
+        public readonly List<ushort> CompactIds = new List<ushort>();
+        public readonly List<Guid> CanonicalIds = new List<Guid>();
+        public readonly List<T> Data = new List<T>();
+
+        public MovementBatch(string identityScopeId)
+        {
+            IdentityScopeId = identityScopeId;
+        }
+
+        public void Add(CoopAgentInfo info, T data)
+        {
+            if (IdentityScopeId == null)
+                CanonicalIds.Add(info.AgentId);
+            else
+                CompactIds.Add(info.MovementId);
+            Data.Add(data);
+        }
+    }
+
     // Broadcast every locally authoritative agent.
     public void PollMovement(float dt)
     {
         if (_disposed || Mission.Current == null) return;
 
         movementPollElapsed += dt;
+        payloadProfileElapsed += dt;
         if (movementPollElapsed < MovementPollingIntervalSeconds) return;
         movementPollElapsed %= MovementPollingIntervalSeconds;
 
-        var ids = new List<Guid>();
-        var data = new List<AgentData>();
-        List<Guid> mountIds = null;
-        List<AgentMountData> mountData = null;
+        var movementGroups = new Dictionary<string, MovementBatch<AgentData>>();
+        var mountGroups = new Dictionary<string, MovementBatch<AgentMountData>>();
+        var equipmentGroups = new Dictionary<string, MovementBatch<AgentEquipmentData>>();
+        MovementBatch<AgentData> legacyMovement = null;
+        MovementBatch<AgentMountData> legacyMountMovement = null;
+        MovementBatch<AgentEquipmentData> legacyEquipment = null;
 
         foreach (var agentInfo in agentRegistry.GetAgents(controllerIdProvider.ControllerId))
         {
@@ -154,43 +192,299 @@ public class AgentMovementHandler : IAgentMovementHandler
 
             if (agent.IsMount)
             {
-                (mountIds ??= new List<Guid>()).Add(agentInfo.AgentId);
-                (mountData ??= new List<AgentMountData>()).Add(new AgentMountData(agent));
+                AddToBatch(
+                    mountGroups,
+                    ref legacyMountMovement,
+                    agentInfo,
+                    new AgentMountData(agent));
             }
             else
             {
-                ids.Add(agentInfo.AgentId);
-                data.Add(new AgentData(agent, GetRegisteredMountId(agent)));
+                GetRegisteredMountIdentity(
+                    agent,
+                    agentInfo.MovementScopeId,
+                    out ushort mountMovementId,
+                    out string mountIdentityScopeId,
+                    out Guid mountAgentId);
+                AddToBatch(
+                    movementGroups,
+                    ref legacyMovement,
+                    agentInfo,
+                    new AgentData(
+                        agent,
+                        mountMovementId,
+                        mountIdentityScopeId,
+                        mountAgentId));
+
+                var equipment = new AgentEquipmentData(agent);
+                if (!lastEquipment.TryGetValue(agentInfo.AgentId, out var previousEquipment))
+                {
+                    lastEquipment[agentInfo.AgentId] = equipment;
+
+                    // Battle spawn/catch-up records already carry the current wield state. Compact ids are
+                    // battle-only, so seeding their cache here avoids immediately resending every agent's
+                    // equipment on the first 40 Hz poll. Legacy Guid registrations still need an initial update.
+                    if (agentInfo.MovementId != 0)
+                        continue;
+                }
+                else if (previousEquipment.Equals(equipment))
+                {
+                    continue;
+                }
+
+                lastEquipment[agentInfo.AgentId] = equipment;
+                AddToBatch(
+                    equipmentGroups,
+                    ref legacyEquipment,
+                    agentInfo,
+                    equipment);
             }
         }
 
-        for (int start = 0; start < ids.Count; start += MaxAgentsPerMovementPacket)
+        SendEquipment(equipmentGroups.Values);
+        SendEquipment(legacyEquipment);
+        if (payloadProfileElapsed >= PayloadProfileIntervalSeconds)
         {
-            int count = Math.Min(MaxAgentsPerMovementPacket, ids.Count - start);
-            var idChunk = new Guid[count];
-            var dataChunk = new AgentData[count];
-            ids.CopyTo(start, idChunk, 0, count);
-            data.CopyTo(start, dataChunk, 0, count);
-            client.SendAll(new MovementPacket(idChunk, dataChunk));
+            payloadProfileElapsed %= PayloadProfileIntervalSeconds;
+            ProfileActualPayloadCapacity(
+                FindLargestBatch(movementGroups.Values, legacyMovement));
+            ProfileActualPayloadCapacity(
+                FindLargestBatch(mountGroups.Values, legacyMountMovement));
+        }
+        SendMovement(movementGroups.Values);
+        SendMovement(legacyMovement);
+        SendMountMovement(mountGroups.Values);
+        SendMountMovement(legacyMountMovement);
+    }
+
+    private static MovementBatch<T> FindLargestBatch<T>(
+        IEnumerable<MovementBatch<T>> batches,
+        MovementBatch<T> legacyBatch)
+    {
+        MovementBatch<T> largest = legacyBatch;
+        foreach (var batch in batches)
+        {
+            if (largest == null || batch.Data.Count > largest.Data.Count)
+                largest = batch;
+        }
+        return largest;
+    }
+
+    private void ProfileActualPayloadCapacity(MovementBatch<AgentData> batch)
+    {
+        if (batch == null || batch.Data.Count == 0) return;
+
+        ProfileActualPayloadCapacity(
+            "agents",
+            batch,
+            count =>
+            {
+                var data = new AgentData[count];
+                batch.Data.CopyTo(0, data, 0, count);
+                if (batch.IdentityScopeId == null)
+                {
+                    var ids = new Guid[count];
+                    batch.CanonicalIds.CopyTo(0, ids, 0, count);
+                    return new MovementPacket(ids, data);
+                }
+
+                var compactIds = new ushort[count];
+                batch.CompactIds.CopyTo(0, compactIds, 0, count);
+                return new MovementPacket(batch.IdentityScopeId, compactIds, data);
+            });
+    }
+
+    private void ProfileActualPayloadCapacity(MovementBatch<AgentMountData> batch)
+    {
+        if (batch == null || batch.Data.Count == 0) return;
+
+        ProfileActualPayloadCapacity(
+            "mounts",
+            batch,
+            count =>
+            {
+                var data = new AgentMountData[count];
+                batch.Data.CopyTo(0, data, 0, count);
+                if (batch.IdentityScopeId == null)
+                {
+                    var ids = new Guid[count];
+                    batch.CanonicalIds.CopyTo(0, ids, 0, count);
+                    return new MountMovementPacket(ids, data);
+                }
+
+                var compactIds = new ushort[count];
+                batch.CompactIds.CopyTo(0, compactIds, 0, count);
+                return new MountMovementPacket(batch.IdentityScopeId, compactIds, data);
+            });
+    }
+
+    private void ProfileActualPayloadCapacity<T>(
+        string payloadName,
+        MovementBatch<T> batch,
+        Func<int, IPacket> createPacket)
+    {
+        int sampleCount = Math.Min(batch.Data.Count, MaxProfileAgents);
+        int maxSafeAgents = 0;
+        int overCeilingStreak = 0;
+        bool foundOverCeiling = false;
+        var sizes = new List<string>();
+
+        for (int count = 1; count <= sampleCount; count++)
+        {
+            int wireBytes = movementPacketCompressor.GetSerializedLength(
+                createPacket(count));
+            sizes.Add($"{count}:{wireBytes}");
+            if (wireBytes <= LiteNetP2PClient.SafeSinglePacketBytes)
+            {
+                maxSafeAgents = count;
+                overCeilingStreak = 0;
+            }
+            else
+            {
+                foundOverCeiling = true;
+                overCeilingStreak++;
+                if (overCeilingStreak >= 3)
+                    break;
+            }
         }
 
-        if (mountIds == null) return;
+        bool isLowerBound = maxSafeAgents > 0 && !foundOverCeiling;
+        Logger.Information(
+            "[BattleTraffic] Actual {PayloadName} capacity: scope={IdentityScopeId}, " +
+            "wireBytes={WireBytes}, maxSafeAgents={MaxSafeAgents}{LowerBound}, ceiling={Ceiling}",
+            payloadName,
+            batch.IdentityScopeId ?? "legacy-guid",
+            string.Join(",", sizes),
+            maxSafeAgents,
+            isLowerBound ? "+" : string.Empty,
+            LiteNetP2PClient.SafeSinglePacketBytes);
+    }
 
-        for (int start = 0; start < mountIds.Count; start += MaxAgentsPerMovementPacket)
+    private static void AddToBatch<T>(
+        Dictionary<string, MovementBatch<T>> compactBatches,
+        ref MovementBatch<T> legacyBatch,
+        CoopAgentInfo agentInfo,
+        T data)
+    {
+        MovementBatch<T> batch;
+        if (agentInfo.MovementId == 0)
         {
-            int count = Math.Min(MaxAgentsPerMovementPacket, mountIds.Count - start);
-            var idChunk = new Guid[count];
-            var dataChunk = new AgentMountData[count];
-            mountIds.CopyTo(start, idChunk, 0, count);
-            mountData.CopyTo(start, dataChunk, 0, count);
-            client.SendAll(new MountMovementPacket(idChunk, dataChunk));
+            batch = legacyBatch ??= new MovementBatch<T>(null);
+        }
+        else if (!compactBatches.TryGetValue(agentInfo.MovementScopeId, out batch))
+        {
+            batch = new MovementBatch<T>(agentInfo.MovementScopeId);
+            compactBatches[agentInfo.MovementScopeId] = batch;
+        }
+
+        batch.Add(agentInfo, data);
+    }
+
+    private void SendEquipment(IEnumerable<MovementBatch<AgentEquipmentData>> batches)
+    {
+        foreach (var batch in batches)
+            SendEquipment(batch);
+    }
+
+    private void SendEquipment(MovementBatch<AgentEquipmentData> batch)
+    {
+        if (batch == null) return;
+
+        const int maxEquipmentPerPacket = 64;
+        for (int start = 0; start < batch.Data.Count; start += maxEquipmentPerPacket)
+        {
+            int count = Math.Min(maxEquipmentPerPacket, batch.Data.Count - start);
+            var equipment = new AgentEquipmentData[count];
+            batch.Data.CopyTo(start, equipment, 0, count);
+
+            if (batch.IdentityScopeId == null)
+            {
+                var ids = new Guid[count];
+                batch.CanonicalIds.CopyTo(start, ids, 0, count);
+                client.SendAll(new AgentEquipmentPacket(ids, equipment));
+            }
+            else
+            {
+                var ids = new ushort[count];
+                batch.CompactIds.CopyTo(start, ids, 0, count);
+                client.SendAll(new AgentEquipmentPacket(
+                    batch.IdentityScopeId, ids, equipment));
+            }
+        }
+    }
+
+    private void SendMovement(IEnumerable<MovementBatch<AgentData>> batches)
+    {
+        foreach (var batch in batches)
+            SendMovement(batch);
+    }
+
+    private void SendMovement(MovementBatch<AgentData> batch)
+    {
+        if (batch == null) return;
+
+        for (int start = 0; start < batch.Data.Count; start += MaxAgentsPerMovementPacket)
+        {
+            int count = Math.Min(MaxAgentsPerMovementPacket, batch.Data.Count - start);
+            var data = new AgentData[count];
+            batch.Data.CopyTo(start, data, 0, count);
+
+            if (batch.IdentityScopeId == null)
+            {
+                var ids = new Guid[count];
+                batch.CanonicalIds.CopyTo(start, ids, 0, count);
+                client.SendAll(new MovementPacket(ids, data));
+            }
+            else
+            {
+                var ids = new ushort[count];
+                batch.CompactIds.CopyTo(start, ids, 0, count);
+                client.SendAll(new MovementPacket(batch.IdentityScopeId, ids, data));
+            }
+        }
+    }
+
+    private void SendMountMovement(IEnumerable<MovementBatch<AgentMountData>> batches)
+    {
+        foreach (var batch in batches)
+            SendMountMovement(batch);
+    }
+
+    private void SendMountMovement(MovementBatch<AgentMountData> batch)
+    {
+        if (batch == null) return;
+
+        for (int start = 0; start < batch.Data.Count; start += MaxAgentsPerMovementPacket)
+        {
+            int count = Math.Min(MaxAgentsPerMovementPacket, batch.Data.Count - start);
+            var data = new AgentMountData[count];
+            batch.Data.CopyTo(start, data, 0, count);
+
+            if (batch.IdentityScopeId == null)
+            {
+                var ids = new Guid[count];
+                batch.CanonicalIds.CopyTo(start, ids, 0, count);
+                client.SendAll(new MountMovementPacket(ids, data));
+            }
+            else
+            {
+                var ids = new ushort[count];
+                batch.CompactIds.CopyTo(start, ids, 0, count);
+                client.SendAll(new MountMovementPacket(
+                    batch.IdentityScopeId, ids, data));
+            }
         }
     }
 
     public void HandlePacket(NetPeer peer, IPacket packet)
     {
         var movement = (MovementPacket)packet;
-        if (movement.AgentIds == null) return;
+        int idCount = movement.AgentIds?.Length ?? movement.AgentGuids?.Length ?? 0;
+        if (idCount == 0 || movement.Agents == null ||
+            movement.Agents.Length != idCount)
+        {
+            return;
+        }
 
         // Resolve and apply the whole batch in ONE game-thread action. Resolving here keeps this ordered behind
         // earlier game-thread spawn/register work that may have been queued by reliable messages.
@@ -200,11 +494,15 @@ public class AgentMovementHandler : IAgentMovementHandler
 
             using (new AllowedThread())
             {
-                for (int i = 0; i < movement.AgentIds.Length; i++)
+                for (int i = 0; i < idCount; i++)
                 {
-                    var agentId = movement.AgentIds[i];
-                    if (agentRegistry.IsLocallyControlled(agentId)) continue;
-                    if (!agentRegistry.TryGetAgentInfo(agentId, out var agentInfo)) continue;
+                    CoopAgentInfo agentInfo;
+                    bool found = movement.AgentIds != null
+                        ? agentRegistry.TryGetAgentInfo(
+                            movement.IdentityScopeId, movement.AgentIds[i], out agentInfo)
+                        : agentRegistry.TryGetAgentInfo(
+                            movement.AgentGuids[i], out agentInfo);
+                    if (!found) continue;
 
                     Agent agent = agentInfo.Agent;
                     AgentData data = movement.Agents[i];
@@ -221,7 +519,7 @@ public class AgentMovementHandler : IAgentMovementHandler
                     if (agentRegistry.IsLocallyControlled(agent))
                         continue;
 
-                    SyncMountState(agent, data);
+                    SyncMountState(agent, movement.IdentityScopeId, data);
 
                     // A puppet horse must not run local AI between owner snapshots and fight their heading/input.
                     if (agent.MountAgent is Agent puppetMount && puppetMount.Controller != AgentControllerType.None)
@@ -259,7 +557,10 @@ public class AgentMovementHandler : IAgentMovementHandler
     // never re-mounts). MountAgent is set directly (controller-independent — puppets have no controller to
     // process a mount/dismount input flag); the movement sync then keeps the rider/horse positioned.
     // AgentData.Apply still syncs the mount's pose while both are mounted.
-    private void SyncMountState(Agent agent, AgentData data)
+    private void SyncMountState(
+        Agent agent,
+        string riderIdentityScopeId,
+        AgentData data)
     {
         bool ownerMounted = data.MountData != null;
 
@@ -277,7 +578,8 @@ public class AgentMovementHandler : IAgentMovementHandler
         {
             // Owner (re)mounted: prefer the exact horse it reports (registered mounts carry their id); fall
             // back to the one the puppet last left for unregistered horses.
-            Agent horse = ResolveRegisteredHorse(data.MountData.MountId);
+            Agent horse = ResolveRegisteredHorse(
+                riderIdentityScopeId, data.MountData);
             if (horse == null) _dismountedHorses.TryGetValue(agent, out horse);
             if (horse != null && horse.IsActive() && horse.RiderAgent == null)
                 agent.MountAgent = horse;
@@ -288,7 +590,8 @@ public class AgentMovementHandler : IAgentMovementHandler
             // Owner switched horses (dismount + different re-mount inside one poll interval): the reported
             // mount id no longer matches the horse the puppet sits on — move it over so damage routed by the
             // horse's id keeps hitting what players actually see.
-            Agent reported = ResolveRegisteredHorse(data.MountData.MountId);
+            Agent reported = ResolveRegisteredHorse(
+                riderIdentityScopeId, data.MountData);
             if (reported != null && !ReferenceEquals(reported, agent.MountAgent)
                 && reported.IsActive() && reported.RiderAgent == null)
             {
@@ -341,20 +644,53 @@ public class AgentMovementHandler : IAgentMovementHandler
 
     // The local agent behind a mount's network id; null when the id is empty/unknown or resolves to a
     // non-mount (a stale id after the registry entry was replaced).
-    private Agent ResolveRegisteredHorse(Guid mountId)
+    private Agent ResolveRegisteredHorse(
+        string riderIdentityScopeId,
+        AgentMountData mountData)
     {
-        if (mountId == Guid.Empty) return null;
-        if (!agentRegistry.TryGetAgentInfo(mountId, out var info)) return null;
+        CoopAgentInfo info = null;
+        bool found;
+        if (mountData.MountMovementId != 0)
+        {
+            string identityScopeId =
+                mountData.MountIdentityScopeId ?? riderIdentityScopeId;
+            found = agentRegistry.TryGetAgentInfo(
+                identityScopeId, mountData.MountMovementId, out info);
+        }
+        else
+        {
+            found = mountData.MountAgentId != Guid.Empty &&
+                    agentRegistry.TryGetAgentInfo(mountData.MountAgentId, out info);
+        }
+
+        if (!found) return null;
         return info.Agent != null && info.Agent.IsMount ? info.Agent : null;
     }
 
-    // The registry id of the agent's current mount, or Guid.Empty when on foot / the horse isn't registered.
-    private Guid GetRegisteredMountId(Agent agent)
+    private void GetRegisteredMountIdentity(
+        Agent agent,
+        string riderIdentityScopeId,
+        out ushort movementId,
+        out string identityScopeId,
+        out Guid agentId)
     {
+        movementId = 0;
+        identityScopeId = null;
+        agentId = Guid.Empty;
+
         var mount = agent.MountAgent;
         if (mount != null && agentRegistry.TryGetAgentInfo(mount, out var mountInfo))
-            return mountInfo.AgentId;
-        return Guid.Empty;
+        {
+            if (mountInfo.MovementId == 0)
+            {
+                agentId = mountInfo.AgentId;
+                return;
+            }
+
+            movementId = mountInfo.MovementId;
+            if (mountInfo.MovementScopeId != riderIdentityScopeId)
+                identityScopeId = mountInfo.MovementScopeId;
+        }
     }
 
     private void Handle_PeerEntered(MessagePayload<NetworkMissionPeerEntered> payload)

--- a/source/Missions/Agents/Handlers/MountMovementApplier.cs
+++ b/source/Missions/Agents/Handlers/MountMovementApplier.cs
@@ -37,7 +37,12 @@ public class MountMovementApplier : IPacketHandler
     public void HandlePacket(NetPeer peer, IPacket packet)
     {
         var movement = (MountMovementPacket)packet;
-        if (movement.MountIds == null) return;
+        int idCount = movement.MountIds?.Length ?? movement.MountGuids?.Length ?? 0;
+        if (idCount == 0 || movement.Mounts == null ||
+            movement.Mounts.Length != idCount)
+        {
+            return;
+        }
 
         GameThread.RunSafe(() =>
         {
@@ -46,11 +51,16 @@ public class MountMovementApplier : IPacketHandler
             // Resolve and apply the whole batch in ONE game-thread action, matching
             // AgentMovementHandler.HandlePacket.
             var toApply = new List<(Agent horse, AgentMountData data)>();
-            for (int i = 0; i < movement.MountIds.Length; i++)
+            for (int i = 0; i < idCount; i++)
             {
-                var mountId = movement.MountIds[i];
-                if (agentRegistry.IsLocallyControlled(mountId)) continue;
-                if (!agentRegistry.TryGetAgentInfo(mountId, out var mountInfo)) continue;
+                CoopAgentInfo mountInfo;
+                bool found = movement.MountIds != null
+                    ? agentRegistry.TryGetAgentInfo(
+                        movement.IdentityScopeId, movement.MountIds[i], out mountInfo)
+                    : agentRegistry.TryGetAgentInfo(
+                        movement.MountGuids[i], out mountInfo);
+                if (!found || agentRegistry.IsLocallyControlled(mountInfo.Agent))
+                    continue;
                 toApply.Add((mountInfo.Agent, movement.Mounts[i]));
             }
 

--- a/source/Missions/Agents/Packets/AgentData.cs
+++ b/source/Missions/Agents/Packets/AgentData.cs
@@ -7,17 +7,17 @@ namespace Missions.Agents.Packets
     [ProtoContract(SkipConstructor = true)]
     public struct AgentData
     {
-        // mountId: the mount's registry id (resolved by the caller — this ctor has no registry access), carried
-        // so the receiver can attach the puppet to the exact horse; Guid.Empty when unregistered/unmounted.
-        public AgentData(Agent agent, System.Guid mountId = default)
+        public AgentData(
+            Agent agent,
+            ushort mountMovementId = 0,
+            string mountIdentityScopeId = null,
+            System.Guid mountAgentId = default)
         {
             Position = agent.Position;
             MovementDirection = agent.GetMovementDirection();
             LookDirection = agent.LookDirection;
             InputVector = agent.MovementInputVector;
             Speed = agent.GetRealGlobalVelocity().AsVec2.Length;
-
-            AgentEquipment = new AgentEquipmentData(agent);
 
             // The rider can be active while its mount is mid-teardown (e.g. right after a battle concludes):
             // reading the mount's native state (MovementInputVector, etc.) then access-violates. Only capture
@@ -26,12 +26,18 @@ namespace Missions.Agents.Packets
             Agent mount = agent.MountAgent;
             if (mount != null && mount.IsActive())
             {
-                MountData = new AgentMountData(mount, mountId);
+                MountData = new AgentMountData(
+                    mount, mountMovementId, mountIdentityScopeId, mountAgentId);
             }
             else
             {
                 MountData = null;
             }
+        }
+
+        public AgentData(Agent agent, System.Guid mountAgentId)
+            : this(agent, 0, null, mountAgentId)
+        {
         }
 
         public void Apply(Agent agent)
@@ -69,9 +75,6 @@ namespace Missions.Agents.Packets
                     : new Vec2(0f, throttle);
             }
 
-            // Update equipment
-            AgentEquipment.Apply(agent);
-
             // NOTE: actions/animations are NOT applied here anymore. They are events, not continuous state, so
             // they are synced separately and on-change by AgentActionHandler (reliable-ordered), not polled with
             // movement. This keeps the movement packet purely continuous state.
@@ -91,9 +94,8 @@ namespace Missions.Agents.Packets
         public Vec3 LookDirection { get; }
         [ProtoMember(4)]
         public Vec2 MovementDirection { get; }
-        [ProtoMember(5)]
-        public AgentEquipmentData AgentEquipment { get; }
-        // 6 was ActionData — actions moved to the event-driven AgentActionHandler; tag left unused for wire stability.
+        // 5 was AgentEquipmentData — wield state moved to reliable on-change updates.
+        // 6 was ActionData — actions moved to the event-driven AgentActionHandler.
         [ProtoMember(7)]
         public AgentMountData MountData { get; }
         /// <summary>The owner's real ground speed, m/s — drives the on-foot puppet's locomotion throttle.</summary>

--- a/source/Missions/Agents/Packets/AgentEquipmentData.cs
+++ b/source/Missions/Agents/Packets/AgentEquipmentData.cs
@@ -1,11 +1,12 @@
 ﻿using ProtoBuf;
+using System;
 using TaleWorlds.Core;
 using TaleWorlds.MountAndBlade;
 
 namespace Missions.Agents.Packets
 {
     [ProtoContract(SkipConstructor = true)]
-    public readonly struct AgentEquipmentData
+    public readonly struct AgentEquipmentData : IEquatable<AgentEquipmentData>
     {
         public AgentEquipmentData(Agent agent)
         {
@@ -113,6 +114,28 @@ namespace Missions.Agents.Packets
             return weapon.Item != null && usageIndex >= 0 && usageIndex < weapon.WeaponsCount
                 ? usageIndex
                 : 0;
+        }
+
+        public bool Equals(AgentEquipmentData other)
+        {
+            return MainHandIndex == other.MainHandIndex &&
+                   OffHandIndex == other.OffHandIndex &&
+                   MainHandUsageIndex == other.MainHandUsageIndex;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is AgentEquipmentData other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = MainHandIndex;
+                hashCode = (hashCode * 397) ^ OffHandIndex;
+                return (hashCode * 397) ^ MainHandUsageIndex;
+            }
         }
 
         [ProtoMember(1)]

--- a/source/Missions/Agents/Packets/AgentEquipmentPacket.cs
+++ b/source/Missions/Agents/Packets/AgentEquipmentPacket.cs
@@ -2,43 +2,42 @@
 using LiteNetLib;
 using ProtoBuf;
 using System;
-using TaleWorlds.MountAndBlade;
 
 namespace Missions.Agents.Packets
 {
-    /// <summary>
-    /// A small batch of agent movement snapshots for one poll tick.
-    /// </summary>
     [ProtoContract]
-    public readonly struct MovementPacket : IPacket
+    public readonly struct AgentEquipmentPacket : IPacket
     {
-        public DeliveryMethod DeliveryMethod => DeliveryMethod.Unreliable;
+        public DeliveryMethod DeliveryMethod => DeliveryMethod.ReliableOrdered;
 
-        public PacketType PacketType => PacketType.Movement;
+        public PacketType PacketType => PacketType.AgentEquipment;
 
         [ProtoMember(1)]
         public string IdentityScopeId { get; }
         [ProtoMember(2)]
         public ushort[] AgentIds { get; }
         [ProtoMember(3)]
-        public AgentData[] Agents { get; }
-        [ProtoMember(4)]
         public Guid[] AgentGuids { get; }
+        [ProtoMember(4)]
+        public AgentEquipmentData[] Equipment { get; }
 
-        public MovementPacket(string identityScopeId, ushort[] agentIds, AgentData[] agents)
+        public AgentEquipmentPacket(
+            string identityScopeId,
+            ushort[] agentIds,
+            AgentEquipmentData[] equipment)
         {
             IdentityScopeId = identityScopeId;
             AgentIds = agentIds;
-            Agents = agents;
             AgentGuids = null;
+            Equipment = equipment;
         }
 
-        public MovementPacket(Guid[] agentGuids, AgentData[] agents)
+        public AgentEquipmentPacket(Guid[] agentGuids, AgentEquipmentData[] equipment)
         {
             IdentityScopeId = null;
             AgentIds = null;
             AgentGuids = agentGuids;
-            Agents = agents;
+            Equipment = equipment;
         }
     }
 }

--- a/source/Missions/Agents/Packets/AgentMountData.cs
+++ b/source/Missions/Agents/Packets/AgentMountData.cs
@@ -10,7 +10,11 @@ namespace Missions.Agents.Packets
     {
         // The parameter is the MOUNT agent itself (callers pass rider.MountAgent), so read it directly —
         // mirroring ApplyMount. Dereferencing .MountAgent here was reading the mount's own (null) mount → NRE.
-        public AgentMountData(Agent mountAgent, Guid mountId = default)
+        public AgentMountData(
+            Agent mountAgent,
+            ushort mountMovementId = 0,
+            string mountIdentityScopeId = null,
+            Guid mountAgentId = default)
         {
             MountInputVector = mountAgent.MovementInputVector;
             MountAction0Flag = (ulong)mountAgent.GetCurrentAnimationFlag(0);
@@ -23,7 +27,14 @@ namespace Missions.Agents.Packets
             MountMovementDirection = mountAgent.GetMovementDirection();
             MountPosition = mountAgent.Position;
             MountSpeed = mountAgent.GetRealGlobalVelocity().AsVec2.Length;
-            MountId = mountId;
+            MountMovementId = mountMovementId;
+            MountIdentityScopeId = mountIdentityScopeId;
+            MountAgentId = mountAgentId;
+        }
+
+        public AgentMountData(Agent mountAgent, Guid mountAgentId)
+            : this(mountAgent, 0, null, mountAgentId)
+        {
         }
 
         public void ApplyMount(Agent mountAgent)
@@ -78,11 +89,9 @@ namespace Missions.Agents.Packets
         public Vec2 MountMovementDirection { get; }
         [ProtoMember(7)]
         public Vec3 MountPosition { get; }
-        /// <summary>The mount's own network id (registry id), or <see cref="Guid.Empty"/> when the horse isn't
-        /// registered. Lets the receiver put the puppet on the EXACT horse the owner rides — including a
-        /// mid-battle switch to a different horse — instead of guessing from the last one it dismounted.</summary>
+        /// <summary>The mount's owner-scoped movement id, or zero when the horse is unregistered.</summary>
         [ProtoMember(8)]
-        public Guid MountId { get; }
+        public ushort MountMovementId { get; }
         [ProtoMember(9)]
         public ulong MountAction0Flag { get; }
         [ProtoMember(10)]
@@ -92,5 +101,10 @@ namespace Missions.Agents.Packets
         /// <summary>The owner's horizontal mount speed, used as the puppet's absolute native speed limit.</summary>
         [ProtoMember(12)]
         public float MountSpeed { get; }
+        /// <summary>Only populated when the mount's original owner differs from the rider's identity scope.</summary>
+        [ProtoMember(13)]
+        public string MountIdentityScopeId { get; }
+        [ProtoMember(14)]
+        public Guid MountAgentId { get; }
     }
 }

--- a/source/Missions/Agents/Packets/CompressedMovementPacket.cs
+++ b/source/Missions/Agents/Packets/CompressedMovementPacket.cs
@@ -1,0 +1,24 @@
+﻿using Common.PacketHandlers;
+using LiteNetLib;
+using ProtoBuf;
+
+namespace Missions.Agents.Packets;
+
+[ProtoContract(SkipConstructor = true)]
+public readonly struct CompressedMovementPacket : IPacket
+{
+    public DeliveryMethod DeliveryMethod => DeliveryMethod.Unreliable;
+
+    public PacketType PacketType => PacketType.CompressedMovement;
+
+    [ProtoMember(1)]
+    public int UncompressedLength { get; }
+    [ProtoMember(2)]
+    public byte[] Payload { get; }
+
+    public CompressedMovementPacket(int uncompressedLength, byte[] payload)
+    {
+        UncompressedLength = uncompressedLength;
+        Payload = payload;
+    }
+}

--- a/source/Missions/Agents/Packets/MountMovementPacket.cs
+++ b/source/Missions/Agents/Packets/MountMovementPacket.cs
@@ -1,4 +1,4 @@
-using Common.PacketHandlers;
+﻿using Common.PacketHandlers;
 using LiteNetLib;
 using ProtoBuf;
 using System;
@@ -20,13 +20,27 @@ namespace Missions.Agents.Packets
         public PacketType PacketType => PacketType.MountMovement;
 
         [ProtoMember(1)]
-        public Guid[] MountIds { get; }
+        public string IdentityScopeId { get; }
         [ProtoMember(2)]
+        public ushort[] MountIds { get; }
+        [ProtoMember(3)]
         public AgentMountData[] Mounts { get; }
+        [ProtoMember(4)]
+        public Guid[] MountGuids { get; }
 
-        public MountMovementPacket(Guid[] mountIds, AgentMountData[] mounts)
+        public MountMovementPacket(string identityScopeId, ushort[] mountIds, AgentMountData[] mounts)
         {
+            IdentityScopeId = identityScopeId;
             MountIds = mountIds;
+            Mounts = mounts;
+            MountGuids = null;
+        }
+
+        public MountMovementPacket(Guid[] mountGuids, AgentMountData[] mounts)
+        {
+            IdentityScopeId = null;
+            MountIds = null;
+            MountGuids = mountGuids;
             Mounts = mounts;
         }
     }

--- a/source/Missions/Battles/BattleDebugCommands.cs
+++ b/source/Missions/Battles/BattleDebugCommands.cs
@@ -63,14 +63,11 @@ internal static class BattleDebugCommands
 
         bool deploymentReady = mission.GetMissionBehavior<DeploymentMissionController>()?.TeamSetupOver == true;
         int activeAgents = mission.Agents.Count(agent => agent.IsActive());
-        MissionResult result = mission.MissionResult;
 
         return $"instance={controller.Session.InstanceId} host={controller.Session.IsLocalHost} " +
             $"activated={controller.Deployment.IsActivated} committed={controller.Deployment.IsCommitted} " +
             $"deploymentReady={deploymentReady} mainAgent={Agent.Main != null} activeAgents={activeAgents} " +
             $"playerSide={playerTeam?.Side.ToString() ?? "None"} enemyParties={enemyParties} enemyActive={enemies.Count} " +
-            $"enemyAi={enemies.Count(agent => agent.IsAIControlled)} enemyMovedSinceLast={moved} " +
-            $"resultReady={result?.BattleResolved == true} battleState={result?.BattleState.ToString() ?? "None"} " +
-            $"playerVictory={result?.PlayerVictory == true} enemyRetreated={result?.EnemyRetreated == true}";
+            $"enemyAi={enemies.Count(agent => agent.IsAIControlled)} enemyMovedSinceLast={moved}";
     }
 }

--- a/source/Missions/Battles/BattleDebugCommands.cs
+++ b/source/Missions/Battles/BattleDebugCommands.cs
@@ -63,11 +63,14 @@ internal static class BattleDebugCommands
 
         bool deploymentReady = mission.GetMissionBehavior<DeploymentMissionController>()?.TeamSetupOver == true;
         int activeAgents = mission.Agents.Count(agent => agent.IsActive());
+        MissionResult result = mission.MissionResult;
 
         return $"instance={controller.Session.InstanceId} host={controller.Session.IsLocalHost} " +
             $"activated={controller.Deployment.IsActivated} committed={controller.Deployment.IsCommitted} " +
             $"deploymentReady={deploymentReady} mainAgent={Agent.Main != null} activeAgents={activeAgents} " +
             $"playerSide={playerTeam?.Side.ToString() ?? "None"} enemyParties={enemyParties} enemyActive={enemies.Count} " +
-            $"enemyAi={enemies.Count(agent => agent.IsAIControlled)} enemyMovedSinceLast={moved}";
+            $"enemyAi={enemies.Count(agent => agent.IsAIControlled)} enemyMovedSinceLast={moved} " +
+            $"resultReady={result?.BattleResolved == true} battleState={result?.BattleState.ToString() ?? "None"} " +
+            $"playerVictory={result?.PlayerVictory == true} enemyRetreated={result?.EnemyRetreated == true}";
     }
 }

--- a/source/Missions/Battles/OwnedAgentReplicator.cs
+++ b/source/Missions/Battles/OwnedAgentReplicator.cs
@@ -4,6 +4,7 @@ using Common.Messaging;
 using GameInterface.Services.MapEvents.Messages;
 using GameInterface.Services.MapEvents.TroopSupply;
 using GameInterface.Services.ObjectManager;
+using Missions.Agents.Packets;
 using Missions.Data;
 using Missions.Messages;
 using Serilog;
@@ -64,6 +65,8 @@ public class OwnedAgentReplicator : IOwnedAgentReplicator
     // that horse's death broadcast never reaches the joiner. Touched only on the game thread (spawn capture
     // and record building both run there), so no lock; per-mission (this component is transient).
     private readonly Dictionary<Guid, Guid> spawnMounts = new Dictionary<Guid, Guid>();
+    private readonly string movementScopeId;
+    private ushort nextMovementId = 1;
 
     public OwnedAgentReplicator(
         IBattleNetwork network,
@@ -81,6 +84,8 @@ public class OwnedAgentReplicator : IOwnedAgentReplicator
         this.session = session;
         this.casualties = casualties;
         this.deployment = deployment;
+        movementScopeId =
+            session.OwnControllerId + ":" + Guid.NewGuid().ToString("N");
 
         messageBroker.Subscribe<AgentSpawnedInBattle>(Handle_AgentSpawnedInBattle);
     }
@@ -152,11 +157,22 @@ public class OwnedAgentReplicator : IOwnedAgentReplicator
 
             // Catch-up records carry the current holder. A migrated NPC must stay under the successor when its
             // original host rejoins; labeling it with the original host would make that client drive it too.
+            Guid mountAgentId = ResolveMountIdFor(info.AgentId, agent);
+            CoopAgentInfo mountInfo = ResolveAgentInfo(mountAgentId);
+
             records.Add(new BattleAgentSpawnData(
                 info.AgentId, characterId, agent.Position, side, agent.Health,
                 session.OwnControllerId, attribution.MapEventPartyId, attribution.TroopSeed,
                 spawnEquipment, bodyProperties, missionEquipmentData,
-                ResolveMountIdFor(info.AgentId, agent), formationIndex));
+                mountAgentId, formationIndex, info.MovementId,
+                mountInfo?.MovementId ?? 0,
+                originalOwnerControllerId: info.OriginalOwner,
+                currentEquipment: new AgentEquipmentData(agent),
+                movementScopeId: info.MovementScopeId,
+                mountOriginalOwnerControllerId:
+                    mountInfo?.OriginalOwner ?? info.OriginalOwner,
+                mountMovementScopeId:
+                    mountInfo?.MovementScopeId ?? info.MovementScopeId));
         }
         return records;
     }
@@ -188,6 +204,14 @@ public class OwnedAgentReplicator : IOwnedAgentReplicator
         return Guid.Empty;
     }
 
+    private CoopAgentInfo ResolveAgentInfo(Guid agentId)
+    {
+        return agentId != Guid.Empty &&
+               coopMissionComponent.AgentRegistry.TryGetAgentInfo(agentId, out var info)
+            ? info
+            : null;
+    }
+
     // Whether an agent belongs to the LOCAL player's own party — the troops withheld until deployment commit
     // (requirement #4). The player's hero and the troops the local supplier spawned for MainParty are own-party;
     // the host's enemy/allied AI (a different origin party) is not, so it shows up frozen during deployment (#1).
@@ -213,18 +237,37 @@ public class OwnedAgentReplicator : IOwnedAgentReplicator
 
         string owner = session.OwnControllerId;
         var agentId = Guid.NewGuid();
-        coopMissionComponent.AgentRegistry.TryRegisterAgent(owner, agentId, agent);
+        ushort movementId = AllocateMovementId();
+        if (!coopMissionComponent.AgentRegistry.TryRegisterAgent(
+                owner,
+                owner,
+                movementScopeId,
+                agentId,
+                movementId,
+                agent))
+            return;
 
         // A cavalry spawn's horse is already live and linked here (the engine spawns it inside the same
         // Mission.SpawnAgent call, from the rider's equipment). Register it with its OWN identity under us, so
         // hits on it route by the horse's id and its death broadcasts like any agent's (issue #1750). Mounts
         // get no casualty attribution — a horse is not a roster troop.
         var mountAgentId = Guid.Empty;
+        ushort mountMovementId = 0;
         if (agent.MountAgent is Agent mount)
         {
             mountAgentId = Guid.NewGuid();
-            if (!coopMissionComponent.AgentRegistry.TryRegisterAgent(owner, mountAgentId, mount))
+            mountMovementId = AllocateMovementId();
+            if (!coopMissionComponent.AgentRegistry.TryRegisterAgent(
+                    owner,
+                    owner,
+                    movementScopeId,
+                    mountAgentId,
+                    mountMovementId,
+                    mount))
+            {
                 mountAgentId = Guid.Empty;
+                mountMovementId = 0;
+            }
             else
                 spawnMounts[agentId] = mountAgentId;
         }
@@ -262,7 +305,16 @@ public class OwnedAgentReplicator : IOwnedAgentReplicator
 
         BattleSideEnum side = agent.Team != null ? agent.Team.Side : BattleSideEnum.None;
         int formationIndex = agent.Formation != null ? (int)agent.Formation.FormationIndex : -1;
-        var data = new BattleAgentSpawnData(agentId, characterId, agent.Position, side, agent.Health, owner, mapEventPartyId, troopSeed, spawnEquipment, bodyProperties, missionEquipmentData, mountAgentId, formationIndex);
+        var data = new BattleAgentSpawnData(
+            agentId, characterId, agent.Position, side, agent.Health, owner,
+            mapEventPartyId, troopSeed, spawnEquipment, bodyProperties,
+            missionEquipmentData, mountAgentId, formationIndex, movementId,
+            mountMovementId,
+            originalOwnerControllerId: owner,
+            currentEquipment: new AgentEquipmentData(agent),
+            movementScopeId: movementScopeId,
+            mountOriginalOwnerControllerId: owner,
+            mountMovementScopeId: movementScopeId);
 
         // Populate MapEvent's UpgradeTroopTracker with spawned agent to handle on the server during battle.
         messageBroker.Publish(this, new TrackTroopForUpgrades(mapEventPartyId, characterId));
@@ -281,6 +333,14 @@ public class OwnedAgentReplicator : IOwnedAgentReplicator
         // SendAll over the mesh reaches every peer in this battle instance (not us).
         Logger.Information("[BattleSync] Captured own spawn {Char} (agent {AgentId}); broadcasting over mesh", characterId, agentId);
         network.SendAll(new NetworkSpawnBattleAgents(new[] { data }));
+    }
+
+    private ushort AllocateMovementId()
+    {
+        ushort movementId = nextMovementId++;
+        if (movementId == 0)
+            throw new InvalidOperationException("A mission controller exhausted its compact movement ids.");
+        return movementId;
     }
 
     private static void AttachPlayerAgent(Agent agent, CharacterObject character)

--- a/source/Missions/Battles/PuppetSpawner.cs
+++ b/source/Missions/Battles/PuppetSpawner.cs
@@ -240,7 +240,15 @@ public class PuppetSpawner : IPuppetSpawner
             agent.SetIsAIPaused(false);
         }
 
-        registry.TryRegisterAgent(data.OwnerControllerId, data.AgentId, agent);
+        registry.TryRegisterAgent(
+            data.OwnerControllerId,
+            data.OriginalOwnerControllerId,
+            data.MovementScopeId,
+            data.AgentId,
+            data.MovementId,
+            agent);
+        if (data.HasCurrentEquipment)
+            data.CurrentEquipment.Apply(agent);
 
         // The owner registered its cavalry's horse with its own network id; our engine spawned a matching
         // horse implicitly (same equipment) inside SpawnAgent. Register OUR copy under the same id, so mount
@@ -250,7 +258,13 @@ public class PuppetSpawner : IPuppetSpawner
         if (data.MountAgentId != Guid.Empty)
         {
             if (agent.MountAgent is Agent mount)
-                registry.TryRegisterAgent(data.OwnerControllerId, data.MountAgentId, mount);
+                registry.TryRegisterAgent(
+                    data.OwnerControllerId,
+                    data.MountOriginalOwnerControllerId,
+                    data.MountMovementScopeId,
+                    data.MountAgentId,
+                    data.MountMovementId,
+                    mount);
             else
                 Logger.Warning("[BattleSync] Spawn record for {AgentId} carries mount {MountId} but the puppet spawned unmounted", data.AgentId, data.MountAgentId);
         }

--- a/source/Missions/Messages/NetworkSpawnBattleAgents.cs
+++ b/source/Missions/Messages/NetworkSpawnBattleAgents.cs
@@ -1,4 +1,5 @@
-using Common.Messaging;
+﻿using Common.Messaging;
+using Missions.Agents.Packets;
 using Missions.Data;
 using ProtoBuf;
 using System;
@@ -64,6 +65,24 @@ public class BattleAgentSpawnData
     // mirrors the owner's actual deployment split instead of a default troop-class grouping.
     [ProtoMember(14)]
     public readonly int FormationIndex;
+    // Compact identities used only by the high-frequency movement stream. The canonical Guids remain
+    // authoritative for reliable gameplay messages.
+    [ProtoMember(15)]
+    public readonly ushort MovementId;
+    [ProtoMember(16)]
+    public readonly ushort MountMovementId;
+    [ProtoMember(17)]
+    public readonly string OriginalOwnerControllerId;
+    [ProtoMember(18)]
+    public readonly AgentEquipmentData CurrentEquipment;
+    [ProtoMember(19)]
+    public readonly bool HasCurrentEquipment;
+    [ProtoMember(20)]
+    public readonly string MovementScopeId;
+    [ProtoMember(21)]
+    public readonly string MountOriginalOwnerControllerId;
+    [ProtoMember(22)]
+    public readonly string MountMovementScopeId;
 
     public BattleAgentSpawnData(
         Guid agentId,
@@ -78,7 +97,14 @@ public class BattleAgentSpawnData
         BodyProperties bodyProperties,
         MissionEquipmentData missionEquipmentData,
         Guid mountAgentId = default,
-        int formationIndex = -1)
+        int formationIndex = -1,
+        ushort movementId = 0,
+        ushort mountMovementId = 0,
+        string originalOwnerControllerId = null,
+        AgentEquipmentData? currentEquipment = null,
+        string movementScopeId = null,
+        string mountOriginalOwnerControllerId = null,
+        string mountMovementScopeId = null)
     {
         AgentId = agentId;
         CharacterId = characterId;
@@ -93,5 +119,14 @@ public class BattleAgentSpawnData
         MissionEquipmentData = missionEquipmentData;
         MountAgentId = mountAgentId;
         FormationIndex = formationIndex;
+        MovementId = movementId;
+        MountMovementId = mountMovementId;
+        OriginalOwnerControllerId = originalOwnerControllerId ?? ownerControllerId;
+        MovementScopeId = movementScopeId ?? OriginalOwnerControllerId;
+        MountOriginalOwnerControllerId =
+            mountOriginalOwnerControllerId ?? OriginalOwnerControllerId;
+        MountMovementScopeId = mountMovementScopeId ?? MovementScopeId;
+        CurrentEquipment = currentEquipment.GetValueOrDefault();
+        HasCurrentEquipment = currentEquipment.HasValue;
     }
 }

--- a/source/Missions/MissionModule.cs
+++ b/source/Missions/MissionModule.cs
@@ -41,6 +41,9 @@ public class MissionModule : Module
             AgentVoicePatchCategory));
 
         builder.RegisterType<LiteNetP2PClient>().As<IBattleNetwork>().InstancePerLifetimeScope();
+        builder.RegisterType<MovementPacketCompressor>()
+            .As<IMovementPacketCompressor>()
+            .InstancePerDependency();
         builder.RegisterType<NoopSteamMissionBridge>().As<ISteamMissionBridge>().InstancePerLifetimeScope();
 
         // MissionContext mirrors the server's instance membership and must live for the whole client
@@ -143,6 +146,7 @@ public class MissionModule : Module
         //builder.RegisterType<NetworkMissileRegistry>().As<INetworkMissileRegistry>().InstancePerDependency();
         builder.RegisterType<NetworkWorldItemRegistry>().As<INetworkWorldItemRegistry>().InstancePerLifetimeScope();
         builder.RegisterType<MissileHandler>().As<IMissileHandler>().InstancePerDependency();
+        builder.RegisterType<AgentEquipmentApplier>().As<IAgentEquipmentApplier>().InstancePerDependency();
         builder.RegisterType<AgentMovementHandler>().As<IAgentMovementHandler>().InstancePerDependency();
         builder.RegisterType<AgentVisualActionAccessor>()
             .As<IAgentVisualActionAccessor>()

--- a/source/Missions/Missions.csproj
+++ b/source/Missions/Missions.csproj
@@ -186,6 +186,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="8.2.0" />
     <PackageReference Include="Fmod5Sharp" Version="3.0.1" />
+    <PackageReference Include="K4os.Compression.LZ4" Version="1.3.8" />
     <PackageReference Include="Krafs.Publicizer" Version="2.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/Missions/NetworkAgentRegistry.cs
+++ b/source/Missions/NetworkAgentRegistry.cs
@@ -1,4 +1,4 @@
-using Common.Logging;
+﻿using Common.Logging;
 using GameInterface.Services.Entity;
 using Serilog;
 using System;
@@ -16,11 +16,21 @@ public interface INetworkAgentRegistry : IDisposable
     /// <summary>Clears all data.</summary>
     void Clear();
     bool TryRegisterAgent(string controllerId, Guid agentId, Agent agent);
+    bool TryRegisterAgent(string controllerId, Guid agentId, ushort movementId, Agent agent);
+    bool TryRegisterAgent(string controllerId, string originalOwner, Guid agentId, ushort movementId, Agent agent);
+    bool TryRegisterAgent(
+        string controllerId,
+        string originalOwner,
+        string movementScopeId,
+        Guid agentId,
+        ushort movementId,
+        Agent agent);
     bool RemoveController(string controllerId);
     bool RemoveAgent(Guid agentId);
     bool RemoveAgent(Agent agent);
     bool TryGetAgentInfo(Agent agent, out CoopAgentInfo agentInfo);
     bool TryGetAgentInfo(Guid agentId, out CoopAgentInfo agentInfo);
+    bool TryGetAgentInfo(string movementScopeId, ushort movementId, out CoopAgentInfo agentInfo);
     bool IsLocallyControlled(Guid agentId);
     bool IsLocallyControlled(Agent agent);
     bool TryTransferAuthority(string controllerId, Guid agentId);
@@ -44,6 +54,7 @@ public class NetworkAgentRegistry : INetworkAgentRegistry
     private readonly object gate = new();
     private readonly Dictionary<Agent, CoopAgentInfo> AgentToInfo = new();
     private readonly Dictionary<Guid, CoopAgentInfo> IdToInfo = new();
+    private readonly Dictionary<(string Scope, ushort MovementId), CoopAgentInfo> MovementIdToInfo = new();
     private readonly Dictionary<string, List<CoopAgentInfo>> ControllerAgentMap = new();
     private readonly IControllerIdProvider controllerIdProvider;
 
@@ -61,6 +72,7 @@ public class NetworkAgentRegistry : INetworkAgentRegistry
         {
             AgentToInfo.Clear();
             IdToInfo.Clear();
+            MovementIdToInfo.Clear();
             ControllerAgentMap.Clear();
         }
     }
@@ -68,9 +80,58 @@ public class NetworkAgentRegistry : INetworkAgentRegistry
     /// <inheritdoc/>
     public bool TryRegisterAgent(string controllerId, Guid agentId, Agent agent)
     {
+        return TryRegisterAgent(
+            controllerId, controllerId, controllerId, agentId, 0, agent);
+    }
+
+    /// <inheritdoc/>
+    public bool TryRegisterAgent(string controllerId, Guid agentId, ushort movementId, Agent agent)
+    {
+        return TryRegisterAgent(
+            controllerId, controllerId, controllerId, agentId, movementId, agent);
+    }
+
+    /// <inheritdoc/>
+    public bool TryRegisterAgent(
+        string controllerId,
+        string originalOwner,
+        Guid agentId,
+        ushort movementId,
+        Agent agent)
+    {
+        return TryRegisterAgent(
+            controllerId,
+            originalOwner,
+            originalOwner,
+            agentId,
+            movementId,
+            agent);
+    }
+
+    /// <inheritdoc/>
+    public bool TryRegisterAgent(
+        string controllerId,
+        string originalOwner,
+        string movementScopeId,
+        Guid agentId,
+        ushort movementId,
+        Agent agent)
+    {
         if (string.IsNullOrEmpty(controllerId))
         {
             Logger.Error($"{nameof(controllerId)} is null or empty.");
+            return false;
+        }
+
+        if (string.IsNullOrEmpty(originalOwner))
+        {
+            Logger.Error($"{nameof(originalOwner)} is null or empty.");
+            return false;
+        }
+
+        if (string.IsNullOrEmpty(movementScopeId))
+        {
+            Logger.Error($"{nameof(movementScopeId)} is null or empty.");
             return false;
         }
 
@@ -86,18 +147,29 @@ public class NetworkAgentRegistry : INetworkAgentRegistry
             return false;
         }
 
-        var agentInfo = new CoopAgentInfo(controllerId, agent, agentId);
+        var agentInfo = new CoopAgentInfo(
+            controllerId,
+            originalOwner,
+            movementScopeId,
+            agent,
+            agentId,
+            movementId);
 
         lock (gate)
         {
-            if (AgentToInfo.ContainsKey(agent) || IdToInfo.ContainsKey(agentId))
+            if (AgentToInfo.ContainsKey(agent) ||
+                IdToInfo.ContainsKey(agentId) ||
+                (movementId != 0 && MovementIdToInfo.ContainsKey((movementScopeId, movementId))))
             {
-                Logger.Error($"Agent is already registered. AgentId: {agentId}");
+                Logger.Error("Agent is already registered. AgentId: {AgentId}, movement identity: {Scope}/{MovementId}",
+                    agentId, movementScopeId, movementId);
                 return false;
             }
 
             AgentToInfo[agent] = agentInfo;
             IdToInfo[agentId] = agentInfo;
+            if (movementId != 0)
+                MovementIdToInfo[(movementScopeId, movementId)] = agentInfo;
 
             if (!ControllerAgentMap.TryGetValue(agentInfo.CurrentAuthority, out var controlledAgents))
             {
@@ -147,6 +219,8 @@ public class NetworkAgentRegistry : INetworkAgentRegistry
         succeeded &= controlledAgents.Remove(agentInfo);
         succeeded &= IdToInfo.Remove(agentInfo.AgentId);
         succeeded &= AgentToInfo.Remove(agentInfo.Agent);
+        if (agentInfo.MovementId != 0)
+            succeeded &= MovementIdToInfo.Remove((agentInfo.MovementScopeId, agentInfo.MovementId));
         return succeeded;
     }
 
@@ -168,6 +242,21 @@ public class NetworkAgentRegistry : INetworkAgentRegistry
         lock (gate)
         {
             return IdToInfo.TryGetValue(agentId, out agentInfo);
+        }
+    }
+
+    /// <inheritdoc/>
+    public bool TryGetAgentInfo(string movementScopeId, ushort movementId, out CoopAgentInfo agentInfo)
+    {
+        if (string.IsNullOrEmpty(movementScopeId) || movementId == 0)
+        {
+            agentInfo = default;
+            return false;
+        }
+
+        lock (gate)
+        {
+            return MovementIdToInfo.TryGetValue((movementScopeId, movementId), out agentInfo);
         }
     }
 
@@ -210,6 +299,8 @@ public class NetworkAgentRegistry : INetworkAgentRegistry
             {
                 IdToInfo.Remove(agentInfo.AgentId);
                 AgentToInfo.Remove(agentInfo.Agent);
+                if (agentInfo.MovementId != 0)
+                    MovementIdToInfo.Remove((agentInfo.MovementScopeId, agentInfo.MovementId));
             }
 
             return ControllerAgentMap.Remove(controllerId);
@@ -300,14 +391,24 @@ public class CoopAgentInfo
 {
     public Agent Agent { get; }
     public Guid AgentId { get; }
+    public ushort MovementId { get; }
     public string OriginalOwner { get; }
+    public string MovementScopeId { get; }
     public string CurrentAuthority { get; internal set; }
 
-    internal CoopAgentInfo(string ownerId, Agent agent, Guid agentId)
+    internal CoopAgentInfo(
+        string currentAuthority,
+        string originalOwner,
+        string movementScopeId,
+        Agent agent,
+        Guid agentId,
+        ushort movementId)
     {
-        OriginalOwner = ownerId;
-        CurrentAuthority = ownerId;
+        OriginalOwner = originalOwner;
+        MovementScopeId = movementScopeId;
+        CurrentAuthority = currentAuthority;
         Agent = agent;
         AgentId = agentId;
+        MovementId = movementId;
     }
 }

--- a/source/Missions/Services/Network/LiteNetP2PClient.cs
+++ b/source/Missions/Services/Network/LiteNetP2PClient.cs
@@ -42,6 +42,7 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
     private readonly IMessageBroker messageBroker;
     private readonly IControllerIdProvider controllerIdProvider;
     private readonly ISteamMissionBridge steamBridge;
+    private readonly IMovementPacketCompressor movementPacketCompressor;
     private readonly Poller poller;
 
     private readonly object peerGate = new();
@@ -81,7 +82,8 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
         IMessageBroker messageBroker,
         IPacketManager packetManager,
         IControllerIdProvider controllerIdProvider,
-        ISteamMissionBridge steamBridge)
+        ISteamMissionBridge steamBridge,
+        IMovementPacketCompressor movementPacketCompressor)
     {
         Config = config;
         this.relayNetwork = relayNetwork;
@@ -91,6 +93,7 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
         this.messageBroker = messageBroker;
         this.controllerIdProvider = controllerIdProvider;
         this.steamBridge = steamBridge;
+        this.movementPacketCompressor = movementPacketCompressor;
 
         netManager = new NetManager(this)
         {
@@ -561,9 +564,10 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
 
     public void SendAll(IPacket packet)
     {
+        byte[] data = movementPacketCompressor.Serialize(packet);
         foreach (var controllerId in missionContext.ControllersInMission)
         {
-            Send(controllerId, packet);
+            Send(controllerId, packet, data);
         }
     }
 
@@ -579,24 +583,29 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
 
     public void SendAllBut(string excludedId, IPacket packet)
     {
+        byte[] data = movementPacketCompressor.Serialize(packet);
         foreach (var controllerId in missionContext.ControllersInMission.Where(id => id != excludedId))
         {
-            Send(controllerId, packet);
+            Send(controllerId, packet, data);
         }
     }
 
     public void Send(string controllerId, IPacket packet)
     {
+        Send(controllerId, packet, movementPacketCompressor.Serialize(packet));
+    }
+
+    private void Send(string controllerId, IPacket packet, byte[] data)
+    {
         // Send directly to direct peer
         if (missionContext.TryGetPeer(controllerId, out var peer))
         {
-            Send(peer, packet);
+            Send(peer, packet, data);
             return;
         }
 
         // Otherwise send relay packet to the server
-        var payload = serializer.Serialize(packet);
-        relayNetwork.SendAll(new RelayPacket(packet.DeliveryMethod, instanceId, controllerId, payload));
+        relayNetwork.SendAll(new RelayPacket(packet.DeliveryMethod, instanceId, controllerId, data));
     }
 
     // Peer-reported MTUs can be optimistic, so cap nonfragmentable sends at a conservative ceiling.
@@ -622,7 +631,11 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
 
     public void Send(NetPeer netPeer, IPacket packet)
     {
-        byte[] data = serializer.Serialize(packet);
+        Send(netPeer, packet, movementPacketCompressor.Serialize(packet));
+    }
+
+    private void Send(NetPeer netPeer, IPacket packet, byte[] data)
+    {
         DeliveryMethod? selectedMethod = SelectDeliveryMethod(
             packet,
             data.Length,
@@ -652,6 +665,11 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
         }
 
         var packet = serializer.Deserialize<IPacket>(reader.GetRemainingBytes());
+        if (!movementPacketCompressor.TryRestore(packet, out packet))
+        {
+            Logger.Warning("Discarding an invalid compressed movement packet");
+            return;
+        }
 
         packetManager.HandleReceive(peer, packet);
     }

--- a/source/Missions/Services/Network/MovementPacketCompressor.cs
+++ b/source/Missions/Services/Network/MovementPacketCompressor.cs
@@ -1,34 +1,23 @@
-﻿using Common.Logging;
-using Common.PacketHandlers;
+﻿using Common.PacketHandlers;
 using Common.Serialization;
 using K4os.Compression.LZ4;
 using Missions.Agents.Packets;
-using Serilog;
 using System;
 using System.Buffers;
-using System.Diagnostics;
 
 namespace Missions.Services.Network;
 
 public interface IMovementPacketCompressor
 {
     byte[] Serialize(IPacket packet);
-    int GetSerializedLength(IPacket packet);
     bool TryRestore(IPacket packet, out IPacket restored);
 }
 
 public class MovementPacketCompressor : IMovementPacketCompressor
 {
     internal const int MaxUncompressedBytes = 4096;
-    private const double DiagnosticIntervalSeconds = 5;
-    private static readonly ILogger Logger = LogManager.GetLogger<MovementPacketCompressor>();
 
     private readonly ICommonSerializer serializer;
-    private readonly object diagnosticGate = new object();
-    private long intervalStarted = Stopwatch.GetTimestamp();
-    private long intervalOriginalBytes;
-    private long intervalWireBytes;
-    private int intervalPackets;
 
     public MovementPacketCompressor(ICommonSerializer serializer)
     {
@@ -37,16 +26,6 @@ public class MovementPacketCompressor : IMovementPacketCompressor
 
     public byte[] Serialize(IPacket packet)
     {
-        return Serialize(packet, recordDiagnostic: true);
-    }
-
-    public int GetSerializedLength(IPacket packet)
-    {
-        return Serialize(packet, recordDiagnostic: false).Length;
-    }
-
-    private byte[] Serialize(IPacket packet, bool recordDiagnostic)
-    {
         byte[] original = serializer.Serialize(packet);
         if (!IsMovement(packet))
             return original;
@@ -54,8 +33,6 @@ public class MovementPacketCompressor : IMovementPacketCompressor
         if (original.Length == 0 ||
             original.Length > MaxUncompressedBytes)
         {
-            if (recordDiagnostic)
-                RecordDiagnostic(original.Length, original.Length);
             return original;
         }
 
@@ -69,8 +46,6 @@ public class MovementPacketCompressor : IMovementPacketCompressor
                 LZ4Level.L00_FAST);
             if (compressedLength <= 0 || compressedLength >= original.Length)
             {
-                if (recordDiagnostic)
-                    RecordDiagnostic(original.Length, original.Length);
                 return original;
             }
 
@@ -78,10 +53,7 @@ public class MovementPacketCompressor : IMovementPacketCompressor
             Buffer.BlockCopy(buffer, 0, payload, 0, compressedLength);
             byte[] envelope = serializer.Serialize(
                 new CompressedMovementPacket(original.Length, payload));
-            byte[] wire = envelope.Length < original.Length ? envelope : original;
-            if (recordDiagnostic)
-                RecordDiagnostic(original.Length, wire.Length);
-            return wire;
+            return envelope.Length < original.Length ? envelope : original;
         }
         finally
         {
@@ -128,38 +100,5 @@ public class MovementPacketCompressor : IMovementPacketCompressor
     {
         return packet.PacketType == PacketType.Movement ||
                packet.PacketType == PacketType.MountMovement;
-    }
-
-    private void RecordDiagnostic(int originalBytes, int wireBytes)
-    {
-        lock (diagnosticGate)
-        {
-            intervalPackets++;
-            intervalOriginalBytes += originalBytes;
-            intervalWireBytes += wireBytes;
-
-            long now = Stopwatch.GetTimestamp();
-            double seconds = (double)(now - intervalStarted) / Stopwatch.Frequency;
-            if (seconds < DiagnosticIntervalSeconds)
-                return;
-
-            double savings = intervalOriginalBytes == 0
-                ? 0
-                : 1d - ((double)intervalWireBytes / intervalOriginalBytes);
-            Logger.Information(
-                "[BattleTraffic] Movement payloads: {Packets} packets, {OriginalBytes} -> {WireBytes} bytes " +
-                "({Savings:P1} saved), {WireBytesPerSecond:F0} bytes/s per peer over {Seconds:F1}s",
-                intervalPackets,
-                intervalOriginalBytes,
-                intervalWireBytes,
-                savings,
-                intervalWireBytes / seconds,
-                seconds);
-
-            intervalStarted = now;
-            intervalOriginalBytes = 0;
-            intervalWireBytes = 0;
-            intervalPackets = 0;
-        }
     }
 }

--- a/source/Missions/Services/Network/MovementPacketCompressor.cs
+++ b/source/Missions/Services/Network/MovementPacketCompressor.cs
@@ -1,0 +1,165 @@
+﻿using Common.Logging;
+using Common.PacketHandlers;
+using Common.Serialization;
+using K4os.Compression.LZ4;
+using Missions.Agents.Packets;
+using Serilog;
+using System;
+using System.Buffers;
+using System.Diagnostics;
+
+namespace Missions.Services.Network;
+
+public interface IMovementPacketCompressor
+{
+    byte[] Serialize(IPacket packet);
+    int GetSerializedLength(IPacket packet);
+    bool TryRestore(IPacket packet, out IPacket restored);
+}
+
+public class MovementPacketCompressor : IMovementPacketCompressor
+{
+    internal const int MaxUncompressedBytes = 4096;
+    private const double DiagnosticIntervalSeconds = 5;
+    private static readonly ILogger Logger = LogManager.GetLogger<MovementPacketCompressor>();
+
+    private readonly ICommonSerializer serializer;
+    private readonly object diagnosticGate = new object();
+    private long intervalStarted = Stopwatch.GetTimestamp();
+    private long intervalOriginalBytes;
+    private long intervalWireBytes;
+    private int intervalPackets;
+
+    public MovementPacketCompressor(ICommonSerializer serializer)
+    {
+        this.serializer = serializer;
+    }
+
+    public byte[] Serialize(IPacket packet)
+    {
+        return Serialize(packet, recordDiagnostic: true);
+    }
+
+    public int GetSerializedLength(IPacket packet)
+    {
+        return Serialize(packet, recordDiagnostic: false).Length;
+    }
+
+    private byte[] Serialize(IPacket packet, bool recordDiagnostic)
+    {
+        byte[] original = serializer.Serialize(packet);
+        if (!IsMovement(packet))
+            return original;
+
+        if (original.Length == 0 ||
+            original.Length > MaxUncompressedBytes)
+        {
+            if (recordDiagnostic)
+                RecordDiagnostic(original.Length, original.Length);
+            return original;
+        }
+
+        int maximumLength = LZ4Codec.MaximumOutputSize(original.Length);
+        byte[] buffer = ArrayPool<byte>.Shared.Rent(maximumLength);
+        try
+        {
+            int compressedLength = LZ4Codec.Encode(
+                original, 0, original.Length,
+                buffer, 0, maximumLength,
+                LZ4Level.L00_FAST);
+            if (compressedLength <= 0 || compressedLength >= original.Length)
+            {
+                if (recordDiagnostic)
+                    RecordDiagnostic(original.Length, original.Length);
+                return original;
+            }
+
+            var payload = new byte[compressedLength];
+            Buffer.BlockCopy(buffer, 0, payload, 0, compressedLength);
+            byte[] envelope = serializer.Serialize(
+                new CompressedMovementPacket(original.Length, payload));
+            byte[] wire = envelope.Length < original.Length ? envelope : original;
+            if (recordDiagnostic)
+                RecordDiagnostic(original.Length, wire.Length);
+            return wire;
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    public bool TryRestore(IPacket packet, out IPacket restored)
+    {
+        if (!(packet is CompressedMovementPacket compressed))
+        {
+            restored = packet;
+            return true;
+        }
+
+        restored = null;
+        if (compressed.Payload == null ||
+            compressed.UncompressedLength <= 0 ||
+            compressed.UncompressedLength > MaxUncompressedBytes)
+        {
+            return false;
+        }
+
+        var decompressed = new byte[compressed.UncompressedLength];
+        try
+        {
+            int decodedLength = LZ4Codec.Decode(
+                compressed.Payload, 0, compressed.Payload.Length,
+                decompressed, 0, decompressed.Length);
+            if (decodedLength != decompressed.Length)
+                return false;
+
+            restored = serializer.Deserialize<IPacket>(decompressed);
+            return restored != null && IsMovement(restored);
+        }
+        catch (Exception)
+        {
+            restored = null;
+            return false;
+        }
+    }
+
+    private static bool IsMovement(IPacket packet)
+    {
+        return packet.PacketType == PacketType.Movement ||
+               packet.PacketType == PacketType.MountMovement;
+    }
+
+    private void RecordDiagnostic(int originalBytes, int wireBytes)
+    {
+        lock (diagnosticGate)
+        {
+            intervalPackets++;
+            intervalOriginalBytes += originalBytes;
+            intervalWireBytes += wireBytes;
+
+            long now = Stopwatch.GetTimestamp();
+            double seconds = (double)(now - intervalStarted) / Stopwatch.Frequency;
+            if (seconds < DiagnosticIntervalSeconds)
+                return;
+
+            double savings = intervalOriginalBytes == 0
+                ? 0
+                : 1d - ((double)intervalWireBytes / intervalOriginalBytes);
+            Logger.Information(
+                "[BattleTraffic] Movement payloads: {Packets} packets, {OriginalBytes} -> {WireBytes} bytes " +
+                "({Savings:P1} saved), {WireBytesPerSecond:F0} bytes/s per peer over {Seconds:F1}s",
+                intervalPackets,
+                intervalOriginalBytes,
+                intervalWireBytes,
+                savings,
+                intervalWireBytes / seconds,
+                seconds);
+
+            intervalStarted = now;
+            intervalOriginalBytes = 0;
+            intervalWireBytes = 0;
+            intervalPackets = 0;
+        }
+    }
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

A large field battle can saturate the battle connection, causing one participant to miss enemy casualties and routs, continue seeing troops fight after another participant has reached the result, and remain trapped in the encounter.

## What is the new behavior?

Resolves #2309

- Compact agent ids instead of sending the whole ID every time
- Only send equipment updates when they change instead of unconditionally
- LZ4 compress movement packets

44% less field battle network throughput per peer

## Bot Changelog Entry

- Reduced large field battle network traffic so casualties, routs, and results stay synchronized for every participant.
