### PR TITLE
Support protobuf serialization on Wine-Mono

### DIFF
--- a/source/Common.Tests/Serialization/ProtoBufSerializerTests.cs
+++ b/source/Common.Tests/Serialization/ProtoBufSerializerTests.cs
@@ -1,0 +1,81 @@
+﻿using Common.Serialization;
+using ProtoBuf;
+using ProtoBuf.Meta;
+
+namespace Common.Tests.Serialization;
+
+public class ProtoBufSerializerTests
+{
+    [ProtoContract(SkipConstructor = true)]
+    public readonly struct SkipConstructorStruct
+    {
+        [ProtoMember(1)]
+        public readonly int Number;
+
+        [ProtoMember(2)]
+        public readonly string Text;
+
+        public SkipConstructorStruct(int number, string text)
+        {
+            Number = number;
+            Text = text;
+        }
+    }
+
+    [ProtoContract(SkipConstructor = true)]
+    public class SkipConstructorClass
+    {
+        [ProtoMember(1)]
+        public int Number { get; }
+
+        public SkipConstructorClass(int number)
+        {
+            Number = number;
+        }
+    }
+
+    [Fact]
+    public void ConfigureRuntimeModel_KeepsCompilationAndUsesDefaultInitializationForStructs()
+    {
+        var model = RuntimeTypeModel.Create();
+        ProtoBufSerializer.ConfigureRuntimeModel(model, isMonoRuntime: true);
+        var metaType = model.Add(typeof(SkipConstructorStruct), applyDefaultBehaviour: true);
+
+        Assert.True(model.AutoCompile);
+        Assert.True(metaType.UseConstructor);
+
+        var expected = new SkipConstructorStruct(42, "linux");
+        using var stream = new MemoryStream();
+        model.Serialize(stream, expected);
+        stream.Position = 0;
+
+        var actual = (SkipConstructorStruct)model.Deserialize(
+            stream,
+            value: null,
+            typeof(SkipConstructorStruct));
+
+        Assert.Equal(expected.Number, actual.Number);
+        Assert.Equal(expected.Text, actual.Text);
+    }
+
+    [Fact]
+    public void ConfigureRuntimeModel_DoesNotChangeReferenceTypeConstruction()
+    {
+        var model = RuntimeTypeModel.Create();
+        ProtoBufSerializer.ConfigureRuntimeModel(model, isMonoRuntime: true);
+        var metaType = model.Add(typeof(SkipConstructorClass), applyDefaultBehaviour: true);
+
+        Assert.False(metaType.UseConstructor);
+    }
+
+    [Fact]
+    public void ConfigureRuntimeModel_DoesNotChangeWindowsStructConstruction()
+    {
+        var model = RuntimeTypeModel.Create();
+        ProtoBufSerializer.ConfigureRuntimeModel(model, isMonoRuntime: false);
+        var metaType = model.Add(typeof(SkipConstructorStruct), applyDefaultBehaviour: true);
+
+        Assert.True(model.AutoCompile);
+        Assert.False(metaType.UseConstructor);
+    }
+}

--- a/source/Common/Serialization/ProtoBufSerializer.cs
+++ b/source/Common/Serialization/ProtoBufSerializer.cs
@@ -1,4 +1,5 @@
 ﻿using ProtoBuf;
+using ProtoBuf.Meta;
 using System;
 using System.IO;
 
