### PR TITLE
[2312] Fix infinite player captivity

### DIFF
--- a/source/E2E.Tests/Services/MapEvents/MapEventEnvironmentTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/MapEventEnvironmentTests.cs
@@ -549,6 +549,64 @@ public class MapEventEnvironmentTests : MapEventTestBase
     }
 
     [Fact]
+    public void PartyScreenDiscard_DuplicatedPlayerPrisoner_ClearsEveryCopyAndRestoresPartyOnce()
+    {
+        // Arrange — create both player parties and attach the captor hero to its authoritative party so
+        // NetworkCompleteDoneLogic resolves the Party screen's right-hand owner and rosters.
+        var (playerHeroId, playerPartyId) = CreatePlayerHeroParty("CaptiveControllerId");
+        var (captorHeroId, captorPartyId) = CreatePlayerHeroParty("CaptorControllerId");
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(captorHeroId, out var captorHero));
+            Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(captorPartyId, out var captorParty));
+
+            using (new AllowedThread())
+            {
+                captorParty.MemberRoster.AddToCounts(captorHero.CharacterObject, 1);
+                captorHero.PartyBelongedTo = captorParty;
+            }
+        });
+
+        DefeatPlayerPartyInBattle(playerHeroId, playerPartyId, captorPartyId);
+        TestEnvironment.FlushCoalescer();
+
+        // Reproduce both possible forms of the malformed live state: a duplicated authoritative count and
+        // a client with one additional stale copy. A relative removal cannot reconcile both states.
+        SeedPartyPrisoner(Server, captorPartyId, playerHeroId, 1);
+        foreach (var client in Clients)
+        {
+            SeedPartyPrisoner(client, captorPartyId, playerHeroId, 2);
+        }
+        int unrelatedPrisoners = GetPartyPrisonerCount(Server, captorPartyId) - 2;
+        Assert.True(unrelatedPrisoners >= 0);
+
+        AssertPlayerPrisonerCount(Server, captorPartyId, playerHeroId, 2);
+        foreach (var client in Clients)
+        {
+            AssertPlayerPrisonerCount(client, captorPartyId, playerHeroId, 3);
+        }
+
+        // Act — the captor moves the player to the normal Party screen's dummy left dismissal roster.
+        ReleasePlayerByPartyScreenDiscard(captorHeroId, captorPartyId, playerHeroId);
+
+        // Assert — one dismissal clears every stale copy while preserving every unrelated prisoner and
+        // restoring the released party exactly once on the server and clients.
+        AssertCaptivity(Server, playerHeroId, null);
+        AssertPlayerPrisonerCount(Server, captorPartyId, playerHeroId, 0);
+        AssertPartyPrisonerCount(Server, captorPartyId, unrelatedPrisoners);
+        AssertPlayerPartyRestored(Server, playerHeroId, playerPartyId);
+
+        foreach (var client in Clients)
+        {
+            AssertCaptivity(client, playerHeroId, null);
+            AssertPlayerPrisonerCount(client, captorPartyId, playerHeroId, 0);
+            AssertPartyPrisonerCount(client, captorPartyId, unrelatedPrisoners);
+            AssertHeroInPartyRoster(client, playerHeroId, playerPartyId);
+        }
+    }
+
+    [Fact]
     public void ServerEndCaptivity_OfPlayerHero_SyncAllClients()
     {
         // Arrange

--- a/source/E2E.Tests/Services/MapEvents/MapEventEnvironmentTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/MapEventEnvironmentTests.cs
@@ -607,6 +607,52 @@ public class MapEventEnvironmentTests : MapEventTestBase
     }
 
     [Fact]
+    public void PartyScreenDiscard_ServerMissingPlayerPrisoner_ClearsStaleClientCopy()
+    {
+        // Arrange — capture a player normally, then reproduce the live divergence: the server has already
+        // lost the prison-roster element while the captor client still displays it and captivity is active.
+        var (playerHeroId, playerPartyId) = CreatePlayerHeroParty("CaptiveControllerId");
+        var (captorHeroId, captorPartyId) = CreatePlayerHeroParty("CaptorControllerId");
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(captorHeroId, out var captorHero));
+            Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(captorPartyId, out var captorParty));
+
+            using (new AllowedThread())
+            {
+                captorParty.MemberRoster.AddToCounts(captorHero.CharacterObject, 1);
+                captorHero.PartyBelongedTo = captorParty;
+            }
+        });
+
+        DefeatPlayerPartyInBattle(playerHeroId, playerPartyId, captorPartyId);
+        TestEnvironment.FlushCoalescer();
+        RemovePartyPrisonerLocally(Server, captorPartyId, playerHeroId);
+
+        AssertPlayerPrisonerCount(Server, captorPartyId, playerHeroId, 0);
+        foreach (var client in Clients)
+        {
+            AssertPlayerPrisonerCount(client, captorPartyId, playerHeroId, 1);
+        }
+
+        // Act — the stale captor view submits the real normal Party-screen discard.
+        ReleasePlayerByPartyScreenDiscard(captorHeroId, captorPartyId, playerHeroId);
+
+        // Assert — the authority sends an absolute tombstone even though it had no element to mutate.
+        AssertCaptivity(Server, playerHeroId, null);
+        AssertPlayerPrisonerCount(Server, captorPartyId, playerHeroId, 0);
+        AssertPlayerPartyRestored(Server, playerHeroId, playerPartyId);
+
+        foreach (var client in Clients)
+        {
+            AssertCaptivity(client, playerHeroId, null);
+            AssertPlayerPrisonerCount(client, captorPartyId, playerHeroId, 0);
+            AssertHeroInPartyRoster(client, playerHeroId, playerPartyId);
+        }
+    }
+
+    [Fact]
     public void ServerEndCaptivity_OfPlayerHero_SyncAllClients()
     {
         // Arrange

--- a/source/E2E.Tests/Services/MapEvents/MapEventTestBase.cs
+++ b/source/E2E.Tests/Services/MapEvents/MapEventTestBase.cs
@@ -1,11 +1,17 @@
-﻿using Common.Network;
+﻿using Common.Messaging;
+using Common.Network;
 using Common.Util;
 using E2E.Tests.Environment;
 using E2E.Tests.Environment.Instance;
 using E2E.Tests.Util;
+using GameInterface.Services.MapEventParties;
+using GameInterface.Services.Party.Data;
+using GameInterface.Services.Party.Messages;
 using GameInterface.Services.PlayerCaptivityService.Messages;
 using GameInterface.Services.Players;
 using GameInterface.Services.Players.Data;
+using GameInterface.Services.TroopRosters.Data;
+using GameInterface.Services.TroopRosters.Interfaces;
 using HarmonyLib;
 using Helpers;
 using Moq;
@@ -609,6 +615,78 @@ public abstract class MapEventTestBase : IDisposable
     }
 
     /// <summary>
+    /// Releases a captured player through the same normal Party-screen command that the captor sends after
+    /// moving the player prisoner into the dummy left-hand dismissal roster.
+    /// </summary>
+    protected void ReleasePlayerByPartyScreenDiscard(string captorHeroId, string captorPartyId, string prisonerHeroId)
+    {
+        var disabledMethods = MapEventDisabledMethods
+            // A release from an active captor separates the restored party with campaign-map pathfinding.
+            // The headless environment has no map scene; the existing escape helper suppresses this same
+            // visual/navigation boundary while retaining the authoritative release state transition.
+            .Append(AccessTools.Method(typeof(MobileParty), nameof(MobileParty.TeleportPartyToOutSideOfEncounterRadius)))
+            .ToList();
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(captorHeroId, out var captorHero));
+            Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(captorPartyId, out var captorParty));
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(prisonerHeroId, out var prisonerHero));
+            Assert.True(Server.ObjectManager.TryGetId(prisonerHero.CharacterObject, out var prisonerCharacterId));
+
+            var emptyRosterDelta = new TroopRosterData(Array.Empty<TroopRosterElementData>());
+            var message = new NetworkCompleteDoneLogic(
+                captorHeroId,
+                Array.Empty<FlattenedTroop>(),
+                Array.Empty<FlattenedTroop>(),
+                Array.Empty<FlattenedTroop>(),
+                emptyRosterDelta,
+                new TroopRosterData(new[]
+                {
+                    new TroopRosterElementData(prisonerCharacterId, 1, 0, 0),
+                }),
+                emptyRosterDelta,
+                new TroopRosterData(new[]
+                {
+                    new TroopRosterElementData(prisonerCharacterId, -1, 0, 0),
+                }),
+                captorParty.ItemRoster.ToArray(),
+                new UpgradedTroopHistoryData(new()),
+                null,
+                null,
+                0,
+                0,
+                0,
+                true,
+                captorParty.Position,
+                PartyScreenHelper.PartyScreenMode.Normal,
+                Server.Resolve<ITroopRosterInterface>().PackTroopRosterOrderData(captorParty.MemberRoster));
+
+            Server.Resolve<IMessageBroker>().Publish(this, message);
+        }, disabledMethods);
+    }
+
+    /// <summary>
+    /// Adds a prisoner count locally to one instance without replication, allowing tests to construct
+    /// malformed and divergent player-prisoner counts.
+    /// </summary>
+    protected void SeedPartyPrisoner(EnvironmentInstance instance, string partyId, string heroId, int count)
+    {
+        instance.Call(() =>
+        {
+            Assert.True(instance.ObjectManager.TryGetObject<MobileParty>(partyId, out var party));
+            Assert.True(instance.ObjectManager.TryGetObject<Hero>(heroId, out var hero));
+
+            using (new AllowedThread())
+            {
+                int index = party.PrisonRoster.FindIndexOfTroop(hero.CharacterObject);
+                Assert.True(index >= 0);
+                party.PrisonRoster.AddToCountsAtIndex(index, count);
+            }
+        });
+    }
+
+    /// <summary>
     /// Asserts the prison roster of the party with <paramref name="partyId"/> holds exactly
     /// <paramref name="expected"/> prisoners on the given <paramref name="instance"/>. Guards the
     /// captor's side of a capture: the prisoner must be counted once everywhere — a replicated add
@@ -623,6 +701,19 @@ public abstract class MapEventTestBase : IDisposable
             Assert.True(
                 expected == party.PrisonRoster.TotalManCount,
                 $"[{instance.GetType().Name}] party {partyId} should have {expected} prisoners, has {party.PrisonRoster.TotalManCount}");
+        });
+    }
+
+    /// <summary>
+    /// Asserts the exact count of one player hero in a party's prison roster.
+    /// </summary>
+    protected void AssertPlayerPrisonerCount(EnvironmentInstance instance, string partyId, string heroId, int expected)
+    {
+        instance.Call(() =>
+        {
+            Assert.True(instance.ObjectManager.TryGetObject<MobileParty>(partyId, out var party));
+            Assert.True(instance.ObjectManager.TryGetObject<Hero>(heroId, out var hero));
+            Assert.Equal(expected, party.PrisonRoster.GetTroopCount(hero.CharacterObject));
         });
     }
 

--- a/source/E2E.Tests/Services/MapEvents/MapEventTestBase.cs
+++ b/source/E2E.Tests/Services/MapEvents/MapEventTestBase.cs
@@ -705,6 +705,30 @@ public abstract class MapEventTestBase : IDisposable
     }
 
     /// <summary>
