### PR TITLE
Restore relayed field-battle movement

### DIFF
--- a/source/E2E.Tests/Services/Missions/MovementTrafficTests.cs
+++ b/source/E2E.Tests/Services/Missions/MovementTrafficTests.cs
@@ -226,7 +226,7 @@ public class MovementTrafficTests : MissionTestEnvironment
     }
 
     [Fact]
-    public void ThreeMountedSnapshots_FitDirectAndRelayDatagrams()
+    public void ThreeMountedSnapshots_FitAndDispatchThroughRelay()
     {
         using var fixture = new MissionEngineFixture();
         var peer = Clients.First();
@@ -234,6 +234,8 @@ public class MovementTrafficTests : MissionTestEnvironment
         peer.Call(() =>
         {
             var mock = fixture.CreateMission(peer);
+            _ = peer.Resolve<ICoopMissionComponent>();
+            var packetManager = peer.Resolve<IPacketManager>();
             var ids = new ushort[3];
             var riders = new AgentData[3];
             var mounts = new AgentMountData[3];
@@ -254,9 +256,9 @@ public class MovementTrafficTests : MissionTestEnvironment
 
             var serializer = new ProtoBufSerializer(new SerializableTypeMapper());
             var compressor = new MovementPacketCompressor(serializer);
-            AssertFitsRelay(serializer, compressor,
+            AssertFitsAndDispatchesThroughRelay(serializer, compressor, packetManager, peer.NetPeer,
                 new MovementPacket("76561198000000042", ids, riders));
-            AssertFitsRelay(serializer, compressor,
+            AssertFitsAndDispatchesThroughRelay(serializer, compressor, packetManager, peer.NetPeer,
                 new MountMovementPacket("76561198000000042", ids, mounts));
         });
     }
@@ -284,22 +286,46 @@ public class MovementTrafficTests : MissionTestEnvironment
             LiteNetP2PClient.SelectDeliveryMethod(ordinaryUnreliable, datagramCeiling - 1, 0));
     }
 
