### PR TITLE
[2365] Keep siege ladders synchronized between players

### DIFF
--- a/source/Coop.Tests/Missions/Battles/SiegeMachineStateReplicatorHostEpochTests.cs
+++ b/source/Coop.Tests/Missions/Battles/SiegeMachineStateReplicatorHostEpochTests.cs
@@ -173,6 +173,43 @@ public class SiegeMachineStateReplicatorHostEpochTests : IDisposable
         Assert.Equal(LocalEpoch + 2, buffered.Value.HostEpoch);
     }
 
+    [Fact]
+    public void PendingAnimationAfterDiscreteState_IsRetainedForOrderedApply()
+    {
+        broker.Publish(this, MachineState(machineId: 26, hostEpoch: LocalEpoch));
+        broker.Publish(this, LadderAnimationState(ladderId: 26, hostEpoch: LocalEpoch));
+        DrainGameThread();
+
+        Assert.True(PendingStates().ContainsKey(26));
+        Assert.True(PendingLadderAnimations().ContainsKey(26));
+    }
+
+    [Fact]
+    public void LaterDiscreteState_RetainsTheLatestPendingAnimation()
+    {
+        broker.Publish(this, LadderAnimationState(ladderId: 27, hostEpoch: LocalEpoch));
+        broker.Publish(this, MachineState(machineId: 27, hostEpoch: LocalEpoch));
+        DrainGameThread();
+
+        Assert.True(PendingStates().ContainsKey(27));
+        Assert.True(PendingLadderAnimations().ContainsKey(27));
+    }
+
+    [Fact]
+    [Trait("Requirement", "BR-102")]
+    public void PendingAnimationFromASupersededEpoch_IsDroppedBeforeRegistration()
+    {
+        broker.Publish(this, LadderAnimationState(ladderId: 28, hostEpoch: LocalEpoch));
+        broker.Publish(this, LadderAnimationState(ladderId: 29, hostEpoch: LocalEpoch + 1));
+        DrainGameThread();
+
+        InvokePrivate("DrainPendingMachineStates");
+
+        var pending = Assert.Single(PendingLadderAnimations());
+        Assert.Equal(29, pending.Key);
+        Assert.Equal(LocalEpoch + 1, pending.Value.HostEpoch);
+    }
+
     // ------------------------------------------------------------------
     // Sender stamping
     // ------------------------------------------------------------------
@@ -229,16 +266,17 @@ public class SiegeMachineStateReplicatorHostEpochTests : IDisposable
         // (A MissionObject test double is impossible here: materializing one runs the
         // ScriptComponentBehavior type initializer, which requires the native engine.)
         var method = typeof(SiegeMachineStateReplicator).GetMethod(
-            "Stamp", BindingFlags.Instance | BindingFlags.NonPublic);
+            "Stamp",
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            null,
+            new[] { typeof(NetworkSiegeMachineState) },
+            null);
         Assert.NotNull(method);
 
-        var ladderFrame = new MatrixFrame(Mat3.Identity, new Vec3(1f, 2f, 3f));
         var captured = new NetworkSiegeMachineState(
             machineId: 30, hitPoints: 42.5f, destructionState: 2, gateState: 1, ladderState: 3,
             moveDistance: 18f, hasArrived: true, weaponState: 4, aimDirection: 0.75f,
-            aimReleaseAngle: 0.25f, ladderAnimationSpeed: 1.73f, ladderAnimationProgress: 0.42f,
-            ladderAnimationState: 2, ladderFallAngularSpeed: -0.5f, ladderFrame: ladderFrame,
-            ladderAnimationIndex: 17);
+            aimReleaseAngle: 0.25f);
 
         var stamped = Assert.IsType<NetworkSiegeMachineState>(
             method!.Invoke(sut, new object[] { captured }));
@@ -254,12 +292,41 @@ public class SiegeMachineStateReplicatorHostEpochTests : IDisposable
         Assert.Equal(4, stamped.WeaponState);
         Assert.Equal(0.75f, stamped.AimDirection);
         Assert.Equal(0.25f, stamped.AimReleaseAngle);
-        Assert.Equal(1.73f, stamped.LadderAnimationSpeed);
-        Assert.Equal(0.42f, stamped.LadderAnimationProgress);
-        Assert.Equal(2, stamped.LadderAnimationState);
-        Assert.Equal(-0.5f, stamped.LadderFallAngularSpeed);
-        Assert.Equal(ladderFrame.origin, stamped.LadderFrame.origin);
-        Assert.Equal(17, stamped.LadderAnimationIndex);
+    }
+
+    [Fact]
+    [Trait("Requirement", "BR-102")]
+    public void OutgoingLadderAnimationState_IsStampedWithTheSendersEpoch_PreservingEveryField()
+    {
+        var method = typeof(SiegeMachineStateReplicator).GetMethod(
+            "Stamp",
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            null,
+            new[] { typeof(NetworkSiegeLadderAnimationState) },
+            null);
+        Assert.NotNull(method);
+
+        var frame = new MatrixFrame(Mat3.Identity, new Vec3(1f, 2f, 3f));
+        var captured = new NetworkSiegeLadderAnimationState(
+            ladderId: 30,
+            animationSpeed: 1.73f,
+            animationProgress: 0.42f,
+            animationState: 2,
+            fallAngularSpeed: -0.5f,
+            frame: frame,
+            animationIndex: 17);
+
+        var stamped = Assert.IsType<NetworkSiegeLadderAnimationState>(
+            method!.Invoke(sut, new object[] { captured }));
+
+        Assert.Equal(LocalEpoch, stamped.HostEpoch);
+        Assert.Equal(30, stamped.LadderId);
+        Assert.Equal(1.73f, stamped.AnimationSpeed);
+        Assert.Equal(0.42f, stamped.AnimationProgress);
+        Assert.Equal(2, stamped.AnimationState);
+        Assert.Equal(-0.5f, stamped.FallAngularSpeed);
+        Assert.Equal(frame.origin, stamped.Frame.origin);
+        Assert.Equal(17, stamped.AnimationIndex);
     }
 
     // ------------------------------------------------------------------
@@ -270,6 +337,10 @@ public class SiegeMachineStateReplicatorHostEpochTests : IDisposable
         => new(machineId, hitPoints: -1f, destructionState: -1, gateState: -1, ladderState: -1,
             moveDistance: -1f, hasArrived: false, weaponState: -1, aimDirection: -1000f,
             aimReleaseAngle: -1000f, hostEpoch: hostEpoch);
+
+    private static NetworkSiegeLadderAnimationState LadderAnimationState(int ladderId, int hostEpoch)
+        => new(ladderId, animationSpeed: -1f, animationProgress: -1f, animationState: 0,
+            fallAngularSpeed: 0f, frame: MatrixFrame.Identity, animationIndex: -1, hostEpoch: hostEpoch);
 
     private Dictionary<int, string> ClaimedMachines()
         => GetField<Dictionary<int, string>>("claimedMachines");
@@ -283,6 +354,17 @@ public class SiegeMachineStateReplicatorHostEpochTests : IDisposable
 
     private Dictionary<int, NetworkSiegeMachineState> PendingStates()
         => GetField<Dictionary<int, NetworkSiegeMachineState>>("pendingByMachineId");
+
+    private Dictionary<int, NetworkSiegeLadderAnimationState> PendingLadderAnimations()
+        => GetField<Dictionary<int, NetworkSiegeLadderAnimationState>>("pendingLadderAnimationsById");
+
+    private void InvokePrivate(string methodName)
+    {
+        var method = typeof(SiegeMachineStateReplicator).GetMethod(
+            methodName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        method!.Invoke(sut, Array.Empty<object>());
+    }
 
     private T GetField<T>(string fieldName)
     {

--- a/source/Coop.Tests/Missions/Battles/SiegeMachineStateReplicatorHostEpochTests.cs
+++ b/source/Coop.Tests/Missions/Battles/SiegeMachineStateReplicatorHostEpochTests.cs
@@ -1,4 +1,4 @@
-using Common;
+﻿using Common;
 using Common.Messaging;
 using Common.Tests.Utils;
 using GameInterface.Services.MapEvents;
@@ -9,6 +9,7 @@ using Moq;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using TaleWorlds.Library;
 using Xunit;
 
 namespace Coop.Tests.Missions.Battles;
@@ -231,10 +232,13 @@ public class SiegeMachineStateReplicatorHostEpochTests : IDisposable
             "Stamp", BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.NotNull(method);
 
+        var ladderFrame = new MatrixFrame(Mat3.Identity, new Vec3(1f, 2f, 3f));
         var captured = new NetworkSiegeMachineState(
             machineId: 30, hitPoints: 42.5f, destructionState: 2, gateState: 1, ladderState: 3,
             moveDistance: 18f, hasArrived: true, weaponState: 4, aimDirection: 0.75f,
-            aimReleaseAngle: 0.25f);
+            aimReleaseAngle: 0.25f, ladderAnimationSpeed: 1.73f, ladderAnimationProgress: 0.42f,
+            ladderAnimationState: 2, ladderFallAngularSpeed: -0.5f, ladderFrame: ladderFrame,
+            ladderAnimationIndex: 17);
 
         var stamped = Assert.IsType<NetworkSiegeMachineState>(
             method!.Invoke(sut, new object[] { captured }));
@@ -250,6 +254,12 @@ public class SiegeMachineStateReplicatorHostEpochTests : IDisposable
         Assert.Equal(4, stamped.WeaponState);
         Assert.Equal(0.75f, stamped.AimDirection);
         Assert.Equal(0.25f, stamped.AimReleaseAngle);
+        Assert.Equal(1.73f, stamped.LadderAnimationSpeed);
+        Assert.Equal(0.42f, stamped.LadderAnimationProgress);
+        Assert.Equal(2, stamped.LadderAnimationState);
+        Assert.Equal(-0.5f, stamped.LadderFallAngularSpeed);
+        Assert.Equal(ladderFrame.origin, stamped.LadderFrame.origin);
+        Assert.Equal(17, stamped.LadderAnimationIndex);
     }
 
     // ------------------------------------------------------------------

--- a/source/Coop.Tests/Missions/Battles/SiegeMachineStateReplicatorTests.cs
+++ b/source/Coop.Tests/Missions/Battles/SiegeMachineStateReplicatorTests.cs
@@ -1,9 +1,13 @@
+﻿using GameInterface.Surrogates;
 using Missions.Battles;
 using Missions.Messages;
+using ProtoBuf.Meta;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using TaleWorlds.Core;
+using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
 using Xunit;
 
