### PR TITLE
[2368] Synchronize time mode during campaign join

### DIFF
--- a/source/Coop.Core/Client/Services/MobileParties/Handlers/JoinCampaignBaselineHandler.cs
+++ b/source/Coop.Core/Client/Services/MobileParties/Handlers/JoinCampaignBaselineHandler.cs
@@ -3,6 +3,7 @@ using Common.Messaging;
 using Common.Util;
 using Coop.Core.Client.Messages;
 using Coop.Core.Server.Services.MobileParties.Messages;
+using GameInterface.Services.Heroes.Interaces;
 using GameInterface.Services.MobileParties.Data;
 using GameInterface.Services.Time.Interfaces;
 
@@ -16,15 +17,18 @@ public sealed class JoinCampaignBaselineHandler : IHandler
     private readonly IMessageBroker messageBroker;
     private readonly IMapTimeTrackerInterface mapTimeTrackerInterface;
     private readonly IMobilePartyBehaviorSnapshot mobilePartyBehaviorSnapshot;
+    private readonly ITimeControlInterface timeControlInterface;
 
     public JoinCampaignBaselineHandler(
         IMessageBroker messageBroker,
         IMapTimeTrackerInterface mapTimeTrackerInterface,
-        IMobilePartyBehaviorSnapshot mobilePartyBehaviorSnapshot)
+        IMobilePartyBehaviorSnapshot mobilePartyBehaviorSnapshot,
+        ITimeControlInterface timeControlInterface)
     {
         this.messageBroker = messageBroker;
         this.mapTimeTrackerInterface = mapTimeTrackerInterface;
         this.mobilePartyBehaviorSnapshot = mobilePartyBehaviorSnapshot;
+        this.timeControlInterface = timeControlInterface;
 
         messageBroker.Subscribe<NetworkJoinCampaignBaseline>(Handle);
     }
@@ -42,7 +46,11 @@ public sealed class JoinCampaignBaselineHandler : IHandler
             bool success = baseline.IsComplete &&
                 mobilePartyBehaviorSnapshot.TryApplyJoinBaseline(
                     baseline.PartyStates,
-                    () => mapTimeTrackerInterface.ApplyCampaignJoinBaseline(baseline.ServerTicks));
+                    () =>
+                    {
+                        timeControlInterface.ClientSetTimeControl(baseline.TimeControlMode);
+                        mapTimeTrackerInterface.ApplyCampaignJoinBaseline(baseline.ServerTicks);
+                    });
 
             messageBroker.Publish(this, new JoinCampaignBaselineApplied(success));
         }, context: nameof(JoinCampaignBaselineHandler));

--- a/source/Coop.Core/Server/Services/MobileParties/JoinCampaignBaselineSender.cs
+++ b/source/Coop.Core/Server/Services/MobileParties/JoinCampaignBaselineSender.cs
@@ -1,6 +1,7 @@
 ﻿using Common.Logging;
 using Common.Network;
 using Coop.Core.Server.Services.MobileParties.Messages;
+using GameInterface.Services.Heroes.Interaces;
 using GameInterface.Services.MobileParties.Data;
 using GameInterface.Services.Time.Interfaces;
 using LiteNetLib;
@@ -23,15 +24,18 @@ internal sealed class JoinCampaignBaselineSender : IJoinCampaignBaselineSender
     private readonly INetwork network;
     private readonly IMapTimeTrackerInterface mapTimeTrackerInterface;
     private readonly IMobilePartyBehaviorSnapshot mobilePartyBehaviorSnapshot;
+    private readonly ITimeControlInterface timeControlInterface;
 
     public JoinCampaignBaselineSender(
         INetwork network,
         IMapTimeTrackerInterface mapTimeTrackerInterface,
-        IMobilePartyBehaviorSnapshot mobilePartyBehaviorSnapshot)
+        IMobilePartyBehaviorSnapshot mobilePartyBehaviorSnapshot,
+        ITimeControlInterface timeControlInterface)
     {
         this.network = network;
         this.mapTimeTrackerInterface = mapTimeTrackerInterface;
         this.mobilePartyBehaviorSnapshot = mobilePartyBehaviorSnapshot;
+        this.timeControlInterface = timeControlInterface;
     }
 
     public void Send(NetPeer peer)
@@ -64,6 +68,10 @@ internal sealed class JoinCampaignBaselineSender : IJoinCampaignBaselineSender
 
         network.SendImmediate(
             peer,
-            new NetworkJoinCampaignBaseline(serverTicks, partyStates, isComplete));
+            new NetworkJoinCampaignBaseline(
+                serverTicks,
+                timeControlInterface.GetTimeControl(),
+                partyStates,
+                isComplete));
     }
 }

