### PR TITLE
Resolve hero field applies in queue order with hero creation

### DIFF
--- a/source/GameInterface.Tests/Services/Heroes/HeroFieldsHandlerThreadingTests.cs
+++ b/source/GameInterface.Tests/Services/Heroes/HeroFieldsHandlerThreadingTests.cs
@@ -1,0 +1,90 @@
+using Common;
+using Common.Messaging;
+using GameInterface.Services.Heroes.Handlers;
+using GameInterface.Services.Heroes.Messages;
+using GameInterface.Services.ObjectManager;
+using Moq;
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
+using System.Threading;
+using TaleWorlds.CampaignSystem;
+using Xunit;
+
+namespace GameInterface.Tests.Services.Heroes;
+
+/// <summary>
+/// Verifies that <see cref="HeroFieldsHandler"/> resolves the target hero on the game-loop thread,
+/// in queue order with the marshaled hero creation, instead of on the network (poller) thread that
+/// publishes the message. A poller-thread lookup races a creation still waiting in the game-thread
+/// queue and permanently drops the one-shot apply, leaving a partially-initialized hero — a
+/// name-less hero in the campaign's hero list breaks every encyclopedia open.
+/// </summary>
+public class HeroFieldsHandlerThreadingTests
+{
+    static HeroFieldsHandlerThreadingTests()
+    {
+        // Coop.Tests starts and continuously pumps a dedicated game-loop thread from a
+        // [ModuleInitializer] (TestGameLoopPump); force that initializer to run so the pump is up
+        // even when this class runs in isolation. RunModuleConstructor is idempotent.
+        RuntimeHelpers.RunModuleConstructor(typeof(Coop.Tests.Mocks.TestNetwork).Module.ModuleHandle);
+    }
+
+    [Fact]
+    public void ChangeName_PublishedWhileCreationIsStillQueued_AppliesAfterTheQueueDrains()
+    {
+        Assert.True(GameThread.Instance.IsInitialized, "game-loop pump was not initialized");
+
+        var hero = (Hero)FormatterServices.GetUninitializedObject(typeof(Hero));
+        bool registered = false;
+
+        var objectManager = new Mock<IObjectManager>();
+        objectManager
+            .Setup(o => o.TryGetObjectWithLogging("hero-1", out hero))
+            .Returns(() => Volatile.Read(ref registered));
+
+        Action<MessagePayload<ChangeName>> subscriber = null;
+        var messageBroker = new Mock<IMessageBroker>();
+        messageBroker
+            .Setup(b => b.Subscribe(It.IsAny<Action<MessagePayload<ChangeName>>>()))
+            .Callback<Action<MessagePayload<ChangeName>>>(s => subscriber = s);
+
+        using var handler = new HeroFieldsHandler(messageBroker.Object, objectManager.Object);
+        Assert.NotNull(subscriber);
+
+        // Not disposed deliberately: the blocker runs on the shared pump thread, and disposing an
+        // event it may still be touching would throw inside the pump and kill it for every later test.
+        var gate = new ManualResetEventSlim(false);
+        var pumpBlocked = new ManualResetEventSlim(false);
+        try
+        {
+            // Park the pump so the queued "creation" below is provably still pending when the
+            // message is handled, mirroring a game loop that is not draining (e.g. while alt-tabbed).
+            GameThread.RunSafe(() =>
+            {
+                pumpBlocked.Set();
+                gate.Wait(TimeSpan.FromSeconds(30));
+            });
+            Assert.True(pumpBlocked.Wait(TimeSpan.FromSeconds(10)), "the pump never picked up the blocker");
+
+            // The marshaled hero creation, still waiting in the game-thread queue.
+            GameThread.EnqueueSafe(() => Volatile.Write(ref registered, true));
+
+            // The one-shot name apply arrives on the poller thread while the creation is still
+            // queued. Resolving here instead of in queue order would drop the name forever.
+            subscriber(new MessagePayload<ChangeName>(this, new ChangeName("New Name", "hero-1")));
+            Assert.Null(hero._name);
+        }
+        finally
+        {
+            gate.Set();
+        }
+
+        // A blocking probe queued after the apply completes only after everything ahead of it in
+        // the queue has drained, so the creation and the apply have both run by the time it returns.
+        GameThread.Run(() => { }, blocking: true);
+
+        Assert.NotNull(hero._name);
+        Assert.Equal("New Name", hero._name.Value);
+    }
+}

--- a/source/GameInterface/Services/Heroes/Handlers/HeroDataHandler.cs
+++ b/source/GameInterface/Services/Heroes/Handlers/HeroDataHandler.cs
@@ -1,22 +1,16 @@
 ﻿using Common;