+    /// Removes one player prisoner only from the selected instance while preserving the hero's captivity
+    /// reference. This reproduces an authority whose roster element is already absent while a client still
+    /// holds the stale prisoner entry.
+    /// </summary>
+    protected void RemovePartyPrisonerLocally(EnvironmentInstance instance, string partyId, string heroId)
+    {
+        instance.Call(() =>
+        {
+            Assert.True(instance.ObjectManager.TryGetObject<MobileParty>(partyId, out var party));
+            Assert.True(instance.ObjectManager.TryGetObject<Hero>(heroId, out var hero));
+
+            using (new AllowedThread())
+            {
+                int index = party.PrisonRoster.FindIndexOfTroop(hero.CharacterObject);
+                Assert.True(index >= 0);
+                party.PrisonRoster.SetElementNumber(index, 0);
+                party.PrisonRoster.RemoveZeroCounts();
+                party.PrisonRoster.InitializeCachedData();
+                hero.PartyBelongedToAsPrisoner = party.Party;
+            }
+        });
+    }
+
+    /// <summary>
     /// Asserts the exact count of one player hero in a party's prison roster.
     /// </summary>
     protected void AssertPlayerPrisonerCount(EnvironmentInstance instance, string partyId, string heroId, int expected)

--- a/source/E2E.Tests/Services/Party/PartyScreenPrisonerReleaseTests.cs
+++ b/source/E2E.Tests/Services/Party/PartyScreenPrisonerReleaseTests.cs
@@ -1,0 +1,83 @@
+using GameInterface.Services.Party.Handlers;
+using GameInterface.Services.Party.Patches;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Roster;
+
+namespace E2E.Tests.Services.Party;
+
+public class PartyScreenPrisonerReleaseTests
+{
+    [Fact]
+    public void ReleaseActions_AreRequestedOnlyByVanillaDefaultDoneCallback()
+    {
+        PartyScreenHelperPatches.ResetReleasedAndTakenPrisonerActionsRequest();
+
+        Assert.False(PartyScreenHelperPatches.ConsumeReleasedAndTakenPrisonerActionsRequest());
+
+        PartyScreenHelperPatches.HandleReleasedAndTakenPrisonersPrefix(
+            new FlattenedTroopRoster(4),
+            new FlattenedTroopRoster(4));
+
+        Assert.True(PartyScreenHelperPatches.ConsumeReleasedAndTakenPrisonerActionsRequest());
+        Assert.False(PartyScreenHelperPatches.ConsumeReleasedAndTakenPrisonerActionsRequest());
+    }
+
+    [Fact]
+    public void TakenHeroAdditions_AreOwnedByTakePrisonerAction()
+    {
+        var delta = new GameInterface.Services.TroopRosters.Data.TroopRosterData(new[]
+        {
+            new GameInterface.Services.TroopRosters.Data.TroopRosterElementData("taken-hero", 1, 0, 0),
+            new GameInterface.Services.TroopRosters.Data.TroopRosterElementData("regular-troop", 3, 0, 0),
+            new GameInterface.Services.TroopRosters.Data.TroopRosterElementData("source-removal", -1, 0, 0),
+        });
+
+        var filtered = PartyDoneLogicHandler.FilterTakenHeroAdditions(
+            delta,
+            new HashSet<string> { "taken-hero", "source-removal" });
+
+        Assert.Collection(
+            filtered.Data,
+            element => Assert.Equal("regular-troop", element.CharacterId),
+            element => Assert.Equal("source-removal", element.CharacterId));
+    }
+
+    [Theory]
+    [InlineData(true, true, true, false)]
+    [InlineData(true, false, true, false)]
+    [InlineData(false, true, false, true)]
+    [InlineData(false, false, true, true)]
+    [InlineData(false, false, false, false)]
+    public void DefaultReleaseCallback_OverridesLeftTransferDestination(
+        bool applyReleaseActions,
+        bool hasLeftParty,
+        bool hasLeftPrisonerRoster,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            PartyDoneLogicHandler.HasLeftPrisonerTransferDestination(
+                applyReleaseActions,
+                hasLeftParty,
+                hasLeftPrisonerRoster));
+    }
+
+    [Fact]
+    public void CommitRollback_RestoresBothLeftRosterSlots()
+    {
+        var logic = new PartyScreenLogic();
+        var originalRightMember = TroopRoster.CreateDummyTroopRoster();
+        var originalRightPrisoner = TroopRoster.CreateDummyTroopRoster();
+        var leftMember = TroopRoster.CreateDummyTroopRoster();
+        var leftPrisoner = TroopRoster.CreateDummyTroopRoster();
+        logic.MemberRosters[(int)PartyScreenLogic.PartyRosterSide.Right] = originalRightMember;
+        logic.PrisonerRosters[(int)PartyScreenLogic.PartyRosterSide.Right] = originalRightPrisoner;
+
+        PartyScreenLogicPatches.RestoreLeftRostersAfterCommit(logic, leftMember, leftPrisoner);
+
+        Assert.Same(leftMember, logic.MemberRosters[(int)PartyScreenLogic.PartyRosterSide.Left]);
+        Assert.Same(leftPrisoner, logic.PrisonerRosters[(int)PartyScreenLogic.PartyRosterSide.Left]);
+        Assert.Same(originalRightMember, logic.MemberRosters[(int)PartyScreenLogic.PartyRosterSide.Right]);
+        Assert.Same(originalRightPrisoner, logic.PrisonerRosters[(int)PartyScreenLogic.PartyRosterSide.Right]);
+    }
+}

--- a/source/E2E.Tests/Services/TroopRosters/TroopRosterMutationReportingTests.cs
+++ b/source/E2E.Tests/Services/TroopRosters/TroopRosterMutationReportingTests.cs
@@ -1,0 +1,21 @@
+using GameInterface.Services.TroopRosters.Patches;
+
+namespace E2E.Tests.Services.TroopRosters;
+
+public class TroopRosterMutationReportingTests
+{
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    [InlineData(true, true, true)]
+    public void ClientMutationReporting_RequiresManagedRoster(
+        bool isClient,
+        bool isRegistered,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            TroopRosterPatches.ShouldReportClientMutation(isClient, isRegistered));
+    }
+}

--- a/source/GameInterface.Tests/Services/Party/PartyScreenRosterBaselineProviderTests.cs
+++ b/source/GameInterface.Tests/Services/Party/PartyScreenRosterBaselineProviderTests.cs
@@ -1,0 +1,35 @@
+﻿using GameInterface.Services.Party;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Roster;
+using Xunit;
+
+namespace GameInterface.Tests.Services.Party;
+
+public class PartyScreenRosterBaselineProviderTests
+{
+    [Fact]
+    public void GetBaselineRoster_MapsEveryPartyScreenRoster()
+    {
+        var logic = new PartyScreenLogic();
+        var rightMember = new TroopRoster();
+        var leftMember = new TroopRoster();
+        var rightPrisoner = new TroopRoster();
+        var leftPrisoner = new TroopRoster();
+        logic.MemberRosters[(int)PartyScreenLogic.PartyRosterSide.Right] = rightMember;
+        logic.MemberRosters[(int)PartyScreenLogic.PartyRosterSide.Left] = leftMember;
+        logic.PrisonerRosters[(int)PartyScreenLogic.PartyRosterSide.Right] = rightPrisoner;
+        logic.PrisonerRosters[(int)PartyScreenLogic.PartyRosterSide.Left] = leftPrisoner;
+        logic._initialData.RightMemberRoster = new TroopRoster();
+        logic._initialData.LeftMemberRoster = new TroopRoster();
+        logic._initialData.RightPrisonerRoster = new TroopRoster();
+        logic._initialData.LeftPrisonerRoster = new TroopRoster();
+
+        var provider = new PartyScreenRosterBaselineProvider();
+
+        Assert.Same(logic._initialData.RightMemberRoster, provider.GetBaselineRoster(logic, rightMember));
+        Assert.Same(logic._initialData.LeftMemberRoster, provider.GetBaselineRoster(logic, leftMember));
+        Assert.Same(logic._initialData.RightPrisonerRoster, provider.GetBaselineRoster(logic, rightPrisoner));
+        Assert.Same(logic._initialData.LeftPrisonerRoster, provider.GetBaselineRoster(logic, leftPrisoner));
+        Assert.Null(provider.GetBaselineRoster(logic, new TroopRoster()));
+    }
+}

--- a/source/GameInterface.Tests/Services/TroopRosters/TroopRosterDeltaHandlerRefreshTests.cs
+++ b/source/GameInterface.Tests/Services/TroopRosters/TroopRosterDeltaHandlerRefreshTests.cs
@@ -3,6 +3,7 @@ using Common.Messaging;
 using Common.Network;
 using GameInterface.Services.MapEvents;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Party;
 using GameInterface.Services.TroopRosters.Handlers;
 using GameInterface.Services.TroopRosters.Messages;
 using Moq;
@@ -44,7 +45,8 @@ public class TroopRosterDeltaHandlerRefreshTests
             messageBroker.Object,
             objectManager.Object,
             new Mock<INetwork>().Object,
