### PR TITLE
Ensure player parties have unlimited wages

### DIFF
--- a/source/GameInterface/Services/MobileParties/Patches/MobilePartyPaymentLimitPatch.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/MobilePartyPaymentLimitPatch.cs
@@ -1,0 +1,25 @@
+﻿using GameInterface.Services.MobileParties.Extensions;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Party;
+
+namespace GameInterface.Services.MobileParties.Patches;
+
+[HarmonyPatch(typeof(MobileParty))]
+internal class MobilePartyPaymentLimitPatch
+{
+    [HarmonyPatch(nameof(MobileParty.PaymentLimit), MethodType.Getter)]
+    [HarmonyPrefix]
+    public static bool PaymentLimitGetterPrefix(MobileParty __instance, ref int __result)
+    {
+        // Restore payment limits for player parties in old saves.
+        // Old saves can have player parties with limited wages from before this was fixed.
+        if (__instance.IsPlayerParty())
+        {
+            __result = Campaign.Current.Models.PartyWageModel.MaxWagePaymentLimit;
+            return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Old saves can have left over payment limits set for player parties. This causes desertions as it is always supposed to be unlimited for player parties.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #2419
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Ensure player parties always have unlimited wages. This should restore old saves with this problem.

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Fixed a problem with desertions happening for players on older saves.