### PR TITLE
Make inventory locks and sort preferences persist across sessions

### DIFF
--- a/source/Coop.Core/Client/Messages/NetworkGameSaveDataReceived.cs
+++ b/source/Coop.Core/Client/Messages/NetworkGameSaveDataReceived.cs
@@ -4,6 +4,7 @@ using Common.Messaging;
 using GameInterface.Services.Alleys;
 using GameInterface.Services.CampaignService.Data;
 using GameInterface.Services.Caravans;
+using GameInterface.Services.Inventory;
 using GameInterface.Services.Inventory.TradeSkills;
 using GameInterface.Services.MobileParties;
 using GameInterface.Services.ObjectManager;
@@ -36,8 +37,10 @@ public record NetworkGameSaveDataReceived : IEvent
     [ProtoMember(8)]
     public TradePlayerData TradePlayerData { get; }
     [ProtoMember(9)]
-    public AttachmentIdMap AttachmentIdMap { get; }
+    public InventoryPlayerData InventoryPlayerData { get; }
     [ProtoMember(10)]
+    public AttachmentIdMap AttachmentIdMap { get; }
+    [ProtoMember(11)]
     public ServerOptions ServerOptions { get; }
 
     public NetworkGameSaveDataReceived(
@@ -49,6 +52,7 @@ public record NetworkGameSaveDataReceived : IEvent
         AlleyPlayerData alleyPlayerData,
         InteractionsPlayerData interactionsPlayerData,
         TradePlayerData tradePlayerData,
+        InventoryPlayerData inventoryPlayerData,
         AttachmentIdMap attachmentIdMap,
         ServerOptions serverOptions)
     {
@@ -60,6 +64,7 @@ public record NetworkGameSaveDataReceived : IEvent
         AlleyPlayerData = alleyPlayerData;
         InteractionsPlayerData = interactionsPlayerData;
         TradePlayerData = tradePlayerData;
+        InventoryPlayerData = inventoryPlayerData;
         AttachmentIdMap = attachmentIdMap;
         ServerOptions = serverOptions;
     }

--- a/source/Coop.Core/Client/Services/Save/Handler/SaveDataHandler.cs
+++ b/source/Coop.Core/Client/Services/Save/Handler/SaveDataHandler.cs
@@ -3,6 +3,7 @@ using Coop.Core.Client.Messages;
 using GameInterface.Services.Alleys.Messages;
 using GameInterface.Services.CampaignService.Messages;
 using GameInterface.Services.Caravans.Messages;
+using GameInterface.Services.Inventory.Messages;
 using GameInterface.Services.Inventory.TradeSkills.Messages;
 using GameInterface.Services.MobileParties.Messages;
 using GameInterface.Services.ObjectManager.Messages;
@@ -47,6 +48,7 @@ internal class SaveDataHandler : IHandler
         messageBroker.Publish(this, new InitializeClientAlleyData(saveDataMessage.AlleyPlayerData));
         messageBroker.Publish(this, new InitializeClientInteractionsData(saveDataMessage.InteractionsPlayerData));
         messageBroker.Publish(this, new InitializeClientTradeData(saveDataMessage.TradePlayerData));
+        messageBroker.Publish(this, new InitializeClientInventoryData(saveDataMessage.InventoryPlayerData));
         messageBroker.Publish(this, new InitializeClientAttachmentIdMap(saveDataMessage.AttachmentIdMap));
         // Add any other CoopSession data initialisations for clients here
     }

--- a/source/Coop.Core/Client/Services/Save/PacketHandlers/GameSaveDataPacketHandler.cs
+++ b/source/Coop.Core/Client/Services/Save/PacketHandlers/GameSaveDataPacketHandler.cs
@@ -6,6 +6,7 @@ using Coop.Core.Common.Network.Packets;
 using GameInterface.Services.Alleys;
 using GameInterface.Services.CampaignService.Data;
 using GameInterface.Services.Caravans;
+using GameInterface.Services.Inventory;
 using GameInterface.Services.Inventory.TradeSkills;
 using GameInterface.Services.MobileParties;
 using GameInterface.Services.ObjectManager;
@@ -109,6 +110,7 @@ internal class GameSaveDataPacketHandler : IPacketHandler
             completedTransfer.AlleyPlayerData,
             completedTransfer.InteractionsPlayerData,
             completedTransfer.TradePlayerData,
+            completedTransfer.InventoryPlayerData,
             completedTransfer.AttachmentIdMap,
             completedTransfer.ServerOptions));
     }
@@ -130,6 +132,7 @@ internal class GameSaveDataPacketHandler : IPacketHandler
             AlleyPlayerData = firstChunk.AlleyPlayerData;
             InteractionsPlayerData = firstChunk.InteractionsPlayerData;
             TradePlayerData = firstChunk.TradePlayerData;