@@ -11,6 +15,50 @@ namespace Coop.Tests.Missions.Battles;
 
 public class SiegeMachineStateReplicatorTests
 {
+    [Fact]
+    public void NetworkSiegeMachineState_RoundTripsLadderAnimationSnapshot()
+    {
+        _ = new SurrogateCollection();
+        var ladderFrame = new MatrixFrame(Mat3.Identity, new Vec3(1f, 2f, 3f));
+        var original = new NetworkSiegeMachineState(
+            machineId: 12,
+            hitPoints: -1f,
+            destructionState: -1,
+            gateState: -1,
+            ladderState: (int)SiegeLadder.LadderState.BeingRaised,
+            moveDistance: -1f,
+            hasArrived: false,
+            weaponState: -1,
+            aimDirection: -1000f,
+            aimReleaseAngle: -1000f,
+            hostEpoch: 4,
+            ladderAnimationSpeed: 1.73f,
+            ladderAnimationProgress: 0.42f,
+            ladderAnimationState: (int)SiegeLadder.LadderAnimationState.PhysicallyDynamic,
+            ladderFallAngularSpeed: -0.5f,
+            ladderFrame: ladderFrame,
+            ladderAnimationIndex: 17);
+
+        NetworkSiegeMachineState result;
+        using (var stream = new MemoryStream())
+        {
+            RuntimeTypeModel.Default.Serialize(stream, original);
+            stream.Position = 0;
+            result = (NetworkSiegeMachineState)RuntimeTypeModel.Default.Deserialize(
+                stream,
+                null,
+                typeof(NetworkSiegeMachineState));
+        }
+
+        Assert.Equal(original.LadderState, result.LadderState);
+        Assert.Equal(original.LadderAnimationSpeed, result.LadderAnimationSpeed);
+        Assert.Equal(original.LadderAnimationProgress, result.LadderAnimationProgress);
+        Assert.Equal(original.LadderAnimationState, result.LadderAnimationState);
+        Assert.Equal(original.LadderFallAngularSpeed, result.LadderFallAngularSpeed);
+        Assert.Equal(original.LadderFrame.origin, result.LadderFrame.origin);
+        Assert.Equal(original.LadderAnimationIndex, result.LadderAnimationIndex);
+    }
+
     [Fact]
     public void AuthoritativeHitPoints_UpdateTheMappedMissionSiegeWeapon()
     {

--- a/source/Coop.Tests/Missions/Battles/SiegeMachineStateReplicatorTests.cs
+++ b/source/Coop.Tests/Missions/Battles/SiegeMachineStateReplicatorTests.cs
@@ -16,10 +16,8 @@ namespace Coop.Tests.Missions.Battles;
 public class SiegeMachineStateReplicatorTests
 {
     [Fact]
-    public void NetworkSiegeMachineState_RoundTripsLadderAnimationSnapshot()
+    public void NetworkSiegeMachineState_RoundTripsDiscreteLadderState()
     {
-        _ = new SurrogateCollection();
-        var ladderFrame = new MatrixFrame(Mat3.Identity, new Vec3(1f, 2f, 3f));
         var original = new NetworkSiegeMachineState(
             machineId: 12,
             hitPoints: -1f,
@@ -31,13 +29,7 @@ public class SiegeMachineStateReplicatorTests
             weaponState: -1,
             aimDirection: -1000f,
             aimReleaseAngle: -1000f,
-            hostEpoch: 4,
-            ladderAnimationSpeed: 1.73f,
-            ladderAnimationProgress: 0.42f,
-            ladderAnimationState: (int)SiegeLadder.LadderAnimationState.PhysicallyDynamic,
-            ladderFallAngularSpeed: -0.5f,
-            ladderFrame: ladderFrame,
-            ladderAnimationIndex: 17);
+            hostEpoch: 4);
 
         NetworkSiegeMachineState result;
         using (var stream = new MemoryStream())
@@ -51,12 +43,43 @@ public class SiegeMachineStateReplicatorTests
         }
 
         Assert.Equal(original.LadderState, result.LadderState);
-        Assert.Equal(original.LadderAnimationSpeed, result.LadderAnimationSpeed);
-        Assert.Equal(original.LadderAnimationProgress, result.LadderAnimationProgress);
-        Assert.Equal(original.LadderAnimationState, result.LadderAnimationState);
-        Assert.Equal(original.LadderFallAngularSpeed, result.LadderFallAngularSpeed);
-        Assert.Equal(original.LadderFrame.origin, result.LadderFrame.origin);
-        Assert.Equal(original.LadderAnimationIndex, result.LadderAnimationIndex);
+        Assert.Equal(original.HostEpoch, result.HostEpoch);
+    }
+
+    [Fact]
+    public void NetworkSiegeLadderAnimationState_RoundTripsSnapshot()
+    {
+        _ = new SurrogateCollection();
+        var ladderFrame = new MatrixFrame(Mat3.Identity, new Vec3(1f, 2f, 3f));
+        var original = new NetworkSiegeLadderAnimationState(
+            ladderId: 12,
+            animationSpeed: 1.73f,
+            animationProgress: 0.42f,
+            animationState: (int)SiegeLadder.LadderAnimationState.PhysicallyDynamic,
+            fallAngularSpeed: -0.5f,
+            frame: ladderFrame,
+            animationIndex: 17,
+            hostEpoch: 4);
+
+        NetworkSiegeLadderAnimationState result;
+        using (var stream = new MemoryStream())
+        {
+            RuntimeTypeModel.Default.Serialize(stream, original);
+            stream.Position = 0;
+            result = (NetworkSiegeLadderAnimationState)RuntimeTypeModel.Default.Deserialize(
+                stream,
+                null,
+                typeof(NetworkSiegeLadderAnimationState));
+        }
+
+        Assert.Equal(original.LadderId, result.LadderId);
+        Assert.Equal(original.AnimationSpeed, result.AnimationSpeed);
+        Assert.Equal(original.AnimationProgress, result.AnimationProgress);
+        Assert.Equal(original.AnimationState, result.AnimationState);
+        Assert.Equal(original.FallAngularSpeed, result.FallAngularSpeed);
+        Assert.Equal(original.Frame.origin, result.Frame.origin);
+        Assert.Equal(original.AnimationIndex, result.AnimationIndex);
+        Assert.Equal(original.HostEpoch, result.HostEpoch);
     }
 
     [Fact]

--- a/source/E2E.Tests/Services/Missions/SiegeLadderAuthorityPatchTests.cs
+++ b/source/E2E.Tests/Services/Missions/SiegeLadderAuthorityPatchTests.cs
@@ -1,0 +1,83 @@
+﻿using GameInterface.Services.MapEvents;
+using HarmonyLib;
+using Missions.Battles;
+using System.Collections.Generic;
+using System.Reflection;
+using TaleWorlds.MountAndBlade;
+using Xunit;
+
+namespace E2E.Tests.Services.Missions;
+
+public class SiegeLadderAuthorityPatchTests
+{
+    [Fact]
+    public void SiegeLadderAuthorityPatches_HookVanillaStateMethods()
+    {
+        var patchType = typeof(BattleSpawnGate).Assembly
+            .GetType("GameInterface.Services.MapEvents.Patches.SiegeLadderAuthorityPatches");
+        Assert.NotNull(patchType);
+
+        var harmony = new Harmony("e2e.siegeladder.authority");
+        var repeatedHarmony = new Harmony("e2e.siegeladder.authority.repeated");
+        try
+        {
+            var patched = harmony.CreateClassProcessor(patchType).Patch()
+                ?? new List<MethodInfo>();
+            var repeated = repeatedHarmony.CreateClassProcessor(patchType).Patch()
+                ?? new List<MethodInfo>();
+
+            Assert.Contains(patched, method => method.Name.Contains("set_State"));
+            Assert.Contains(patched, method => method.Name.Contains("OnTick"));
+            Assert.Contains(patched, method => method.Name.Contains("OnLadderStateChange"));
+            Assert.Contains(repeated, method => method.Name.Contains("OnTick"));
+        }
+        finally
+        {
+            repeatedHarmony.UnpatchAll(repeatedHarmony.Id);
+            harmony.UnpatchAll(harmony.Id);
+        }
+    }
+
+    [Theory]
+    [InlineData(
+        SiegeLadder.LadderState.OnLand,
+        SiegeLadder.LadderState.BeingRaised,
+        "BeingRaisedStartFromGround")]
+    [InlineData(
+        SiegeLadder.LadderState.BeingPushedBack,
+        SiegeLadder.LadderState.BeingRaised,
+        "BeingPushedBackStopped")]
+    [InlineData(
+        SiegeLadder.LadderState.OnWall,
+        SiegeLadder.LadderState.BeingRaised,
+        "BeingPushedBackStartFromWall,BeingPushedBack,BeingPushedBackStopped")]
+    [InlineData(
+        SiegeLadder.LadderState.OnWall,
+        SiegeLadder.LadderState.BeingPushedBack,
+        "BeingPushedBackStartFromWall")]
+    [InlineData(
+        SiegeLadder.LadderState.BeingRaised,
+        SiegeLadder.LadderState.BeingPushedBack,
+        "BeingRaisedStopped")]
+    [InlineData(
+        SiegeLadder.LadderState.OnLand,
+        SiegeLadder.LadderState.BeingPushedBack,
+        "BeingRaisedStartFromGround,BeingRaised,BeingRaisedStopped")]
+    [InlineData(
+        SiegeLadder.LadderState.BeingRaised,
+        SiegeLadder.LadderState.OnWall,
+        "FallToWall")]
+    [InlineData(
+        SiegeLadder.LadderState.BeingPushedBack,
+        SiegeLadder.LadderState.OnLand,
+        "FallToLand")]
+    public void GetLadderTransitionStates_ReconstructSkippedVanillaStates(
+        SiegeLadder.LadderState currentState,
+        SiegeLadder.LadderState targetState,
+        string expected)
+    {
+        Assert.Equal(
+            expected,
+            string.Join(",", SiegeMachineStateReplicator.GetLadderTransitionStates(currentState, targetState)));
+    }
+}

--- a/source/GameInterface.Tests/Services/SiegeEvents/SiegeAftermathPendingTests.cs
+++ b/source/GameInterface.Tests/Services/SiegeEvents/SiegeAftermathPendingTests.cs
@@ -1,4 +1,4 @@
-using GameInterface.Services.SiegeEvents.Patches;
+﻿using GameInterface.Services.SiegeEvents.Patches;
 using GameInterface.Services.SiegeEvents.Interfaces;
 using System;
 using System.Collections.Generic;
@@ -12,6 +12,7 @@ using FormatterServices = System.Runtime.Serialization.FormatterServices;
 
 namespace GameInterface.Tests.Services.SiegeEvents;
 
+[Collection(nameof(SiegeAftermathCampaignCollection))]
 public sealed class SiegeAftermathPendingTests : IDisposable
 {
     public SiegeAftermathPendingTests()
@@ -145,18 +146,27 @@ public sealed class SiegeAftermathPendingTests : IDisposable
     [Fact]
     public void NarrationContext_IsParticipantScopedAndIndependentOfChoicePrompt()
     {
-        var participantSettlement = CreateSettlement(CreateUninitialized<Clan>(), CreateUninitialized<Clan>());
-        var unrelatedSettlement = CreateSettlement(CreateUninitialized<Clan>(), CreateUninitialized<Clan>());
-        var siegeEventInterface = new SiegeEventInterface();
+        var originalCampaign = Campaign.Current;
+        try
+        {
+            Campaign.Current = null;
+            var participantSettlement = CreateSettlement(CreateUninitialized<Clan>(), CreateUninitialized<Clan>());
+            var unrelatedSettlement = CreateSettlement(CreateUninitialized<Clan>(), CreateUninitialized<Clan>());
+            var siegeEventInterface = new SiegeEventInterface();
 
-        siegeEventInterface.SetLocalAftermathNarrationContext(participantSettlement);
-        siegeEventInterface.SetLocalAftermathNarration(unrelatedSettlement,
-            (int)SiegeAftermathAction.SiegeAftermath.Devastate);
-        Assert.True(siegeEventInterface.HasLocalAftermathNarrationContext(participantSettlement));
+            siegeEventInterface.SetLocalAftermathNarrationContext(participantSettlement);
+            siegeEventInterface.SetLocalAftermathNarration(unrelatedSettlement,
+                (int)SiegeAftermathAction.SiegeAftermath.Devastate);
+            Assert.True(siegeEventInterface.HasLocalAftermathNarrationContext(participantSettlement));
 
-        siegeEventInterface.SetLocalAftermathNarration(participantSettlement,
-            (int)SiegeAftermathAction.SiegeAftermath.Pillage);
-        Assert.False(siegeEventInterface.HasLocalAftermathNarrationContext(participantSettlement));
+            siegeEventInterface.SetLocalAftermathNarration(participantSettlement,
+                (int)SiegeAftermathAction.SiegeAftermath.Pillage);
+            Assert.False(siegeEventInterface.HasLocalAftermathNarrationContext(participantSettlement));
+        }
+        finally
+        {
+            Campaign.Current = originalCampaign;
+        }
     }
 
     private static (Settlement Settlement, SiegeAftermathPatches.PendingAftermath Pending) AddBoundPending()
@@ -230,3 +240,6 @@ public sealed class SiegeAftermathPendingTests : IDisposable
         }
     }
 }