-    private static void AssertFitsRelay(
+    private static void AssertFitsAndDispatchesThroughRelay(
         ProtoBufSerializer serializer,
         MovementPacketCompressor compressor,
+        IPacketManager packetManager,
+        NetPeer sourcePeer,
         IPacket packet)
     {
         byte[] payload = compressor.Serialize(packet);
+        Assert.IsType<CompressedMovementPacket>(
+            serializer.Deserialize<IPacket>(payload));
         Assert.True(payload.Length <= LiteNetP2PClient.SafeSinglePacketBytes,
             $"Direct payload was {payload.Length} bytes");
 
-        byte[] relay = serializer.Serialize(new RelayPacket(
+        byte[] relayBytes = serializer.Serialize(new RelayPacket(
             packet.DeliveryMethod,
             "MapEvent_Created_0000",
             "76561198000000042",
             payload));
-        Assert.True(relay.Length <= LiteNetP2PClient.SafeSinglePacketBytes,
-            $"Relay payload was {relay.Length} bytes");
+        Assert.True(relayBytes.Length <= LiteNetP2PClient.SafeSinglePacketBytes,
+            $"Relay payload was {relayBytes.Length} bytes");
+
+        var relay = Assert.IsType<RelayPacket>(
+            serializer.Deserialize<IPacket>(relayBytes));
+        IPacket received = serializer.Deserialize<IPacket>(relay.Payload);
+
+        var restoredHandler = new RecordingPacketHandler(packet.PacketType);
+        packetManager.RegisterPacketHandler(restoredHandler);
+
+        try
+        {
+            packetManager.HandleReceive(sourcePeer, received);
+
+            Assert.Equal(1, restoredHandler.HandleCount);
+            Assert.Same(sourcePeer, restoredHandler.SourcePeer);
+            Assert.Equal(packet.GetType(), restoredHandler.Received.GetType());
+        }
+        finally
+        {
+            packetManager.RemovePacketHandler(restoredHandler);
+        }
     }
 
     private static Agent SpawnRider(MockMission mock)
@@ -335,6 +361,30 @@ public class MovementTrafficTests : MissionTestEnvironment
         {
             PacketType = packetType;
             DeliveryMethod = deliveryMethod;
+        }
+    }
+
+    private sealed class RecordingPacketHandler : IPacketHandler
+    {
+        public PacketType PacketType { get; }
+        public int HandleCount { get; private set; }
+        public NetPeer SourcePeer { get; private set; } = null!;
+        public IPacket Received { get; private set; } = null!;
+
+        public RecordingPacketHandler(PacketType packetType)
+        {
+            PacketType = packetType;
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public void HandlePacket(NetPeer peer, IPacket packet)
+        {
+            HandleCount++;
+            SourcePeer = peer;
+            Received = packet;
         }
     }
 }

--- a/source/Missions/MissionModule.cs
+++ b/source/Missions/MissionModule.cs
@@ -44,6 +44,10 @@ public class MissionModule : Module
         builder.RegisterType<MovementPacketCompressor>()
             .As<IMovementPacketCompressor>()
             .InstancePerDependency();
+        builder.RegisterType<CompressedMovementPacketHandler>()
+            .AsSelf()
+            .InstancePerLifetimeScope()
+            .AutoActivate();
         builder.RegisterType<NoopSteamMissionBridge>().As<ISteamMissionBridge>().InstancePerLifetimeScope();
 
         // MissionContext mirrors the server's instance membership and must live for the whole client

--- a/source/Missions/Services/Network/CompressedMovementPacketHandler.cs
+++ b/source/Missions/Services/Network/CompressedMovementPacketHandler.cs
@@ -1,0 +1,45 @@
+﻿using Common.Logging;
+using Common.PacketHandlers;
+using LiteNetLib;
+using Serilog;
+
+namespace Missions.Services.Network;
+
+/// <summary>
+/// Restores compressed movement packets before dispatching them to the mission packet handlers.
+/// </summary>
+public class CompressedMovementPacketHandler : IPacketHandler
+{
+    private static readonly ILogger Logger = LogManager.GetLogger<CompressedMovementPacketHandler>();
+
+    private readonly IPacketManager packetManager;
+    private readonly IMovementPacketCompressor movementPacketCompressor;
+
+    public PacketType PacketType => PacketType.CompressedMovement;
+
+    public CompressedMovementPacketHandler(
+        IPacketManager packetManager,
+        IMovementPacketCompressor movementPacketCompressor)
+    {
+        this.packetManager = packetManager;
+        this.movementPacketCompressor = movementPacketCompressor;
+
+        packetManager.RegisterPacketHandler(this);
+    }
+
+    public void Dispose()
+    {
+        packetManager.RemovePacketHandler(this);
+    }
+
+    public void HandlePacket(NetPeer peer, IPacket packet)
+    {
+        if (!movementPacketCompressor.TryRestore(packet, out IPacket restored))
+        {
+            Logger.Warning("Discarding an invalid compressed movement packet");
+            return;
+        }
+
+        packetManager.HandleReceive(peer, restored);
+    }
+}

--- a/source/Missions/Services/Network/LiteNetP2PClient.cs
+++ b/source/Missions/Services/Network/LiteNetP2PClient.cs
@@ -665,12 +665,6 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
         }
 
         var packet = serializer.Deserialize<IPacket>(reader.GetRemainingBytes());
-        if (!movementPacketCompressor.TryRestore(packet, out packet))
-        {
-            Logger.Warning("Discarding an invalid compressed movement packet");
-            return;
-        }
-
         packetManager.HandleReceive(peer, packet);
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Remote troops, riders, and horses can stop moving during field battles when their movement traffic falls back through the server, causing severe desync after #2314.

## What is the new behavior?

Remote troops, riders, and horses keep receiving movement updates when battle traffic falls back through the server, while direct P2P battles continue to use the same behavior.

## Bot Changelog Entry

- Fixed severe field-battle desync when player connections use the server relay.