+            InventoryPlayerData = firstChunk.InventoryPlayerData;
             AttachmentIdMap = firstChunk.AttachmentIdMap;
             ServerOptions = firstChunk.ServerOptions;
         }
@@ -144,6 +147,7 @@ internal class GameSaveDataPacketHandler : IPacketHandler
         public AlleyPlayerData AlleyPlayerData { get; }
         public InteractionsPlayerData InteractionsPlayerData { get; }
         public TradePlayerData TradePlayerData { get; }
+        public InventoryPlayerData InventoryPlayerData { get; }
         public AttachmentIdMap AttachmentIdMap { get; }
         public ServerOptions ServerOptions { get; }
 

--- a/source/Coop.Core/Common/Network/Packets/GameSaveDataChunkPacket.cs
+++ b/source/Coop.Core/Common/Network/Packets/GameSaveDataChunkPacket.cs
@@ -2,6 +2,7 @@
 using GameInterface.Services.Alleys;
 using GameInterface.Services.CampaignService.Data;
 using GameInterface.Services.Caravans;
+using GameInterface.Services.Inventory;
 using GameInterface.Services.Inventory.TradeSkills;
 using GameInterface.Services.MobileParties;
 using GameInterface.Services.ObjectManager;
@@ -64,9 +65,12 @@ public readonly struct GameSaveDataChunkPacket : IPacket
     public readonly TradePlayerData TradePlayerData;
 
     [ProtoMember(14)]
-    public readonly AttachmentIdMap AttachmentIdMap;
+    public readonly InventoryPlayerData InventoryPlayerData;
 
     [ProtoMember(15)]
+    public readonly AttachmentIdMap AttachmentIdMap;
+
+    [ProtoMember(16)]
     public readonly ServerOptions ServerOptions;
 
     public GameSaveDataChunkPacket(
@@ -83,6 +87,7 @@ public readonly struct GameSaveDataChunkPacket : IPacket
         AlleyPlayerData alleyPlayerData,
         InteractionsPlayerData interactionsPlayerData,
         TradePlayerData tradePlayerData,
+        InventoryPlayerData inventoryPlayerData,
         AttachmentIdMap attachmentIdMap,
         ServerOptions serverOptions)
     {
@@ -99,6 +104,7 @@ public readonly struct GameSaveDataChunkPacket : IPacket
         AlleyPlayerData = alleyPlayerData;
         InteractionsPlayerData = interactionsPlayerData;
         TradePlayerData = tradePlayerData;
+        InventoryPlayerData = inventoryPlayerData;
         AttachmentIdMap = attachmentIdMap;
         ServerOptions = serverOptions;
     }

--- a/source/Coop.Core/Common/Network/Packets/GameSaveDataPacket.cs
+++ b/source/Coop.Core/Common/Network/Packets/GameSaveDataPacket.cs
@@ -2,6 +2,7 @@
 using GameInterface.Services.Alleys;
 using GameInterface.Services.CampaignService.Data;
 using GameInterface.Services.Caravans;
+using GameInterface.Services.Inventory;
 using GameInterface.Services.Inventory.TradeSkills;
 using GameInterface.Services.MobileParties;
 using GameInterface.Services.ObjectManager;
@@ -57,9 +58,12 @@ public readonly struct GameSaveDataPacket : IPacket
     public readonly TradePlayerData TradePlayerData;
 
     [ProtoMember(9)]
-    public readonly AttachmentIdMap AttachmentIdMap;
+    public readonly InventoryPlayerData InventoryPlayerData;
 
     [ProtoMember(10)]
+    public readonly AttachmentIdMap AttachmentIdMap;
+
+    [ProtoMember(11)]
     public readonly ServerOptions ServerOptions;
 
     public GameSaveDataPacket(
@@ -71,6 +75,7 @@ public readonly struct GameSaveDataPacket : IPacket
         AlleyPlayerData alleyPlayerData,
         InteractionsPlayerData interactionsPlayerData,
         TradePlayerData tradePlayerData,
+        InventoryPlayerData inventoryPlayerData,
         AttachmentIdMap attachmentIdMap,
         ServerOptions serverOptions)
     {
@@ -82,6 +87,7 @@ public readonly struct GameSaveDataPacket : IPacket
         AlleyPlayerData = alleyPlayerData;
         InteractionsPlayerData = interactionsPlayerData;
         TradePlayerData = tradePlayerData;
+        InventoryPlayerData = inventoryPlayerData;
         AttachmentIdMap = attachmentIdMap;
         ServerOptions = serverOptions;
     }

--- a/source/Coop.Core/Server/Connections/States/TransferSaveState.cs
+++ b/source/Coop.Core/Server/Connections/States/TransferSaveState.cs
@@ -72,6 +72,7 @@ public class TransferSaveState : ConnectionStateBase
                 Clone(coopSessionProvider.CoopSession?.AlleyPlayerData),
                 Clone(coopSessionProvider.CoopSession?.InteractionsPlayerData),
                 Clone(coopSessionProvider.CoopSession?.TradePlayerData),