+
+[CollectionDefinition(nameof(SiegeAftermathCampaignCollection), DisableParallelization = true)]
+public sealed class SiegeAftermathCampaignCollection { }

--- a/source/GameInterface/Services/MapEvents/Patches/SiegeLadderAuthorityPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/SiegeLadderAuthorityPatches.cs
@@ -1,0 +1,134 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using TaleWorlds.MountAndBlade;
+
+namespace GameInterface.Services.MapEvents.Patches;
+
+[HarmonyPatch]
+internal class SiegeLadderAuthorityPatches
+{
+    private const int LocalMaintenanceClientChecks = 4;
+    private const int ExpectedOnTickClientChecks = 8;
+
+    [HarmonyPatch(typeof(SiegeLadder), nameof(SiegeLadder.State), MethodType.Setter)]
+    [HarmonyPrefix]
+    private static bool StateSetterPrefix(SiegeLadder __instance)
+    {
+        if (!BattleSpawnConfig.Enabled || !BattleSpawnGate.IsCoopBattleActive) return true;
+        if (SiegeMissionAuthorityGate.SuppressCapture) return true;
+        if (!SiegeMissionAuthorityGate.IsAuthorityKnown) return false;
+
+        return SiegeMissionAuthorityGate.IsMachineSimulatedLocally(__instance.Id.Id);
+    }
+
+    [HarmonyPatch(typeof(SiegeLadder), "OnTick")]
+    [HarmonyTranspiler]
+    private static IEnumerable<CodeInstruction> OnTickTranspiler(
+        IEnumerable<CodeInstruction> instructions,
+        MethodBase __originalMethod)
+    {
+        var nativeClientGetter = AccessTools.PropertyGetter(typeof(GameNetwork), nameof(GameNetwork.IsClientOrReplay));
+        var coopClientGetter = AccessTools.Method(typeof(SiegeLadderAuthorityPatches), nameof(IsClientForSiegeLadder));
+        int clientChecks = 0;
+        int existingCoopChecks = 0;
+
+        foreach (var instruction in instructions)
+        {
+            if (instruction.Calls(coopClientGetter))
+            {
+                existingCoopChecks++;
+                yield return instruction;
+                continue;
+            }
+
+            if (!instruction.Calls(nativeClientGetter))
+            {
+                yield return instruction;
+                continue;
+            }
+
+            clientChecks++;
+            // The first four guards maintain local queues and standing points; later guards drive shared animation.
+            if (clientChecks <= LocalMaintenanceClientChecks)
+            {
+                yield return instruction;
+                continue;
+            }
+
+            instruction.opcode = OpCodes.Ldarg_0;
+            instruction.operand = null;
+            yield return instruction;
+            yield return new CodeInstruction(OpCodes.Call, coopClientGetter);
+        }
+
+        bool firstApplication = clientChecks == ExpectedOnTickClientChecks && existingCoopChecks == 0;
+        bool repeatedApplication = clientChecks == LocalMaintenanceClientChecks
+            && existingCoopChecks == ExpectedOnTickClientChecks - LocalMaintenanceClientChecks;
+        if (!firstApplication && !repeatedApplication)
+        {
+            throw new InvalidOperationException(
+                $"Failed to patch siege ladder authority checks in {__originalMethod.Name}: " +
+                $"found {clientChecks} native and {existingCoopChecks} co-op checks.");
+        }
+    }
+
+    [HarmonyPatch(typeof(SiegeLadder), "OnLadderStateChange")]
+    [HarmonyTranspiler]
+    private static IEnumerable<CodeInstruction> OnLadderStateChangeTranspiler(
+        IEnumerable<CodeInstruction> instructions,
+        MethodBase __originalMethod)
+    {
+        return UseCoopClientPath(instructions, __originalMethod);
+    }
+
+    // Received states need vanilla's client animation path while the elected mission host advances the ladder.
+    private static IEnumerable<CodeInstruction> UseCoopClientPath(
+        IEnumerable<CodeInstruction> instructions,
+        MethodBase originalMethod)
+    {
+        var nativeClientGetter = AccessTools.PropertyGetter(typeof(GameNetwork), nameof(GameNetwork.IsClientOrReplay));
+        var coopClientGetter = AccessTools.Method(typeof(SiegeLadderAuthorityPatches), nameof(IsClientForSiegeLadder));
+        int replacements = 0;
+        int existingReplacements = 0;
+
+        foreach (var instruction in instructions)
+        {
+            if (instruction.Calls(coopClientGetter))
+            {
+                existingReplacements++;
+                yield return instruction;
+                continue;
+            }
+
+            if (!instruction.Calls(nativeClientGetter))
+            {
+                yield return instruction;
+                continue;
+            }
+
+            instruction.opcode = OpCodes.Ldarg_0;
+            instruction.operand = null;
+            yield return instruction;
+            yield return new CodeInstruction(OpCodes.Call, coopClientGetter);
+            replacements++;
+        }
+
+        if (replacements == 0 && existingReplacements == 0)
+        {
+            throw new InvalidOperationException(
+                $"Failed to patch siege ladder authority checks in {originalMethod.Name}.");
+        }
+    }
+
+    private static bool IsClientForSiegeLadder(SiegeLadder ladder)
+    {
+        if (GameNetwork.IsClientOrReplay) return true;
+        if (!BattleSpawnConfig.Enabled || !BattleSpawnGate.IsCoopBattleActive) return false;
+        if (!SiegeMissionAuthorityGate.IsAuthorityKnown) return true;
+
+        return !SiegeMissionAuthorityGate.IsMachineSimulatedLocally(ladder.Id.Id);
+    }
+}

--- a/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
+++ b/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
@@ -353,7 +353,8 @@ public class SiegeDebugCommand
             return $"Settlement with id {args[0]} not found";
         }
 
-        var leader = settlement.SiegeEvent?.BesiegerCamp?.LeaderParty;
+        var camp = settlement.SiegeEvent?.BesiegerCamp;
+        var leader = camp?.LeaderParty;
         if (leader == null)
         {
             return $"{settlement.Name} has no active siege leader";
@@ -364,7 +365,21 @@ public class SiegeDebugCommand
             return "Unable to resolve SiegeEventInterface";
         }
 
+        var siegeParties = camp._besiegerParties.ToArray();
+        foreach (var party in siegeParties)
+        {
+            if (party != leader)
+            {
+                siegeEventInterface.BreakSiege(party);
+            }
+        }
+
         siegeEventInterface.BreakSiege(leader);
+        if (settlement.SiegeEvent != null)
+        {
+            return $"Failed to stop the siege of {settlement.Name}; " +
+                $"{settlement.SiegeEvent.BesiegerCamp?._besiegerParties.Count ?? 0} parties remain";
+        }
 
         var restoreResult = PartyCommands.RestorePositionCommand(new List<string>
         {
@@ -498,12 +513,14 @@ public class SiegeDebugCommand
             return $"{settlement.Name} is not under siege";
         }
 
+        ClearSiegeEngines(attackerEngines);
+        ClearSiegeEngines(defenderEngines);
         if (attackerEngines.DeployedSiegeEngines.Count > 0
             || attackerEngines.ReservedSiegeEngines.Count > 0
             || defenderEngines.DeployedSiegeEngines.Count > 0
             || defenderEngines.ReservedSiegeEngines.Count > 0)
         {
-            return $"{settlement.Name} already has campaign siege engines; stop and recreate the fixture";
+            return $"Failed to remove the campaign siege engines from {settlement.Name}";
         }
 
         var preparations = attackerEngines.SiegePreparations;
@@ -515,6 +532,34 @@ public class SiegeDebugCommand
 
         return $"Prepared a ladder-only assault at {settlement.Name} ({settlement.StringId}): " +
             $"preparation={preparations.Progress:0.00} attackerEngines=0 defenderEngines=0";
+    }
+
+    private static void ClearSiegeEngines(SiegeEnginesContainer siegeEngines)
+    {
+        for (int i = siegeEngines.DeployedRangedSiegeEngines.Length - 1; i >= 0; i--)
+        {
+            if (siegeEngines.DeployedRangedSiegeEngines[i] != null)
+            {
+                siegeEngines.RemoveDeployedSiegeEngine(i, isRanged: true, moveToReserve: false);
+            }
+        }
+
+        for (int i = siegeEngines.DeployedMeleeSiegeEngines.Length - 1; i >= 0; i--)
+        {
+            if (siegeEngines.DeployedMeleeSiegeEngines[i] != null)
+            {
+                siegeEngines.RemoveDeployedSiegeEngine(i, isRanged: false, moveToReserve: false);
+            }
+        }
+
+        while (siegeEngines.ReservedSiegeEngines.Count > 0)
+        {
+            var siegeEngine = siegeEngines.ReservedSiegeEngines[0];
+            if (!siegeEngines.RemovedSiegeEngineFromReservedSiegeEngines(siegeEngine))
+            {
+                break;
+            }
+        }
     }
 
     [CommandLineArgumentFunction("stage_machines", "coop.debug.siege")]

