### PR TITLE
[2356] Prevent crashes after mounted puppet deaths

### DIFF
--- a/source/E2E.Tests/Environment/MockEngine/MirrorAgent.cs
+++ b/source/E2E.Tests/Environment/MockEngine/MirrorAgent.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
@@ -43,6 +44,7 @@ public sealed class MirrorAgent
     /// <summary>The rider currently on this (mount) agent; kept in step with the rider's
     /// <see cref="MountAgent"/> by the <c>set_MountAgent</c> shim.</summary>
     public Agent RiderAgent { get; set; }
+    public List<AgentComponent> Components { get; } = new List<AgentComponent>();
     /// <summary>The mission this agent was spawned into (its mock's shell) — read by the movement apply path's
     /// <c>agent.Mission != Mission.Current</c> staleness guard.</summary>
     public Mission Mission { get; set; }

--- a/source/E2E.Tests/Environment/MockEngine/MissionEngineFixture.cs
+++ b/source/E2E.Tests/Environment/MockEngine/MissionEngineFixture.cs
@@ -80,6 +80,11 @@ public sealed class MissionEngineFixture : IDisposable
         Prefix(typeof(Agent), "get_IsHuman", nameof(Agent_get_IsHuman));
         Prefix(typeof(Agent), "get_IsMount", nameof(Agent_get_IsMount));
         Prefix(typeof(Agent), "get_RiderAgent", nameof(Agent_get_RiderAgent));