+                Clone(coopSessionProvider.CoopSession?.InventoryPlayerData),
                 attachmentIdMapper.BuildServerMap(),
                 serverOptionsProvider.GetServerOptions());
 
@@ -127,6 +128,7 @@ public class TransferSaveState : ConnectionStateBase
                 chunkIndex == 0 ? snapshot.AlleyPlayerData : null,
                 chunkIndex == 0 ? snapshot.InteractionsPlayerData : null,
                 chunkIndex == 0 ? snapshot.TradePlayerData : null,
+                chunkIndex == 0 ? snapshot.InventoryPlayerData : null,
                 chunkIndex == 0 ? snapshot.AttachmentIdMap : null,
                 chunkIndex == 0 ? snapshot.ServerOptions : null);
 

--- a/source/Coop.Core/Server/Services/Save/Handlers/SaveGameHandler.cs
+++ b/source/Coop.Core/Server/Services/Save/Handlers/SaveGameHandler.cs
@@ -57,7 +57,8 @@ internal class SaveGameHandler : IHandler
             current?.CaravansPlayerData ?? empty.CaravansPlayerData,
             current?.AlleyPlayerData ?? empty.AlleyPlayerData,
             current?.InteractionsPlayerData ?? empty.InteractionsPlayerData,
-            current?.TradePlayerData ?? empty.TradePlayerData);
+            current?.TradePlayerData ?? empty.TradePlayerData,
+            current?.InventoryPlayerData ?? empty.InventoryPlayerData);
 
         coopSessionProvider.CoopSession = session;
 
@@ -78,7 +79,8 @@ internal class SaveGameHandler : IHandler
             loaded?.CaravansPlayerData ?? empty.CaravansPlayerData,
             loaded?.AlleyPlayerData ?? empty.AlleyPlayerData,
             loaded?.InteractionsPlayerData ?? empty.InteractionsPlayerData,
-            loaded?.TradePlayerData ?? empty.TradePlayerData);
+            loaded?.TradePlayerData ?? empty.TradePlayerData,
+            loaded?.InventoryPlayerData ?? empty.InventoryPlayerData);
 
         coopSessionProvider.CoopSession = savedSession;
     }

--- a/source/Coop.Tests/Client/States/ReceivingSavedDataStateTests.cs
+++ b/source/Coop.Tests/Client/States/ReceivingSavedDataStateTests.cs
@@ -17,6 +17,7 @@ using Xunit;
 using Xunit.Abstractions;
 using GameInterface.Services.Inventory.TradeSkills;
 using GameInterface.Services.CampaignService.Data;
+using GameInterface.Services.Inventory;
 
 namespace Coop.Tests.Client.States
 {
@@ -38,7 +39,18 @@ namespace Coop.Tests.Client.States
         }
 
         private static NetworkGameSaveDataReceived SaveData(byte[] data, string campaignId) =>
-            new NetworkGameSaveDataReceived(data, campaignId, new CraftingPlayerData(new(), new(), new()), new WorkshopPlayerData(new()), new CaravansPlayerData(new(), new()), new AlleyPlayerData(new()), new InteractionsPlayerData(new(), new(), new(), new()), new TradePlayerData(new()), new AttachmentIdMap(new()), new ServerOptions(new()));
+            new NetworkGameSaveDataReceived(
+                data,
+                campaignId,
+                new CraftingPlayerData(new(), new(), new()),
+                new WorkshopPlayerData(new()),
+                new CaravansPlayerData(new(), new()),
+                new AlleyPlayerData(new()),
+                new InteractionsPlayerData(new(), new(), new(), new()),
+                new TradePlayerData(new()),
+                new InventoryPlayerData(new(), new()),
+                new AttachmentIdMap(new()),
+                new ServerOptions(new()));
 
         [Fact]
         public void StateEntered_Shows_LoadingProgressMessage()

--- a/source/Coop.Tests/Server/Services/Save/JSONSessionTests.cs
+++ b/source/Coop.Tests/Server/Services/Save/JSONSessionTests.cs
@@ -10,6 +10,7 @@ using GameInterface.Services.Alleys;
 using Xunit;
 using Xunit.Abstractions;
 using GameInterface.Services.Inventory.TradeSkills;
+using GameInterface.Services.Inventory;
 
 namespace Coop.Tests.Server.Services.Save
 {
@@ -42,7 +43,8 @@ namespace Coop.Tests.Server.Services.Save
                 new CaravansPlayerData(new(), new()),
                 new AlleyPlayerData(new()),
                 new InteractionsPlayerData(new(), new(), new(), new()),
-                new TradePlayerData(new()));
+                new TradePlayerData(new()),
+                new InventoryPlayerData(new(), new()));
 
             string saveFile = SAVE_PATH + sessionData.UniqueGameId + ".json";
 