--- a/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
+++ b/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
@@ -467,6 +467,56 @@ public class SiegeDebugCommand
             string.Join(Environment.NewLine, joined);
     }
 
+    [CommandLineArgumentFunction("prepare_ladders_only", "coop.debug.siege")]
+    public static string PrepareLaddersOnly(List<string> args)
+    {
+        if (args.Count != 1)
+        {
+            return "Usage: coop.debug.siege.prepare_ladders_only <settlementId>";
+        }
+
+        if (ModInformation.IsClient)
+        {
+            return "This command can only be used by the server";
+        }
+
+        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
+        {
+            return "Unable to resolve ObjectManager";
+        }
+
+        if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
+        {
+            return $"Settlement with id {args[0]} not found";
+        }
+
+        var siegeEvent = settlement.SiegeEvent;
+        var attackerEngines = siegeEvent?.BesiegerCamp?.SiegeEngines;
+        var defenderEngines = settlement.SiegeEngines;
+        if (siegeEvent == null || attackerEngines == null || defenderEngines == null)
+        {
+            return $"{settlement.Name} is not under siege";
+        }
+
+        if (attackerEngines.DeployedSiegeEngines.Count > 0
+            || attackerEngines.ReservedSiegeEngines.Count > 0
+            || defenderEngines.DeployedSiegeEngines.Count > 0
+            || defenderEngines.ReservedSiegeEngines.Count > 0)
+        {
+            return $"{settlement.Name} already has campaign siege engines; stop and recreate the fixture";
+        }
+
+        var preparations = attackerEngines.SiegePreparations;
+        if (!preparations.IsConstructed)
+        {
+            preparations.SetProgress(1f);
+            siegeEvent.CreateSiegeObject(preparations, siegeEvent.GetSiegeEventSide(BattleSideEnum.Attacker));
+        }
+
+        return $"Prepared a ladder-only assault at {settlement.Name} ({settlement.StringId}): " +
+            $"preparation={preparations.Progress:0.00} attackerEngines=0 defenderEngines=0";
+    }
+
     [CommandLineArgumentFunction("stage_machines", "coop.debug.siege")]
     public static string StageMachines(List<string> args)
     {
@@ -878,7 +928,8 @@ public class SiegeDebugCommand
                     $" disabled={(machine.IsDisabled ? 1 : 0)} visible={(machine.GameEntity.IsVisibleIncludeParents() ? 1 : 0)}" +
                     $" deactivated={(machine.IsDeactivated ? 1 : 0)} aiOff={(machine.IsDisabledForAI ? 1 : 0)}" +
                     $" simLocal={(SiegeMissionAuthorityGate.IsMachineSimulatedLocally(machine.Id.Id) ? 1 : 0)}" +
-                    $" pts={machine.StandingPoints.Count} ptsOff={deactivatedPoints} ptsUsed={usedPoints}");
+                    $" pts={machine.StandingPoints.Count} ptsOff={deactivatedPoints} ptsUsed={usedPoints}" +
+                    DescribeMissionMachineState(machine));
             }
             else if (missionObject is TaleWorlds.MountAndBlade.DeploymentPoint deploymentPoint)
             {
@@ -905,5 +956,21 @@ public class SiegeDebugCommand
         var dump = string.Join(Environment.NewLine, lines);
         Logger.Information("[MachineDump]\n{Dump}", dump);
         return dump;
+    }
+
+    private static string DescribeMissionMachineState(TaleWorlds.MountAndBlade.UsableMachine machine)
+    {
+        if (!(machine is TaleWorlds.MountAndBlade.SiegeLadder ladder))
+        {
+            return string.Empty;
+        }
+
+        int animationIndex = ladder._ladderSkeleton.GetAnimationIndexAtChannel(0);
+        float animationProgress = animationIndex >= 0
+            ? ladder._ladderSkeleton.GetAnimationParameterAtChannel(0)
+            : 0f;
+
+        return $" ladderState={ladder.State} ladderAnimation={ladder._animationState}" +
+            $" ladderAnimationIndex={animationIndex} ladderProgress={animationProgress:0.000}";
     }
 }

--- a/source/Missions/Battles/BattleDebugCommands.cs
+++ b/source/Missions/Battles/BattleDebugCommands.cs
@@ -1,9 +1,17 @@
-﻿using System.Collections.Generic;
+﻿using Common;
+using GameInterface;
+using GameInterface.Services.MapEvents;
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.Core;
+using TaleWorlds.Engine;
 using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
+using TaleWorlds.MountAndBlade.View.Screens;
+using TaleWorlds.ScreenSystem;
 using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace Missions.Battles;
@@ -13,6 +21,7 @@ internal static class BattleDebugCommands
 {
     private static readonly Dictionary<int, Vec3> EnemyPositions = new Dictionary<int, Vec3>();
     private static Mission observedMission;
+    private static Camera ladderCamera;
 
     [CommandLineArgumentFunction("state", "coop.debug.battle")]
     public static string State(List<string> args)
@@ -33,6 +42,7 @@ internal static class BattleDebugCommands
         if (observedMission != mission)
         {
             EnemyPositions.Clear();
+            ReleaseLadderCamera();
             observedMission = mission;
         }
 
@@ -69,5 +79,137 @@ internal static class BattleDebugCommands
             $"deploymentReady={deploymentReady} mainAgent={Agent.Main != null} activeAgents={activeAgents} " +
             $"playerSide={playerTeam?.Side.ToString() ?? "None"} enemyParties={enemyParties} enemyActive={enemies.Count} " +
             $"enemyAi={enemies.Count(agent => agent.IsAIControlled)} enemyMovedSinceLast={moved}";
+    }
+
+    [CommandLineArgumentFunction("ladder_state", "coop.debug.battle")]
+    public static string LadderState(List<string> args)
+    {
+        if (args.Count > 1 || (args.Count == 1 && !int.TryParse(args[0], out _)))
+        {
+            return "Usage: coop.debug.battle.ladder_state [machineId]";
+        }
+
+        var mission = Mission.Current;
+        if (mission == null || !mission.IsSiegeBattle)
+        {
+            return "No active siege mission";
+        }
+
+        if (!ContainerProvider.TryResolve<INetworkAgentRegistry>(out var agentRegistry))
+        {
+            return "Unable to resolve NetworkAgentRegistry";
+        }
+
+        int? selectedId = args.Count == 1 ? int.Parse(args[0]) : null;
+        var ladders = mission.MissionObjects
+            .OfType<SiegeLadder>()
+            .Where(ladder => selectedId == null || ladder.Id.Id == selectedId.Value)
+            .OrderBy(ladder => ladder.Id.Id)
+            .ToArray();
+        if (ladders.Length == 0)
+        {
+            return selectedId == null
+                ? "No siege ladders are registered"
+                : $"Siege ladder {selectedId.Value} was not found";
+        }
+
+        var output = new StringBuilder();
+        output.AppendLine($"ladders={ladders.Length} authority={SiegeMissionAuthorityGate.IsLocalAuthority} " +
+            $"known={SiegeMissionAuthorityGate.IsAuthorityKnown}");
+        foreach (var ladder in ladders)
+        {
+            int animationIndex = ladder._ladderSkeleton.GetAnimationIndexAtChannel(0);
+            float animationProgress = animationIndex >= 0
+                ? ladder._ladderSkeleton.GetAnimationParameterAtChannel(0)
+                : 0f;
+
+            var users = new List<string>();
+            int deactivatedPoints = 0;
+            foreach (var standingPoint in ladder.StandingPoints)
+            {
+                if (standingPoint.IsDeactivated) deactivatedPoints++;
+
+                var agent = standingPoint.UserAgent ?? standingPoint.MovingAgent;
+                if (agent == null) continue;
+
+                string role = standingPoint.GameEntity.HasTag(ladder.AttackerTag)
+                    ? "attacker"
+                    : standingPoint.GameEntity.HasTag(ladder.DefenderTag) ? "defender" : "other";
+                string controller = agentRegistry.TryGetAgentInfo(agent, out var info)
+                    ? info.CurrentAuthority
+                    : "unregistered";
+                users.Add($"{role}:{controller}:{agent.Index}");
+            }
+
+            output.AppendLine($"ladder={ladder.Id.Id:D5} state={ladder.State} animation={ladder._animationState} " +
+                $"animationIndex={animationIndex} progress={animationProgress:0.000} " +
+                $"simLocal={SiegeMissionAuthorityGate.IsMachineSimulatedLocally(ladder.Id.Id)} " +
+                $"points={ladder.StandingPoints.Count} pointsOff={deactivatedPoints} " +
+                $"users={(users.Count > 0 ? string.Join(",", users) : "none")}");
+        }
+
+        return output.ToString();
+    }
+
+    [CommandLineArgumentFunction("focus_ladder", "coop.debug.battle")]
+    public static string FocusLadder(List<string> args)
+    {
+        if (args.Count != 1 || !int.TryParse(args[0], out int machineId))
+        {
+            return "Usage: coop.debug.battle.focus_ladder <machineId>";
+        }
+
+        var mission = Mission.Current;
+        var ladder = mission?.MissionObjects
+            .OfType<SiegeLadder>()
+            .FirstOrDefault(candidate => candidate.Id.Id == machineId);
+        if (ladder == null)
+        {
+            return $"Siege ladder {machineId} was not found";
+        }
+
+        if (!(ScreenManager.TopScreen is MissionScreen missionScreen) || missionScreen.CombatCamera == null)
+        {
+            return "The mission screen is not active";
+        }
+
+        ReleaseLadderCamera();
+        ladderCamera = Camera.CreateCamera();
+        ladderCamera.FillParametersFrom(missionScreen.CombatCamera);
+
+        var frame = ladder.GameEntity.GetGlobalFrame();
+        var target = frame.origin + (Vec3.Up * 2.5f);
+        var position = target - (frame.rotation.f * 12f) + (Vec3.Up * 4f);
+        ladderCamera.LookAt(position, target, Vec3.Up);
+        missionScreen.CustomCamera = ladderCamera;
+
+        return $"Focused the mission camera on siege ladder {machineId}";
+    }
+
+    [CommandLineArgumentFunction("release_ladder_camera", "coop.debug.battle")]
+    public static string ReleaseLadderCameraCommand(List<string> args)
+    {
+        if (args.Count != 0)
+        {
+            return "Usage: coop.debug.battle.release_ladder_camera";
+        }
+
+        bool released = ReleaseLadderCamera();
+        return released ? "Released the ladder camera" : "No ladder camera was active";
+    }
+
+    private static bool ReleaseLadderCamera()
+    {
+        if (ladderCamera == null) return false;
+
+        if (ScreenManager.TopScreen is MissionScreen missionScreen
+            && missionScreen.CustomCamera == ladderCamera)
+        {
+            missionScreen.CustomCamera = null;
+        }
+
+        ladderCamera.ReleaseCamera();
+        ladderCamera = null;
+        return true;
     }
 }