+        Prefix(typeof(Agent), nameof(Agent.AddComponent), nameof(Agent_AddComponent));
+        Prefix(typeof(Agent), nameof(Agent.RemoveComponent), nameof(Agent_RemoveComponent));
+        harmony.Patch(
+            AccessTools.Constructor(typeof(CommonAIComponent), new[] { typeof(Agent) }),
+            prefix: new HarmonyMethod(AccessTools.Method(typeof(MissionEngineFixture), nameof(CommonAIComponent_ctor))));
 
         // RegisterBlow is overloaded — pin the (Blow, in AttackCollisionData) signature.
         harmony.Patch(
@@ -345,7 +350,17 @@ public sealed class MissionEngineFixture : IDisposable
     private static bool Agent_set_Controller(Agent __instance, AgentControllerType value)
     {
         if (!AgentMirror.TryGet(__instance, out var m)) return true;
+        AgentControllerType oldController = m.Controller;
+        if (value == oldController) return false;
+
         m.Controller = value;
+        if (m.IsActive)
+        {
+            if (value == AgentControllerType.AI)
+                __instance.AddComponent(new CommonAIComponent(__instance));
+            else if (oldController == AgentControllerType.AI && __instance.CommonAIComponent != null)
+                __instance.RemoveComponent(__instance.CommonAIComponent);
+        }
         return false;
     }
 
@@ -430,6 +445,31 @@ public sealed class MissionEngineFixture : IDisposable
     {
         if (!AgentMirror.TryGet(__instance, out var m)) return true;
         __result = m.RiderAgent;
+        return false;
+    }
+
+    private static bool CommonAIComponent_ctor(CommonAIComponent __instance, Agent agent)
+    {
+        if (!AgentMirror.TryGet(agent, out _)) return true;
+        __instance.ReservedRiderAgentIndex = -1;
+        return false;
+    }
+
+    private static bool Agent_AddComponent(Agent __instance, AgentComponent agentComponent)
+    {
+        if (!AgentMirror.TryGet(__instance, out var mirror)) return true;
+        mirror.Components.Add(agentComponent);
+        if (agentComponent is CommonAIComponent commonAi)
+            __instance.CommonAIComponent = commonAi;
+        return false;
+    }
+
+    private static bool Agent_RemoveComponent(Agent __instance, AgentComponent agentComponent, ref bool __result)
+    {
+        if (!AgentMirror.TryGet(__instance, out var mirror)) return true;
+        __result = mirror.Components.Remove(agentComponent);
+        if (__result && ReferenceEquals(__instance.CommonAIComponent, agentComponent))
+            __instance.CommonAIComponent = null;
         return false;
     }
 

--- a/source/E2E.Tests/Services/Missions/BattleDeathMirrorTests.cs
+++ b/source/E2E.Tests/Services/Missions/BattleDeathMirrorTests.cs
@@ -4,6 +4,7 @@ using Common.Messaging;
 using E2E.Tests.Environment.MockEngine;
 using GameInterface.Services.MapEvents.Messages;
 using Missions;
+using Missions.Agents;
 using Missions.Battles;
 using Missions.Messages;
 using TaleWorlds.Core;
@@ -153,7 +154,8 @@ public class BattleDeathMirrorTests : MissionTestEnvironment
             using var applier = new PuppetDeathApplier(
                 broker,
                 peer.Resolve<ICoopMissionComponent>(),
-                new CasualtyAttributionMap());
+                new CasualtyAttributionMap(),
+                peer.Resolve<IPuppetMountStateRepairer>());
 
             broker.Publish(this,
                 new NetworkBattleAgentDied(

--- a/source/E2E.Tests/Services/Missions/BattleMountIdentityTests.cs
+++ b/source/E2E.Tests/Services/Missions/BattleMountIdentityTests.cs
@@ -6,6 +6,7 @@ using GameInterface.Services.MapEvents;
 using GameInterface.Services.MapEvents.Messages;
 using GameInterface.Services.MapEvents.TroopSupply;
 using Missions;
+using Missions.Agents;
 using Missions.Agents.Handlers;
 using Missions.Agents.Packets;
 using Missions.Battles;
@@ -284,15 +285,17 @@ public class BattleMountIdentityTests : MissionTestEnvironment
 
         var riderId = Guid.NewGuid();
         var horseId = Guid.NewGuid();
-        Agent ownerRider = null, ownerHorse = null, puppetHorse = null;
+        Agent ownerRider = null, ownerHorse = null, puppetRider = null, puppetHorse = null;
         CoopBattleController ownerController = null, attackerController = null;
 
         attacker.Call(() =>
         {
             var mock = fixture.CreateMission(attacker);
             attackerController = attacker.Resolve<CoopBattleController>();
-            (_, puppetHorse) = RegisterMountedRider(
+            (puppetRider, puppetHorse) = RegisterMountedRider(
                 mock, attacker.Resolve<INetworkAgentRegistry>(), "owner", riderId, horseId, AgentControllerType.None);
+            puppetHorse.AddComponent(new CommonAIComponent(puppetHorse));
+            puppetHorse.CommonAIComponent.OnMountReserved(puppetRider.Index);
         });
 
         owner.Call(() =>
@@ -313,6 +316,24 @@ public class BattleMountIdentityTests : MissionTestEnvironment
         // standing — the horse lives on masterless at its owner and dies only through its own broadcast.
         Assert.True(AgentMirror.TryGet(puppetHorse, out var puppetHorseMirror));
         Assert.True(puppetHorseMirror.IsActive);
+        Assert.Null(puppetHorseMirror.RiderAgent);
+        Assert.Equal(AgentControllerType.None, puppetHorse.Controller);
+        Assert.NotNull(puppetHorse.CommonAIComponent);
+        Assert.Equal(-1, puppetHorse.CommonAIComponent.ReservedRiderAgentIndex);
+        Assert.Single(puppetHorseMirror.Components.OfType<CommonAIComponent>());
+
+        attacker.Call(() =>
+        {
+            var repairer = attacker.Resolve<IPuppetMountStateRepairer>();
+            repairer.PrepareForAiControl(puppetHorse);
+            puppetHorse.Controller = AgentControllerType.AI;
+            Assert.Single(puppetHorseMirror.Components.OfType<CommonAIComponent>());
+
+            puppetHorse.Controller = AgentControllerType.None;
+            repairer.PreserveRiderlessPuppet(puppetHorse);
+            Assert.NotNull(puppetHorse.CommonAIComponent);
+            Assert.Single(puppetHorseMirror.Components.OfType<CommonAIComponent>());
+        });
 
         // A later hit on the now-masterless puppet horse still routes by the horse's own id.
         attacker.Call(() =>
@@ -326,6 +347,52 @@ public class BattleMountIdentityTests : MissionTestEnvironment
 
         GC.KeepAlive(ownerController);
         GC.KeepAlive(attackerController);
+    }
+
+    [Fact]
+    public void RiderDeathBeforeFirstMovement_ClearsTheAiHorsesReservation()
+    {
+        using var fixture = new MissionEngineFixture();
+        var owner = Clients.First();
+        var peer = Clients.Skip(1).First();
+        SetControllerId(owner, "owner");
+        SetControllerId(peer, "peer");
+
+        var riderId = Guid.NewGuid();
+        var horseId = Guid.NewGuid();
+        Agent puppetHorse = null;
+        CoopBattleController ownerController = null, peerController = null;
+
+        peer.Call(() =>
+        {
+            var mock = fixture.CreateMission(peer);
+            peerController = peer.Resolve<CoopBattleController>();
+            var (puppetRider, horse) = RegisterMountedRider(
+                mock, peer.Resolve<INetworkAgentRegistry>(), "owner", riderId, horseId, AgentControllerType.None);
+            puppetHorse = horse;
+            puppetHorse.Controller = AgentControllerType.AI;
+            puppetHorse.CommonAIComponent.OnMountReserved(puppetRider.Index);
+        });
+
+        owner.Call(() =>
+        {
+            var mock = fixture.CreateMission(owner);
+            ownerController = owner.Resolve<CoopBattleController>();
+            var (rider, _) = RegisterMountedRider(
+                mock, owner.Resolve<INetworkAgentRegistry>(), "owner", riderId, horseId, AgentControllerType.AI);
+            owner.Resolve<IMessageBroker>().Publish(this, new BattleAgentDied(rider, null, wounded: false));
+        });
+
+        Assert.True(AgentMirror.TryGet(puppetHorse, out var horseMirror));
+        Assert.True(horseMirror.IsActive);
+        Assert.Null(horseMirror.RiderAgent);
+        Assert.Equal(AgentControllerType.AI, puppetHorse.Controller);
+        Assert.NotNull(puppetHorse.CommonAIComponent);
+        Assert.Equal(-1, puppetHorse.CommonAIComponent.ReservedRiderAgentIndex);
+        Assert.Single(horseMirror.Components.OfType<CommonAIComponent>());
+
+        GC.KeepAlive(ownerController);
+        GC.KeepAlive(peerController);
     }
 
     /// <summary>A rider-death broadcast dismounts the puppet and leaves the horse standing, even an unregistered
@@ -351,6 +418,7 @@ public class BattleMountIdentityTests : MissionTestEnvironment
             riderPuppet = mock.SpawnAgent(new AgentBuildData(character).Controller(AgentControllerType.None));
             puppetHorse = mock.SpawnMount(riderPuppet); // NOT registered
             Assert.True(peer.Resolve<INetworkAgentRegistry>().TryRegisterAgent("owner", riderId, riderPuppet));
+            Assert.Null(puppetHorse.CommonAIComponent);
         });
 
         owner.Call(() =>
@@ -371,6 +439,10 @@ public class BattleMountIdentityTests : MissionTestEnvironment
         Assert.True(AgentMirror.TryGet(puppetHorse, out var horseMirror));
         Assert.True(horseMirror.IsActive);
         Assert.Null(horseMirror.RiderAgent);
+        Assert.Equal(AgentControllerType.None, puppetHorse.Controller);
+        Assert.NotNull(puppetHorse.CommonAIComponent);
+        Assert.Equal(-1, puppetHorse.CommonAIComponent.ReservedRiderAgentIndex);
+        Assert.Single(horseMirror.Components.OfType<CommonAIComponent>());
 
         GC.KeepAlive(ownerController);
         GC.KeepAlive(peerController);

--- a/source/E2E.Tests/Services/Missions/MountedPuppetMovementTests.cs
+++ b/source/E2E.Tests/Services/Missions/MountedPuppetMovementTests.cs
@@ -458,16 +458,20 @@ public class MountedPuppetMovementTests : MissionTestEnvironment
             Agent sourceHorse = mock.SpawnMount();
             Assert.True(AgentMirror.TryGet(sourceHorse, out var sourceHorseMirror));
             sourceHorseMirror.RealGlobalVelocity = new Vec3(0.6f, 0.8f, 5f);
-            component.AgentMovementHandler.MountMovementApplier.HandlePacket(
-                null,
-                new MountMovementPacket(
-                    new[] { horseId },
-                    new[] { new AgentMountData(sourceHorse, horseId) }));
+            var packet = new MountMovementPacket(
+                new[] { horseId },
+                new[] { new AgentMountData(sourceHorse, horseId) });
+            component.AgentMovementHandler.MountMovementApplier.HandlePacket(null, packet);
 
             Assert.Equal(AgentControllerType.None, puppetHorseMirror.Controller);
             Assert.Equal(1f, puppetHorseMirror.MaximumSpeedLimit);
             Assert.False(puppetHorseMirror.LastMaximumSpeedLimitIsMultiplier);
             Assert.Equal(1, puppetHorseMirror.SetMaximumSpeedLimitCalls);
+            Assert.NotNull(puppetHorse.CommonAIComponent);
+
+            puppetHorse.CommonAIComponent.OnMountReserved(47);
+            component.AgentMovementHandler.MountMovementApplier.HandlePacket(null, packet);
+            Assert.Equal(47, puppetHorse.CommonAIComponent.ReservedRiderAgentIndex);
         });
     }
 