-            refresher);
+            refresher,
+            new NullPartyScreenRosterBaselineProvider());
 
         Assert.NotNull(subscriber);
         subscriber!(new MessagePayload<NetworkTroopRosterElementBatch>(
@@ -63,6 +65,112 @@ public class TroopRosterDeltaHandlerRefreshTests
         Assert.Same(roster, refresher.RefreshedRoster);
         Assert.Equal(1, refresher.HealthyCountAtRefresh);
         Assert.Equal(1, refresher.RefreshCount);
+    }
+
+    [Fact]
+    public void NetworkRemoval_UpdatesPartyScreenBaseline()
+    {
+        var roster = new TroopRoster();
+        var baselineRoster = new TroopRoster();
+        var character = new CharacterObject();
+        roster.AddToCounts(character, 1);
+        baselineRoster.AddToCounts(character, 1);
+
+        var objectManager = new Mock<IObjectManager>();
+        objectManager.Setup(o => o.TryGetObjectWithLogging("roster", out roster)).Returns(true);
+        objectManager.Setup(o => o.TryGetObjectWithLogging("character", out character)).Returns(true);
+
+        Action<MessagePayload<NetworkTroopRosterElementBatch>>? subscriber = null;
+        var messageBroker = new Mock<IMessageBroker>();
+        messageBroker
+            .Setup(b => b.Subscribe(It.IsAny<Action<MessagePayload<NetworkTroopRosterElementBatch>>>()!))
+            .Callback<Action<MessagePayload<NetworkTroopRosterElementBatch>>>(handler => subscriber = handler);
+
+        using var refreshed = new ManualResetEventSlim(false);
+        using var handler = new TroopRosterDeltaHandler(
+            messageBroker.Object,
+            objectManager.Object,
+            new Mock<INetwork>().Object,
+            new RecordingEncounterMenuConditionRefresher(refreshed),
+            new FixedPartyScreenRosterBaselineProvider(roster, baselineRoster));
+
+        subscriber!(new MessagePayload<NetworkTroopRosterElementBatch>(
+            this,
+            new NetworkTroopRosterElementBatch(
+                "roster",
+                "character",
+                new[] { TroopRosterElementOperation.AddCounts(-1, 0, 0, true) })));
+
+        Assert.True(refreshed.Wait(TimeSpan.FromSeconds(10)), "roster apply did not complete");
+        Assert.Equal(0, roster.GetTroopCount(character));
+        Assert.Equal(0, baselineRoster.GetTroopCount(character));
+    }
+
+    [Fact]
+    public void AbsoluteZero_RemovesStalePartyScreenBaselineWhenLiveRosterIsEmpty()
+    {
+        var roster = new TroopRoster();
+        var baselineRoster = new TroopRoster();
+        var character = new CharacterObject();
+        baselineRoster.AddToCounts(character, 1);
+
+        var objectManager = new Mock<IObjectManager>();
+        objectManager.Setup(o => o.TryGetObjectWithLogging("roster", out roster)).Returns(true);
+        objectManager.Setup(o => o.TryGetObjectWithLogging("character", out character)).Returns(true);
+
+        Action<MessagePayload<NetworkTroopRosterSetNumber>>? setNumberSubscriber = null;
+        Action<MessagePayload<NetworkTroopRosterRemoveZeroCounts>>? removeZeroSubscriber = null;
+        var messageBroker = new Mock<IMessageBroker>();
+        messageBroker
+            .Setup(b => b.Subscribe(It.IsAny<Action<MessagePayload<NetworkTroopRosterSetNumber>>>()!))
+            .Callback<Action<MessagePayload<NetworkTroopRosterSetNumber>>>(handler => setNumberSubscriber = handler);
+        messageBroker
+            .Setup(b => b.Subscribe(It.IsAny<Action<MessagePayload<NetworkTroopRosterRemoveZeroCounts>>>()!))
+            .Callback<Action<MessagePayload<NetworkTroopRosterRemoveZeroCounts>>>(handler => removeZeroSubscriber = handler);
+
+        using var refreshed = new ManualResetEventSlim(false);
+        using var handler = new TroopRosterDeltaHandler(
+            messageBroker.Object,
+            objectManager.Object,
+            new Mock<INetwork>().Object,
+            new RecordingEncounterMenuConditionRefresher(refreshed),
+            new FixedPartyScreenRosterBaselineProvider(roster, baselineRoster));
+
+        setNumberSubscriber!(
+            new MessagePayload<NetworkTroopRosterSetNumber>(
+                this,
+                new NetworkTroopRosterSetNumber("roster", "character", 0)));
+        Assert.True(refreshed.Wait(TimeSpan.FromSeconds(10)), "absolute roster correction did not complete");
+        Assert.Equal(0, baselineRoster.GetTroopCount(character));
+
+        refreshed.Reset();
+        removeZeroSubscriber!(
+            new MessagePayload<NetworkTroopRosterRemoveZeroCounts>(
+                this,
+                new NetworkTroopRosterRemoveZeroCounts("roster")));
+
+        Assert.True(refreshed.Wait(TimeSpan.FromSeconds(10)), "zero-count removal did not complete");
+        Assert.Equal(-1, baselineRoster.FindIndexOfTroop(character));
+    }
+
+    private sealed class NullPartyScreenRosterBaselineProvider : IPartyScreenRosterBaselineProvider
+    {
+        public TroopRoster GetBaselineRoster(TroopRoster candidate) => null!;
+    }
+
+    private sealed class FixedPartyScreenRosterBaselineProvider : IPartyScreenRosterBaselineProvider
+    {
+        private readonly TroopRoster roster;
+        private readonly TroopRoster baselineRoster;
+
+        public FixedPartyScreenRosterBaselineProvider(TroopRoster roster, TroopRoster baselineRoster)
+        {
+            this.roster = roster;
+            this.baselineRoster = baselineRoster;
+        }
+
+        public TroopRoster GetBaselineRoster(TroopRoster candidate)
+            => ReferenceEquals(candidate, roster) ? baselineRoster : null!;
     }
 
     private sealed class RecordingEncounterMenuConditionRefresher : IEncounterMenuConditionRefresher

--- a/source/GameInterface/GameInterfaceModule.cs
+++ b/source/GameInterface/GameInterfaceModule.cs
@@ -60,6 +60,7 @@ public class GameInterfaceModule : Module
         builder.RegisterType<PrisonerSaleValidator>().As<IPrisonerSaleValidator>().InstancePerDependency();
         builder.RegisterType<PlayerRansomReleaseSettlementProvider>().As<IPlayerRansomReleaseSettlementProvider>().InstancePerDependency();
         builder.RegisterType<PrisonerSaleProcessor>().As<IPrisonerSaleProcessor>().InstancePerDependency();
+        builder.RegisterType<PartyScreenRosterBaselineProvider>().As<IPartyScreenRosterBaselineProvider>().InstancePerDependency();
         builder.RegisterType<MapEventLogger>().As<IMapEventLogger>().InstancePerLifetimeScope();
         builder.RegisterType<TroopRosterLogger>().As<ITroopRosterLogger>().InstancePerLifetimeScope();
         builder.RegisterType<PartySyncPerformanceClock>().As<IPartySyncPerformanceClock>().InstancePerLifetimeScope();

--- a/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
@@ -226,6 +226,100 @@ public class MapEventDebugCommands
         return true;
     }
 