--- a/source/Missions/Battles/SiegeMachineStateReplicator.cs
+++ b/source/Missions/Battles/SiegeMachineStateReplicator.cs
@@ -7,6 +7,7 @@ using Serilog;
 using System;
 using System.Collections.Generic;
 using TaleWorlds.Core;
+using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.Missions;
 
@@ -47,6 +48,9 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
     // Aim replication: -1000 sentinel (a valid angle can be -1) and vanilla's own re-send threshold.
     private const float AimSentinel = -1000f;
     private const float AimEpsilon = 0.02f;
+    private const float LadderAnimationSentinel = -1f;
+    private const float LadderAnimationEpsilon = 0.01f;
+    private const float LadderFrameEpsilon = 0.001f;
 
     private static readonly ILogger Logger = LogManager.GetLogger<SiegeMachineStateReplicator>();
 
@@ -224,7 +228,13 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
                 && previous.WeaponState == state.WeaponState
                 && Math.Abs(previous.MoveDistance - state.MoveDistance) < MoveDistanceThreshold
                 && Math.Abs(previous.AimDirection - state.AimDirection) < AimEpsilon
-                && Math.Abs(previous.AimReleaseAngle - state.AimReleaseAngle) < AimEpsilon)
+                && Math.Abs(previous.AimReleaseAngle - state.AimReleaseAngle) < AimEpsilon
+                && Math.Abs(previous.LadderAnimationSpeed - state.LadderAnimationSpeed) < LadderAnimationEpsilon
+                && Math.Abs(previous.LadderAnimationProgress - state.LadderAnimationProgress) < LadderAnimationEpsilon
+                && previous.LadderAnimationState == state.LadderAnimationState
+                && Math.Abs(previous.LadderFallAngularSpeed - state.LadderFallAngularSpeed) < LadderAnimationEpsilon
+                && previous.LadderAnimationIndex == state.LadderAnimationIndex
+                && LadderFramesEqual(previous.LadderFrame, state.LadderFrame))
             {
                 continue;
             }
@@ -234,6 +244,15 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
         }
     }
 
+    private static bool LadderFramesEqual(MatrixFrame left, MatrixFrame right)
+    {
+        float thresholdSquared = LadderFrameEpsilon * LadderFrameEpsilon;
+        return (left.origin - right.origin).LengthSquared < thresholdSquared
+            && (left.rotation.s - right.rotation.s).LengthSquared < thresholdSquared
+            && (left.rotation.f - right.rotation.f).LengthSquared < thresholdSquared
+            && (left.rotation.u - right.rotation.u).LengthSquared < thresholdSquared;
+    }
+
     // BR-102: an outgoing state asserts this sender's simulation authority NOW, so stamp the current
     // host epoch at the send boundary (CaptureState stays a pure machine read; lastSent keeps the
     // unstamped capture, whose delta comparison never looks at the epoch).
@@ -241,7 +260,9 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
     {
         return new NetworkSiegeMachineState(state.MachineId, state.HitPoints, state.DestructionState,
             state.GateState, state.LadderState, state.MoveDistance, state.HasArrived, state.WeaponState,
-            state.AimDirection, state.AimReleaseAngle, session.HostEpoch);
+            state.AimDirection, state.AimReleaseAngle, session.HostEpoch,
+            state.LadderAnimationSpeed, state.LadderAnimationProgress, state.LadderAnimationState,
+            state.LadderFallAngularSpeed, state.LadderFrame, state.LadderAnimationIndex);
     }
 
     // BR-102: drop a host-authority message stamped by an earlier hosting generation (a deposed host
@@ -262,7 +283,9 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
     private static NetworkSiegeMachineState CaptureState(UsableMachine machine, bool isHost, bool simulatedLocally)
     {
         ReadState(machine, out var hitPoints, out var destructionState, out var gateState, out var ladderState,
-            out var moveDistance, out var hasArrived, out var weaponState, out var aimDirection, out var aimReleaseAngle);
+            out var moveDistance, out var hasArrived, out var weaponState, out var aimDirection, out var aimReleaseAngle,
+            out var ladderAnimationSpeed, out var ladderAnimationProgress, out var ladderAnimationState,
+            out var ladderFallAngularSpeed, out var ladderFrame, out var ladderAnimationIndex);
 
         if (isHost && !simulatedLocally)
         {
@@ -280,6 +303,12 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
             hitPoints = -1f;
             destructionState = -1;
             ladderState = -1;
+            ladderAnimationSpeed = LadderAnimationSentinel;
+            ladderAnimationProgress = LadderAnimationSentinel;
+            ladderAnimationState = -1;
+            ladderFallAngularSpeed = 0f;
+            ladderFrame = MatrixFrame.Zero;
+            ladderAnimationIndex = -1;
             if (!IsMovementMachine(machine))
             {
                 gateState = -1;
@@ -289,7 +318,10 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
         }
 
         return new NetworkSiegeMachineState(machine.Id.Id, hitPoints, destructionState, gateState, ladderState,
-            moveDistance, hasArrived, weaponState, aimDirection, aimReleaseAngle);
+            moveDistance, hasArrived, weaponState, aimDirection, aimReleaseAngle,
+            ladderAnimationSpeed: ladderAnimationSpeed, ladderAnimationProgress: ladderAnimationProgress,
+            ladderAnimationState: ladderAnimationState, ladderFallAngularSpeed: ladderFallAngularSpeed,
+            ladderFrame: ladderFrame, ladderAnimationIndex: ladderAnimationIndex);
     }
 
     private void DeactivateNewMachines()
@@ -944,7 +976,9 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
 
     private static void ReadState(UsableMachine machine, out float hitPoints, out int destructionState,
         out int gateState, out int ladderState, out float moveDistance, out bool hasArrived, out int weaponState,
-        out float aimDirection, out float aimReleaseAngle)
+        out float aimDirection, out float aimReleaseAngle, out float ladderAnimationSpeed,
+        out float ladderAnimationProgress, out int ladderAnimationState, out float ladderFallAngularSpeed,
+        out MatrixFrame ladderFrame, out int ladderAnimationIndex)
     {
         hitPoints = -1f;
         destructionState = -1;
@@ -958,7 +992,26 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
         // network message); it rides the same field as the castle gate's.
         gateState = machine is CastleGate gate ? (int)gate.State
             : machine is SiegeTower gateTower ? (int)gateTower.State : -1;
-        ladderState = machine is SiegeLadder ladder ? (int)ladder.State : -1;
+        ladderState = -1;
+        ladderAnimationSpeed = LadderAnimationSentinel;
+        ladderAnimationProgress = LadderAnimationSentinel;
+        ladderAnimationState = -1;
+        ladderFallAngularSpeed = 0f;
+        ladderFrame = MatrixFrame.Zero;
+        ladderAnimationIndex = -1;
+        if (machine is SiegeLadder ladder)
+        {
+            ladderState = (int)ladder.State;
+            ladderAnimationState = (int)ladder._animationState;
+            ladderFallAngularSpeed = ladder._fallAngularSpeed;
+            ladderFrame = ladder._ladderObject.GameEntity.GetGlobalFrame();
+            ladderAnimationIndex = ladder._ladderSkeleton.GetAnimationIndexAtChannel(0);
+            if (ladderAnimationIndex >= 0)
+            {
+                ladderAnimationSpeed = ladder._ladderSkeleton.GetAnimationSpeedAtChannel(0);
+                ladderAnimationProgress = ladder._ladderSkeleton.GetAnimationParameterAtChannel(0);
+            }
+        }
         weaponState = -1;
         aimDirection = AimSentinel;
         aimReleaseAngle = AimSentinel;
@@ -1096,9 +1149,39 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
             gateTower.State = (SiegeTower.GateState)state.GateState;
         }
 
-        if (state.LadderState >= 0 && machine is SiegeLadder ladder && (int)ladder.State != state.LadderState)
+        if (state.LadderState >= 0 && machine is SiegeLadder ladder)
         {
-            ladder.State = (SiegeLadder.LadderState)state.LadderState;
+            var targetState = (SiegeLadder.LadderState)state.LadderState;
+            if (ladder.State != targetState)
+            {
+                // Poll snapshots can skip vanilla's synchronous transition states that start or finish animations.
+                foreach (var transitionState in GetLadderTransitionStates(ladder.State, targetState))
+                {
+                    ladder.State = transitionState;
+                }
+                ladder.State = targetState;
+            }
+
+            if (state.LadderAnimationState >= 0)
+            {
+                ladder._animationState = (SiegeLadder.LadderAnimationState)state.LadderAnimationState;
+                ladder._fallAngularSpeed = state.LadderFallAngularSpeed;
+                ladder._lastDotProductOfAnimationAndTargetRotation = -1000f;
+
+                var ladderFrame = state.LadderFrame;
+                ladderFrame.rotation.Orthonormalize();
+                ladder._ladderObject.GameEntity.SetGlobalFrame(ladderFrame);
+
+                if (state.LadderAnimationIndex >= 0)
+                {
+                    ladder._ladderSkeleton.SetAnimationAtChannel(state.LadderAnimationIndex, 0);
+                    ladder._ladderSkeleton.SetAnimationSpeedAtChannel(0, state.LadderAnimationSpeed);
+                    ladder._ladderSkeleton.SetAnimationParameterAtChannel(
+                        0,
+                        MBMath.ClampFloat(state.LadderAnimationProgress, 0f, 1f));
+                    ladder._ladderSkeleton.ForceUpdateBoneFrames();
+                }
+            }
         }
 
         if (state.HitPoints >= 0f && machine.DestructionComponent != null)