-using Common.Logging;
 using Common.Messaging;
 using GameInterface.Services.Heroes.Messages;
 using GameInterface.Services.Heroes.Patches;
 using GameInterface.Services.ObjectManager;
 using SandBox.GauntletUI;
-using Serilog;
-using System;
 using TaleWorlds.CampaignSystem;
-using TaleWorlds.Library;
 using TaleWorlds.Localization;
 using TaleWorlds.ScreenSystem;
 
 namespace GameInterface.Services.Heroes.Handlers;
 internal class HeroDataHandler : IHandler
 {
-    private static readonly ILogger Logger = LogManager.GetLogger<HeroDataHandler>();
-
     private readonly IMessageBroker messageBroker;
     private readonly IObjectManager objectManager;
 
@@ -38,15 +32,14 @@ internal class HeroDataHandler : IHandler
     {
         var data = payload.What.Data;
 
-        if (objectManager.TryGetObject<Hero>(data.HeroStringId, out var hero) == false)
-        {
-            Logger.Error("Unable to get {type} from id {stringId}", typeof(Hero), data.HeroStringId);
-            return;
-        }
-
-        // The refresh touches the clan screen UI, which must run on the main thread.
+        // Resolve the hero on the game-loop thread, in queue order with the marshaled hero
+        // creation — a network-thread lookup races a creation still waiting in the game-thread
+        // queue and permanently drops this one-shot name, leaving a name-less hero. The clan
+        // screen refresh must also run on the main thread.
         GameThread.RunSafe(() =>
         {
+            if (!objectManager.TryGetObjectWithLogging<Hero>(data.HeroStringId, out var hero)) return;
+
             var fullName = new TextObject(data.FullName);
             var firstName = new TextObject(data.FirstName);
 

--- a/source/GameInterface/Services/Heroes/Handlers/HeroFieldsHandler.cs
+++ b/source/GameInterface/Services/Heroes/Handlers/HeroFieldsHandler.cs
@@ -1,9 +1,8 @@
-﻿using Common;
-using Common.Logging;
+using Common;
 using Common.Messaging;
 using GameInterface.Services.Heroes.Messages;
 using GameInterface.Services.ObjectManager;
-using Serilog;
+using System;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Localization;
@@ -15,8 +14,6 @@ namespace GameInterface.Services.Heroes.Handlers
     /// </summary>
     public class HeroFieldsHandler : IHandler
     {
-        private static readonly ILogger Logger = LogManager.GetLogger<HeroFieldsHandler>();
-
         private readonly IMessageBroker messageBroker;
         private readonly IObjectManager objectManager;
 
@@ -53,170 +50,140 @@ namespace GameInterface.Services.Heroes.Handlers
             messageBroker.Unsubscribe<ChangeBirthDay>(Handle);
             messageBroker.Unsubscribe<ChangePower>(Handle);
             messageBroker.Unsubscribe<ChangeCulture>(Handle);
+            messageBroker.Unsubscribe<ChangeHomeSettlement>(Handle);
             messageBroker.Unsubscribe<ChangePregnant>(Handle);
+        }
+
+        /// <summary>
+        /// Resolves the hero and applies the change on the game-loop thread, in queue order with the
+        /// marshaled hero creation. A lookup on the network thread races a creation still waiting in
+        /// the game-thread queue, permanently dropping the one-shot apply and leaving a
+        /// partially-initialized hero.
+        /// </summary>
+        private void MarshalApply(string heroId, string context, Action<Hero> apply)
+        {
+            GameThread.RunSafe(() =>
+            {
+                if (!objectManager.TryGetObjectWithLogging<Hero>(heroId, out var instance)) return;
+
+                apply(instance);
+            }, context: context);
         }
 
         private void Handle(MessagePayload<ChangePregnant> payload)
         {
             var data = payload.What;
-            if (objectManager.TryGetObject<Hero>(data.HeroId, out var instance) == false)
-            {
-                Logger.Error("Unable to find {type} with id: {id}", typeof(Hero), data.HeroId);
-                return;
-            }
-            instance.IsPregnant = data.IsPregnant;
+
+            MarshalApply(data.HeroId, nameof(ChangePregnant), instance => instance.IsPregnant = data.IsPregnant);
         }
 
         private void Handle(MessagePayload<ChangeHomeSettlement> payload)
         {
             var data = payload.What;
-            if (objectManager.TryGetObject<Hero>(data.HeroId, out var instance) == false)
-            {
-                Logger.Error("Unable to find {type} with id: {id}", typeof(Hero), data.HeroId);
-                return;
-            }
 
-            if (data.SettlementStringId == null)
+            MarshalApply(data.HeroId, nameof(ChangeHomeSettlement), instance =>
             {
-                instance._homeSettlement = null;
-                return;
-            }
+                if (data.SettlementStringId == null)
+                {
+                    instance._homeSettlement = null;
+                    return;
+                }
 
-            if (objectManager.TryGetObject<Settlement>(data.SettlementStringId, out var settlement) == false)
-            {
-                Logger.Error("Unable to find {type} with id: {id}", typeof(Settlement), data.SettlementStringId);
-                return;
-            }
-            instance._homeSettlement = settlement;
+                if (!objectManager.TryGetObjectWithLogging<Settlement>(data.SettlementStringId, out var settlement)) return;
+
+                instance._homeSettlement = settlement;
+            });
         }
 
         private void Handle(MessagePayload<ChangeCulture> payload)
         {
             var data = payload.What;
-            if (objectManager.TryGetObject<Hero>(data.HeroId, out var instance) == false)
+
+            MarshalApply(data.HeroId, nameof(ChangeCulture), instance =>
             {
-                Logger.Error("Unable to find {type} with id: {id}", typeof(Hero), data.HeroId);
-                return;
-            }
-            //Add CultureObject to objectManager?
-            if (objectManager.TryGetObject<CultureObject>(data.CultureStringId, out var culture) == false)
-            {
-                Logger.Error("Unable to find {type} with id: {id}", typeof(Hero), data.HeroId);
-                return;
-            }
-            instance.Culture = culture;
+                //Add CultureObject to objectManager?
+                if (!objectManager.TryGetObjectWithLogging<CultureObject>(data.CultureStringId, out var culture)) return;
+
+                instance.Culture = culture;
+            });
         }
 
         private void Handle(MessagePayload<ChangePower> payload)
         {
             var data = payload.What;
-            if (objectManager.TryGetObject<Hero>(data.HeroId, out var instance) == false)
-            {
-                Logger.Error("Unable to find {type} with id: {id}", typeof(Hero), data.HeroId);
-                return;
-            }
-            instance._power = data.Power;
+
+            MarshalApply(data.HeroId, nameof(ChangePower), instance => instance._power = data.Power);
         }
 
         private void Handle(MessagePayload<ChangeBirthDay> payload)
         {
             var data = payload.What;
-            if (objectManager.TryGetObject<Hero>(data.HeroId, out var instance) == false)
-            {
-                Logger.Error("Unable to find {type} with id: {id}", typeof(Hero), data.HeroId);
-                return;
-            }
-            instance._birthDay = new CampaignTime(data.BirthDay);
+
+            MarshalApply(data.HeroId, nameof(ChangeBirthDay), instance => instance._birthDay = new CampaignTime(data.BirthDay));
         }
 
         private void Handle(MessagePayload<ChangeDefaultAge> payload)
         {
             var data = payload.What;
-            if (objectManager.TryGetObject<Hero>(data.HeroId, out var instance) == false)
-            {
-                Logger.Error("Unable to find {type} with id: {id}", typeof(Hero), data.HeroId);
-                return;
-            }
-            instance._defaultAge = data.Age;
+
+            MarshalApply(data.HeroId, nameof(ChangeDefaultAge), instance => instance._defaultAge = data.Age);
         }
 
         private void Handle(MessagePayload<ChangeSpcDaysInLocation> payload)
         {
             var data = payload.What;
-            if (objectManager.TryGetObject<Hero>(data.HeroId, out var instance) == false)
-            {
-                Logger.Error("Unable to find {type} with id: {id}", typeof(Hero), data.HeroId);
-                return;
-            }
 
-            //instance.SpcDaysInLocation = data.Days;
+            MarshalApply(data.HeroId, nameof(ChangeSpcDaysInLocation), instance =>
+            {
+                //instance.SpcDaysInLocation = data.Days;
+            });
         }
 
         private void Handle(MessagePayload<ChangeHeroLevel> payload)
         {
             var data = payload.What;
-            if (objectManager.TryGetObject<Hero>(data.HeroId, out var instance) == false)
-            {
-                Logger.Error("Unable to find {type} with id: {id}", typeof(Hero), data.HeroId);
-                return;
-            }
-            instance.Level = data.HeroLevel;
+
+            MarshalApply(data.HeroId, nameof(ChangeHeroLevel), instance => instance.Level = data.HeroLevel);
         }
 
         private void Handle(MessagePayload<ChangeHeroState> payload)
         {
             var data = payload.What;
-            if (objectManager.TryGetObject<Hero>(data.HeroId, out var instance) == false)
-            {
-                Logger.Error("Unable to find {type} with id: {id}", typeof(Hero), data.HeroId);
-                return;
-            }
-            instance._heroState = (Hero.CharacterStates)data.HeroState;
+
+            MarshalApply(data.HeroId, nameof(ChangeHeroState), instance => instance._heroState = (Hero.CharacterStates)data.HeroState);
         }
 
         private void Handle(MessagePayload<ChangeName> payload)
         {
             var data = payload.What;
-            if (objectManager.TryGetObject<Hero>(data.HeroId, out var instance) == false)
-            {
-                Logger.Error("Unable to find {type} with id: {id}", typeof(Hero), data.HeroId);
-                return;
-            }
-            instance._name = new TextObject(data.NewName);
+
+            MarshalApply(data.HeroId, nameof(ChangeName), instance => instance._name = new TextObject(data.NewName));
         }
 
         private void Handle(MessagePayload<ChangeFirstName> payload)
         {
             var data = payload.What;
-            if (objectManager.TryGetObject<Hero>(data.HeroId, out var instance) == false)
-            {
-                Logger.Error("Unable to find {type} with id: {id}", typeof(Hero), data.HeroId);
-                return;
-            }
-            instance._firstName = new TextObject(data.NewName);
+
+            MarshalApply(data.HeroId, nameof(ChangeFirstName), instance => instance._firstName = new TextObject(data.NewName));
         }
+
         private void Handle(MessagePayload<ChangeCharacterObject> payload)
         {
             var data = payload.What;
 
-            GameThread.RunSafe(() =>
+            MarshalApply(data.HeroId, nameof(ChangeCharacterObject), instance =>
             {
-                if (!objectManager.TryGetObjectWithLogging<Hero>(data.HeroId, out var instance)) return;
                 if (!objectManager.TryGetObjectWithLogging<CharacterObject>(data.CharacterObjectId, out var character)) return;
 
                 instance._characterObject = character;
-            }, context: nameof(ChangeCharacterObject));
+            });
         }
+
         private void Handle(MessagePayload<ChangeLastTimeStamp> payload)
         {
             var data = payload.What;
-            if(objectManager.TryGetObject<Hero>(data.HeroId, out var instance) == false)
-            {
-                Logger.Error("Unable to find {type} with id: {id}", typeof(Hero), data.HeroId);
-                return;
-            }
 
-            instance.LastTimeStampForActivity = data.LastTimeStamp;
+            MarshalApply(data.HeroId, nameof(ChangeLastTimeStamp), instance => instance.LastTimeStampForActivity = data.LastTimeStamp);
         }
     }
 }