+    [CommandLineArgumentFunction("request_player_field_battle", "coop.debug.mapevent")]
+    public static string RequestPlayerFieldBattle(List<string> args)
+    {
+        if (!ModInformation.IsClient)
+            return "Run this command on the attacking client.";
+
+        if (args.Count != 1)
+            return "Usage: coop.debug.mapevent.request_player_field_battle <defenderMobilePartyId>";
+
+        var attacker = MobileParty.MainParty;
+        if (attacker?.Party == null || !attacker.IsActive || attacker.MapEvent != null)
+            return "The local player must lead an active party outside a map event.";
+
+        if (!TryGetObjectManager(out var objectManager))
+            return "Unable to resolve ObjectManager.";
+
+        var defenderError = string.Empty;
+        if ((!objectManager.TryGetObject(args[0], out MobileParty defender) &&
+             !CommandHelpers.TryGetMobileParty(args[0], out defender, out defenderError)) ||
+            defender?.Party == null)
+            return "Unable to resolve defender party: " + defenderError;
+
+        if (defender == attacker || !defender.IsActive || defender.MapEvent != null)
+            return "The defender must be a distinct active party outside a map event.";
+
+        if (attacker.CurrentSettlement != null || defender.CurrentSettlement != null)
+            return "Both player parties must be outside settlements.";
+
+        if (attacker.MapFaction == null || defender.MapFaction == null ||
+            attacker.MapFaction == defender.MapFaction)
+            return "Player parties must belong to distinct map factions.";
+
+        if (!objectManager.TryGetId(defender, out var defenderMobilePartyId) ||
+            !ContainerProvider.TryResolve<IPlayerManager>(out var playerManager) ||
+            !playerManager.Players.Any(player => player.MobilePartyId == defenderMobilePartyId))
+            return "The defender must belong to a registered player.";
+
+        if (!objectManager.TryGetId(attacker.Party, out var attackerPartyId) ||
+            !objectManager.TryGetId(defender.Party, out var defenderPartyId))
+            return "Unable to resolve the registered PartyBase ids.";
+
+        if (!ContainerProvider.TryResolve<INetwork>(out var network))
+            return "Unable to resolve the client network.";
+
+        network.SendAll(new NetworkRequestConversation(
+            defenderPartyId,
+            attackerPartyId,
+            forcePlayerOutFromSettlement: false,
+            ConversationRestartSource.PlayerEncounter,
+            armyTalkEncounter: false));
+
+        return
+            "Player field-battle interaction requested through the production conversation path.\n" +
+            $"AttackerPartyId: {attacker.StringId}\n" +
+            $"DefenderPartyId: {defender.StringId}";
+    }
+
+    [CommandLineArgumentFunction("player_interaction_state", "coop.debug.mapevent")]
+    public static string PlayerInteractionState(List<string> args)
+    {
+        if (args.Count != 0)
+            return "Usage: coop.debug.mapevent.player_interaction_state";
+
+        return
+            $"Active: {PlayerPartyInteractionDialogState.HasActiveState}\n" +
+            $"SessionId: {PlayerPartyInteractionDialogState.SessionId ?? "none"}\n" +
+            $"PartyId: {PlayerPartyInteractionDialogState.PartyId ?? "none"}\n" +
+            $"OtherPartyId: {PlayerPartyInteractionDialogState.OtherPartyId ?? "none"}\n" +
+            $"Phase: {PlayerPartyInteractionDialogState.Phase}\n" +
+            $"Proposal: {PlayerPartyInteractionDialogState.Proposal}";
+    }
+
+    [CommandLineArgumentFunction("submit_player_interaction", "coop.debug.mapevent")]
+    public static string SubmitPlayerInteraction(List<string> args)
+    {
+        if (!ModInformation.IsClient)
+            return "Run this command on a player client.";
+
+        if (args.Count != 1 ||
+            !Enum.TryParse(args[0], ignoreCase: true, out PlayerPartyInteractionOption option) ||
+            option == PlayerPartyInteractionOption.None)
+            return "Usage: coop.debug.mapevent.submit_player_interaction <option>";
+
+        if (!PlayerPartyInteractionDialogState.HasActiveState)
+            return "No player-party interaction is active.";
+
+        if (!PlayerPartyInteractionDialogState.IsOptionEnabled(option))
+            return $"Player-party interaction option '{option}' is not enabled.";
+
+        var sessionId = PlayerPartyInteractionDialogState.SessionId;
+        PlayerPartyInteractionDialogState.Submit(option);
+        return $"Submitted player-party interaction option '{option}' for session '{sessionId}'.";
+    }
+
     private static bool AreFactionsAtWar(IFaction first, IFaction second)
     {
         try

--- a/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
@@ -7,12 +7,14 @@ using GameInterface.Registry.Auto;
 using GameInterface.Services.MapEvents;
 using GameInterface.Services.MapEvents.Messages.Conversation;
 using GameInterface.Services.MapEvents.Messages.Leave;
+using GameInterface.Services.MapEvents.PlayerPartyInteractions;
 using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Services.MapEvents.Handlers;
 using GameInterface.Services.MobileParties.Messages.Behavior;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
 using GameInterface.Services.Villages.Interfaces;
+using GameInterface.Utils.Commands;
 using Helpers;
 using Serilog;
 using System;
@@ -43,6 +45,7 @@ public class MapEventDebugCommands
 {
     private static readonly ILogger Logger = LogManager.GetLogger<MapEventDebugCommands>();
     private static WoundedAlliedFixture woundedAlliedFixture;
+    private static PlayerFieldBattleFixture playerFieldBattleFixture;
 
     private sealed class WoundedAlliedFixture
     {
@@ -55,6 +58,15 @@ public class MapEventDebugCommands
         public float OriginalRecentEventsMorale;
         public TroopRosterElement[] OriginalRoster;
         public CampaignVec2 OriginalPosition;
+    }
+
+    private sealed class PlayerFieldBattleFixture
+    {
+        public MobileParty AttackerParty;
+        public MobileParty DefenderParty;
+        public IFaction AttackerFaction;
+        public IFaction DefenderFaction;
+        public bool WasAtWar;
     }
 
     /// <summary>
@@ -79,6 +91,151 @@ public class MapEventDebugCommands
         return party.Party != null &&
                objectManager.TryGetId(party.Party, out string partyBaseId) &&
                partyBaseId == id;
+    }
+
+    [CommandLineArgumentFunction("start_player_field_battle", "coop.debug.mapevent")]
+    public static string StartPlayerFieldBattle(List<string> args)
+    {
+        if (!ModInformation.IsServer)
+            return "Run this command on the server.";
+
+        if (args.Count != 2)
+            return "Usage: coop.debug.mapevent.start_player_field_battle <attackerMobilePartyId> <defenderMobilePartyId>";
+
+        if (playerFieldBattleFixture != null)
+            return "A player field-battle fixture is already pending restoration.";
+
+        if (!TryGetObjectManager(out var objectManager))
+            return "Unable to resolve ObjectManager.";
+
+        var attackerError = string.Empty;
+        if ((!objectManager.TryGetObject(args[0], out MobileParty attacker) &&
+             !CommandHelpers.TryGetMobileParty(args[0], out attacker, out attackerError)) ||
+            attacker?.Party == null)
+            return "Unable to resolve attacker party: " + attackerError;
+
+        var defenderError = string.Empty;
+        if ((!objectManager.TryGetObject(args[1], out MobileParty defender) &&
+             !CommandHelpers.TryGetMobileParty(args[1], out defender, out defenderError)) ||
+            defender?.Party == null)
+            return "Unable to resolve defender party: " + defenderError;
+
+        if (attacker == defender)
+            return "Attacker and defender parties must be distinct.";
+
+        if (!attacker.IsActive || !defender.IsActive || attacker.MapEvent != null || defender.MapEvent != null)
+            return "Both player parties must be active and outside a map event.";
+
+        if (attacker.CurrentSettlement != null || defender.CurrentSettlement != null)
+            return "Both player parties must be outside settlements.";
+
+        var attackerFaction = attacker.MapFaction;
+        var defenderFaction = defender.MapFaction;
+        if (attackerFaction == null || defenderFaction == null || attackerFaction == defenderFaction)
+            return "Player parties must belong to distinct map factions.";
+
+        if (!objectManager.TryGetId(attacker, out var attackerMobilePartyId) ||
+            !objectManager.TryGetId(defender, out var defenderMobilePartyId) ||
+            !ContainerProvider.TryResolve<IPlayerManager>(out var playerManager))
+            return "Unable to resolve the registered player-party identities.";
+
+        var attackerPlayer = playerManager.Players.FirstOrDefault(player =>
+            player.MobilePartyId == attackerMobilePartyId);
+        var defenderPlayer = playerManager.Players.FirstOrDefault(player =>
+            player.MobilePartyId == defenderMobilePartyId);
+        if (attackerPlayer == null || defenderPlayer == null ||
+            !playerManager.IsConnected(attackerPlayer) || !playerManager.IsConnected(defenderPlayer))
+            return "Both parties must belong to connected players.";
+
+        if (!objectManager.TryGetId(attacker.Party, out var attackerPartyBaseId) ||
+            !objectManager.TryGetId(defender.Party, out var defenderPartyBaseId))
+            return "Unable to resolve the registered PartyBase ids.";
+
+        if (!ContainerProvider.TryResolve<IPlayerPartyHostileEncounterService>(out var encounterService))
+            return "Unable to resolve the player hostile-encounter service.";
+
+        var fixture = new PlayerFieldBattleFixture
+        {
+            AttackerParty = attacker,
+            DefenderParty = defender,
+            AttackerFaction = attackerFaction,
+            DefenderFaction = defenderFaction,
+            WasAtWar = AreFactionsAtWar(attackerFaction, defenderFaction),
+        };
+        playerFieldBattleFixture = fixture;
+
+        var sessionId = "live-test-" + Guid.NewGuid().ToString("N");
+        if (!encounterService.TryStartHostileEncounter(
+                sessionId,
+                attackerPartyBaseId,
+                defenderPartyBaseId,
+                responderSurrenders: false))
+        {
+            var partiallyCreatedMapEvent = attacker.MapEvent;
+            if (partiallyCreatedMapEvent != null &&
+                partiallyCreatedMapEvent == defender.MapEvent &&
+                !partiallyCreatedMapEvent.IsFinalized)
+                partiallyCreatedMapEvent.FinalizeEvent();
+
+            var peaceRestored = RestoreFixtureWarState(fixture);
+            playerFieldBattleFixture = null;
+            return $"Failed to start the player field-battle fixture. PeaceRestored: {peaceRestored}";
+        }
+
+        var mapEvent = attacker.MapEvent;
+        var mapEventId = mapEvent != null && objectManager.TryGetId(mapEvent, out var resolvedMapEventId)
+            ? resolvedMapEventId
+            : "<unresolved>";
+
+        return
+            "Player field-battle fixture started.\n" +
+            $"MapEventId: {mapEventId}\n" +
+            $"AttackerPartyId: {args[0]}\n" +
+            $"DefenderPartyId: {args[1]}\n" +
+            $"OriginalWarState: {fixture.WasAtWar}";
+    }
+
+    [CommandLineArgumentFunction("restore_player_field_battle", "coop.debug.mapevent")]
+    public static string RestorePlayerFieldBattle(List<string> args)
+    {
+        if (!ModInformation.IsServer)
+            return "Run this command on the server.";
+
+        if (args.Count != 0)
+            return "Usage: coop.debug.mapevent.restore_player_field_battle";
+
+        var fixture = playerFieldBattleFixture;
+        if (fixture == null)
+            return "No player field-battle fixture is pending restoration.";
+
+        if (fixture.AttackerParty.MapEvent != null || fixture.DefenderParty.MapEvent != null)
+            return "Cannot restore the player field-battle fixture while its map event is active.";
+
+        var peaceRestored = RestoreFixtureWarState(fixture);
+
+        playerFieldBattleFixture = null;
+        return $"Player field-battle fixture restored. PeaceRestored: {peaceRestored}";
+    }
+
+    private static bool RestoreFixtureWarState(PlayerFieldBattleFixture fixture)
+    {
+        if (fixture.WasAtWar || !AreFactionsAtWar(fixture.AttackerFaction, fixture.DefenderFaction))
+            return false;
+
+        MakePeaceAction.Apply(fixture.AttackerFaction, fixture.DefenderFaction);
+        return true;
+    }
+
+    private static bool AreFactionsAtWar(IFaction first, IFaction second)
+    {
+        try
+        {
+            return FactionManager.IsAtWarAgainstFaction(first, second);
+        }
+        catch (NullReferenceException)
+        {
+            return false;
+        }
     }
 
     /// <summary>

--- a/source/GameInterface/Services/Party/Handlers/PartyDoneLogicHandler.cs
+++ b/source/GameInterface/Services/Party/Handlers/PartyDoneLogicHandler.cs
@@ -93,8 +93,8 @@ internal class PartyDoneLogicHandler : IHandler
 
         var message = new NetworkCompleteDoneLogic(
             mainHeroId,
+            FlattenedTroopSerializer.Serialize(obj.What.ReleasedPrisonersRoster, objectManager),
             FlattenedTroopSerializer.Serialize(obj.What.TakenPrisonersRoster, objectManager),
-            FlattenedTroopSerializer.Serialize(obj.What.DonatedPrisonersRoster, objectManager),
             FlattenedTroopSerializer.Serialize(obj.What.RecruitedPrisonersRoster, objectManager),
             leftMemberRosterData,
             leftPrisonerRosterData,
@@ -110,7 +110,8 @@ internal class PartyDoneLogicHandler : IHandler
             obj.What.DoNotApplyGoldTransactions,
             releaserPartyPosition,
             obj.What.PartyScreenMode,
-            rightMemberOrderData
+            rightMemberOrderData,
+            obj.What.ApplyReleasedAndTakenPrisonerActions
         );
 
         network.SendAll(message);
@@ -139,7 +140,8 @@ internal class PartyDoneLogicHandler : IHandler
 
             if (!TryResolveCompleteDoneLogic(message, out var leftParty, out var leftPrisonerRoster, out var upgradedTroopHistory)) return;
 
-            var donatedPrisonersRoster = FlattenedTroopSerializer.Deserialize(message.DonatedPrisonersRoster, objectManager);
+            var releasedPrisonersRoster = FlattenedTroopSerializer.Deserialize(message.ReleasedPrisonersRoster, objectManager);
+            var takenPrisonersRoster = FlattenedTroopSerializer.Deserialize(message.TakenPrisonersRoster, objectManager);
             var recruitedPrisonersRoster = FlattenedTroopSerializer.Deserialize(message.RecruitedPrisonersRoster, objectManager);
             var releasedPlayerCaptivityEvents = new List<PlayerCaptivityEndedByServer>();
             var leftPrisonerRosterData = message.LeftPrisonerRosterData;
@@ -150,10 +152,32 @@ internal class PartyDoneLogicHandler : IHandler
                 releasedPlayerCaptivityEvents = CreatePlayerCaptivityReleaseEvents(
                     message.LeftPrisonerRosterData,
                     message.RightPrisonerRosterData,
-                    leftParty != null || leftPrisonerRoster != null,
+                    HasLeftPrisonerTransferDestination(
+                        message.ApplyReleasedAndTakenPrisonerActions,
+                        leftParty != null,
+                        leftPrisonerRoster != null),
                     message.ReleaserPartyPosition,
                     out leftPrisonerRosterData,
                     out rightPrisonerRosterData);
+            }
+            var takenHeroCharacterIds = new HashSet<string>();
+            var actionRostersAreValid =
+                !message.ApplyReleasedAndTakenPrisonerActions ||
+                TryValidatePrisonerActionRosters(
+                    releasedPrisonersRoster,
+                    takenPrisonersRoster,
+                    rightPrisonerRosterData,
+                    out takenHeroCharacterIds);
+            if (!actionRostersAreValid)
+            {
+                logger.Error("Rejected Party screen prisoner actions because transfer history did not match the signed right-prisoner delta");
+                return;
+            }
+            if (message.ApplyReleasedAndTakenPrisonerActions)
+            {
+                rightPrisonerRosterData = FilterTakenHeroAdditions(
+                    rightPrisonerRosterData,
+                    takenHeroCharacterIds);
             }
 
             var rosterDeltas = CreateRosterDeltas(
@@ -164,15 +188,16 @@ internal class PartyDoneLogicHandler : IHandler
                 leftPrisonerRosterData,
                 rightPrisonerRosterData);
 
-            PublishPlayerCaptivityReleaseEvents(releasedPlayerCaptivityEvents);
-
             // Only apply deltas if not ransoming. SellPrisonersAction already changes troop rosters
             if (message.PartyScreenMode != Helpers.PartyScreenHelper.PartyScreenMode.Ransom)
             {
                 troopRosterInterface.ApplyTroopRosterDeltas(rosterDeltas);
             }
+            PublishPlayerCaptivityReleaseEvents(releasedPlayerCaptivityEvents);
             ApplyRightOwnerPartyItemRoster(mainHero, message);
-            NotifyDonatedPrisonersChanged(donatedPrisonersRoster);
+            if (message.ApplyReleasedAndTakenPrisonerActions)
+                ApplyReleasedAndTakenPrisonerActions(mainHero, releasedPrisonersRoster, takenPrisonersRoster);
+            NotifyTakenPrisonersChanged(takenPrisonersRoster);
             ApplyPartyRewardChanges(mainHero, message);
             ApplyUpgradedTroopHistory(mainHero, upgradedTroopHistory);
             ApplyPrisonerRecruitmentEffects(mainHero, message, recruitedPrisonersRoster);
@@ -258,12 +283,115 @@ internal class PartyDoneLogicHandler : IHandler
         }
     }
 