--- a/source/Missions/Agents/Handlers/AgentMovementHandler.cs
+++ b/source/Missions/Agents/Handlers/AgentMovementHandler.cs
@@ -49,6 +49,7 @@ public class AgentMovementHandler : IAgentMovementHandler
     private readonly INetworkAgentRegistry agentRegistry;
     private readonly IControllerIdProvider controllerIdProvider;
     private readonly IAgentEquipmentApplier equipmentApplier;
+    private readonly IPuppetMountStateRepairer puppetMountStateRepairer;
     private readonly Dictionary<Guid, AgentEquipmentData> lastEquipment = new Dictionary<Guid, AgentEquipmentData>();
 
     // A puppet's horse, remembered when its owner dismounts, so a later re-mount can put it back on the
@@ -77,7 +78,8 @@ public class AgentMovementHandler : IAgentMovementHandler
         IMessageBroker messageBroker,
         INetworkAgentRegistry agentRegistry,
         IControllerIdProvider controllerIdProvider,
-        IAgentEquipmentApplier equipmentApplier)
+        IAgentEquipmentApplier equipmentApplier,
+        IPuppetMountStateRepairer puppetMountStateRepairer)
     {
         Logger.Verbose("Creating {handlerType}", typeof(AgentMovementHandler));
 
@@ -87,6 +89,7 @@ public class AgentMovementHandler : IAgentMovementHandler
         this.agentRegistry = agentRegistry;
         this.controllerIdProvider = controllerIdProvider;
         this.equipmentApplier = equipmentApplier;
+        this.puppetMountStateRepairer = puppetMountStateRepairer;
 
         // Server-mediated membership. A peer entering is the cue to clear any STALE party it left behind
         // on a missed disconnect (so its rejoin re-spawns clean); a leave/disconnect releases its party.
@@ -97,7 +100,7 @@ public class AgentMovementHandler : IAgentMovementHandler
         this.packetManager.RegisterPacketHandler(this);
         this.packetManager.RegisterPacketHandler(equipmentApplier);
 
-        _mountMovementApplier = new MountMovementApplier(agentRegistry, _interpolator);
+        _mountMovementApplier = new MountMovementApplier(agentRegistry, _interpolator, puppetMountStateRepairer);
         this.packetManager.RegisterPacketHandler(_mountMovementApplier);
     }
 
