### PR TITLE
Restrict gold and food change in map events

### DIFF
--- a/source/GameInterface/Services/Clans/Patches/ClanDefaultClanFinanceModelPatches.cs
+++ b/source/GameInterface/Services/Clans/Patches/ClanDefaultClanFinanceModelPatches.cs
@@ -1,5 +1,7 @@
 ﻿using Common.Messaging;
 using GameInterface.Services.Clans.Interfaces;
+using GameInterface.Services.Heroes.Extensions;
+using GameInterface.Services.MapEvents.Patches;
 using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Services.UI.Notifications.Messages;
 using HarmonyLib;
@@ -54,5 +56,22 @@ internal class DefaultClanFinanceModelPatches
         {
             MessageBroker.Instance.Publish(__instance, new NotifyMoraleLossDueToFunds(mobileParty, mobileParty.RecentEventsMorale - initialRecentEventsMorale));
         }
+    }
+
+    [HarmonyPatch(nameof(DefaultClanFinanceModel.CalculateClanGoldChange))]
+    [HarmonyPrefix]
+    public static bool CalculateClanGoldChangePrefix(Clan clan)
+    {
+        // Calculate gold change for AI led clans normally
+        if (clan.Leader == null || !clan.Leader.IsPlayerHero()) return true;
+
+        var clanLeaderMapEvent = clan.Leader.PartyBelongedTo.MapEvent;
+
+        // Clan leader not in a map event, calculate gold change normally
+        if (clanLeaderMapEvent == null) return true;
+
+        // Use AI join window to determine if the gold change should be calculated.
+        // This way players only have a gold change at most once during a map event.
+        return InteractionPatches.IsWithinAiJoinWindow(clanLeaderMapEvent);
     }
 }

--- a/source/GameInterface/Services/Clans/Patches/ClanDefaultClanFinanceModelPatches.cs
+++ b/source/GameInterface/Services/Clans/Patches/ClanDefaultClanFinanceModelPatches.cs
@@ -65,7 +65,7 @@ internal class DefaultClanFinanceModelPatches
         // Calculate gold change for AI led clans normally
         if (clan.Leader == null || !clan.Leader.IsPlayerHero()) return true;
 
-        var clanLeaderMapEvent = clan.Leader.PartyBelongedTo.MapEvent;
+        var clanLeaderMapEvent = clan.Leader.PartyBelongedTo?.MapEvent;
 
         // Clan leader not in a map event, calculate gold change normally
         if (clanLeaderMapEvent == null) return true;

--- a/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
@@ -309,7 +309,7 @@ internal class InteractionPatches
     /// <summary>True while a player's battle is still within its post-start window for AI parties to join as
     /// reinforcements (<see cref="MapEventConfig.PlayerBattleAiJoinWindowHours"/>). The window is opened in
     /// <see cref="Postfix_Initialize"/>; only the server ever populates it, so this is a server-side query.</summary>
-    internal static bool IsWithinAiJoinWindow(MapEvent mapEvent)
+    public static bool IsWithinAiJoinWindow(MapEvent mapEvent)
         => playerBattleAiJoinWindows.TryGetValue(mapEvent, out var window) && !window.Expired;
 
     [HarmonyPatch(typeof(MapEvent), nameof(MapEvent.CanPartyJoinBattle))]

--- a/source/GameInterface/Services/MobileParties/Patches/Disable/DisableFoodConsumptionBehavior.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/Disable/DisableFoodConsumptionBehavior.cs
@@ -1,4 +1,6 @@
 ﻿using Common;
+using GameInterface.Services.MapEvents.Patches;
+using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Services.MobileParties.Interfaces;
 using HarmonyLib;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
@@ -32,6 +34,12 @@ internal class FoodConsumptionBehaviorPatches
     [HarmonyPrefix]
     public static bool DailyTickPartyPrefix(FoodConsumptionBehavior __instance, MobileParty party)
     {
+        // Use AI join window to determine if a player party should consume food and breed animals.
+        // This way players only have food change at most once during a map event.
+        if (party.IsPlayerParty()
+            && party.MapEvent != null
+            && !InteractionPatches.IsWithinAiJoinWindow(party.MapEvent)) return false;
+
         if (!ContainerProvider.TryResolve<IFoodConsumptionBehaviorInterface>(out var foodConsumptionBehaviorInterface)) return false;
 
         // Custom implementation to move check for starving player parties into daily tick from OnTick

--- a/source/GameInterface/Services/UI/Notifications/Handlers/GoldNotificationHandler.cs
+++ b/source/GameInterface/Services/UI/Notifications/Handlers/GoldNotificationHandler.cs
@@ -135,6 +135,10 @@ internal class GoldNotificationHandler : IHandler
             if (clan != Clan.PlayerClan) return;
 
             var goldChange = data.GoldChange;
+
+            // Don't notify client of daily gold change if there is no change
+            if (goldChange == 0) return;
+
             TextObject textObject = new TextObject("{=dPD5zood}Daily Gold Change: {CHANGE}{GOLD_ICON}", null);
             textObject.SetTextVariable("CHANGE", goldChange);
             textObject.SetTextVariable("GOLD_ICON", "{=!}<img src=\"General\\Icons\\Coin@2x\" extend=\"6\">");


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Other... Please describe: QoL


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Many players have reported that daily gold change happening during battles is very frustrating, especially in the early game.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Block repeated gold and food changes by using the same system that prevents AI parties reinforcing after a day.
Original idea suggested by @Gerseras.

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Gold and food changes can now only happen one time during a battle.