--- a/source/Coop.Core/Server/Services/MobileParties/Messages/NetworkJoinCampaignBaseline.cs
+++ b/source/Coop.Core/Server/Services/MobileParties/Messages/NetworkJoinCampaignBaseline.cs
@@ -1,4 +1,5 @@
 ﻿using Common.Messaging;
+using GameInterface.Services.Heroes.Enum;
 using GameInterface.Services.MobileParties.Data;
 using ProtoBuf;
 
@@ -19,12 +20,17 @@ public readonly struct NetworkJoinCampaignBaseline : IMessage
     [ProtoMember(3)]
     public readonly bool IsComplete;
 
+    [ProtoMember(4)]
+    public readonly TimeControlEnum TimeControlMode;
+
     public NetworkJoinCampaignBaseline(
         long serverTicks,
+        TimeControlEnum timeControlMode,
         MobilePartyJoinState[] partyStates,
         bool isComplete = true)
     {
         ServerTicks = serverTicks;
+        TimeControlMode = timeControlMode;
         PartyStates = partyStates;
         IsComplete = isComplete;
     }

--- a/source/Coop.Tests/Client/Services/MobileParties/JoinCampaignBaselineHandlerTests.cs
+++ b/source/Coop.Tests/Client/Services/MobileParties/JoinCampaignBaselineHandlerTests.cs
@@ -3,6 +3,8 @@ using Common.Tests.Utils;
 using Coop.Core.Client.Messages;
 using Coop.Core.Client.Services.MobileParties.Handlers;
 using Coop.Core.Server.Services.MobileParties.Messages;
+using GameInterface.Services.Heroes.Enum;
+using GameInterface.Services.Heroes.Interaces;
 using GameInterface.Services.MobileParties.Data;
 using GameInterface.Services.Time.Interfaces;
 using Moq;
@@ -18,6 +20,7 @@ public class JoinCampaignBaselineHandlerTests
     private readonly Mock<IMapTimeTrackerInterface> mapTimeTracker = new Mock<IMapTimeTrackerInterface>();
     private readonly Mock<IMobilePartyBehaviorSnapshot> mobilePartyBehaviorSnapshot =
         new Mock<IMobilePartyBehaviorSnapshot>();
+    private readonly Mock<ITimeControlInterface> timeControl = new Mock<ITimeControlInterface>();
     private readonly JoinCampaignBaselineHandler handler;
 
     public JoinCampaignBaselineHandlerTests(ITestOutputHelper output)
@@ -26,18 +29,27 @@ public class JoinCampaignBaselineHandlerTests
         handler = new JoinCampaignBaselineHandler(
             messageBroker,
             mapTimeTracker.Object,
-            mobilePartyBehaviorSnapshot.Object);
+            mobilePartyBehaviorSnapshot.Object,
+            timeControl.Object);
     }
 
     [Fact]
     public void CompleteBaseline_AppliesAllPartyStateBeforePublishingSuccess()
     {
         var partyStates = new[] { new MobilePartyJoinState() };
+        bool timeControlApplied = false;
         bool timeApplied = false;
         bool partyStateApplied = false;
+        timeControl
+            .Setup(time => time.ClientSetTimeControl(TimeControlEnum.Play_2x))
+            .Callback(() => timeControlApplied = true);
         mapTimeTracker
             .Setup(tracker => tracker.ApplyCampaignJoinBaseline(123456L))
-            .Callback(() => timeApplied = true);
+            .Callback(() =>
+            {
+                Assert.True(timeControlApplied);
+                timeApplied = true;
+            });
         mobilePartyBehaviorSnapshot
             .Setup(snapshot => snapshot.TryApplyJoinBaseline(partyStates, It.IsAny<Action>()))
             .Callback<MobilePartyJoinState[], Action>((_, beforeApply) =>
@@ -53,8 +65,12 @@ public class JoinCampaignBaselineHandlerTests
             Assert.True(payload.What.Success);
         });
 
-        var applied = Apply(new NetworkJoinCampaignBaseline(123456L, partyStates));
+        var applied = Apply(new NetworkJoinCampaignBaseline(
+            123456L,
+            TimeControlEnum.Play_2x,
+            partyStates));
 