### PR DESCRIPTION
Fixes #2396

## Root cause

The encyclopedia was not failing to open — it was throwing a `NullReferenceException` inside the native `DefaultEncyclopediaHeroPage.InitializeListItems()` on every open, and `OnTickRobustnessPatches`/`ScreenManagerRobustnessPatches` swallowed the crash, so the UI silently did nothing. The NRE came from `hero.Name.ToString()` on a hero whose name was never applied.

Client-side hero creation is marshaled onto the game-loop thread (`AutoRegistryHandler.Handle_NetworkCreateInstance` -> `GameThread.RunSafe`), but `HeroDataHandler.Handle_HeroChangeName` and every handler in `HeroFieldsHandler` resolved the hero id **immediately on the network (poller) thread** and dropped the message when the lookup failed. A field apply arriving while the creation was still sitting in the game-thread queue — near-certain while the game loop is starved during an alt-tab — was lost forever. `ChangeHeroName` is one-shot (published from the `Hero.SetName` prefix, never re-sent), so the skeleton hero created by `HeroRegistry.OnClientCreated` stayed name-less in `CampaignObjectManager.AliveHeroes` until reconnect, which matches the reported workaround.

The attached client log shows the exact sequence: six dropped messages for `Created_3276` at 14:26:58 ("Unable to find/get Hero"), first encyclopedia NRE at 14:26:59, and no further errors for that id (the creation landed moments later).

## Fix

Resolve the hero id inside `GameThread.RunSafe`, so lookups run in queue order behind the marshaled creation — the same contract `GenericHandler.MarshalApply` documents for AutoSync applies, and the same shape the `ChangeCharacterObject` handler and `Handle_NetworkDestroyInstance` already use. This also moves the field writes themselves onto the game-loop thread instead of mutating game state from the poller thread. In passing, `Dispose` now unsubscribes `ChangeHomeSettlement`, which was missing.

## Testing

- New regression test `HeroFieldsHandlerThreadingTests` parks the test game-loop pump, queues the "creation", publishes `ChangeName` from the poller-stand-in thread, and asserts the name applies once the queue drains. Verified red on the old code (name dropped) and green on the fix.
- GameInterface.Tests: 672 passed, 11 skipped (pre-existing skips)
- Coop.IntegrationTests: 128 passed, 2 skipped
- E2E.Tests `Services.Heroes` filter: 21 passed
