### PR TITLE
Fix MountMovementPacket flaky test: stop tiered compilation from dropping Harmony detours

### DIFF
--- a/source/E2E.Tests/E2E.Tests.csproj
+++ b/source/E2E.Tests/E2E.Tests.csproj
@@ -13,6 +13,10 @@
     <Optimize>false</Optimize>
     <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
+    <!-- e2e.runsettings pins the testhost's JIT behavior so Harmony detours can't be dropped
+         mid-test; see the comment there. dotnet test picks this up; direct vstest.console runs
+         need /Settings:e2e.runsettings. -->
+    <RunSettingsFilePath>$(MSBuildThisFileDirectory)e2e.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/E2E.Tests/e2e.runsettings
+++ b/source/E2E.Tests/e2e.runsettings
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Tiered compilation background-promotes a method after ~30 calls and republishes its native
+  code. On Linux CI that republish intermittently drops a live Harmony detour (MonoMod loses the
+  re-apply race), so a MissionEngineFixture shim that provably fired for sibling calls suddenly
+  stops and the RAW game method runs — e.g. MountMovementPacket_RoundTripsHorizontalMountSpeed
+  NRE'ing inside the real Agent.GetCurrentAction (clean stack frame, no _PatchN suffix).
+
+  Disabling CALL COUNTING keeps tiering's initial Tier-0 quick-JIT exactly as it is today but
+  never promotes, so published code never changes and detours stay valid for the process
+  lifetime. (A blanket TieredCompilation=false is NOT equivalent: full-opt first-call JIT
+  deterministically broke AutoSync-dependent tests on every OS — WorkshopPurchaseConversation
+  ClientPrediction and MapEventEnvironment DuplicateEscapeRequests.)
+-->
+<RunSettings>
+  <RunConfiguration>
+    <EnvironmentVariables>
+      <DOTNET_TC_CallCounting>0</DOTNET_TC_CallCounting>
+    </EnvironmentVariables>
+  </RunConfiguration>
+</RunSettings>


### PR DESCRIPTION
## Problem

`MountedPuppetMovementTests.MountMovementPacket_RoundTripsHorizontalMountSpeed` flakes on Linux CI ([example run](https://github.com/Bannerlord-Coop-Team/BannerlordCoop/actions/runs/30183199582)) with:

```
System.NullReferenceException
   at TaleWorlds.MountAndBlade.Agent.GetCurrentAction(Int32 channelNo)
   at Missions.Agents.Packets.AgentMountData..ctor(...)
```

The top frame has **no `_PatchN` suffix** — the raw game method ran even though `MissionEngineFixture` had prefixed it at test start. The three shims called immediately before it (`get_MovementInputVector`, `GetCurrentAnimationFlag`, `GetCurrentActionProgress`) all dereference the null `MBAPI.IMBAgent` if unpatched, and they worked — so exactly one method's detour vanished mid-test.

## Root cause

Calls through a detoured Tier-0 method still tick its tiered-compilation call counter. At ~30 calls the runtime background-promotes the method and republishes its native code. MonoMod re-applies detours on recompile reliably on Windows, but on Linux it intermittently loses that race — the detour stays dead until the next test's fixture re-patches, so exactly one test fails. `Agent.GetCurrentAction` is the hottest fixture-patched method (~4 calls per `ApplyMount`), so it crosses the threshold first.

**Standalone repro** (16 Harmony-patched methods in an optimized assembly, per-test-style patch/unpatch cycles, background JIT noise, 2-CPU Linux container, net6.0): stock lost a detour in **1/20** processes (prefix stopped firing mid-window, original body ran); Windows clean 3/3 — matching the CI-only flakiness.

## Fix

`e2e.runsettings` sets `DOTNET_TC_CallCounting=0` for the E2E testhost (wired via `RunSettingsFilePath`, which `dotnet test` — the CI path — resolves automatically). Tiering stays on and every method keeps today's Tier-0 code forever: no promotion → published code never changes → detours stay valid for the process lifetime.

**Why not `<TieredCompilation>false</TieredCompilation>`:** tried first and rejected — full-opt first-call JIT deterministically broke `WorkshopPurchaseConversationTests.ClientPrediction_WhenBehaviorStorageHasNoFreeSlots...` and `MapEventEnvironmentTests.DuplicateEscapeRequests_ReleaseOnlyOnce` on **both** OSes (AutoSync `Hero.set_HitPoints` handler exceptions — same family as the June `<Optimize>false</Optimize>` inlining trap).

## Validation

| Check | Result |
|---|---|
| Linux repro, stock | 1/20 processes lose a detour |
| Linux repro, `DOTNET_TC_CallCounting=0` | **0/40** |
| Linux, full 114-case shard ×3 with knob | **0 failures** (113 pass + 1 standing skip, sentinels included) |
| Windows, mount classes + both sentinel tests with knob | **37/37** |
| runsettings→testhost propagation | proven: a known-bad knob (`DOTNET_TieredCompilation=0`) in the runsettings makes the sentinel fail via `dotnet test`; restoring the real knob passes |

Note: direct `vstest.console.exe` runs on the DLL need `/Settings:e2e.runsettings` to pick up the knob; `dotnet test` needs nothing. Windows runs never exhibited the loss regardless.