@@ -1114,6 +1197,62 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
             {
                 destruction.SetDestructionLevel(state.DestructionState, -1, 0f, TaleWorlds.Library.Vec3.Zero, TaleWorlds.Library.Vec3.Zero);
             }
+        }
+    }
+
+    internal static IEnumerable<SiegeLadder.LadderState> GetLadderTransitionStates(
+        SiegeLadder.LadderState currentState,
+        SiegeLadder.LadderState targetState)
+    {
+        if (targetState == SiegeLadder.LadderState.BeingRaised)
+        {
+            if (currentState == SiegeLadder.LadderState.OnLand
+                || currentState == SiegeLadder.LadderState.FallToLand)
+            {
+                yield return SiegeLadder.LadderState.BeingRaisedStartFromGround;
+            }
+            else if (currentState == SiegeLadder.LadderState.OnWall
+                || currentState == SiegeLadder.LadderState.FallToWall)
+            {
+                yield return SiegeLadder.LadderState.BeingPushedBackStartFromWall;
+                yield return SiegeLadder.LadderState.BeingPushedBack;
+                yield return SiegeLadder.LadderState.BeingPushedBackStopped;
+            }
+            else if (currentState == SiegeLadder.LadderState.BeingPushedBack
+                || currentState == SiegeLadder.LadderState.BeingPushedBackStartFromWall)
+            {
+                yield return SiegeLadder.LadderState.BeingPushedBackStopped;
+            }
+        }
+        else if (targetState == SiegeLadder.LadderState.BeingPushedBack)
+        {
+            if (currentState == SiegeLadder.LadderState.OnWall
+                || currentState == SiegeLadder.LadderState.FallToWall)
+            {
+                yield return SiegeLadder.LadderState.BeingPushedBackStartFromWall;
+            }
+            else if (currentState == SiegeLadder.LadderState.OnLand
+                || currentState == SiegeLadder.LadderState.FallToLand)
+            {
+                yield return SiegeLadder.LadderState.BeingRaisedStartFromGround;
+                yield return SiegeLadder.LadderState.BeingRaised;
+                yield return SiegeLadder.LadderState.BeingRaisedStopped;
+            }
+            else if (currentState == SiegeLadder.LadderState.BeingRaised
+                || currentState == SiegeLadder.LadderState.BeingRaisedStartFromGround)
+            {
+                yield return SiegeLadder.LadderState.BeingRaisedStopped;
+            }
+        }
+        else if (targetState == SiegeLadder.LadderState.OnWall
+            && currentState != SiegeLadder.LadderState.FallToWall)
+        {
+            yield return SiegeLadder.LadderState.FallToWall;
+        }
+        else if (targetState == SiegeLadder.LadderState.OnLand
+            && currentState != SiegeLadder.LadderState.FallToLand)
+        {
+            yield return SiegeLadder.LadderState.FallToLand;
         }
     }
 

--- a/source/Missions/Battles/SiegeMachineStateReplicator.cs
+++ b/source/Missions/Battles/SiegeMachineStateReplicator.cs
@@ -65,10 +65,14 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
     private readonly List<UsableMachine> machines = new List<UsableMachine>();
     private readonly Dictionary<int, UsableMachine> machinesById = new Dictionary<int, UsableMachine>();
     private readonly Dictionary<int, NetworkSiegeMachineState> lastSent = new Dictionary<int, NetworkSiegeMachineState>();
+    private readonly Dictionary<int, NetworkSiegeLadderAnimationState> lastSentLadderAnimations =
+        new Dictionary<int, NetworkSiegeLadderAnimationState>();
     private readonly HashSet<int> deactivated = new HashSet<int>();
     // States that arrived before their MissionObject registered (catch-up during a peer's scene load);
     // re-applied once the object appears. Keyed by machine id, latest state wins.
     private readonly Dictionary<int, NetworkSiegeMachineState> pendingByMachineId = new Dictionary<int, NetworkSiegeMachineState>();
+    private readonly Dictionary<int, NetworkSiegeLadderAnimationState> pendingLadderAnimationsById =
+        new Dictionary<int, NetworkSiegeLadderAnimationState>();
     // Peer-side: last RangedSiegeWeapon.WeaponState applied per machine, so the wind-up/reload animation fires
     // only on a state transition (the state message re-sends whenever any field, e.g. HitPoints, changes).
     private readonly Dictionary<int, int> peerWeaponState = new Dictionary<int, int>();
@@ -107,6 +111,7 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
         this.hostEpochPolicy = hostEpochPolicy;
 
         messageBroker.Subscribe<NetworkSiegeMachineState>(Handle_NetworkMachineState);
+        messageBroker.Subscribe<NetworkSiegeLadderAnimationState>(Handle_NetworkLadderAnimationState);
         messageBroker.Subscribe<NetworkSiegeMachineClaim>(Handle_NetworkMachineClaim);
         messageBroker.Subscribe<NetworkSiegeMachineAuthority>(Handle_NetworkMachineAuthority);
         messageBroker.Subscribe<MissionPeerLeft>(Handle_MissionPeerLeft);
@@ -116,6 +121,7 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
     public void Dispose()
     {
         messageBroker.Unsubscribe<NetworkSiegeMachineState>(Handle_NetworkMachineState);
+        messageBroker.Unsubscribe<NetworkSiegeLadderAnimationState>(Handle_NetworkLadderAnimationState);
         messageBroker.Unsubscribe<NetworkSiegeMachineClaim>(Handle_NetworkMachineClaim);
         messageBroker.Unsubscribe<NetworkSiegeMachineAuthority>(Handle_NetworkMachineAuthority);
         messageBroker.Unsubscribe<MissionPeerLeft>(Handle_MissionPeerLeft);
@@ -160,8 +166,10 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
         if (trackedMission != mission)
         {
             lastSent.Clear();
+            lastSentLadderAnimations.Clear();
             deactivated.Clear();
             pendingByMachineId.Clear();
+            pendingLadderAnimationsById.Clear();
             peerWeaponState.Clear();
             claimedMachines.Clear();
             pendingClaimSeconds.Clear();
@@ -218,30 +226,47 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
             if (!isHost && !simulatedLocally) continue;
 
             var state = CaptureState(machine, isHost, simulatedLocally);
-
-            if (lastSent.TryGetValue(machineId, out var previous)
-                && previous.HitPoints == state.HitPoints
-                && previous.DestructionState == state.DestructionState
-                && previous.GateState == state.GateState
-                && previous.LadderState == state.LadderState
-                && previous.HasArrived == state.HasArrived
-                && previous.WeaponState == state.WeaponState
-                && Math.Abs(previous.MoveDistance - state.MoveDistance) < MoveDistanceThreshold
-                && Math.Abs(previous.AimDirection - state.AimDirection) < AimEpsilon
-                && Math.Abs(previous.AimReleaseAngle - state.AimReleaseAngle) < AimEpsilon
-                && Math.Abs(previous.LadderAnimationSpeed - state.LadderAnimationSpeed) < LadderAnimationEpsilon
-                && Math.Abs(previous.LadderAnimationProgress - state.LadderAnimationProgress) < LadderAnimationEpsilon
-                && previous.LadderAnimationState == state.LadderAnimationState
-                && Math.Abs(previous.LadderFallAngularSpeed - state.LadderFallAngularSpeed) < LadderAnimationEpsilon
-                && previous.LadderAnimationIndex == state.LadderAnimationIndex
-                && LadderFramesEqual(previous.LadderFrame, state.LadderFrame))
+            if (!MachineStatesEqual(machineId, state))
             {
-                continue;
+                lastSent[machineId] = state;
+                network.SendAll(Stamp(state));
             }
 
-            lastSent[machineId] = state;
-            network.SendAll(Stamp(state));
+            if (simulatedLocally && machine is SiegeLadder ladder)
+            {
+                var ladderAnimation = CaptureLadderAnimationState(ladder);
+                if (!LadderAnimationStatesEqual(machineId, ladderAnimation))
+                {
+                    lastSentLadderAnimations[machineId] = ladderAnimation;
+                    network.SendAll(Stamp(ladderAnimation));
+                }
+            }
         }
+    }
+
+    private bool MachineStatesEqual(int machineId, NetworkSiegeMachineState state)
+    {
+        return lastSent.TryGetValue(machineId, out var previous)
+            && previous.HitPoints == state.HitPoints
+            && previous.DestructionState == state.DestructionState
+            && previous.GateState == state.GateState
+            && previous.LadderState == state.LadderState
+            && previous.HasArrived == state.HasArrived
+            && previous.WeaponState == state.WeaponState
+            && Math.Abs(previous.MoveDistance - state.MoveDistance) < MoveDistanceThreshold
+            && Math.Abs(previous.AimDirection - state.AimDirection) < AimEpsilon
+            && Math.Abs(previous.AimReleaseAngle - state.AimReleaseAngle) < AimEpsilon;
+    }
+
+    private bool LadderAnimationStatesEqual(int ladderId, NetworkSiegeLadderAnimationState state)
+    {
+        return lastSentLadderAnimations.TryGetValue(ladderId, out var previous)
+            && Math.Abs(previous.AnimationSpeed - state.AnimationSpeed) < LadderAnimationEpsilon
+            && Math.Abs(previous.AnimationProgress - state.AnimationProgress) < LadderAnimationEpsilon
+            && previous.AnimationState == state.AnimationState
+            && Math.Abs(previous.FallAngularSpeed - state.FallAngularSpeed) < LadderAnimationEpsilon
+            && previous.AnimationIndex == state.AnimationIndex
+            && LadderFramesEqual(previous.Frame, state.Frame);
     }
 
     private static bool LadderFramesEqual(MatrixFrame left, MatrixFrame right)
@@ -260,9 +285,20 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
     {
         return new NetworkSiegeMachineState(state.MachineId, state.HitPoints, state.DestructionState,
             state.GateState, state.LadderState, state.MoveDistance, state.HasArrived, state.WeaponState,
-            state.AimDirection, state.AimReleaseAngle, session.HostEpoch,
-            state.LadderAnimationSpeed, state.LadderAnimationProgress, state.LadderAnimationState,
-            state.LadderFallAngularSpeed, state.LadderFrame, state.LadderAnimationIndex);
+            state.AimDirection, state.AimReleaseAngle, session.HostEpoch);
+    }
+
+    private NetworkSiegeLadderAnimationState Stamp(NetworkSiegeLadderAnimationState state)
+    {
+        return new NetworkSiegeLadderAnimationState(
+            state.LadderId,
+            state.AnimationSpeed,
+            state.AnimationProgress,
+            state.AnimationState,
+            state.FallAngularSpeed,
+            state.Frame,
+            state.AnimationIndex,
+            session.HostEpoch);
     }
 
     // BR-102: drop a host-authority message stamped by an earlier hosting generation (a deposed host
