### PR TITLE
Fix flaky workshop and siege aftermath tests

### DIFF
--- a/source/E2E.Tests/Services/Workshops/WorkshopPurchaseConversationTests.cs
+++ b/source/E2E.Tests/Services/Workshops/WorkshopPurchaseConversationTests.cs
@@ -254,6 +254,11 @@ public class WorkshopPurchaseConversationTests : IDisposable
             workshopsBehavior._workshopData = Array.Empty<WorkshopsCampaignBehavior.WorkshopData>();
             workshopsBehavior._warehouseRosterPerSettlement = Array.Empty<KeyValuePair<Settlement, ItemRoster>>();
 
+            // The capacity patch counts workshops attached to towns.
+            var town = ObjectHelper.SkipConstructor<Town>();
+            town.Workshops = new[] { workshop };
+            Campaign.Current._towns.Add(town);
+
             ChangeOwnerOfWorkshopActionPatches.ApplyPredictedWorkshopOwnership(workshop, buyer);
             ChangeOwnerOfWorkshopActionPatches.ApplyPredictedWorkshopData(workshop, buyer);
         });

--- a/source/GameInterface.Tests/Services/SiegeEvents/SiegeAftermathPendingTests.cs
+++ b/source/GameInterface.Tests/Services/SiegeEvents/SiegeAftermathPendingTests.cs
@@ -1,4 +1,4 @@
-using GameInterface.Services.SiegeEvents.Patches;
+﻿using GameInterface.Services.SiegeEvents.Patches;
 using GameInterface.Services.SiegeEvents.Interfaces;
 using System;
 using System.Collections.Generic;
@@ -12,6 +12,7 @@ using FormatterServices = System.Runtime.Serialization.FormatterServices;
 
 namespace GameInterface.Tests.Services.SiegeEvents;
 
+[Collection(nameof(CampaignCurrentCollection))]
 public sealed class SiegeAftermathPendingTests : IDisposable
 {
     public SiegeAftermathPendingTests()
@@ -145,18 +146,28 @@ public sealed class SiegeAftermathPendingTests : IDisposable
     [Fact]
     public void NarrationContext_IsParticipantScopedAndIndependentOfChoicePrompt()
     {
-        var participantSettlement = CreateSettlement(CreateUninitialized<Clan>(), CreateUninitialized<Clan>());
-        var unrelatedSettlement = CreateSettlement(CreateUninitialized<Clan>(), CreateUninitialized<Clan>());
-        var siegeEventInterface = new SiegeEventInterface();
+        // Bootstrap tests can leave an uninitialized Campaign.Current behind.
+        var previousCampaign = Campaign.Current;
+        Campaign.Current = null;
+        try
+        {
+            var participantSettlement = CreateSettlement(CreateUninitialized<Clan>(), CreateUninitialized<Clan>());
+            var unrelatedSettlement = CreateSettlement(CreateUninitialized<Clan>(), CreateUninitialized<Clan>());
+            var siegeEventInterface = new SiegeEventInterface();
 
-        siegeEventInterface.SetLocalAftermathNarrationContext(participantSettlement);
-        siegeEventInterface.SetLocalAftermathNarration(unrelatedSettlement,
-            (int)SiegeAftermathAction.SiegeAftermath.Devastate);
-        Assert.True(siegeEventInterface.HasLocalAftermathNarrationContext(participantSettlement));
+            siegeEventInterface.SetLocalAftermathNarrationContext(participantSettlement);
+            siegeEventInterface.SetLocalAftermathNarration(unrelatedSettlement,
+                (int)SiegeAftermathAction.SiegeAftermath.Devastate);
+            Assert.True(siegeEventInterface.HasLocalAftermathNarrationContext(participantSettlement));
 
-        siegeEventInterface.SetLocalAftermathNarration(participantSettlement,
-            (int)SiegeAftermathAction.SiegeAftermath.Pillage);
-        Assert.False(siegeEventInterface.HasLocalAftermathNarrationContext(participantSettlement));
+            siegeEventInterface.SetLocalAftermathNarration(participantSettlement,
+                (int)SiegeAftermathAction.SiegeAftermath.Pillage);
+            Assert.False(siegeEventInterface.HasLocalAftermathNarrationContext(participantSettlement));
+        }
+        finally
+        {
+            Campaign.Current = previousCampaign;
+        }
     }
 
     private static (Settlement Settlement, SiegeAftermathPatches.PendingAftermath Pending) AddBoundPending()
@@ -230,3 +241,9 @@ public sealed class SiegeAftermathPendingTests : IDisposable
         }
     }
 }
+
+/// <summary>
+/// Serializes tests that temporarily replace the process-wide campaign.
+/// </summary>
+[CollectionDefinition(nameof(CampaignCurrentCollection), DisableParallelization = true)]
+public sealed class CampaignCurrentCollection { }


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] CI related changes

## What is the current behavior?

The workshop E2E fixture reports zero capacity because its workshop is not attached to a town. The siege aftermath test can inherit a half-initialized `Campaign.Current` from parallel bootstrap tests.

## What is the new behavior?

The workshop fixture now matches the map capacity model, and the siege aftermath tests isolate `Campaign.Current`.

## Bot Changelog Entry