+        timeControl.Verify(time => time.ClientSetTimeControl(TimeControlEnum.Play_2x), Times.Once);
         mapTimeTracker.Verify(tracker => tracker.ApplyCampaignJoinBaseline(123456L), Times.Once);
         mobilePartyBehaviorSnapshot.Verify(
             snapshot => snapshot.TryApplyJoinBaseline(partyStates, It.IsAny<Action>()),
@@ -74,13 +90,20 @@ public class JoinCampaignBaselineHandlerTests
             .Setup(snapshot => snapshot.TryApplyJoinBaseline(partyStates, It.IsAny<Action>()))
             .Returns(false);
 
-        var applied = Apply(new NetworkJoinCampaignBaseline(123456L, partyStates, isComplete));
+        var applied = Apply(new NetworkJoinCampaignBaseline(
+            123456L,
+            TimeControlEnum.Play_1x,
+            partyStates,
+            isComplete));
 
         mobilePartyBehaviorSnapshot.Verify(
             snapshot => snapshot.TryApplyJoinBaseline(partyStates, It.IsAny<Action>()),
             Times.Exactly(expectedApplyAttempts));
         mapTimeTracker.Verify(
             tracker => tracker.ApplyCampaignJoinBaseline(It.IsAny<long>()),
+            Times.Never);
+        timeControl.Verify(
+            time => time.ClientSetTimeControl(It.IsAny<TimeControlEnum>()),
             Times.Never);
         Assert.False(applied.Success);
     }

--- a/source/Coop.Tests/Server/Connections/States/LoadingStateTests.cs
+++ b/source/Coop.Tests/Server/Connections/States/LoadingStateTests.cs
@@ -10,6 +10,7 @@ using Coop.Core.Server.Services.MobileParties;
 using Coop.Core.Server.Services.MobileParties.Messages;
 using Coop.Tests.Extensions;
 using Coop.Tests.Mocks;
+using GameInterface.Services.Heroes.Enum;
 using GameInterface.Services.MobileParties.Data;
 using LiteNetLib;
 using Moq;
@@ -132,7 +133,10 @@ namespace Coop.Tests.Server.Connections.States
                 .Setup(sender => sender.Send(playerPeer))
                 .Callback(() => serverComponent.TestNetwork.SendImmediate(
                     playerPeer,
-                    new NetworkJoinCampaignBaseline(123L, Array.Empty<MobilePartyJoinState>())));
+                    new NetworkJoinCampaignBaseline(
+                        123L,
+                        TimeControlEnum.Play_1x,
+                        Array.Empty<MobilePartyJoinState>())));
             StartReplay(state);
             var beforeAck = serverComponent.TestNetwork.GetPeerMessages(playerPeer).ToArray();
             Assert.Equal(

--- a/source/Coop.Tests/Server/Services/MobileParties/NetworkJoinCampaignBaselineTests.cs
+++ b/source/Coop.Tests/Server/Services/MobileParties/NetworkJoinCampaignBaselineTests.cs
@@ -3,6 +3,7 @@ using Common.Messaging;
 using Common.Serialization;
 using Coop.Core.Server.Connections.Messages;
 using Coop.Core.Server.Services.MobileParties.Messages;
+using GameInterface.Services.Heroes.Enum;
 using GameInterface.Services.MobileParties.Data;
 using GameInterface.Surrogates;
 using System;
@@ -60,11 +61,15 @@ public class NetworkJoinCampaignBaselineTests
             StartTransitionNextFrameToExitFromPort = true,
             ForceAiNoPathMode = true,
         };
-        var expected = new NetworkJoinCampaignBaseline(987654321L, new[] { state });
+        var expected = new NetworkJoinCampaignBaseline(
+            987654321L,
+            TimeControlEnum.Play_2x,
+            new[] { state });
 
         var received = RoundTrip(expected);
 
         Assert.Equal(expected.ServerTicks, received.ServerTicks);
+        Assert.Equal(expected.TimeControlMode, received.TimeControlMode);
         Assert.True(received.IsComplete);
         Assert.Single(received.PartyStates);
     }
@@ -74,6 +79,7 @@ public class NetworkJoinCampaignBaselineTests
     {
         var message = new NetworkJoinCampaignBaseline(
             123L,
+            TimeControlEnum.Play_1x,
             Array.Empty<MobilePartyJoinState>(),
             isComplete: false);
 


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

A joining client can stay in its default paused time mode while the server campaign keeps advancing, so repeated tick baselines move the client forward without letting it simulate between them.

## What is the new behavior?

Follow-up to #2368.

The join baseline carries the server current time-control mode and applies it before the authoritative tick baseline. The client can then use the existing current-speed correction to close the remaining gap, while the merged prolonged-join pause remains the fallback.

## Bot Changelog Entry

- Fixed joining clients remaining paused while catching up to a running campaign.