@@ -283,9 +319,7 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
     private static NetworkSiegeMachineState CaptureState(UsableMachine machine, bool isHost, bool simulatedLocally)
     {
         ReadState(machine, out var hitPoints, out var destructionState, out var gateState, out var ladderState,
-            out var moveDistance, out var hasArrived, out var weaponState, out var aimDirection, out var aimReleaseAngle,
-            out var ladderAnimationSpeed, out var ladderAnimationProgress, out var ladderAnimationState,
-            out var ladderFallAngularSpeed, out var ladderFrame, out var ladderAnimationIndex);
+            out var moveDistance, out var hasArrived, out var weaponState, out var aimDirection, out var aimReleaseAngle);
 
         if (isHost && !simulatedLocally)
         {
@@ -303,12 +337,6 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
             hitPoints = -1f;
             destructionState = -1;
             ladderState = -1;
-            ladderAnimationSpeed = LadderAnimationSentinel;
-            ladderAnimationProgress = LadderAnimationSentinel;
-            ladderAnimationState = -1;
-            ladderFallAngularSpeed = 0f;
-            ladderFrame = MatrixFrame.Zero;
-            ladderAnimationIndex = -1;
             if (!IsMovementMachine(machine))
             {
                 gateState = -1;
@@ -318,10 +346,28 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
         }
 
         return new NetworkSiegeMachineState(machine.Id.Id, hitPoints, destructionState, gateState, ladderState,
-            moveDistance, hasArrived, weaponState, aimDirection, aimReleaseAngle,
-            ladderAnimationSpeed: ladderAnimationSpeed, ladderAnimationProgress: ladderAnimationProgress,
-            ladderAnimationState: ladderAnimationState, ladderFallAngularSpeed: ladderFallAngularSpeed,
-            ladderFrame: ladderFrame, ladderAnimationIndex: ladderAnimationIndex);
+            moveDistance, hasArrived, weaponState, aimDirection, aimReleaseAngle);
+    }
+
+    private static NetworkSiegeLadderAnimationState CaptureLadderAnimationState(SiegeLadder ladder)
+    {
+        int animationIndex = ladder._ladderSkeleton.GetAnimationIndexAtChannel(0);
+        float animationSpeed = LadderAnimationSentinel;
+        float animationProgress = LadderAnimationSentinel;
+        if (animationIndex >= 0)
+        {
+            animationSpeed = ladder._ladderSkeleton.GetAnimationSpeedAtChannel(0);
+            animationProgress = ladder._ladderSkeleton.GetAnimationParameterAtChannel(0);
+        }
+
+        return new NetworkSiegeLadderAnimationState(
+            ladder.Id.Id,
+            animationSpeed,
+            animationProgress,
+            (int)ladder._animationState,
+            ladder._fallAngularSpeed,
+            ladder._ladderObject.GameEntity.GetGlobalFrame(),
+            animationIndex);
     }
 
     private void DeactivateNewMachines()
@@ -939,11 +985,21 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
     // buffer only fills from received states, so a client that receives none skips it.
     private void DrainPendingMachineStates()
     {
-        if (pendingByMachineId.Count == 0) return;
+        DrainPendingGeneralMachineStates();
+        DrainPendingLadderAnimationStates();
+    }
 
+    private void DrainPendingGeneralMachineStates()
+    {
         List<int> applied = null;
         foreach (var pending in pendingByMachineId)
         {
+            if (DropStaleHostEpoch(pending.Value.HostEpoch, nameof(NetworkSiegeMachineState)))
+            {
+                if (applied == null) applied = new List<int>();
+                applied.Add(pending.Key);
+                continue;
+            }
             if (!machinesById.TryGetValue(pending.Key, out var machine)) continue;
 
             SiegeMissionAuthorityGate.SuppressCapture = true;
@@ -974,11 +1030,35 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
         foreach (var id in applied) pendingByMachineId.Remove(id);
     }
 
+    private void DrainPendingLadderAnimationStates()
+    {
+        List<int> applied = null;
+        foreach (var pending in pendingLadderAnimationsById)
+        {
+            if (DropStaleHostEpoch(pending.Value.HostEpoch, nameof(NetworkSiegeLadderAnimationState)))
+            {
+                if (applied == null) applied = new List<int>();
+                applied.Add(pending.Key);
+                continue;
+            }
+            if (!machinesById.TryGetValue(pending.Key, out var machine)) continue;
+
+            if (machine is SiegeLadder ladder
+                && !SiegeMissionAuthorityGate.IsMachineSimulatedLocally(pending.Key))
+            {
+                ApplyLadderAnimation(ladder, pending.Value);
+            }
+            if (applied == null) applied = new List<int>();
+            applied.Add(pending.Key);
+        }
+
+        if (applied == null) return;
+        foreach (var id in applied) pendingLadderAnimationsById.Remove(id);
+    }
+
     private static void ReadState(UsableMachine machine, out float hitPoints, out int destructionState,
         out int gateState, out int ladderState, out float moveDistance, out bool hasArrived, out int weaponState,
-        out float aimDirection, out float aimReleaseAngle, out float ladderAnimationSpeed,
-        out float ladderAnimationProgress, out int ladderAnimationState, out float ladderFallAngularSpeed,
-        out MatrixFrame ladderFrame, out int ladderAnimationIndex)
+        out float aimDirection, out float aimReleaseAngle)
     {
         hitPoints = -1f;
         destructionState = -1;
@@ -992,26 +1072,7 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
         // network message); it rides the same field as the castle gate's.
         gateState = machine is CastleGate gate ? (int)gate.State
             : machine is SiegeTower gateTower ? (int)gateTower.State : -1;
-        ladderState = -1;
-        ladderAnimationSpeed = LadderAnimationSentinel;
-        ladderAnimationProgress = LadderAnimationSentinel;
-        ladderAnimationState = -1;
-        ladderFallAngularSpeed = 0f;
-        ladderFrame = MatrixFrame.Zero;
-        ladderAnimationIndex = -1;
-        if (machine is SiegeLadder ladder)
-        {
-            ladderState = (int)ladder.State;
-            ladderAnimationState = (int)ladder._animationState;
-            ladderFallAngularSpeed = ladder._fallAngularSpeed;
-            ladderFrame = ladder._ladderObject.GameEntity.GetGlobalFrame();
-            ladderAnimationIndex = ladder._ladderSkeleton.GetAnimationIndexAtChannel(0);
-            if (ladderAnimationIndex >= 0)
-            {
-                ladderAnimationSpeed = ladder._ladderSkeleton.GetAnimationSpeedAtChannel(0);
-                ladderAnimationProgress = ladder._ladderSkeleton.GetAnimationParameterAtChannel(0);
-            }
-        }
+        ladderState = machine is SiegeLadder ladder ? (int)ladder.State : -1;
         weaponState = -1;
         aimDirection = AimSentinel;
         aimReleaseAngle = AimSentinel;
@@ -1063,11 +1124,12 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
                 {
                     // The MissionObject isn't registered yet (catch-up during scene load); buffer and re-apply
                     // from Tick once RefreshMachineCache sees it, instead of dropping it permanently.
-                    pendingByMachineId[obj.MachineId] = obj;
+                    BufferMachineState(obj);
                     return;
                 }
             }
 
+            pendingByMachineId.Remove(obj.MachineId);
             SiegeMissionAuthorityGate.SuppressCapture = true;
             try
             {
@@ -1090,6 +1152,52 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
                 ApplyWeaponAnimation(machine, obj.WeaponState);
             }
         });
+    }
+
+    private void Handle_NetworkLadderAnimationState(MessagePayload<NetworkSiegeLadderAnimationState> payload)
+    {
+        var obj = payload.What;
+
+        GameThread.RunSafe(() =>
+        {
+            if (Mission.Current == null) return;
+            if (DropStaleHostEpoch(obj.HostEpoch, nameof(NetworkSiegeLadderAnimationState))) return;
+
+            RefreshMachineCache();
+            if (!machinesById.TryGetValue(obj.LadderId, out var machine))
+            {
+                trackedObjectCount = -1;
+                RefreshMachineCache();
+                if (!machinesById.TryGetValue(obj.LadderId, out machine))
+                {
+                    BufferLadderAnimationState(obj);
+                    return;
+                }
+            }
+
+            if (pendingByMachineId.ContainsKey(obj.LadderId))
+            {
+                BufferLadderAnimationState(obj);
+                return;
+            }
+
+            pendingLadderAnimationsById.Remove(obj.LadderId);
+            if (machine is SiegeLadder ladder
+                && !SiegeMissionAuthorityGate.IsMachineSimulatedLocally(obj.LadderId))
+            {
+                ApplyLadderAnimation(ladder, obj);
+            }
+        });
+    }
+
+    private void BufferMachineState(NetworkSiegeMachineState state)
+    {
+        pendingByMachineId[state.MachineId] = state;
+    }
+
+    private void BufferLadderAnimationState(NetworkSiegeLadderAnimationState state)
+    {
+        pendingLadderAnimationsById[state.LadderId] = state;
     }
 
     private static void Apply(UsableMachine machine, NetworkSiegeMachineState state)
@@ -1161,27 +1269,6 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
                 }
                 ladder.State = targetState;
             }
-
-            if (state.LadderAnimationState >= 0)
-            {
-                ladder._animationState = (SiegeLadder.LadderAnimationState)state.LadderAnimationState;
-                ladder._fallAngularSpeed = state.LadderFallAngularSpeed;
-                ladder._lastDotProductOfAnimationAndTargetRotation = -1000f;
-
-                var ladderFrame = state.LadderFrame;
-                ladderFrame.rotation.Orthonormalize();
-                ladder._ladderObject.GameEntity.SetGlobalFrame(ladderFrame);
-
-                if (state.LadderAnimationIndex >= 0)
-                {
-                    ladder._ladderSkeleton.SetAnimationAtChannel(state.LadderAnimationIndex, 0);
-                    ladder._ladderSkeleton.SetAnimationSpeedAtChannel(0, state.LadderAnimationSpeed);
-                    ladder._ladderSkeleton.SetAnimationParameterAtChannel(
-                        0,
-                        MBMath.ClampFloat(state.LadderAnimationProgress, 0f, 1f));
-                    ladder._ladderSkeleton.ForceUpdateBoneFrames();
-                }
-            }
         }
 
         if (state.HitPoints >= 0f && machine.DestructionComponent != null)