@@ -404,7 +407,10 @@ public class AgentMovementHandler : IAgentMovementHandler
 
                     // A puppet horse must not run local AI between owner snapshots and fight their heading/input.
                     if (agent.MountAgent is Agent puppetMount && puppetMount.Controller != AgentControllerType.None)
+                    {
                         puppetMount.Controller = AgentControllerType.None;
+                        puppetMountStateRepairer.PreserveRiderlessPuppet(puppetMount);
+                    }
 
                     data.Apply(agent);
 
@@ -495,6 +501,7 @@ public class AgentMovementHandler : IAgentMovementHandler
         if (mount.Controller != AgentControllerType.AI)
         {
             mount.SetMaximumSpeedLimit(-1f, isMultiplier: false);
+            puppetMountStateRepairer.PrepareForAiControl(mount);
             mount.Controller = AgentControllerType.AI;
         }
     }
@@ -506,7 +513,10 @@ public class AgentMovementHandler : IAgentMovementHandler
             && !agentRegistry.IsLocallyControlled(mount)) return;
         mount.SetMaximumSpeedLimit(-1f, isMultiplier: false);
         if (mount.Controller != AgentControllerType.AI)
+        {
+            puppetMountStateRepairer.PrepareForAiControl(mount);
             mount.Controller = AgentControllerType.AI;
+        }
     }
 
     /// <summary>