--- a/source/Coop.Tests/Server/Services/Save/SaveLoadCoopSessionTests.cs
+++ b/source/Coop.Tests/Server/Services/Save/SaveLoadCoopSessionTests.cs
@@ -3,6 +3,7 @@ using Coop.Core.Server.Services.Save;
 using GameInterface.CoopSessionData.Save.Data;
 using GameInterface.Services.Alleys;
 using GameInterface.Services.Caravans;
+using GameInterface.Services.Inventory;
 using GameInterface.Services.Inventory.TradeSkills;
 using GameInterface.Services.MobileParties;
 using GameInterface.Services.Players.Data;
@@ -51,7 +52,8 @@ namespace Coop.Tests.Server.Services.Save
                 new CaravansPlayerData(new(), new()),
                 new AlleyPlayerData(new()),
                 new InteractionsPlayerData(new(), new(), new(), new()),
-                new TradePlayerData(new()));
+                new TradePlayerData(new()),
+                new InventoryPlayerData(new(), new()));
 
             string saveFile = sessionData.UniqueGameId;
 
@@ -92,7 +94,8 @@ namespace Coop.Tests.Server.Services.Save
                 new CaravansPlayerData(new(), new()),
                 new AlleyPlayerData(new()),
                 new InteractionsPlayerData(new(), new(), new(), new()),
-                new TradePlayerData(new()));
+                new TradePlayerData(new()),
+                new InventoryPlayerData(new(), new()));
 
             string saveFile = SAVE_PATH + sessionData.UniqueGameId;
 

--- a/source/GameInterface/CoopSessionData/Save/Data/CoopSession.cs
+++ b/source/GameInterface/CoopSessionData/Save/Data/CoopSession.cs
@@ -1,5 +1,6 @@
 ﻿using GameInterface.Services.Alleys;
 using GameInterface.Services.Caravans;
+using GameInterface.Services.Inventory;
 using GameInterface.Services.Inventory.TradeSkills;
 using GameInterface.Services.MobileParties;
 using GameInterface.Services.Players.Data;
@@ -24,6 +25,7 @@ public interface ICoopSession
     AlleyPlayerData AlleyPlayerData { get; }
     InteractionsPlayerData InteractionsPlayerData { get; }
     TradePlayerData TradePlayerData { get; }
+    InventoryPlayerData InventoryPlayerData { get; }
 }
 
 /// <inheritdoc cref="ICoopSession"/>
@@ -41,7 +43,8 @@ public class CoopSession : ICoopSession
         new CaravansPlayerData(new(), new()),
         new AlleyPlayerData(new()),
         new InteractionsPlayerData(new(), new(), new(), new()),
-        new TradePlayerData(new()));
+        new TradePlayerData(new()),
+        new InventoryPlayerData(new(), new()));
 
     [ProtoMember(1)]
     public string UniqueGameId { get; }
@@ -59,6 +62,8 @@ public class CoopSession : ICoopSession
     public InteractionsPlayerData InteractionsPlayerData { get; }
     [ProtoMember(8)]
     public TradePlayerData TradePlayerData { get; }
+    [ProtoMember(9)]
+    public InventoryPlayerData InventoryPlayerData { get; }
 
     public CoopSession(
         string uniqueGameId,
@@ -68,7 +73,8 @@ public class CoopSession : ICoopSession
         CaravansPlayerData caravansPlayerData,
         AlleyPlayerData alleyPlayerData,
         InteractionsPlayerData interactionsPlayerData,
-        TradePlayerData tradePlayerData)
+        TradePlayerData tradePlayerData,
+        InventoryPlayerData inventoryPlayerData)
     {
         UniqueGameId = uniqueGameId;
         Players = players;
@@ -78,5 +84,6 @@ public class CoopSession : ICoopSession
         AlleyPlayerData = alleyPlayerData;
         InteractionsPlayerData = interactionsPlayerData;
         TradePlayerData = tradePlayerData;
+        InventoryPlayerData = inventoryPlayerData;
     }
 }