@@ -1198,6 +1285,26 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
                 destruction.SetDestructionLevel(state.DestructionState, -1, 0f, TaleWorlds.Library.Vec3.Zero, TaleWorlds.Library.Vec3.Zero);
             }
         }
+    }
+
+    private static void ApplyLadderAnimation(SiegeLadder ladder, NetworkSiegeLadderAnimationState state)
+    {
+        ladder._animationState = (SiegeLadder.LadderAnimationState)state.AnimationState;
+        ladder._fallAngularSpeed = state.FallAngularSpeed;
+        ladder._lastDotProductOfAnimationAndTargetRotation = -1000f;
+
+        var ladderFrame = state.Frame;
+        ladderFrame.rotation.Orthonormalize();
+        ladder._ladderObject.GameEntity.SetGlobalFrame(ladderFrame);
+
+        if (state.AnimationIndex < 0) return;
+
+        ladder._ladderSkeleton.SetAnimationAtChannel(state.AnimationIndex, 0);
+        ladder._ladderSkeleton.SetAnimationSpeedAtChannel(0, state.AnimationSpeed);
+        ladder._ladderSkeleton.SetAnimationParameterAtChannel(
+            0,
+            MBMath.ClampFloat(state.AnimationProgress, 0f, 1f));
+        ladder._ladderSkeleton.ForceUpdateBoneFrames();
     }
 
     internal static IEnumerable<SiegeLadder.LadderState> GetLadderTransitionStates(
@@ -1361,9 +1468,25 @@ public class SiegeMachineStateReplicator : ISiegeMachineStateReplicator
                 (machineId, simulatedLocally) => CaptureState(machinesById[machineId], isHost, simulatedLocally),
                 state => network.Send(controllerId, Stamp(state)));
 
+            int ladderAnimationsSent = 0;
+            foreach (var machine in machines)
+            {
+                if (!(machine is SiegeLadder ladder)
+                    || !SiegeMissionAuthorityGate.IsMachineSimulatedLocally(machine.Id.Id))
+                {
+                    continue;
+                }
+
+                network.Send(controllerId, Stamp(CaptureLadderAnimationState(ladder)));
+                ladderAnimationsSent++;
+            }
+
             if (sent > 0)
                 Logger.Information("[BattleSync] Replayed {Count} siege machine state(s) to joining {Controller} as {Role}",
                     sent, controllerId, isHost ? "host" : "claimant");
+            if (ladderAnimationsSent > 0)
+                Logger.Information("[BattleSync] Replayed {Count} siege ladder animation state(s) to joining {Controller}",
+                    ladderAnimationsSent, controllerId);
         });
     }
 

--- a/source/Missions/Messages/NetworkSiegeLadderAnimationState.cs
+++ b/source/Missions/Messages/NetworkSiegeLadderAnimationState.cs
@@ -1,0 +1,52 @@
+﻿using Common.Messaging;
+using ProtoBuf;
+using TaleWorlds.Library;
+
+namespace Missions.Messages;
+
+/// <summary>
+/// Mission host → peers (over the mesh): one siege ladder's continuous animation snapshot.
+/// Discrete ladder gameplay state remains part of <see cref="NetworkSiegeMachineState"/>.
+/// </summary>
+[ProtoContract(SkipConstructor = true)]
+public class NetworkSiegeLadderAnimationState : IEvent
+{
+    [ProtoMember(1)]
+    public readonly int LadderId;
+    [ProtoMember(2)]
+    public readonly float AnimationSpeed;
+    [ProtoMember(3)]
+    public readonly float AnimationProgress;
+    /// <summary>SiegeLadder.LadderAnimationState.</summary>
+    [ProtoMember(4)]
+    public readonly int AnimationState;
+    [ProtoMember(5)]
+    public readonly float FallAngularSpeed;
+    [ProtoMember(6)]
+    public readonly MatrixFrame Frame;
+    /// <summary>Authority ladder skeleton channel animation index; -1 when no animation is active.</summary>
+    [ProtoMember(7)]
+    public readonly int AnimationIndex;
+    [ProtoMember(8)]
+    public readonly int HostEpoch;
+
+    public NetworkSiegeLadderAnimationState(
+        int ladderId,
+        float animationSpeed,
+        float animationProgress,
+        int animationState,
+        float fallAngularSpeed,
+        MatrixFrame frame,
+        int animationIndex,
+        int hostEpoch = 0)
+    {
+        LadderId = ladderId;
+        AnimationSpeed = animationSpeed;
+        AnimationProgress = animationProgress;
+        AnimationState = animationState;
+        FallAngularSpeed = fallAngularSpeed;
+        Frame = frame;
+        AnimationIndex = animationIndex;
+        HostEpoch = hostEpoch;
+    }
+}

--- a/source/Missions/Messages/NetworkSiegeMachineState.cs
+++ b/source/Missions/Messages/NetworkSiegeMachineState.cs
@@ -1,5 +1,6 @@
 ﻿using Common.Messaging;
 using ProtoBuf;
+using TaleWorlds.Library;
 
 namespace Missions.Messages;
 
@@ -47,8 +48,41 @@ public class NetworkSiegeMachineState : IEvent
     /// </summary>
     [ProtoMember(11)]
     public readonly int HostEpoch;
+    /// <summary>Authority ladder skeleton channel speed; -1 for non-ladders.</summary>
+    [ProtoMember(12)]
+    public readonly float LadderAnimationSpeed;
+    /// <summary>Authority ladder skeleton channel progress; -1 for non-ladders.</summary>
+    [ProtoMember(13)]
+    public readonly float LadderAnimationProgress;
+    /// <summary>SiegeLadder.LadderAnimationState; -1 for non-ladders.</summary>
+    [ProtoMember(14)]
+    public readonly int LadderAnimationState;
+    [ProtoMember(15)]
+    public readonly float LadderFallAngularSpeed;
+    [ProtoMember(16)]
+    public readonly MatrixFrame LadderFrame;
+    /// <summary>Authority ladder skeleton channel animation index; -1 when no channel animation is active.</summary>
+    [ProtoMember(17)]
+    public readonly int LadderAnimationIndex;
 
-    public NetworkSiegeMachineState(int machineId, float hitPoints, int destructionState, int gateState, int ladderState, float moveDistance, bool hasArrived, int weaponState, float aimDirection, float aimReleaseAngle, int hostEpoch = 0)
+    public NetworkSiegeMachineState(
+        int machineId,
+        float hitPoints,
+        int destructionState,
+        int gateState,
+        int ladderState,
+        float moveDistance,
+        bool hasArrived,
+        int weaponState,
+        float aimDirection,
+        float aimReleaseAngle,
+        int hostEpoch = 0,
+        float ladderAnimationSpeed = -1f,
+        float ladderAnimationProgress = -1f,
+        int ladderAnimationState = -1,
+        float ladderFallAngularSpeed = 0f,
+        MatrixFrame ladderFrame = default,
+        int ladderAnimationIndex = -1)
     {
         MachineId = machineId;
         HitPoints = hitPoints;
@@ -61,5 +95,11 @@ public class NetworkSiegeMachineState : IEvent
         AimDirection = aimDirection;
         AimReleaseAngle = aimReleaseAngle;
         HostEpoch = hostEpoch;
+        LadderAnimationSpeed = ladderAnimationSpeed;
+        LadderAnimationProgress = ladderAnimationProgress;
+        LadderAnimationState = ladderAnimationState;
+        LadderFallAngularSpeed = ladderFallAngularSpeed;
+        LadderFrame = ladderFrame;
+        LadderAnimationIndex = ladderAnimationIndex;
     }
 }

--- a/source/Missions/Messages/NetworkSiegeMachineState.cs
+++ b/source/Missions/Messages/NetworkSiegeMachineState.cs
@@ -1,6 +1,5 @@
 ﻿using Common.Messaging;
 using ProtoBuf;
-using TaleWorlds.Library;
 
 namespace Missions.Messages;
 
@@ -48,23 +47,6 @@ public class NetworkSiegeMachineState : IEvent
     /// </summary>
     [ProtoMember(11)]
     public readonly int HostEpoch;
-    /// <summary>Authority ladder skeleton channel speed; -1 for non-ladders.</summary>
-    [ProtoMember(12)]
-    public readonly float LadderAnimationSpeed;
-    /// <summary>Authority ladder skeleton channel progress; -1 for non-ladders.</summary>
-    [ProtoMember(13)]
-    public readonly float LadderAnimationProgress;
-    /// <summary>SiegeLadder.LadderAnimationState; -1 for non-ladders.</summary>
-    [ProtoMember(14)]
-    public readonly int LadderAnimationState;
-    [ProtoMember(15)]
-    public readonly float LadderFallAngularSpeed;
-    [ProtoMember(16)]
-    public readonly MatrixFrame LadderFrame;
-    /// <summary>Authority ladder skeleton channel animation index; -1 when no channel animation is active.</summary>
-    [ProtoMember(17)]
-    public readonly int LadderAnimationIndex;
-
     public NetworkSiegeMachineState(
         int machineId,
         float hitPoints,
@@ -76,13 +58,7 @@ public class NetworkSiegeMachineState : IEvent
         int weaponState,
         float aimDirection,
         float aimReleaseAngle,
-        int hostEpoch = 0,
-        float ladderAnimationSpeed = -1f,
-        float ladderAnimationProgress = -1f,
-        int ladderAnimationState = -1,
-        float ladderFallAngularSpeed = 0f,
-        MatrixFrame ladderFrame = default,
-        int ladderAnimationIndex = -1)
+        int hostEpoch = 0)
     {
         MachineId = machineId;
         HitPoints = hitPoints;
@@ -95,11 +71,5 @@ public class NetworkSiegeMachineState : IEvent
         AimDirection = aimDirection;
         AimReleaseAngle = aimReleaseAngle;
         HostEpoch = hostEpoch;
-        LadderAnimationSpeed = ladderAnimationSpeed;
-        LadderAnimationProgress = ladderAnimationProgress;
-        LadderAnimationState = ladderAnimationState;
-        LadderFallAngularSpeed = ladderFallAngularSpeed;
-        LadderFrame = ladderFrame;
-        LadderAnimationIndex = ladderAnimationIndex;
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Siege ladders can enter different states on different players' screens, so one player may see a ladder raised while another sees it down and unusable.

## What is the new behavior?

Resolves #2365

Siege ladders now stay synchronized through raising, push-back, and their final positions, so every player sees the same ladder state and can continue using them.

## Bot Changelog Entry

- Fixed siege ladders desynchronizing between players.