-    private static void NotifyDonatedPrisonersChanged(FlattenedTroopRoster donatedPrisonersRoster)
+    private HashSet<string> GetTakenHeroCharacterIds(FlattenedTroopRoster takenPrisonersRoster)
+    {
+        var characterIds = new HashSet<string>();
+        foreach (var element in takenPrisonersRoster)
+        {
+            if (element.Troop?.IsHero == true &&
+                objectManager.TryGetIdWithLogging(element.Troop, out var characterId))
+                characterIds.Add(characterId);
+        }
+
+        return characterIds;
+    }
+
+    private bool TryValidatePrisonerActionRosters(
+        FlattenedTroopRoster releasedPrisonersRoster,
+        FlattenedTroopRoster takenPrisonersRoster,
+        TroopRosterData rightPrisonerRosterData,
+        out HashSet<string> takenHeroCharacterIds)
+    {
+        takenHeroCharacterIds = GetTakenHeroCharacterIds(takenPrisonersRoster);
+        var signedDeltas = (rightPrisonerRosterData.Data ?? Array.Empty<TroopRosterElementData>())
+            .GroupBy(element => element.CharacterId)
+            .ToDictionary(group => group.Key, group => group.Sum(element => element.Number));
+
+        return ActionsMatchDelta(releasedPrisonersRoster, signedDeltas, expectedSign: -1) &&
+               ActionsMatchDelta(takenPrisonersRoster, signedDeltas, expectedSign: 1);
+    }
+
+    private bool ActionsMatchDelta(
+        FlattenedTroopRoster actionRoster,
+        IReadOnlyDictionary<string, int> signedDeltas,
+        int expectedSign)
+    {
+        var actionCounts = new Dictionary<string, int>();
+        foreach (var element in actionRoster)
+        {
+            if (element.Troop == null ||
+                !objectManager.TryGetIdWithLogging(element.Troop, out var characterId))
+                return false;
+
+            actionCounts.TryGetValue(characterId, out var count);
+            actionCounts[characterId] = count + 1;
+        }
+
+        return actionCounts.All(action =>
+            signedDeltas.TryGetValue(action.Key, out var delta) &&
+            delta == expectedSign * action.Value);
+    }
+
+    internal static TroopRosterData FilterTakenHeroAdditions(
+        TroopRosterData delta,
+        HashSet<string> takenHeroCharacterIds)
+    {
+        if (delta.Data == null || takenHeroCharacterIds.Count == 0)
+            return delta;
+
+        var filtered = delta.Data
+            .Where(element => element.Number <= 0 || !takenHeroCharacterIds.Contains(element.CharacterId))
+            .ToArray();
+        return filtered.Length == delta.Data.Length
+            ? delta
+            : new TroopRosterData(filtered);
+    }
+
+    internal static bool HasLeftPrisonerTransferDestination(
+        bool applyReleasedAndTakenPrisonerActions,
+        bool hasLeftParty,
+        bool hasLeftPrisonerRoster)
+        => !applyReleasedAndTakenPrisonerActions && (hasLeftParty || hasLeftPrisonerRoster);
+
+    private static void ApplyReleasedAndTakenPrisonerActions(
+        Hero mainHero,
+        FlattenedTroopRoster releasedPrisonersRoster,
+        FlattenedTroopRoster takenPrisonersRoster)
+    {
+        var nonPlayerReleases = new FlattenedTroopRoster(4);
+        foreach (var element in releasedPrisonersRoster)
+        {
+            if (element.Troop?.HeroObject?.IsPlayerHero() != true)
+                nonPlayerReleases[element.Descriptor] = element;
+        }
+
+        if (!nonPlayerReleases.IsEmpty<FlattenedTroopRosterElement>())
+            EndCaptivityAction.ApplyByReleasedByChoice(nonPlayerReleases);
+
+        if (takenPrisonersRoster.IsEmpty<FlattenedTroopRosterElement>())
+            return;
+
+        var captorParty = mainHero.PartyBelongedTo?.Party;
+        if (captorParty == null)
+        {
+            logger.Error("Cannot apply Party screen prisoner captures because main hero {Hero} has no party", mainHero);
+            return;
+        }
+
+        foreach (var element in takenPrisonersRoster)
+        {
+            if (element.Troop?.HeroObject is Hero hero)
+                TakePrisonerAction.Apply(captorParty, hero);
+        }
+        CampaignEventDispatcher.Instance.OnPrisonerTaken(takenPrisonersRoster);
+    }
+
+    private static void NotifyTakenPrisonersChanged(FlattenedTroopRoster takenPrisonersRoster)
     {
         if (Settlement.CurrentSettlement == null) return;
-        if (donatedPrisonersRoster.IsEmpty<FlattenedTroopRosterElement>()) return;
+        if (takenPrisonersRoster.IsEmpty<FlattenedTroopRosterElement>()) return;
 
-        CampaignEventDispatcher.Instance.OnPrisonersChangeInSettlement(Settlement.CurrentSettlement, donatedPrisonersRoster, null, true);
+        CampaignEventDispatcher.Instance.OnPrisonersChangeInSettlement(Settlement.CurrentSettlement, takenPrisonersRoster, null, true);
     }
 
     private static void ApplyPartyRewardChanges(Hero mainHero, NetworkCompleteDoneLogic message)

--- a/source/GameInterface/Services/Party/Handlers/PartyDoneLogicHandler.cs
+++ b/source/GameInterface/Services/Party/Handlers/PartyDoneLogicHandler.cs
@@ -146,6 +146,11 @@ internal class PartyDoneLogicHandler : IHandler
             var releasedPlayerCaptivityEvents = new List<PlayerCaptivityEndedByServer>();
             var leftPrisonerRosterData = message.LeftPrisonerRosterData;
             var rightPrisonerRosterData = message.RightPrisonerRosterData;
+            // Validate the client-reported release/take history against the signed delta before
+            // removing player-prisoner releases from the apply delta. Player releases are handled
+            // by PlayerCaptivityServerHandler rather than by a roster mutation, so validating the
+            // filtered delta would always reject a legitimate dismissal (the -1 entry is gone).
+            var signedRightPrisonerRosterData = rightPrisonerRosterData;
             // SellPrisonersHandler owns ransom releases so the same player is not released twice.
             if (message.PartyScreenMode != Helpers.PartyScreenHelper.PartyScreenMode.Ransom)
             {
@@ -166,7 +171,7 @@ internal class PartyDoneLogicHandler : IHandler
                 TryValidatePrisonerActionRosters(
                     releasedPrisonersRoster,
                     takenPrisonersRoster,
-                    rightPrisonerRosterData,
+                    signedRightPrisonerRosterData,
                     out takenHeroCharacterIds);
             if (!actionRostersAreValid)
             {

--- a/source/GameInterface/Services/Party/Messages/NetworkCompleteDoneLogic.cs
+++ b/source/GameInterface/Services/Party/Messages/NetworkCompleteDoneLogic.cs
@@ -16,10 +16,10 @@ internal readonly struct NetworkCompleteDoneLogic : ICommand
     public readonly string MainHeroId;
 
     [ProtoMember(2)]
-    public readonly FlattenedTroop[] TakenPrisonersRoster;
+    public readonly FlattenedTroop[] ReleasedPrisonersRoster;
 
     [ProtoMember(3)]
-    public readonly FlattenedTroop[] DonatedPrisonersRoster;
+    public readonly FlattenedTroop[] TakenPrisonersRoster;
 
     [ProtoMember(4)]
     public readonly FlattenedTroop[] RecruitedPrisonersRoster;
@@ -69,10 +69,13 @@ internal readonly struct NetworkCompleteDoneLogic : ICommand
     [ProtoMember(19)]
     public readonly TroopRosterOrderData RightMemberOrderData;
 
+    [ProtoMember(20)]
+    public readonly bool ApplyReleasedAndTakenPrisonerActions;
+
     public NetworkCompleteDoneLogic(
         string mainHeroId,
+        FlattenedTroop[] releasedPrisonersRoster,
         FlattenedTroop[] takenPrisonersRoster,
-        FlattenedTroop[] donatedPrisonersRoster,
         FlattenedTroop[] recruitedPrisonersRoster,
         TroopRosterData leftMemberRosterData,
         TroopRosterData leftPrisonerRosterData,
@@ -88,11 +91,12 @@ internal readonly struct NetworkCompleteDoneLogic : ICommand
         bool doNotApplyGoldTransactions,
         CampaignVec2 releaserPartyPosition,
         PartyScreenHelper.PartyScreenMode partyScreenMode,
-        TroopRosterOrderData rightMemberOrderData)
+        TroopRosterOrderData rightMemberOrderData,
+        bool applyReleasedAndTakenPrisonerActions = false)
     {
         MainHeroId = mainHeroId;
+        ReleasedPrisonersRoster = releasedPrisonersRoster;
         TakenPrisonersRoster = takenPrisonersRoster;
-        DonatedPrisonersRoster = donatedPrisonersRoster;
         RecruitedPrisonersRoster = recruitedPrisonersRoster;
         LeftMemberRosterData = leftMemberRosterData;
         LeftPrisonerRosterData = leftPrisonerRosterData;
@@ -109,5 +113,6 @@ internal readonly struct NetworkCompleteDoneLogic : ICommand
         ReleaserPartyPosition = releaserPartyPosition;
         PartyScreenMode = partyScreenMode;
         RightMemberOrderData = rightMemberOrderData;
+        ApplyReleasedAndTakenPrisonerActions = applyReleasedAndTakenPrisonerActions;
     }
 }

--- a/source/GameInterface/Services/Party/Messages/PartyDoneLogicAttempted.cs
+++ b/source/GameInterface/Services/Party/Messages/PartyDoneLogicAttempted.cs
@@ -11,8 +11,8 @@ namespace GameInterface.Services.Party.Messages;
 public readonly struct PartyDoneLogicAttempted : IEvent
 {
     public readonly Hero MainHero;
+    public readonly FlattenedTroopRoster ReleasedPrisonersRoster;
     public readonly FlattenedTroopRoster TakenPrisonersRoster;
-    public readonly FlattenedTroopRoster DonatedPrisonersRoster;
     public readonly FlattenedTroopRoster RecruitedPrisonersRoster;
     public readonly TroopRoster LeftMemberRoster;
     public readonly TroopRoster LeftPrisonerRoster;
@@ -32,11 +32,12 @@ public readonly struct PartyDoneLogicAttempted : IEvent
     public readonly int PartyMoraleChangeAmount;
     public readonly bool DoNotApplyGoldTransactions;
     public readonly PartyScreenHelper.PartyScreenMode PartyScreenMode;
+    public readonly bool ApplyReleasedAndTakenPrisonerActions;
 
     public PartyDoneLogicAttempted(
         Hero mainHero,
+        FlattenedTroopRoster releasedPrisonersRoster,
         FlattenedTroopRoster takenPrisonersRoster,
-        FlattenedTroopRoster donatedPrisonersRoster,
         FlattenedTroopRoster recruitedPrisonersRoster,
         TroopRoster leftMemberRoster,
         TroopRoster leftPrisonerRoster,
@@ -53,11 +54,12 @@ public readonly struct PartyDoneLogicAttempted : IEvent
         int partyInfluenceChangeAmount,
         int partyMoraleChangeAmount,
         bool doNotApplyGoldTransactions,
-        PartyScreenHelper.PartyScreenMode partyScreenMode)
+        PartyScreenHelper.PartyScreenMode partyScreenMode,
+        bool applyReleasedAndTakenPrisonerActions = false)
     {
         MainHero = mainHero;
+        ReleasedPrisonersRoster = releasedPrisonersRoster;
         TakenPrisonersRoster = takenPrisonersRoster;
-        DonatedPrisonersRoster = donatedPrisonersRoster;
         RecruitedPrisonersRoster = recruitedPrisonersRoster;
         LeftMemberRoster = leftMemberRoster;
         LeftPrisonerRoster = leftPrisonerRoster;
@@ -75,5 +77,6 @@ public readonly struct PartyDoneLogicAttempted : IEvent
         PartyMoraleChangeAmount = partyMoraleChangeAmount;
         DoNotApplyGoldTransactions = doNotApplyGoldTransactions;
         PartyScreenMode = partyScreenMode;
+        ApplyReleasedAndTakenPrisonerActions = applyReleasedAndTakenPrisonerActions;
     }
 }