--- a/source/GameInterface/Services/Inventory/Handlers/InventoryDataInitializationHandler.cs
+++ b/source/GameInterface/Services/Inventory/Handlers/InventoryDataInitializationHandler.cs
@@ -1,0 +1,92 @@
+﻿using Common.Logging;
+using Common.Messaging;
+using Common.Network;
+using GameInterface.Services.Heroes.Messages;
+using GameInterface.Services.Inventory.Interfaces;
+using GameInterface.Services.Inventory.Messages;
+using GameInterface.Services.ObjectManager;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.CampaignBehaviors;
+
+namespace GameInterface.Services.Inventory.Handlers;
+
+internal class InventoryDataInitializationHandler : IHandler
+{
+    private static readonly ILogger Logger = LogManager.GetLogger<InventoryDataInitializationHandler>();
+
+    private readonly IMessageBroker messageBroker;
+    private readonly IObjectManager objectManager;
+    private readonly INetwork network;
+    private readonly ISessionInventoryPlayerDataInterface sessionInventoryPlayerDataInterface;
+
+    private InventoryPlayerData inventoryPlayerData;
+
+    public InventoryDataInitializationHandler(
+        IMessageBroker messageBroker,
+        IObjectManager objectManager,
+        INetwork network,
+        ISessionInventoryPlayerDataInterface sessionInventoryPlayerDataInterface)
+    {
+        this.messageBroker = messageBroker;
+        this.objectManager = objectManager;
+        this.network = network;
+        this.sessionInventoryPlayerDataInterface = sessionInventoryPlayerDataInterface;
+
+        messageBroker.Subscribe<InitializeClientInventoryData>(Handle);
+        messageBroker.Subscribe<PlayerHeroChanged>(Handle);
+        messageBroker.Subscribe<NetworkInitializeServerInventoryDataKeys>(Handle);
+    }
+
+    public void Dispose()
+    {
+        messageBroker.Unsubscribe<InitializeClientInventoryData>(Handle);
+        messageBroker.Unsubscribe<PlayerHeroChanged>(Handle);
+        messageBroker.Unsubscribe<NetworkInitializeServerInventoryDataKeys>(Handle);
+    }
+
+    private void Handle(MessagePayload<InitializeClientInventoryData> obj)
+    {
+        inventoryPlayerData = obj.What.InventoryPlayerData;
+    }
+
+    // Need to load interactions data when the hero changes for the player
+    private void Handle(MessagePayload<PlayerHeroChanged> obj)
+    {
+        if (!objectManager.TryGetIdWithLogging(obj.What.NewHero, out string playerHeroId)) return;
+
+        ViewDataTrackerCampaignBehavior viewDataTrackerCampaignBehavior = Campaign.Current.GetCampaignBehavior<ViewDataTrackerCampaignBehavior>();
+
+        viewDataTrackerCampaignBehavior._inventoryItemLocks = GetInventoryItemLocks(playerHeroId);
+        viewDataTrackerCampaignBehavior._inventorySortPreferences = GetInventorySortPreferences(playerHeroId);
+
+        network.SendAll(new NetworkInitializeServerInventoryDataKeys(playerHeroId));
+    }
+
+    private void Handle(MessagePayload<NetworkInitializeServerInventoryDataKeys> obj)
+    {
+        sessionInventoryPlayerDataInterface.AddPlayerKeys(obj.What.PlayerHeroId);
+    }
+
+    private List<string> GetInventoryItemLocks(string playerHeroId)
+    {
+        var inventoryItemLocks = new List<string>();
+
+        // Null and key check for players without existing inventory data
+        if (inventoryPlayerData?.PlayerInventoryLocks?.ContainsKey(playerHeroId) != true) return inventoryItemLocks;
+
+        return inventoryPlayerData.PlayerInventoryLocks[playerHeroId];
+    }
+
+    private Dictionary<int, Tuple<int, int>> GetInventorySortPreferences(string playerHeroId)
+    {
+        var inventorySortPreferences = new Dictionary<int, Tuple<int, int>>();
+
+        // Null and key check for players without existing inventory data
+        if (inventoryPlayerData?.PlayerInventorySortPreferences?.ContainsKey(playerHeroId) != true) return inventorySortPreferences;
+
+        return inventoryPlayerData.PlayerInventorySortPreferences[playerHeroId];
+    }
+}

--- a/source/GameInterface/Services/Inventory/Handlers/InventoryDataInitializationHandler.cs
+++ b/source/GameInterface/Services/Inventory/Handlers/InventoryDataInitializationHandler.cs
@@ -52,7 +52,7 @@ internal class InventoryDataInitializationHandler : IHandler
         inventoryPlayerData = obj.What.InventoryPlayerData;
     }
 