--- a/source/Missions/Agents/Handlers/MountMovementApplier.cs
+++ b/source/Missions/Agents/Handlers/MountMovementApplier.cs
@@ -21,11 +21,16 @@ public class MountMovementApplier : IPacketHandler
 {
     private readonly INetworkAgentRegistry agentRegistry;
     private readonly IAgentPositionInterpolator interpolator;
+    private readonly IPuppetMountStateRepairer puppetMountStateRepairer;
 
-    public MountMovementApplier(INetworkAgentRegistry agentRegistry, IAgentPositionInterpolator interpolator)
+    public MountMovementApplier(
+        INetworkAgentRegistry agentRegistry,
+        IAgentPositionInterpolator interpolator,
+        IPuppetMountStateRepairer puppetMountStateRepairer)
     {
         this.agentRegistry = agentRegistry;
         this.interpolator = interpolator;
+        this.puppetMountStateRepairer = puppetMountStateRepairer;
     }
 
     public PacketType PacketType => PacketType.MountMovement;
@@ -91,6 +96,7 @@ public class MountMovementApplier : IPacketHandler
 
                     if (horse.Controller != AgentControllerType.None)
                         horse.Controller = AgentControllerType.None;
+                    puppetMountStateRepairer.PreserveRiderlessPuppet(horse);
 
                     data.ApplyMount(horse);
                     interpolator.SetMountTarget(horse, data.MountPosition, data.MountMovementDirection);

--- a/source/Missions/Agents/PuppetMountStateRepairer.cs
+++ b/source/Missions/Agents/PuppetMountStateRepairer.cs
@@ -1,0 +1,55 @@
+﻿using TaleWorlds.Core;
+using TaleWorlds.MountAndBlade;
+
+namespace Missions.Agents;
+
+public interface IPuppetMountStateRepairer
+{
+    void PrepareForAiControl(Agent mount);
+
+    void PreserveRiderlessPuppet(Agent mount);
+
+    void RepairAfterRiderDeath(Agent mount);
+}
+
+public class PuppetMountStateRepairer : IPuppetMountStateRepairer
+{
+    public void PrepareForAiControl(Agent mount)
+    {
+        if (mount == null
+            || mount.Controller == AgentControllerType.AI
+            || mount.CommonAIComponent == null)
+        {
+            return;
+        }
+
+        mount.RemoveComponent(mount.CommonAIComponent);
+    }
+
+    public void PreserveRiderlessPuppet(Agent mount)
+    {
+        if (mount == null
+            || !mount.IsActive()
+            || mount.RiderAgent != null
+            || mount.Controller != AgentControllerType.None)
+        {
+            return;
+        }
+
+        if (mount.CommonAIComponent == null)
+            mount.AddComponent(new CommonAIComponent(mount));
+    }
+
+    public void RepairAfterRiderDeath(Agent mount)
+    {
+        PreserveRiderlessPuppet(mount);
+        if (mount?.CommonAIComponent == null
+            || !mount.IsActive()
+            || mount.RiderAgent != null)
+        {
+            return;
+        }
+
+        mount.CommonAIComponent.OnMountUnreserved();
+    }
+}

--- a/source/Missions/Battles/CoopBattleController.cs
+++ b/source/Missions/Battles/CoopBattleController.cs
@@ -6,6 +6,7 @@ using GameInterface.Services.MapEvents;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
 using LiteNetLib;
+using Missions.Agents;
 using Missions.Data;
 using Missions.Messages;
 using Missions.Services.Network;
@@ -87,7 +88,8 @@ public class CoopBattleController : CoopMissionController
         IAgentFormationAssigner formationAssigner,
         IMissionContext missionContext,
         IHostEpochPolicy hostEpochPolicy,
-        IBattleAgentBudget agentBudget)
+        IBattleAgentBudget agentBudget,
+        IPuppetMountStateRepairer puppetMountStateRepairer)
         : base(network, messageBroker, objectManager, coopMissionComponent)
     {
         var session = new BattleSession(controllerIdProvider, hostRegistry);
@@ -100,7 +102,11 @@ public class CoopBattleController : CoopMissionController
         deathReporter = new AgentDeathReporter(network, relayNetwork, messageBroker, objectManager, coopMissionComponent, session, casualties);
         routReporter = new AgentRoutReporter(network, messageBroker, coopMissionComponent, session, casualties);
         puppetSpawner = new PuppetSpawner(messageBroker, objectManager, playerManager, coopMissionComponent, session, casualties, deployment, formationAssigner, agentBudget);
-        puppetDeathApplier = new PuppetDeathApplier(messageBroker, coopMissionComponent, casualties);
+        puppetDeathApplier = new PuppetDeathApplier(
+            messageBroker,
+            coopMissionComponent,
+            casualties,
+            puppetMountStateRepairer);
         puppetRoutApplier = new PuppetRoutApplier(messageBroker, coopMissionComponent, casualties);
         damageRouter = new BattleDamageRouter(network, messageBroker, coopMissionComponent, session);
         reinforcementFielder = new ReinforcementFielder(messageBroker, objectManager, coopMissionComponent, session, deployment, formationAssigner, casualties, agentBudget);

--- a/source/Missions/Battles/PuppetDeathApplier.cs
+++ b/source/Missions/Battles/PuppetDeathApplier.cs
@@ -3,6 +3,7 @@ using Common.Logging;
 using Common.Messaging;
 using Common.Util;
 using GameInterface.Services.MapEvents;
+using Missions.Agents;
 using Missions.Messages;
 using Serilog;
 using System;
@@ -33,17 +34,20 @@ public class PuppetDeathApplier : IPuppetDeathApplier
     private readonly IMessageBroker messageBroker;
     private readonly ICoopMissionComponent coopMissionComponent;
     private readonly ICasualtyAttributionMap casualties;
+    private readonly IPuppetMountStateRepairer puppetMountStateRepairer;
     private readonly Dictionary<Guid, NetworkBattleAgentDied> pendingDeaths =
         new Dictionary<Guid, NetworkBattleAgentDied>();
 
     public PuppetDeathApplier(
         IMessageBroker messageBroker,
         ICoopMissionComponent coopMissionComponent,
-        ICasualtyAttributionMap casualties)
+        ICasualtyAttributionMap casualties,
+        IPuppetMountStateRepairer puppetMountStateRepairer)
     {
         this.messageBroker = messageBroker;
         this.coopMissionComponent = coopMissionComponent;
         this.casualties = casualties;
+        this.puppetMountStateRepairer = puppetMountStateRepairer;
 
         messageBroker.Subscribe<NetworkBattleAgentDied>(Handle_NetworkBattleAgentDied);
     }