--- a/source/GameInterface/Services/Party/PartyScreenRosterBaselineProvider.cs
+++ b/source/GameInterface/Services/Party/PartyScreenRosterBaselineProvider.cs
@@ -1,0 +1,37 @@
+﻿using TaleWorlds.CampaignSystem.GameState;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Roster;
+using TaleWorlds.Core;
+
+namespace GameInterface.Services.Party;
+
+internal interface IPartyScreenRosterBaselineProvider
+{
+    TroopRoster GetBaselineRoster(TroopRoster roster);
+}
+
+internal class PartyScreenRosterBaselineProvider : IPartyScreenRosterBaselineProvider
+{
+    public TroopRoster GetBaselineRoster(TroopRoster roster)
+    {
+        var logic = Game.Current?.GameStateManager?.LastOrDefault<PartyState>()?.PartyScreenLogic;
+        return GetBaselineRoster(logic, roster);
+    }
+
+    internal TroopRoster GetBaselineRoster(PartyScreenLogic logic, TroopRoster roster)
+    {
+        if (logic == null || roster == null)
+            return null;
+
+        if (ReferenceEquals(roster, logic.MemberRosters[(int)PartyScreenLogic.PartyRosterSide.Right]))
+            return logic._initialData.RightMemberRoster;
+        if (ReferenceEquals(roster, logic.MemberRosters[(int)PartyScreenLogic.PartyRosterSide.Left]))
+            return logic._initialData.LeftMemberRoster;
+        if (ReferenceEquals(roster, logic.PrisonerRosters[(int)PartyScreenLogic.PartyRosterSide.Right]))
+            return logic._initialData.RightPrisonerRoster;
+        if (ReferenceEquals(roster, logic.PrisonerRosters[(int)PartyScreenLogic.PartyRosterSide.Left]))
+            return logic._initialData.LeftPrisonerRoster;
+
+        return null;
+    }
+}

--- a/source/GameInterface/Services/Party/Patches/PartyScreenHelperPatches.cs
+++ b/source/GameInterface/Services/Party/Patches/PartyScreenHelperPatches.cs
@@ -4,6 +4,7 @@ using GameInterface.Services.Party.Messages;
 using HarmonyLib;
 using Helpers;
 using Serilog;
+using System;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Roster;
@@ -16,6 +17,18 @@ namespace GameInterface.Services.Party.Patches;
 internal class PartyScreenHelperPatches
 {
     private static readonly ILogger Logger = LogManager.GetLogger<PartyScreenHelperPatches>();
+    [ThreadStatic]
+    private static bool _releasedAndTakenPrisonerActionsRequested;
+
+    internal static void ResetReleasedAndTakenPrisonerActionsRequest()
+        => _releasedAndTakenPrisonerActionsRequested = false;
+
+    internal static bool ConsumeReleasedAndTakenPrisonerActionsRequest()
+    {
+        var requested = _releasedAndTakenPrisonerActionsRequested;
+        _releasedAndTakenPrisonerActionsRequested = false;
+        return requested;
+    }
 
     [HarmonyPatch(nameof(PartyScreenHelper.OpenScreenAsCreateClanPartyForHeroPartyScreenClosed))]
     [HarmonyPrefix]
@@ -102,9 +115,10 @@ internal class PartyScreenHelperPatches
     [HarmonyPrefix]
     public static bool HandleReleasedAndTakenPrisonersPrefix(FlattenedTroopRoster takenPrisonerRoster, FlattenedTroopRoster releasedPrisonerRoster)
     {
-        var message = new PrisonersReleasedAndTaken(releasedPrisonerRoster, takenPrisonerRoster);
-        MessageBroker.Instance.Publish(null, message);
-
+        // PartyDoneLogicAttempted carries both histories with the authoritative roster deltas. The server
+        // applies those deltas first, then runs the vanilla release/take side effects. Sending a second command
+        // here made the semantic action mutate the roster before the same PartyDone delta was applied.
+        _releasedAndTakenPrisonerActionsRequested = true;
         return false;
     }
 }

--- a/source/GameInterface/Services/Party/Patches/PartyScreenLogicPatches.cs
+++ b/source/GameInterface/Services/Party/Patches/PartyScreenLogicPatches.cs
@@ -37,22 +37,25 @@ internal class PartyScreenLogicPatches
             return false;
         }
 
+        FlattenedTroopRoster releasedPrisonersRoster = new FlattenedTroopRoster(4);
         FlattenedTroopRoster takenPrisonersRoster = new FlattenedTroopRoster(4);
-        FlattenedTroopRoster donatedPrisonersRoster = new FlattenedTroopRoster(4);
         foreach (Tuple<CharacterObject, int> tuple in __instance.CurrentData.TransferredPrisonersHistory)
         {
             int number = MathF.Abs(tuple.Item2);
             if (tuple.Item2 < 0)
             {
-                takenPrisonersRoster.Add(tuple.Item1, number, 0);
+                releasedPrisonersRoster.Add(tuple.Item1, number, 0);
             }
             else if (tuple.Item2 > 0)
             {
-                donatedPrisonersRoster.Add(tuple.Item1, number, 0);
+                takenPrisonersRoster.Add(tuple.Item1, number, 0);
             }
         }
 
-        bool flag = __instance.PartyPresentationDoneButtonDelegate(__instance.MemberRosters[0], __instance.PrisonerRosters[0], __instance.MemberRosters[1], __instance.PrisonerRosters[1], donatedPrisonersRoster, takenPrisonersRoster, isForced, __instance.LeftOwnerParty, __instance.RightOwnerParty);
+        PartyScreenHelperPatches.ResetReleasedAndTakenPrisonerActionsRequest();
+        bool flag = __instance.PartyPresentationDoneButtonDelegate(__instance.MemberRosters[0], __instance.PrisonerRosters[0], __instance.MemberRosters[1], __instance.PrisonerRosters[1], takenPrisonersRoster, releasedPrisonersRoster, isForced, __instance.LeftOwnerParty, __instance.RightOwnerParty);
+        bool applyReleasedAndTakenPrisonerActions =
+            PartyScreenHelperPatches.ConsumeReleasedAndTakenPrisonerActionsRequest();
         if (flag)
         {
             FlattenedTroopRoster recruitedPrisonersRoster = new FlattenedTroopRoster(4);
@@ -69,8 +72,8 @@ internal class PartyScreenLogicPatches
 
             var message = new PartyDoneLogicAttempted(
                 Hero.MainHero,
+                releasedPrisonersRoster,
                 takenPrisonersRoster,
-                donatedPrisonersRoster,
                 recruitedPrisonersRoster,
                 __instance.MemberRosters[0],
                 __instance.PrisonerRosters[0],
@@ -87,7 +90,8 @@ internal class PartyScreenLogicPatches
                 __instance.CurrentData.PartyInfluenceChangeAmount.Item2,
                 __instance.CurrentData.PartyMoraleChangeAmount,
                 __instance.DoNotApplyGoldTransactions,
-                partyScreenMode
+                partyScreenMode,
+                applyReleasedAndTakenPrisonerActions
             );
 
             MessageBroker.Instance.Publish(__instance, message);
@@ -116,8 +120,10 @@ internal class PartyScreenLogicPatches
                     // In vanilla, the rosters would already be updated but with this patch the rosters are reset on the client to be managed by the server.
                     // This assigns a duplicate version of the left rosters needed in extra logic handled by the PartyScreenHelper when closing the party screen.
                     // For example, the left member roster when creating a new clan party is not managed on the server but the server does need this data.
-                    __instance.MemberRosters[0] = duplicateLeftMemberRoster;
-                    __instance.PrisonerRosters[1] = duplicateLeftPrisonerRoster;
+                    RestoreLeftRostersAfterCommit(
+                        __instance,
+                        duplicateLeftMemberRoster,
+                        duplicateLeftPrisonerRoster);
                 }
                 finally
                 {
@@ -127,6 +133,15 @@ internal class PartyScreenLogicPatches
         }
         __result = flag;
         return false;
+    }
+
+    internal static void RestoreLeftRostersAfterCommit(
+        PartyScreenLogic partyScreenLogic,
+        TroopRoster leftMemberRoster,
+        TroopRoster leftPrisonerRoster)
+    {
+        partyScreenLogic.MemberRosters[(int)PartyScreenLogic.PartyRosterSide.Left] = leftMemberRoster;
+        partyScreenLogic.PrisonerRosters[(int)PartyScreenLogic.PartyRosterSide.Left] = leftPrisonerRoster;
     }
 
     /// <summary>

--- a/source/GameInterface/Services/PlayerCaptivityService/Commands/PlayerCaptivityCommands.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Commands/PlayerCaptivityCommands.cs
@@ -8,14 +8,11 @@ using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Services.MobileParties.Messages.Behavior;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Party;
-using GameInterface.Services.Party.Data;
-using GameInterface.Services.Party.Messages;
 using GameInterface.Services.PartyBases.Extensions;
 using GameInterface.Services.PlayerCaptivityService.Messages;
 using GameInterface.Services.Players;
-using GameInterface.Services.TroopRosters.Data;
-using GameInterface.Services.TroopRosters.Interfaces;
 using GameInterface.Utils.Commands;
+using Helpers;
 using Serilog;
 using System;
 using System.Collections.Generic;
@@ -25,6 +22,7 @@ using System.Text;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
+using TaleWorlds.CampaignSystem.GameState;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Roster;
 using TaleWorlds.CampaignSystem.Settlements;
@@ -608,7 +606,8 @@ Reports the hero's current captivity state on this process.";
 @"Usage:
   coop.debug.player_captivity.discard_player_from_party_screen <heroId> <captorPartyId>
 
-Simulates the normal party screen's dummy-left prisoner discard for a captured player.";
+Moves a captured player into the active normal Party screen's left dismissal roster and presses Done.
+Run this on the client that controls the captor after opening the Party screen.";
 
     [CommandLineArgumentFunction("discard_player_from_party_screen", "coop.debug.player_captivity")]
     public static string DiscardPlayerFromPartyScreen(List<string> args)
@@ -617,6 +616,9 @@ Simulates the normal party screen's dummy-left prisoner discard for a captured p
             "discard_player_from_party_screen",
             DiscardPlayerFromPartyScreenUsage,
             args);
+
+        if (!ModInformation.IsClient)
+            return "Run this command on the client that controls the captor party.";
 
         if (!ctx.RequireArgCount(2, out var error))
             return error;
@@ -641,63 +643,77 @@ Simulates the normal party screen's dummy-left prisoner discard for a captured p
         if (captor.LeaderHero == null)
             return $"Captor party '{captor.StringId}' has no leader hero.";
 
-        if (!objectManager.TryGetId(captor.LeaderHero, out var captorHeroId) ||
-            !objectManager.TryGetId(prisoner.CharacterObject, out var prisonerCharacterId))
-            return "Failed to resolve the registered captor or prisoner id.";
+        if (MobileParty.MainParty != captor)
+            return "Run this command on the client that controls the captor party.";
 