-    // Need to load interactions data when the hero changes for the player
+    // Need to load inventory data when the hero changes for the player
     private void Handle(MessagePayload<PlayerHeroChanged> obj)
     {
         if (!objectManager.TryGetIdWithLogging(obj.What.NewHero, out string playerHeroId)) return;

--- a/source/GameInterface/Services/Inventory/Handlers/InventoryDataInitializationHandler.cs
+++ b/source/GameInterface/Services/Inventory/Handlers/InventoryDataInitializationHandler.cs
@@ -1,4 +1,5 @@
-﻿using Common.Logging;
+﻿using Common;
+using Common.Logging;
 using Common.Messaging;
 using Common.Network;
 using GameInterface.Services.Heroes.Messages;
@@ -67,7 +68,10 @@ internal class InventoryDataInitializationHandler : IHandler
 
     private void Handle(MessagePayload<NetworkInitializeServerInventoryDataKeys> obj)
     {
-        sessionInventoryPlayerDataInterface.AddPlayerKeys(obj.What.PlayerHeroId);
+        GameThread.RunSafe(() =>
+        {
+            sessionInventoryPlayerDataInterface.AddPlayerKeys(obj.What.PlayerHeroId);
+        });
     }
 
     private List<string> GetInventoryItemLocks(string playerHeroId)

--- a/source/GameInterface/Services/Inventory/Handlers/InventoryStatesHandler.cs
+++ b/source/GameInterface/Services/Inventory/Handlers/InventoryStatesHandler.cs
@@ -1,0 +1,83 @@
+﻿using Common;
+using Common.Logging;
+using Common.Messaging;
+using Common.Network;
+using GameInterface.Services.Inventory.Interfaces;
+using GameInterface.Services.Inventory.Messages;
+using GameInterface.Services.ObjectManager;
+using Serilog;
+
+namespace GameInterface.Services.Inventory.Handlers;
+
+internal class InventoryStatesHandler : IHandler
+{
+    private static readonly ILogger Logger = LogManager.GetLogger<InventoryStatesHandler>();
+
+    private readonly IMessageBroker messageBroker;
+    private readonly IObjectManager objectManager;
+    private readonly INetwork network;
+    private readonly ISessionInventoryPlayerDataInterface sessionInventoryPlayerDataInterface;
+
+    public InventoryStatesHandler(
+        IMessageBroker messageBroker,
+        IObjectManager objectManager,
+        INetwork network,
+        ISessionInventoryPlayerDataInterface sessionInventoryPlayerDataInterface)
+    {
+        this.messageBroker = messageBroker;
+        this.objectManager = objectManager;
+        this.network = network;
+        this.sessionInventoryPlayerDataInterface = sessionInventoryPlayerDataInterface;
+
+        messageBroker.Subscribe<SaveItemLockStates>(Handle_SaveItemLockStates);
+        messageBroker.Subscribe<NetworkSaveItemLockStates>(Handle_NetworkSaveItemLockStates);
+
+        messageBroker.Subscribe<SaveItemSortStates>(Handle_SaveItemSortStates);
+        messageBroker.Subscribe<NetworkSaveItemSortStates>(Handle_NetworkSaveItemSortStates);
+    }
+
+    public void Dispose()
+    {
+        messageBroker.Unsubscribe<SaveItemLockStates>(Handle_SaveItemLockStates);
+        messageBroker.Unsubscribe<NetworkSaveItemLockStates>(Handle_NetworkSaveItemLockStates);
+
+        messageBroker.Unsubscribe<SaveItemSortStates>(Handle_SaveItemSortStates);
+        messageBroker.Unsubscribe<NetworkSaveItemSortStates>(Handle_NetworkSaveItemSortStates);
+    }
+
+    private void Handle_SaveItemLockStates(MessagePayload<SaveItemLockStates> obj)
+    {
+        GameThread.RunSafe(() =>
+        {
+            if (!objectManager.TryGetIdWithLogging(obj.What.MainHero, out var mainHeroId)) return;
+
+            network.SendAll(new NetworkSaveItemLockStates(mainHeroId, obj.What.ItemLockIds));
+        });
+    }
+
+    private void Handle_NetworkSaveItemLockStates(MessagePayload<NetworkSaveItemLockStates> obj)
+    {
+        GameThread.RunSafe(() =>
+        {
+            sessionInventoryPlayerDataInterface.SetInventoryLocks(obj.What.MainHeroId, obj.What.ItemLockIds);
+        });
+    }
+
+    private void Handle_SaveItemSortStates(MessagePayload<SaveItemSortStates> obj)
+    {
+        GameThread.RunSafe(() =>
+        {
+            if (!objectManager.TryGetIdWithLogging(obj.What.MainHero, out var mainHeroId)) return;
+
+            network.SendAll(new NetworkSaveItemSortStates(mainHeroId, obj.What.UsageType, obj.What.SortPreference));
+        });
+    }
+
+    private void Handle_NetworkSaveItemSortStates(MessagePayload<NetworkSaveItemSortStates> obj)
+    {
+        GameThread.RunSafe(() =>
+        {
+            sessionInventoryPlayerDataInterface.SetSortPreference(obj.What.MainHeroId, obj.What.UsageType, obj.What.SortPreference);
+        });
+    }
+}

--- a/source/GameInterface/Services/Inventory/Interfaces/SessionInventoryPlayerDataInterface.cs
+++ b/source/GameInterface/Services/Inventory/Interfaces/SessionInventoryPlayerDataInterface.cs
@@ -18,14 +18,12 @@ public class SessionInventoryPlayerDataInterface : ISessionInventoryPlayerDataIn
 {
     private static readonly ILogger Logger = LogManager.GetLogger<SessionInventoryPlayerDataInterface>();
     private readonly ICoopSessionProvider coopSessionProvider;
-    private readonly IObjectManager objectManager;
 
     private InventoryPlayerData InventoryPlayerData => coopSessionProvider.CoopSession.InventoryPlayerData;
 
-    public SessionInventoryPlayerDataInterface(ICoopSessionProvider coopSessionProvider, IObjectManager objectManager)
+    public SessionInventoryPlayerDataInterface(ICoopSessionProvider coopSessionProvider)
     {
         this.coopSessionProvider = coopSessionProvider;
-        this.objectManager = objectManager;
     }
 
     public void SetInventoryLocks(string playerHeroId, IEnumerable<string> lockedItemIds)

--- a/source/GameInterface/Services/Inventory/Interfaces/SessionInventoryPlayerDataInterface.cs
+++ b/source/GameInterface/Services/Inventory/Interfaces/SessionInventoryPlayerDataInterface.cs
@@ -1,0 +1,62 @@
+﻿using Common.Logging;
+using GameInterface.CoopSessionData;
+using GameInterface.Services.ObjectManager;
+using Serilog;
+using System;
+using System.Collections.Generic;
+
+namespace GameInterface.Services.Inventory.Interfaces;
+
+public interface ISessionInventoryPlayerDataInterface : IGameAbstraction
+{
+    void SetInventoryLocks(string playerHeroId, IEnumerable<string> lockedItemIds);
+    void SetSortPreference(string playerHeroId, int usageType, Tuple<int, int> preference);
+    void AddPlayerKeys(string playerHeroId);
+}
+
+public class SessionInventoryPlayerDataInterface : ISessionInventoryPlayerDataInterface
+{
+    private static readonly ILogger Logger = LogManager.GetLogger<SessionInventoryPlayerDataInterface>();
+    private readonly ICoopSessionProvider coopSessionProvider;
+    private readonly IObjectManager objectManager;
+
+    private InventoryPlayerData InventoryPlayerData => coopSessionProvider.CoopSession.InventoryPlayerData;
+
+    public SessionInventoryPlayerDataInterface(ICoopSessionProvider coopSessionProvider, IObjectManager objectManager)
+    {
+        this.coopSessionProvider = coopSessionProvider;
+        this.objectManager = objectManager;
+    }
+
+    public void SetInventoryLocks(string playerHeroId, IEnumerable<string> lockedItemIds)
+    {
+        if (!InventoryPlayerData.PlayerInventoryLocks.ContainsKey(playerHeroId)) return;
+
+        InventoryPlayerData.PlayerInventoryLocks[playerHeroId] = (List<string>)lockedItemIds;
+    }
+
+    public void SetSortPreference(string playerHeroId, int usageType, Tuple<int, int> preference)
+    {
+        if (!InventoryPlayerData.PlayerInventorySortPreferences.ContainsKey(playerHeroId)) return;
+
+        InventoryPlayerData.PlayerInventorySortPreferences[playerHeroId][usageType] = preference;
+    }
+
+    public void AddPlayerKeys(string playerHeroId)
+    {
+        if (InventoryPlayerData == null)
+        {
+            Logger.Error("InventoryPlayerData was null");
+            return;
+        }
+
+        if (!InventoryPlayerData.PlayerInventoryLocks.ContainsKey(playerHeroId))
+        {
+            InventoryPlayerData.PlayerInventoryLocks[playerHeroId] = new();
+        }
+        if (!InventoryPlayerData.PlayerInventorySortPreferences.ContainsKey(playerHeroId))
+        {
+            InventoryPlayerData.PlayerInventorySortPreferences[playerHeroId] = new();
+        }
+    }
+}

--- a/source/GameInterface/Services/Inventory/InventoryPlayerData.cs
+++ b/source/GameInterface/Services/Inventory/InventoryPlayerData.cs
@@ -1,0 +1,30 @@
+﻿using ProtoBuf;
+using System;
+using System.Collections.Generic;
+
+namespace GameInterface.Services.Inventory;
+
+/// <summary>
+/// Some data structures for managing the inventory are player specific and have to be managed separately
+/// _inventoryItemLocks is unique for each player, need unique list per player
+/// _inventorySortPreferences is unique for each player, need unique list per player
+/// </summary>
+[ProtoContract(SkipConstructor = true)]
+public class InventoryPlayerData
+{
+    // Dictionary<PlayerHeroId, List<ItemId>>
+    [ProtoMember(1)]
+    public Dictionary<string, List<string>> PlayerInventoryLocks { get; }
+
+    // Dictionary<PlayerHeroId, Dictionary<UsageType, Preference>
+    [ProtoMember(2)]
+    public Dictionary<string, Dictionary<int, Tuple<int, int>>> PlayerInventorySortPreferences { get; }
+
+    public InventoryPlayerData(
+        Dictionary<string, List<string>> playerInventoryLocks,
+        Dictionary<string, Dictionary<int, Tuple<int, int>>> playerInventorySortPreferences)
+    {
+        PlayerInventoryLocks = playerInventoryLocks;
+        PlayerInventorySortPreferences = playerInventorySortPreferences;
+    }
+}

--- a/source/GameInterface/Services/Inventory/Messages/InventoryInitializationMessages.cs
+++ b/source/GameInterface/Services/Inventory/Messages/InventoryInitializationMessages.cs
@@ -1,0 +1,26 @@
+﻿using Common.Messaging;
+using ProtoBuf;
+
+namespace GameInterface.Services.Inventory.Messages;
+
+public record InitializeClientInventoryData : IEvent
+{
+    public InventoryPlayerData InventoryPlayerData;
+
+    public InitializeClientInventoryData(InventoryPlayerData inventoryPlayerData)
+    {
+        InventoryPlayerData = inventoryPlayerData;
+    }
+}
+
+[ProtoContract(SkipConstructor = true)]
+public class NetworkInitializeServerInventoryDataKeys : ICommand
+{
+    [ProtoMember(1)]
+    public string PlayerHeroId;
+
+    public NetworkInitializeServerInventoryDataKeys(string playerHeroId)
+    {
+        PlayerHeroId = playerHeroId;
+    }
+}

--- a/source/GameInterface/Services/Inventory/Messages/InventoryViewDataMessages.cs
+++ b/source/GameInterface/Services/Inventory/Messages/InventoryViewDataMessages.cs
@@ -1,0 +1,79 @@
+﻿using Common.Messaging;
+using ProtoBuf;
+using System;
+using System.Collections.Generic;
+using TaleWorlds.CampaignSystem;
+
+namespace GameInterface.Services.Inventory.Messages;
+
+public readonly struct SaveItemLockStates : IEvent
+{
+    public readonly Hero MainHero;
+    public readonly IEnumerable<string> ItemLockIds;
+
+    public SaveItemLockStates(
+        Hero mainHero,
+        IEnumerable<string> itemLockIds)
+    {
+        MainHero = mainHero;
+        ItemLockIds = itemLockIds;
+    }
+}
+
+public readonly struct SaveItemSortStates : IEvent
+{
+    public readonly Hero MainHero;
+    public readonly int UsageType;
+    public readonly Tuple<int, int> SortPreference;
+
+    public SaveItemSortStates(
+        Hero mainHero,
+        int usageType,
+        Tuple<int, int> sortPreference)
+    {
+        MainHero = mainHero;
+        UsageType = usageType;
+        SortPreference = sortPreference;
+    }
+}
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkSaveItemLockStates : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string MainHeroId;
+
+    [ProtoMember(2)]
+    public readonly IEnumerable<string> ItemLockIds;
+
+    public NetworkSaveItemLockStates(
+        string mainHeroId,
+        IEnumerable<string> itemLockIds)
+    {
+        MainHeroId = mainHeroId;
+        ItemLockIds = itemLockIds;
+    }
+}
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkSaveItemSortStates : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string MainHeroId;
+
+    [ProtoMember(2)]
+    public readonly int UsageType;
+    
+    [ProtoMember(3)]
+    public readonly Tuple<int, int> SortPreference;
+
+    public NetworkSaveItemSortStates(
+        string mainHeroId,
+        int usageType,
+        Tuple<int, int> sortPreference)
+    {
+        MainHeroId = mainHeroId;
+        UsageType = usageType;
+        SortPreference = sortPreference;
+    }
+}

