### PR TITLE
Remove w from vec3 surrogate and use custom surrogate for colors

### DIFF
--- a/source/GameInterface/Surrogates/AtmosphereInfoSurrogate.cs
+++ b/source/GameInterface/Surrogates/AtmosphereInfoSurrogate.cs
@@ -62,7 +62,7 @@ internal struct SunInformationSurrogate
 {
     [ProtoMember(1)] public float Altitude { get; set; }
     [ProtoMember(2)] public float Angle { get; set; }
-    [ProtoMember(3)] public Vec3Surrogate Color { get; set; }
+    [ProtoMember(3)] public ColorSurrogate Color { get; set; }
     [ProtoMember(4)] public float Brightness { get; set; }
     [ProtoMember(5)] public float MaxBrightness { get; set; }
     [ProtoMember(6)] public float Size { get; set; }
@@ -123,7 +123,7 @@ internal struct SnowInformationSurrogate
 internal struct AmbientInformationSurrogate
 {
     [ProtoMember(1)] public float EnvironmentMultiplier { get; set; }
-    [ProtoMember(2)] public Vec3Surrogate AmbientColor { get; set; }
+    [ProtoMember(2)] public ColorSurrogate AmbientColor { get; set; }
     [ProtoMember(3)] public float MieScatterStrength { get; set; }
     [ProtoMember(4)] public float RayleighConstant { get; set; }
 

--- a/source/GameInterface/Surrogates/ColorSurrogate.cs
+++ b/source/GameInterface/Surrogates/ColorSurrogate.cs
@@ -4,7 +4,7 @@ using TaleWorlds.Library;
 namespace GameInterface.Surrogates;
 
 [ProtoContract]
-internal struct Vec3Surrogate
+internal struct ColorSurrogate
 {
     [ProtoMember(1)]
     public float X { get; set; }
@@ -15,14 +15,18 @@ internal struct Vec3Surrogate
     [ProtoMember(3)]
     public float Z { get; set; }
 
-    public Vec3Surrogate(Vec3 v)
+    [ProtoMember(4)]
+    public float W { get; set; }
+
+    public ColorSurrogate(Vec3 v)
     {
         X = v.x;
         Y = v.y;
         Z = v.z;
+        W = v.w;
     }
 
-    public static implicit operator Vec3Surrogate(Vec3 v) => new Vec3Surrogate(v);
+    public static implicit operator ColorSurrogate(Vec3 v) => new ColorSurrogate(v);
 
-    public static implicit operator Vec3(Vec3Surrogate s) => new Vec3(s.X, s.Y, s.Z);
+    public static implicit operator Vec3(ColorSurrogate s) => new Vec3(s.X, s.Y, s.Z, s.W);
 }


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
Taleworlds is using an own implementation of vec3 and is reusing it to for colors. So they added a w property which would be a Vec4 and use it for the alpha channel


## What is the new behavior?
No longer sync w of Vec3 and use its default value of -1 instead. Add a custom Surrogate for colors which actually contains the w of Vec3. Will reduce networkload per Agent by atleast 8 bytes as its atleast 2 floats less to transmit

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->


## Other information