-        if (!ContainerProvider.TryResolve<IMessageBroker>(out var messageBroker) ||
-            !ContainerProvider.TryResolve<INetwork>(out var network) ||
-            !ContainerProvider.TryResolve<ITroopRosterInterface>(out var troopRosterInterface))
-            return "Failed to resolve party-screen synchronization services.";
+        if (Game.Current?.GameStateManager?.ActiveState is not PartyState partyState ||
+            partyState.PartyScreenLogic == null)
+            return "Open the normal Party screen before running this command.";
 
-        var emptyRosterDelta = new TroopRosterData(Array.Empty<TroopRosterElementData>());
-        var leftDummyDiscardDelta = new TroopRosterData(new[]
+        if (partyState.PartyScreenMode != PartyScreenHelper.PartyScreenMode.Normal)
+            return $"The active Party screen is '{partyState.PartyScreenMode}', not Normal.";
+
+        var partyScreenLogic = partyState.PartyScreenLogic;
+        var leftPrisonerRoster =
+            partyScreenLogic.PrisonerRosters[(int)PartyScreenLogic.PartyRosterSide.Left];
+        if (partyScreenLogic.LeftOwnerParty != null ||
+            leftPrisonerRoster.OwnerParty != null ||
+            objectManager.TryGetId(leftPrisonerRoster, out _) ||
+            partyScreenLogic.RightOwnerParty?.MobileParty != captor ||
+            partyScreenLogic.PrisonerRosters[(int)PartyScreenLogic.PartyRosterSide.Right] != captor.PrisonRoster)
+            return "The active Party screen is not the captor's prisoner-dismissal screen.";
+
+        var rightPrisonerRoster =
+            partyScreenLogic.PrisonerRosters[(int)PartyScreenLogic.PartyRosterSide.Right];
+        var rightIndex = rightPrisonerRoster.FindIndexOfTroop(prisoner.CharacterObject);
+        if (rightIndex < 0)
+            return $"The active Party screen does not contain '{GetHeroDisplayName(prisoner)}' as a prisoner.";
+
+        var prisonerElement = rightPrisonerRoster.GetElementCopyAtIndex(rightIndex);
+        if (!partyScreenLogic.IsTroopTransferable(
+                PartyScreenLogic.TroopType.Prisoner,
+                prisoner.CharacterObject,
+                (int)PartyScreenLogic.PartyRosterSide.Right))
+            return $"The active Party screen does not allow '{GetHeroDisplayName(prisoner)}' to be transferred.";
+
+        var targetIndex = partyScreenLogic.GetIndexToInsertTroop(
+            PartyScreenLogic.PartyRosterSide.Left,
+            PartyScreenLogic.TroopType.Prisoner,
+            prisonerElement);
+        var command = new PartyScreenLogic.PartyCommand();
+        command.FillForTransferTroop(
+            PartyScreenLogic.PartyRosterSide.Right,
+            PartyScreenLogic.TroopType.Prisoner,
+            prisoner.CharacterObject,
+            prisonerElement.Number,
+            prisonerElement.WoundedNumber,
+            targetIndex);
+
+        // PartyCharacterVM.ApplyTransfer is patched with this same scope. Drive PartyScreenLogic directly
+        // so the automation exercises the real transfer history, both Done handlers, network messages,
+        // rollback, and state close without synthesizing either wire payload.
+        using (new Common.Util.AllowedThread())
         {
-            new TroopRosterElementData(prisonerCharacterId, 1, 0, 0),
-        });
-        var rightPrisonerDelta = new TroopRosterData(new[]
-        {
-            new TroopRosterElementData(prisonerCharacterId, -1, 0, 0),
-        });
-
-        var message = new NetworkCompleteDoneLogic(
-            captorHeroId,
-            Array.Empty<FlattenedTroop>(),
-            Array.Empty<FlattenedTroop>(),
-            Array.Empty<FlattenedTroop>(),
-            emptyRosterDelta,
-            leftDummyDiscardDelta,
-            emptyRosterDelta,
-            rightPrisonerDelta,
-            captor.ItemRoster.ToArray(),
-            new UpgradedTroopHistoryData(new()),
-            null,
-            null,
-            0,
-            0,
-            0,
-            true,
-            captor.Position,
-            Helpers.PartyScreenHelper.PartyScreenMode.Normal,
-            troopRosterInterface.PackTroopRosterOrderData(captor.MemberRoster));
-
-        if (ModInformation.IsClient)
-        {
-            if (MobileParty.MainParty != captor)
-                return "Run this command on the client that controls the captor party.";
-
-            network.SendAll(message);
+            partyScreenLogic.AddCommand(command);
+            partyScreenLogic.RemoveZeroCounts();
         }
-        else
-        {
-            messageBroker.Publish(typeof(PlayerCaptivityCommands), message);
-        }
+
+        var movedCount = leftPrisonerRoster.GetTroopCount(prisoner.CharacterObject);
+        if (movedCount != prisonerElement.Number ||
+            rightPrisonerRoster.GetTroopCount(prisoner.CharacterObject) != 0)
+            return "PartyScreenLogic did not move the complete prisoner stack to the dismissal roster.";
+
+        PartyScreenHelper.CloseScreen(isForced: false);
+        var screenClosed = Game.Current.GameStateManager.ActiveState != partyState;
 
         return
-            "Player prisoner discard submitted.\n" +
+            "Player prisoner discarded through the active Party screen.\n" +
             $"Hero: {GetHeroDisplayName(prisoner)}\n" +
             $"Captor StringId: {captor.StringId}\n" +
-            $"SubmissionSide: {(ModInformation.IsClient ? "client-network" : "server-local")}";
+            $"TransferredCount: {movedCount}\n" +
+            $"ActionPath: {nameof(PartyScreenLogic)}.{nameof(PartyScreenLogic.AddCommand)} -> " +
+            $"{nameof(PartyScreenHelper)}.{nameof(PartyScreenHelper.CloseScreen)}\n" +
+            $"ScreenClosed: {screenClosed}";
     }
 
     private const string ObservePlayerUsage =

--- a/source/GameInterface/Services/PlayerCaptivityService/Commands/PlayerCaptivityCommands.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Commands/PlayerCaptivityCommands.cs
@@ -608,7 +608,7 @@ Reports the hero's current captivity state on this process.";
 @"Usage:
   coop.debug.player_captivity.discard_player_from_party_screen <heroId> <captorPartyId>
 
-Simulates the normal party screen's dummy-left prisoner discard for a captured player. Server only.";
+Simulates the normal party screen's dummy-left prisoner discard for a captured player.";
 
     [CommandLineArgumentFunction("discard_player_from_party_screen", "coop.debug.player_captivity")]
     public static string DiscardPlayerFromPartyScreen(List<string> args)
@@ -618,10 +618,7 @@ Simulates the normal party screen's dummy-left prisoner discard for a captured p
             DiscardPlayerFromPartyScreenUsage,
             args);
 
-        if (!ctx.RequireServer(out var error))
-            return error;
-
-        if (!ctx.RequireArgCount(2, out error))
+        if (!ctx.RequireArgCount(2, out var error))
             return error;
 
         if (!ctx.TryGetArg(0, "heroId", out var heroId, out error) ||
@@ -649,6 +646,7 @@ Simulates the normal party screen's dummy-left prisoner discard for a captured p
             return "Failed to resolve the registered captor or prisoner id.";
 
         if (!ContainerProvider.TryResolve<IMessageBroker>(out var messageBroker) ||
+            !ContainerProvider.TryResolve<INetwork>(out var network) ||
             !ContainerProvider.TryResolve<ITroopRosterInterface>(out var troopRosterInterface))
             return "Failed to resolve party-screen synchronization services.";
 
@@ -683,12 +681,23 @@ Simulates the normal party screen's dummy-left prisoner discard for a captured p
             Helpers.PartyScreenHelper.PartyScreenMode.Normal,
             troopRosterInterface.PackTroopRosterOrderData(captor.MemberRoster));
 
-        messageBroker.Publish(typeof(PlayerCaptivityCommands), message);
+        if (ModInformation.IsClient)
+        {
+            if (MobileParty.MainParty != captor)
+                return "Run this command on the client that controls the captor party.";
+
+            network.SendAll(message);
+        }
+        else
+        {
+            messageBroker.Publish(typeof(PlayerCaptivityCommands), message);
+        }
 
         return
             "Player prisoner discard submitted.\n" +
             $"Hero: {GetHeroDisplayName(prisoner)}\n" +
-            $"Captor StringId: {captor.StringId}";
+            $"Captor StringId: {captor.StringId}\n" +
+            $"SubmissionSide: {(ModInformation.IsClient ? "client-network" : "server-local")}";
     }
 
     private const string ObservePlayerUsage =

--- a/source/GameInterface/Services/PlayerCaptivityService/Commands/PlayerCaptivityCommands.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Commands/PlayerCaptivityCommands.cs
@@ -2,6 +2,7 @@
 using Common.Logging;
 using Common.Messaging;
 using Common.Network;
+using Common.Util;
 using GameInterface.Services.MapEventParties;
 using GameInterface.Services.MobileParties.Data;
 using GameInterface.Services.MobileParties.Extensions;
@@ -692,7 +693,7 @@ Run this on the client that controls the captor after opening the Party screen."
         // PartyCharacterVM.ApplyTransfer is patched with this same scope. Drive PartyScreenLogic directly
         // so the automation exercises the real transfer history, both Done handlers, network messages,
         // rollback, and state close without synthesizing either wire payload.
