### PR TITLE
[2368] Pause prolonged joins during initial catch-up

### DIFF
--- a/source/Coop.Core/Server/Connections/States/LoadingState.cs
+++ b/source/Coop.Core/Server/Connections/States/LoadingState.cs
@@ -54,7 +54,10 @@ public class LoadingState : ConnectionStateBase
 
     public override bool IsLoading => true;
 
-    internal bool IsFinalCatchUpPending =>
+    internal bool IsJoinCatchUpPending =>
+        phase == JoinPhase.WaitingForReplayApplied ||
+        phase == JoinPhase.InitialBaselineQueued ||
+        phase == JoinPhase.WaitingForInitialBaseline ||
         phase == JoinPhase.FinalBaselineQueued ||
         phase == JoinPhase.WaitingForFinalBaseline ||
         phase == JoinPhase.WorldReadyQueued ||

--- a/source/Coop.Core/Server/Services/Time/OverloadedPeerManager.cs
+++ b/source/Coop.Core/Server/Services/Time/OverloadedPeerManager.cs
@@ -33,7 +33,7 @@ internal class OverloadedPeerManager : IOverloadedPeerManager
 
     private TimeControlEnum? originalSpeed;
     private volatile NetPeer[] cachedOverloadedPeers = Array.Empty<NetPeer>();
-    private readonly Dictionary<NetPeer, DateTime> finalCatchUpStartedUtc = new Dictionary<NetPeer, DateTime>();
+    private readonly Dictionary<NetPeer, DateTime> joinCatchUpStartedUtc = new Dictionary<NetPeer, DateTime>();
 
     // Diagnostics for the catch-up pause: when it started and when depths were last logged, so a
     // long pause leaves periodic evidence in the log instead of only an in-game message.
@@ -66,7 +66,7 @@ internal class OverloadedPeerManager : IOverloadedPeerManager
     {
         // Removes pause policy from time handler
         timeControlInterface.RemoveUnpausePolicy(PlayersOverloadedPolicy);
-        finalCatchUpStartedUtc.Clear();
+        joinCatchUpStartedUtc.Clear();
     }
 
     private static int GetQueueDepth(NetPeer peer)
@@ -87,33 +87,33 @@ internal class OverloadedPeerManager : IOverloadedPeerManager
             .ToList();
     }
 
-    private List<NetPeer> UpdateFinalCatchUpPeers(DateTime utcNow)
+    private List<NetPeer> UpdateJoinCatchUpPeers(DateTime utcNow)
     {
         var peers = connectionCollection
-            .Where(logic => logic.State is LoadingState { IsFinalCatchUpPending: true })
+            .Where(logic => logic.State is LoadingState { IsJoinCatchUpPending: true })
             .Select(logic => logic.Peer)
             .ToList();
         var activePeers = new HashSet<NetPeer>(peers);
 
-        foreach (var peer in finalCatchUpStartedUtc.Keys.Where(peer => !activePeers.Contains(peer)).ToArray())
+        foreach (var peer in joinCatchUpStartedUtc.Keys.Where(peer => !activePeers.Contains(peer)).ToArray())
         {
-            finalCatchUpStartedUtc.Remove(peer);
+            joinCatchUpStartedUtc.Remove(peer);
         }
 
         foreach (var peer in peers)
         {
-            if (!finalCatchUpStartedUtc.ContainsKey(peer))
+            if (!joinCatchUpStartedUtc.ContainsKey(peer))
             {
-                finalCatchUpStartedUtc.Add(peer, utcNow);
+                joinCatchUpStartedUtc.Add(peer, utcNow);
             }
         }
 
         return peers;
     }
 
-    private List<NetPeer> GetStalledJoiningPeers(IEnumerable<NetPeer> finalCatchUpPeers, DateTime utcNow) =>
-        finalCatchUpPeers
-            .Where(peer => utcNow - finalCatchUpStartedUtc[peer] >= JoinCatchUpPauseDelay)
+    private List<NetPeer> GetStalledJoiningPeers(IEnumerable<NetPeer> joinCatchUpPeers, DateTime utcNow) =>
+        joinCatchUpPeers
+            .Where(peer => utcNow - joinCatchUpStartedUtc[peer] >= JoinCatchUpPauseDelay)
             .ToList();
 
     private int GetReportedQueueDepth(NetPeer peer) =>
@@ -133,8 +133,8 @@ internal class OverloadedPeerManager : IOverloadedPeerManager
 
     internal void CheckForOverloadedPeers(DateTime utcNow)
     {
-        var finalCatchUpPeers = UpdateFinalCatchUpPeers(utcNow);
-        var stalledJoiningPeers = GetStalledJoiningPeers(finalCatchUpPeers, utcNow);
+        var joinCatchUpPeers = UpdateJoinCatchUpPeers(utcNow);
+        var stalledJoiningPeers = GetStalledJoiningPeers(joinCatchUpPeers, utcNow);
 
         // While paused for overload, hold until every peer has drained below the (lower) resume
         // threshold, not just back under the pause threshold. The gap between the two thresholds is

--- a/source/Coop.Tests/Server/Connections/States/LoadingStateTests.cs
+++ b/source/Coop.Tests/Server/Connections/States/LoadingStateTests.cs
@@ -230,23 +230,32 @@ namespace Coop.Tests.Server.Connections.States
         }
 
         [Fact]