--- a/source/GameInterface/Services/Inventory/Patches/SPInventoryVMPatches.cs
+++ b/source/GameInterface/Services/Inventory/Patches/SPInventoryVMPatches.cs
@@ -1,0 +1,31 @@
+﻿using Common.Messaging;
+using GameInterface.Services.Inventory.Messages;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.ViewModelCollection.Inventory;
+
+namespace GameInterface.Services.Inventory.Patches;
+
+[HarmonyPatch(typeof(SPInventoryVM))]
+internal class SPInventoryVMPatches
+{
+    [HarmonyPatch(nameof(SPInventoryVM.SaveItemLockStates))]
+    [HarmonyPostfix]
+    public static void SaveItemLockStatesPostfix(SPInventoryVM __instance)
+    {
+        // Send full list of inventory locks to server. This is reset locally every time
+        var message = new SaveItemLockStates(Hero.MainHero, __instance._viewDataTracker.GetInventoryLocks());
+        MessageBroker.Instance.Publish(__instance, message);
+    }
+
+    [HarmonyPatch(nameof(SPInventoryVM.SaveItemSortStates))]
+    [HarmonyPostfix]
+    public static void SaveItemSortStatesPostfix(SPInventoryVM __instance)
+    {
+        var usageType = (int)__instance._usageType;
+        var sortPreference = __instance._viewDataTracker.InventoryGetSortPreference(usageType);
+
+        var message = new SaveItemSortStates(Hero.MainHero, usageType, sortPreference);
+        MessageBroker.Instance.Publish(__instance, message);
+    }
+}


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] New feature (non-breaking change that adds functionality)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Item locks and sort preferences do not persist across play sessions.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #2371 
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Item locks and sort preferences in the inventory screen are now kept across sessions.