-        using (new Common.Util.AllowedThread())
+        using (new AllowedThread())
         {
             partyScreenLogic.AddCommand(command);
             partyScreenLogic.RemoveZeroCounts();

--- a/source/GameInterface/Services/PlayerCaptivityService/Handlers/PlayerCaptivityServerHandler.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Handlers/PlayerCaptivityServerHandler.cs
@@ -15,6 +15,7 @@ using GameInterface.Services.PartyVisuals.Extensions;
 using GameInterface.Services.PartyVisuals.Messages;
 using GameInterface.Services.PlayerCaptivityService.Messages;
 using GameInterface.Services.Players;
+using GameInterface.Services.TroopRosters.Messages;
 using Helpers;
 using LiteNetLib;
 using SandBox.View.Map.Managers;
@@ -607,18 +608,33 @@ internal class PlayerCaptivityServerHandler : IHandler
         // the hero, null it directly so the cleared state still auto-syncs to the owning client.
         if (captorParty != null)
         {
-            // Publish absolute zeroes so clients converge even when their stale count differs from the server.
             var prisonRoster = captorParty.PrisonRoster;
             int prisonerIndex = prisonRoster.FindIndexOfTroop(playerHero.CharacterObject);
-            if (prisonerIndex >= 0)
+            // Apply the authoritative cleanup without letting the roster patches publish a conditional
+            // mutation. The explicit identity-keyed tombstone below must be sent even when this element
+            // was already absent on the server but remains stale on one or more clients.
+            using (new AllowedThread())
             {
-                if (prisonRoster.GetElementWoundedNumber(prisonerIndex) != 0)
+                if (prisonerIndex >= 0)
                 {
-                    prisonRoster.SetElementWoundedNumber(prisonerIndex, 0);
+                    if (prisonRoster.GetElementWoundedNumber(prisonerIndex) != 0)
+                    {
+                        prisonRoster.SetElementWoundedNumber(prisonerIndex, 0);
+                    }
+                    prisonRoster.SetElementNumber(prisonerIndex, 0);
                 }
-                prisonRoster.SetElementNumber(prisonerIndex, 0);
+                // Match the roster-wide cleanup every client applies below, including when the target
+                // player element was already absent but another depleted element remains.
                 prisonRoster.RemoveZeroCounts();
+                prisonRoster.InitializeCachedData();
             }
+
+            // Publish absolute zeroes regardless of authoritative element presence. A normal Party-screen
+            // release can arrive after another server path removed the roster element while the captor client
+            // still has a stale copy; skipping the tombstone in that state reproduces the ghost prisoner.
+            messageBroker.Publish(this, new ElementWoundedNumberSet(prisonRoster, playerHero.CharacterObject, 0));
+            messageBroker.Publish(this, new ElementNumberSet(prisonRoster, playerHero.CharacterObject, 0));
+            messageBroker.Publish(this, new ZeroCountsRemoved(prisonRoster));
         }
         if (playerHero.PartyBelongedToAsPrisoner != null)
         {

--- a/source/GameInterface/Services/PlayerCaptivityService/Handlers/PlayerCaptivityServerHandler.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Handlers/PlayerCaptivityServerHandler.cs
@@ -605,9 +605,20 @@ internal class PlayerCaptivityServerHandler : IHandler
         // PartyBelongedToAsPrisoner via the engine hook; do this regardless of whether the captor is still
         // active, since a captor defeated in battle may already be inactive. If the roster no longer holds
         // the hero, null it directly so the cleared state still auto-syncs to the owning client.
-        if (captorParty != null && captorParty.PrisonRoster.Contains(playerHero.CharacterObject))
+        if (captorParty != null)
         {
-            captorParty.PrisonRoster.RemoveTroop(playerHero.CharacterObject);
+            // Publish absolute zeroes so clients converge even when their stale count differs from the server.
+            var prisonRoster = captorParty.PrisonRoster;
+            int prisonerIndex = prisonRoster.FindIndexOfTroop(playerHero.CharacterObject);
+            if (prisonerIndex >= 0)
+            {
+                if (prisonRoster.GetElementWoundedNumber(prisonerIndex) != 0)
+                {
+                    prisonRoster.SetElementWoundedNumber(prisonerIndex, 0);
+                }
+                prisonRoster.SetElementNumber(prisonerIndex, 0);
+                prisonRoster.RemoveZeroCounts();
+            }
         }
         if (playerHero.PartyBelongedToAsPrisoner != null)
         {

--- a/source/GameInterface/Services/TroopRosters/Handlers/TroopRosterDeltaHandler.cs
+++ b/source/GameInterface/Services/TroopRosters/Handlers/TroopRosterDeltaHandler.cs
@@ -6,6 +6,7 @@ using Common.Network.Coalescing;
 using Common.Util;
 using GameInterface.Services.MapEvents;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Party;
 using static GameInterface.Services.ObjectManager.ObjectManager;
 using GameInterface.Services.TroopRosters.Coalescing;
 using GameInterface.Services.TroopRosters.Messages;
@@ -39,15 +40,19 @@ internal class TroopRosterDeltaHandler : IHandler
     private readonly INetwork network;
     private readonly ISendCoalescer coalescer;
     private readonly IEncounterMenuConditionRefresher encounterMenuConditionRefresher;
+    private readonly IPartyScreenRosterBaselineProvider partyScreenRosterBaselineProvider;
 
     public TroopRosterDeltaHandler(IMessageBroker messageBroker, IObjectManager objectManager, INetwork network,
-        IEncounterMenuConditionRefresher encounterMenuConditionRefresher, ISendCoalescer coalescer = null)
+        IEncounterMenuConditionRefresher encounterMenuConditionRefresher,
+        IPartyScreenRosterBaselineProvider partyScreenRosterBaselineProvider,
+        ISendCoalescer coalescer = null)
     {
         this.messageBroker = messageBroker;
         this.objectManager = objectManager;
         this.network = network;
         this.encounterMenuConditionRefresher = encounterMenuConditionRefresher;
         this.coalescer = coalescer;
+        this.partyScreenRosterBaselineProvider = partyScreenRosterBaselineProvider;
 
         // Authority send path: the roster patches publish these local events (server-only) with the server index.
         messageBroker.Subscribe<CountsAtIndexAdded>(Handle_CountsAtIndexAdded);
@@ -262,6 +267,12 @@ internal class TroopRosterDeltaHandler : IHandler
             {
                 if (!objectManager.TryGetObjectWithLogging(rosterId, out roster)) return;
                 roster.RemoveZeroCounts();
+                var baselineRoster = partyScreenRosterBaselineProvider.GetBaselineRoster(roster);
+                if (baselineRoster != null)
+                {
+                    baselineRoster.RemoveZeroCounts();
+                    baselineRoster.InitializeCachedData();
+                }
                 roster.InitializeCachedData();
             }
 
@@ -286,6 +297,13 @@ internal class TroopRosterDeltaHandler : IHandler
                 if (!objectManager.TryGetObjectWithLogging<CharacterObject>(characterId, out var character)) return;
 
                 apply(roster, character);
+                // Done resets live rosters from this snapshot, so authority changes must update both copies.
+                var baselineRoster = partyScreenRosterBaselineProvider.GetBaselineRoster(roster);
+                if (baselineRoster != null)
+                {
+                    apply(baselineRoster, character);
+                    baselineRoster.InitializeCachedData();
+                }
             }
 
             // Coalesced roster changes can land after the map event opens its encounter menu.

--- a/source/GameInterface/Services/TroopRosters/Patches/TroopRosterCreateDummyPatch.cs
+++ b/source/GameInterface/Services/TroopRosters/Patches/TroopRosterCreateDummyPatch.cs
@@ -1,11 +1,9 @@
 using Common;
-using Common.Logging;
 using Common.Messaging;
 using Common.Util;
 using GameInterface.Policies;
 using GameInterface.Registry.Auto;
 using HarmonyLib;
-using Serilog;
 using System;
 using System.Reflection;
 using TaleWorlds.CampaignSystem.Roster;
@@ -15,8 +13,6 @@ namespace GameInterface.Services.TroopRosters.Patches;
 [HarmonyPatch(typeof(TroopRoster))]
 internal class TroopRosterCreateDummyPatch
 {
-    private static readonly ILogger Logger = LogManager.GetLogger<TroopRosterCreateDummyPatch>();
-
     private static readonly ConstructorInfo TroopRosterCtor = AccessTools.Constructor(typeof(TroopRoster), Type.EmptyTypes);
 
     [HarmonyPatch(nameof(TroopRoster.CreateDummyTroopRoster))]
@@ -28,7 +24,9 @@ internal class TroopRosterCreateDummyPatch
 
         if (ModInformation.IsClient)
         {
-            Logger.Error("Client created managed object {Type}", typeof(TroopRoster));
+            // Party, tooltip, battle-tally, and other presentation flows create local scratch rosters on
+            // clients. They deliberately have no network identity; server-created managed rosters arrive
+            // through the object registry instead of this factory.
             return true;
         }
 

--- a/source/GameInterface/Services/TroopRosters/Patches/TroopRosterPatches.cs
+++ b/source/GameInterface/Services/TroopRosters/Patches/TroopRosterPatches.cs
@@ -42,6 +42,9 @@ internal class TroopRosterPatches
     internal static bool IsRegistered(TroopRoster roster)
         => ContainerProvider.TryResolve<IObjectManager>(out var objectManager) && objectManager.TryGetId(roster, out _);
 
+    internal static bool ShouldReportClientMutation(bool isClient, bool isRegistered)
+        => isClient && isRegistered;
+
     [HarmonyPatch(nameof(TroopRoster.AddToCountsAtIndex))]
     [HarmonyPrefix]
     private static void PrefixAddToCountsAtIndex(TroopRoster __instance, int index, int countChange,
@@ -50,7 +53,8 @@ internal class TroopRosterPatches
         if (CallOriginalPolicy.IsOriginalAllowed()) return;
         if (ModInformation.IsClient)
         {
-            Logger.Error("Client attempted to {methodName} on a managed {type}", nameof(TroopRoster.AddToCountsAtIndex), typeof(TroopRoster));
+            if (ShouldReportClientMutation(ModInformation.IsClient, IsRegistered(__instance)))
+                Logger.Error("Client attempted to {methodName} on a managed {type}", nameof(TroopRoster.AddToCountsAtIndex), typeof(TroopRoster));
             return;
         }
 
@@ -86,7 +90,8 @@ internal class TroopRosterPatches
         if (CallOriginalPolicy.IsOriginalAllowed()) return;
         if (ModInformation.IsClient)
         {
-            Logger.Error("Client attempted to {methodName} on a managed {type}", nameof(TroopRoster.RemoveZeroCounts), typeof(TroopRoster));
+            if (ShouldReportClientMutation(ModInformation.IsClient, IsRegistered(__instance)))
+                Logger.Error("Client attempted to {methodName} on a managed {type}", nameof(TroopRoster.RemoveZeroCounts), typeof(TroopRoster));
             return;
         }
 
@@ -113,7 +118,8 @@ internal class TroopRosterPatches
         if (CallOriginalPolicy.IsOriginalAllowed()) return;
         if (ModInformation.IsClient)
         {
-            Logger.Error("Client attempted to {methodName} on a managed {type}", nameof(TroopRoster.SetElementNumber), typeof(TroopRoster));
+            if (ShouldReportClientMutation(ModInformation.IsClient, IsRegistered(__instance)))
+                Logger.Error("Client attempted to {methodName} on a managed {type}", nameof(TroopRoster.SetElementNumber), typeof(TroopRoster));
             return;
         }
 
@@ -146,7 +152,8 @@ internal class TroopRosterPatches
         if (CallOriginalPolicy.IsOriginalAllowed()) return;
         if (ModInformation.IsClient)
         {
-            Logger.Error("Client attempted to {methodName} on a managed {type}", nameof(TroopRoster.SetElementWoundedNumber), typeof(TroopRoster));
+            if (ShouldReportClientMutation(ModInformation.IsClient, IsRegistered(__instance)))
+                Logger.Error("Client attempted to {methodName} on a managed {type}", nameof(TroopRoster.SetElementWoundedNumber), typeof(TroopRoster));
             return;
         }
 
@@ -177,7 +184,8 @@ internal class TroopRosterPatches
         if (CallOriginalPolicy.IsOriginalAllowed()) return;
         if (ModInformation.IsClient)
         {
-            Logger.Error("Client attempted to {methodName} on a managed {type}", nameof(TroopRoster.SetElementXp), typeof(TroopRoster));
+            if (ShouldReportClientMutation(ModInformation.IsClient, IsRegistered(__instance)))
+                Logger.Error("Client attempted to {methodName} on a managed {type}", nameof(TroopRoster.SetElementXp), typeof(TroopRoster));
             return;
         }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Releasing a captured player from the captor's Party screen can restore the player's party while leaving the player listed as a prisoner. Releasing the stale entry again can teleport the restored party back to the captor and discard its roster state.

## What is the new behavior?

Resolves #2312

Releasing a captured player from the Party screen now removes the prisoner entry completely across the server and clients, restores the player's party once, and prevents a second release from teleporting or wiping that party.

## Bot Changelog Entry

- Fixed released players remaining in another player's prisoner list and being teleported or wiped by a second release.