@@ -90,6 +94,9 @@ public class PuppetDeathApplier : IPuppetDeathApplier
         Logger.Information("[DeathDiag] Killing puppet {AgentId}: agentPresent={Present}, health={Health}", death.AgentId, agent != null, agent?.Health ?? -1f);
         if (agent != null && agent.Health > 0)
         {
+            Agent mount = agent.MountAgent;
+            LogMountState("before", agent, mount);
+
             Agent affectorAgent = null;
             if (death.AffectorAgentId != Guid.Empty
                 && registry.TryGetAgentInfo(death.AffectorAgentId, out var affectorInfo))
@@ -116,6 +123,9 @@ public class PuppetDeathApplier : IPuppetDeathApplier
                         agent.RegisterBlow(blow, default);
                     }
                 });
+
+            puppetMountStateRepairer.RepairAfterRiderDeath(mount);
+            LogMountState("after", agent, mount);
         }
 
         // Deregister after the game-thread kill. Removing on the poll thread before the queued apply would
@@ -123,6 +133,32 @@ public class PuppetDeathApplier : IPuppetDeathApplier
         registry.RemoveAgent(death.AgentId);
         casualties.Forget(death.AgentId);
         return true;
+    }
+
+    private static void LogMountState(string phase, Agent rider, Agent mount)
+    {
+        if (mount == null) return;
+
+        CommonAIComponent commonAi = mount.CommonAIComponent;
+        int reservedRiderIndex = commonAi?.ReservedRiderAgentIndex ?? -1;
+        Agent reservedRider = reservedRiderIndex >= 0
+            ? Mission.Current.FindAgentWithIndex(reservedRiderIndex)
+            : null;
+
+        Logger.Information(
+            "[DeathDiag] Mounted puppet death {Phase}: riderIndex={RiderIndex}, mountIndex={MountIndex}, " +
+            "mountRiderIndex={MountRiderIndex}, mountActive={MountActive}, hasCommonAi={HasCommonAi}, " +
+            "reservedRiderIndex={ReservedRiderIndex}, reservedRiderPresent={ReservedRiderPresent}, " +
+            "reservedRiderActive={ReservedRiderActive}",
+            phase,
+            rider.Index,
+            mount.Index,
+            mount.RiderAgent?.Index ?? -1,
+            mount.IsActive(),
+            commonAi != null,
+            reservedRiderIndex,
+            reservedRider != null,
+            reservedRider?.IsActive() ?? false);
     }
 
     private static Blow CreateReplicatedBlow(NetworkBattleAgentDied message, int ownerId)

--- a/source/Missions/MissionModule.cs
+++ b/source/Missions/MissionModule.cs
@@ -145,6 +145,9 @@ public class MissionModule : Module
         // Slots spawned agents into their team formation so vanilla's formation markers/order-targeting see
         // them. Injected into the battle spawn sub-services (stateless, so transient lifetime is moot).
         builder.RegisterType<AgentFormationAssigner>().As<IAgentFormationAssigner>().InstancePerDependency();
+        builder.RegisterType<PuppetMountStateRepairer>()
+            .As<IPuppetMountStateRepairer>()
+            .InstancePerDependency();
 
         builder.RegisterType<NetworkAgentRegistry>().As<INetworkAgentRegistry>().InstancePerLifetimeScope();
         //builder.RegisterType<NetworkMissileRegistry>().As<INetworkMissileRegistry>().InstancePerDependency();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Mounted puppet deaths can crash another client when nearby soldiers search for the surviving riderless horse.

## What is the new behavior?

Resolves #2356

Mounted puppet deaths now leave surviving horses available without crashing nearby clients.

## Bot Changelog Entry

- Fixed a client crash after mounted troops die in field battles.