@@ -14,6 +15,15 @@ public interface ICommonSerializer
 public class ProtoBufSerializer : ICommonSerializer
 {
     private readonly ISerializableTypeMapper typeMapper;
+
+    // Proton reports Windows, so its managed runtime is the reliable discriminator.
+    public static bool IsMonoRuntime { get; } = Type.GetType("Mono.Runtime") != null;
+    public static bool AutoCompileEnabled => RuntimeTypeModel.Default.AutoCompile;
+
+    public static void ConfigureRuntimeModel()
+    {
+        RuntimeTypeModel.Default.AutoCompile = !IsMonoRuntime;
+    }
 
     public ProtoBufSerializer(ISerializableTypeMapper typeMapper)
     {

--- a/source/Common/Serialization/ProtoBufSerializer.cs
+++ b/source/Common/Serialization/ProtoBufSerializer.cs
@@ -19,10 +19,27 @@ public class ProtoBufSerializer : ICommonSerializer
     // Proton reports Windows, so its managed runtime is the reliable discriminator.
     public static bool IsMonoRuntime { get; } = Type.GetType("Mono.Runtime") != null;
     public static bool AutoCompileEnabled => RuntimeTypeModel.Default.AutoCompile;
+    public static bool StructFactoryWorkaroundEnabled => IsMonoRuntime;
 
     public static void ConfigureRuntimeModel()
     {
-        RuntimeTypeModel.Default.AutoCompile = !IsMonoRuntime;
+        ConfigureRuntimeModel(RuntimeTypeModel.Default, IsMonoRuntime);
+    }
+
+    internal static void ConfigureRuntimeModel(RuntimeTypeModel model, bool isMonoRuntime)
+    {
+        model.AfterApplyDefaultBehaviour -= ConfigureMonoValueType;
+        if (isMonoRuntime) model.AfterApplyDefaultBehaviour += ConfigureMonoValueType;
+        model.AutoCompile = true;
+    }
+
+    private static void ConfigureMonoValueType(object sender, TypeAddedEventArgs args)
+    {
+        if (!args.Type.IsValueType || args.MetaType.UseConstructor) return;
+
+        // Wine-Mono rejects protobuf-net's uninitialized-object factory IL for value types.
+        // Its no-factory path returns the same zero-initialized default value.
+        args.MetaType.UseConstructor = true;
     }
 
     public ProtoBufSerializer(ISerializableTypeMapper typeMapper)

--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -219,9 +219,10 @@ namespace Coop
                 ?.InformationalVersion ?? "unknown";
             Logger.Information("BannerlordCoop build {Build}", informationalVersion);
             Logger.Information(
-                "[Protobuf] MonoRuntime={MonoRuntime} AutoCompile={AutoCompile} CLRVersion={ClrVersion}",
+                "[Protobuf] MonoRuntime={MonoRuntime} AutoCompile={AutoCompile} StructFactoryWorkaround={StructFactoryWorkaround} CLRVersion={ClrVersion}",
                 ProtoBufSerializer.IsMonoRuntime,
                 ProtoBufSerializer.AutoCompileEnabled,
+                ProtoBufSerializer.StructFactoryWorkaroundEnabled,
                 Environment.Version);
 
             Logger.Verbose("Coop Mod Module Started");

--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -1,5 +1,6 @@
 ﻿using Common;
 using Common.Logging;
+using Common.Serialization;
 using Coop.Core;
 using Coop.Core.Common.Session;
 using Coop.Lib.NoHarmony;
@@ -67,6 +68,7 @@ namespace Coop
         public override void NoHarmonyInit() 
         {
             AssemblyHellscape.CreateAssemblyBindingRedirects();
+            ProtoBufSerializer.ConfigureRuntimeModel();
 
             var fullCommandLine = Utilities.GetFullCommandLineString();
             var args = fullCommandLine.Split(' ').ToList();
@@ -216,6 +218,11 @@ namespace Coop
                 .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
                 ?.InformationalVersion ?? "unknown";
             Logger.Information("BannerlordCoop build {Build}", informationalVersion);
+            Logger.Information(
+                "[Protobuf] MonoRuntime={MonoRuntime} AutoCompile={AutoCompile} CLRVersion={ClrVersion}",
+                ProtoBufSerializer.IsMonoRuntime,
+                ProtoBufSerializer.AutoCompileEnabled,
+                Environment.Version);
 
             Logger.Verbose("Coop Mod Module Started");
         }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Starting BannerlordCoop through Proton with Wine-Mono fails when protobuf-net generates the factory for a `SkipConstructor` value type, requiring Linux users to install the Microsoft .NET Framework into their Proton prefix.

Fixes #2095.

## What is the new behavior?

Wine-Mono keeps protobuf serializers compiled. Value types use the same zero-initialized no-factory path, avoiding the invalid factory IL without interpreting network traffic. Reference types and native Windows behavior are unchanged. The selected runtime, compile mode, and workaround state are written to the Coop startup log.

## Bot Changelog Entry

- Added Wine-Mono-compatible compiled serialization without requiring Microsoft .NET Framework.