-        public void FinalCatchUpPending_StartsWithFinalBaselineAndEndsWithCampaignEntry()
+        public void JoinCatchUpPending_StartsAfterReplayAndEndsWithCampaignEntry()
         {
             var state = connectionLogic.SetState<LoadingState>();
-            Assert.False(state.IsFinalCatchUpPending);
+            Assert.False(state.IsJoinCatchUpPending);
 
-            StartBaseline(state);
-            SendAndDrain(state, JoinSyncSignal.BaselineRequested);
-            Assert.False(state.IsFinalCatchUpPending);
+            CampaignEntered(state);
+            Assert.False(state.IsJoinCatchUpPending);
+            DrainGameThread();
+            Assert.True(state.IsJoinCatchUpPending);
+
+            Signal(state, JoinSyncSignal.ReplayApplied);
+            Assert.True(state.IsJoinCatchUpPending);
+            DrainGameThread();
+
+            Signal(state, JoinSyncSignal.BaselineRequested);
+            Assert.True(state.IsJoinCatchUpPending);
+            DrainGameThread();
 
             SendAndDrain(state, JoinSyncSignal.BaselineApplied);
-            Assert.True(state.IsFinalCatchUpPending);
+            Assert.True(state.IsJoinCatchUpPending);
 
             SendAndDrain(state, JoinSyncSignal.FinalBaselineApplied);
-            Assert.True(state.IsFinalCatchUpPending);
+            Assert.True(state.IsJoinCatchUpPending);
 
             SendAndDrain(state, JoinSyncSignal.CatchUpApplied);
-            Assert.False(state.IsFinalCatchUpPending);
+            Assert.False(state.IsJoinCatchUpPending);
             Assert.IsType<CampaignState>(connectionLogic.State);
         }
 

--- a/source/Coop.Tests/Server/Services/Time/OverloadedPeerManagerTests.cs
+++ b/source/Coop.Tests/Server/Services/Time/OverloadedPeerManagerTests.cs
@@ -104,14 +104,14 @@ public class OverloadedPeerManagerTests
     }
 
     [Fact]
-    public void FinalJoinCatchUp_PausesAfterTwentySecondsRegardlessOfPacketCount()
+    public void InitialJoinCatchUp_PausesAfterTwentySecondsRegardlessOfPacketCount()
     {
         var timeControlMock = serverComponent.Container.Resolve<Mock<ITimeControlInterface>>();
         timeControlMock.Setup(t => t.GetTimeControl()).Returns(TimeControlEnum.Play_1x);
         var connections = serverComponent.Container.Resolve<ConnectionCollection>();
         var manager = (OverloadedPeerManager)serverComponent.Container.Resolve<IOverloadedPeerManager>();
         var peer = AddConnectedPeer(connections);
-        StartFinalCatchUp(connections, peer);
+        StartInitialCatchUp(connections, peer);
         peer.SetQueueLength(100);
         DateTime startedUtc = DateTime.UtcNow;
 
@@ -183,7 +183,7 @@ public class OverloadedPeerManagerTests
     }
 
     [Fact]
-    public void LoadingPeerBeforeFinalCatchUp_DoesNotPauseAfterGracePeriod()
+    public void LoadingPeerBeforeJoinCatchUp_DoesNotPauseAfterGracePeriod()
     {
         var timeControlMock = serverComponent.Container.Resolve<Mock<ITimeControlInterface>>();
         var connections = serverComponent.Container.Resolve<ConnectionCollection>();
@@ -210,6 +210,15 @@ public class OverloadedPeerManagerTests
 
     private void StartFinalCatchUp(ConnectionCollection connections, LiteNetLib.NetPeer peer)
     {
+        var state = StartInitialCatchUp(connections, peer);
+        SendAndDrain(state, peer, JoinSyncSignal.BaselineRequested);
+        SendAndDrain(state, peer, JoinSyncSignal.BaselineApplied);
+
+        Assert.True(state.IsJoinCatchUpPending);
+    }
+
+    private LoadingState StartInitialCatchUp(ConnectionCollection connections, LiteNetLib.NetPeer peer)
+    {
         serverComponent.Container.Resolve<IConnectionMessageQueue>().BeginQueueing(peer);
         var state = connections.ConnectionStates[peer].SetState<LoadingState>();
 
@@ -217,10 +226,9 @@ public class OverloadedPeerManagerTests
             new MessagePayload<NetworkPlayerCampaignEntered>(peer, new NetworkPlayerCampaignEntered()));
         DrainGameThread();
         SendAndDrain(state, peer, JoinSyncSignal.ReplayApplied);
-        SendAndDrain(state, peer, JoinSyncSignal.BaselineRequested);
-        SendAndDrain(state, peer, JoinSyncSignal.BaselineApplied);
 
-        Assert.True(state.IsFinalCatchUpPending);
+        Assert.True(state.IsJoinCatchUpPending);
+        return state;
     }
 
     private static void SendAndDrain(LoadingState state, LiteNetLib.NetPeer peer, JoinSyncSignal signal)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Closes #2368.

A joining client can remain in the initial campaign-baseline refresh loop indefinitely while campaign time continues advancing. The 20-second catch-up pause only watches the later final synchronization phases, so it never triggers for this state.

## What is the new behavior?

The post-save catch-up window now starts after replay and includes initial-baseline synchronization. If any of those phases lasts 20 seconds, campaign time pauses until the join completes or the client disconnects. Save transfer remains excluded so normal loading does not pause the campaign.

## Bot Changelog Entry

- Fixed dedicated-server joins getting stuck while repeatedly synchronizing campaign data.