### PR TITLE
Restore missing player workshop data on join

### DIFF
--- a/source/E2E.Tests/Services/Workshops/WorkshopDataRepairTests.cs
+++ b/source/E2E.Tests/Services/Workshops/WorkshopDataRepairTests.cs
@@ -1,0 +1,164 @@
+using Common.Util;
+using E2E.Tests.Environment;
+using E2E.Tests.Environment.Instance;
+using GameInterface.CoopSessionData;
+using GameInterface.Services.Workshops;
+using GameInterface.Services.Workshops.Handlers;
+using GameInterface.Services.Workshops.Messages;
+using System.Collections.Generic;
+using System.Linq;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.CampaignBehaviors;
+using TaleWorlds.CampaignSystem.Roster;
+using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.CampaignSystem.Settlements.Workshops;
+using TaleWorlds.Library;
+using Xunit.Abstractions;
+
+namespace E2E.Tests.Services.Workshops;
+
+/// <summary>
+/// Saves created while MaximumWorkshopsPlayerCanHave returned the vanilla value (issue #2373)
+/// contain player-owned workshops without WorkshopData: the behavior arrays were capped at the
+/// vanilla size, native AddNewWorkshopData drops silently when no slot is free, and the Clan
+/// screen then throws on GetOutputDailyChange for the owner. These tests cover the
+/// WorkshopRepairer paths that backfill the missing data.
+/// </summary>
+public class WorkshopDataRepairTests : IDisposable
+{
+    private E2ETestEnvironment TestEnvironment { get; }
+    private EnvironmentInstance Server => TestEnvironment.Server;
+    private IEnumerable<EnvironmentInstance> Clients => TestEnvironment.Clients;
+
+    public WorkshopDataRepairTests(ITestOutputHelper output)
+    {
+        TestEnvironment = new E2ETestEnvironment(output);
+    }
+
+    public void Dispose()
+    {
+        TestEnvironment.Dispose();
+    }
+
+    [Fact]
+    public void ServerWorkshopDataKeys_WhenOwnedWorkshopMissingBehaviorData_RestoresDataOnServerAndAllClients()
+    {
+        var client = Clients.First();
+        var workshopId = TestEnvironment.CreateRegisteredObject<Workshop>();
+        var heroId = TestEnvironment.CreateRegisteredObject<Hero>();
+
+        foreach (var instance in Clients.Append(Server))
+        {
+            PreparePoisonedWorkshopState(instance, workshopId, heroId, trackInOwnedList: true);
+        }
+
+        client.Call(() => client.Resolve<Common.Network.INetwork>().SendAll(
+            new NetworkInitializeServerWorkshopDataKeys(heroId)));
+
+        AssertWorkshopDataRestored(Server, workshopId);
+        foreach (var environmentClient in Clients)
+        {
+            AssertWorkshopDataRestored(environmentClient, workshopId);
+        }
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Workshop>(workshopId, out var workshop));
+            Assert.True(Server.ObjectManager.TryGetId(workshop.Settlement, out var settlementId));
+
+            var workshopPlayerData = Server.Resolve<ICoopSessionProvider>().CoopSession.WorkshopPlayerData;
+            var warehouseSlots = Assert.Contains(heroId, workshopPlayerData.PlayerWarehouseRosterPerSettlement);
+            Assert.Contains(warehouseSlots, slot => slot.Key == settlementId);
+        });
+    }
+
+    [Fact]
+    public void RepairClientWorkshopData_WhenOwnedWorkshopMissingBehaviorData_PreparesClanFinanceWorkshopData()
+    {
+        var client = Clients.First();
+        var workshopId = TestEnvironment.CreateRegisteredObject<Workshop>();
+        var heroId = TestEnvironment.CreateRegisteredObject<Hero>();
+
+        PreparePoisonedWorkshopState(client, workshopId, heroId, trackInOwnedList: true);
+
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Hero>(heroId, out var hero));
+
+            var workshopsBehavior = Campaign.Current.GetCampaignBehavior<WorkshopsCampaignBehavior>();
+            WorkshopRepairer.RepairClientWorkshopData(workshopsBehavior, hero);
+        });
+
+        AssertWorkshopDataRestored(client, workshopId);
+    }
+
+    [Fact]
+    public void GetWorkshopsOwnedBy_WhenOwnerOnlyTrackedByWorkshopField_IncludesWorkshop()
+    {
+        var client = Clients.First();
+        var workshopId = TestEnvironment.CreateRegisteredObject<Workshop>();
+        var heroId = TestEnvironment.CreateRegisteredObject<Hero>();
+
+        // Workshop.Owner points at the hero but Hero._ownedWorkshops does not list the workshop —
+        // the divergence a client accumulates mid-session, and exactly what the Clan screen lists.
+        PreparePoisonedWorkshopState(client, workshopId, heroId, trackInOwnedList: false);
+
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Workshop>(workshopId, out var workshop));
+            Assert.True(client.ObjectManager.TryGetObject<Hero>(heroId, out var hero));
+
+            var ownedWorkshops = WorkshopsCampaignBehaviorInitializationHandler.GetWorkshopsOwnedBy(hero);
+
+            Assert.Contains(workshop, ownedWorkshops);
+
+            var workshopsBehavior = Campaign.Current.GetCampaignBehavior<WorkshopsCampaignBehavior>();
+            WorkshopRepairer.RepairClientWorkshopData(workshopsBehavior, hero);
+        });
+
+        AssertWorkshopDataRestored(client, workshopId);
+    }
+
+    private static void PreparePoisonedWorkshopState(EnvironmentInstance instance, string workshopId, string heroId, bool trackInOwnedList)
+    {
+        instance.Call(() =>
+        {
+            Assert.True(instance.ObjectManager.TryGetObject<Workshop>(workshopId, out var workshop));
+            Assert.True(instance.ObjectManager.TryGetObject<Hero>(heroId, out var hero));
+
+            if (hero._ownedWorkshops == null)
+            {
+                hero._ownedWorkshops = new MBList<Workshop>();
+            }
+            hero._ownedWorkshops.Remove(workshop);
+            if (trackInOwnedList)
+            {
+                hero._ownedWorkshops.Add(workshop);
+            }
+            workshop._owner = hero;
+
+            // The poisoned-save shape: the workshop is player-owned but the behavior storage has
+            // no entry (and no capacity) for it.
+            var workshopsBehavior = Campaign.Current.GetCampaignBehavior<WorkshopsCampaignBehavior>();
+            workshopsBehavior._workshopData = Array.Empty<WorkshopsCampaignBehavior.WorkshopData>();
+            workshopsBehavior._warehouseRosterPerSettlement = Array.Empty<KeyValuePair<Settlement, ItemRoster>>();
+
+            // The capacity patch counts workshops attached to towns.
+            var town = ObjectHelper.SkipConstructor<Town>();
+            town.Workshops = new[] { workshop };
+            Campaign.Current._towns.Add(town);
+        });
+    }
+
+    private static void AssertWorkshopDataRestored(EnvironmentInstance instance, string workshopId)
+    {
+        instance.Call(() =>
+        {
+            Assert.True(instance.ObjectManager.TryGetObject<Workshop>(workshopId, out var workshop));
+
+            var workshopsBehavior = Campaign.Current.GetCampaignBehavior<WorkshopsCampaignBehavior>();
+            Assert.NotNull(workshopsBehavior.GetDataOfWorkshop(workshop));
+            Assert.Single(workshopsBehavior._workshopData, data => data?.Workshop == workshop);
+        });
+    }
+}

--- a/source/E2E.Tests/Services/Workshops/WorkshopDataRepairTests.cs
+++ b/source/E2E.Tests/Services/Workshops/WorkshopDataRepairTests.cs
@@ -2,6 +2,8 @@ using Common.Util;
 using E2E.Tests.Environment;
 using E2E.Tests.Environment.Instance;
 using GameInterface.CoopSessionData;
+using GameInterface.Services.Players;
+using GameInterface.Services.Players.Data;
 using GameInterface.Services.Workshops;
 using GameInterface.Services.Workshops.Handlers;
 using GameInterface.Services.Workshops.Messages;
@@ -68,6 +70,49 @@ public class WorkshopDataRepairTests : IDisposable
 
             var workshopPlayerData = Server.Resolve<ICoopSessionProvider>().CoopSession.WorkshopPlayerData;
             var warehouseSlots = Assert.Contains(heroId, workshopPlayerData.PlayerWarehouseRosterPerSettlement);
+            Assert.Contains(warehouseSlots, slot => slot.Key == settlementId);
+        });
+    }
+
+    [Fact]
+    public void ServerWorkshopDataKeys_WhenOfflinePlayerWorkshopMissingBehaviorData_RestoresDataWithoutOwnerJoining()
+    {
+        var client = Clients.First();
+        var joiningWorkshopId = TestEnvironment.CreateRegisteredObject<Workshop>();
+        var joiningHeroId = TestEnvironment.CreateRegisteredObject<Hero>();
+        var offlineWorkshopId = TestEnvironment.CreateRegisteredObject<Workshop>();
+        var offlineHeroId = TestEnvironment.CreateRegisteredObject<Hero>();
+
+        foreach (var instance in Clients.Append(Server))
+        {
+            PreparePoisonedWorkshopState(instance, joiningWorkshopId, joiningHeroId, trackInOwnedList: true);
+            PreparePoisonedWorkshopState(instance, offlineWorkshopId, offlineHeroId, trackInOwnedList: true);
+        }
+
+        // The offline player never announces; the server only knows them through the player
+        // registry, which the saved session repopulates on load.
+        Server.Call(() =>
+        {
+            Server.Resolve<IPlayerManager>().AddPlayer(
+                new Player("OfflineController", offlineHeroId, null, null, null));
+        });
+
+        client.Call(() => client.Resolve<Common.Network.INetwork>().SendAll(
+            new NetworkInitializeServerWorkshopDataKeys(joiningHeroId)));
+
+        foreach (var instance in Clients.Append(Server))
+        {
+            AssertWorkshopDataRestored(instance, joiningWorkshopId);
+            AssertWorkshopDataRestored(instance, offlineWorkshopId);
+        }
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Workshop>(offlineWorkshopId, out var workshop));
+            Assert.True(Server.ObjectManager.TryGetId(workshop.Settlement, out var settlementId));
+
+            var workshopPlayerData = Server.Resolve<ICoopSessionProvider>().CoopSession.WorkshopPlayerData;
+            var warehouseSlots = Assert.Contains(offlineHeroId, workshopPlayerData.PlayerWarehouseRosterPerSettlement);
             Assert.Contains(warehouseSlots, slot => slot.Key == settlementId);
         });
     }

--- a/source/E2E.Tests/Services/Workshops/WorkshopDataRepairTests.cs
+++ b/source/E2E.Tests/Services/Workshops/WorkshopDataRepairTests.cs
@@ -86,7 +86,7 @@ public class WorkshopDataRepairTests : IDisposable
             Assert.True(client.ObjectManager.TryGetObject<Hero>(heroId, out var hero));
 
             var workshopsBehavior = Campaign.Current.GetCampaignBehavior<WorkshopsCampaignBehavior>();
-            WorkshopRepairer.RepairClientWorkshopData(workshopsBehavior, hero);
+            client.Resolve<IWorkshopRepairer>().RepairClientWorkshopData(workshopsBehavior, hero);
         });
 
         AssertWorkshopDataRestored(client, workshopId);
@@ -113,7 +113,7 @@ public class WorkshopDataRepairTests : IDisposable
             Assert.Contains(workshop, ownedWorkshops);
 
             var workshopsBehavior = Campaign.Current.GetCampaignBehavior<WorkshopsCampaignBehavior>();
-            WorkshopRepairer.RepairClientWorkshopData(workshopsBehavior, hero);
+            client.Resolve<IWorkshopRepairer>().RepairClientWorkshopData(workshopsBehavior, hero);
         });
 
         AssertWorkshopDataRestored(client, workshopId);

--- a/source/GameInterface/GameInterfaceModule.cs
+++ b/source/GameInterface/GameInterfaceModule.cs
@@ -24,6 +24,7 @@ using GameInterface.Services.Players;
 using GameInterface.Services.Stances;
 using GameInterface.Services.TroopRosters.Logging;
 using GameInterface.Services.Time;
+using GameInterface.Services.Workshops;
 using GameInterface.Surrogates;
 using HarmonyLib;
 using Serilog;
@@ -61,6 +62,7 @@ public class GameInterfaceModule : Module
         builder.RegisterType<PlayerRansomReleaseSettlementProvider>().As<IPlayerRansomReleaseSettlementProvider>().InstancePerDependency();
         builder.RegisterType<PrisonerSaleProcessor>().As<IPrisonerSaleProcessor>().InstancePerDependency();
         builder.RegisterType<PartyScreenRosterBaselineProvider>().As<IPartyScreenRosterBaselineProvider>().InstancePerDependency();
+        builder.RegisterType<WorkshopRepairer>().As<IWorkshopRepairer>().InstancePerDependency();
         builder.RegisterType<MapEventLogger>().As<IMapEventLogger>().InstancePerLifetimeScope();
         builder.RegisterType<TroopRosterLogger>().As<ITroopRosterLogger>().InstancePerLifetimeScope();
         builder.RegisterType<PartySyncPerformanceClock>().As<IPartySyncPerformanceClock>().InstancePerLifetimeScope();

--- a/source/GameInterface/Services/Workshops/Handlers/WorkshopsCampaignBehaviorInitializationHandler.cs
+++ b/source/GameInterface/Services/Workshops/Handlers/WorkshopsCampaignBehaviorInitializationHandler.cs
@@ -64,13 +64,46 @@ namespace GameInterface.Services.Workshops.Handlers
             WorkshopsCampaignBehavior workshopsCampaignBehavior = Campaign.Current.GetCampaignBehavior<WorkshopsCampaignBehavior>();
 
             workshopsCampaignBehavior._warehouseRosterPerSettlement = GetWarehouseRosterPerSettlement(playerHeroId, playerHero);
+            WorkshopRepairer.RepairClientWorkshopData(workshopsCampaignBehavior, playerHero);
 
             network.SendAll(new NetworkInitializeServerWorkshopDataKeys(playerHeroId));
         }
 
         private void Handle(MessagePayload<NetworkInitializeServerWorkshopDataKeys> obj)
         {
-            sessionWorkshopPlayerDataInterface.AddPlayerKeys(obj.What.PlayerHeroId);
+            string playerHeroId = obj.What.PlayerHeroId;
+            sessionWorkshopPlayerDataInterface.AddPlayerKeys(playerHeroId);
+
+            if (!objectManager.TryGetObjectWithLogging(playerHeroId, out Hero playerHero)) return;
+
+            WorkshopRepairer.RepairServerWorkshopData(playerHero, playerHeroId, objectManager, sessionWorkshopPlayerDataInterface);
+        }
+
+        internal static IEnumerable<Workshop> GetWorkshopsOwnedBy(Hero playerHero)
+        {
+            // Hero._ownedWorkshops and Workshop._owner can diverge in coop (only the list is
+            // synced mid-session), and the Clan screen lists workshops by Workshop.Owner, so
+            // cover both sources.
+            var ownedWorkshops = new List<Workshop>();
+            if (playerHero.OwnedWorkshops != null)
+            {
+                ownedWorkshops.AddRange(playerHero.OwnedWorkshops);
+            }
+
+            foreach (Town town in Town.AllTowns)
+            {
+                if (town?.Workshops == null) continue;
+
+                foreach (Workshop workshop in town.Workshops)
+                {
+                    if (workshop?.Owner == playerHero && !ownedWorkshops.Contains(workshop))
+                    {
+                        ownedWorkshops.Add(workshop);
+                    }
+                }
+            }
+
+            return ownedWorkshops;
         }
 
         private KeyValuePair<Settlement, ItemRoster>[] GetWarehouseRosterPerSettlement(string playerHeroId, Hero playerHero)
@@ -107,7 +140,7 @@ namespace GameInterface.Services.Workshops.Handlers
                     }
                 }
 
-                AddMissingOwnedWorkshopRosters(warehouseRosterPerSettlement, playerHero.OwnedWorkshops);
+                AddMissingOwnedWorkshopRosters(warehouseRosterPerSettlement, GetWorkshopsOwnedBy(playerHero));
             }, blocking: true);
 
             return CreateWarehouseRosterSlots(warehouseRosterPerSettlement, maxWorkshopCount);

--- a/source/GameInterface/Services/Workshops/Handlers/WorkshopsCampaignBehaviorInitializationHandler.cs
+++ b/source/GameInterface/Services/Workshops/Handlers/WorkshopsCampaignBehaviorInitializationHandler.cs
@@ -25,6 +25,7 @@ namespace GameInterface.Services.Workshops.Handlers
         private readonly IObjectManager objectManager;
         private readonly INetwork network;
         private readonly ISessionWorkshopPlayerDataInterface sessionWorkshopPlayerDataInterface;
+        private readonly IWorkshopRepairer workshopRepairer;
 
         private WorkshopPlayerData workshopPlayerData;
 
@@ -32,12 +33,14 @@ namespace GameInterface.Services.Workshops.Handlers
             IMessageBroker messageBroker,
             IObjectManager objectManager,
             INetwork network,
-            ISessionWorkshopPlayerDataInterface sessionWorkshopPlayerDataInterface)
+            ISessionWorkshopPlayerDataInterface sessionWorkshopPlayerDataInterface,
+            IWorkshopRepairer workshopRepairer)
         {
             this.messageBroker = messageBroker;
             this.objectManager = objectManager;
             this.network = network;
             this.sessionWorkshopPlayerDataInterface = sessionWorkshopPlayerDataInterface;
+            this.workshopRepairer = workshopRepairer;
             messageBroker.Subscribe<InitializeClientWorkshopData>(Handle);
             messageBroker.Subscribe<PlayerHeroChanged>(Handle);
             messageBroker.Subscribe<NetworkInitializeServerWorkshopDataKeys>(Handle);
@@ -64,7 +67,7 @@ namespace GameInterface.Services.Workshops.Handlers
             WorkshopsCampaignBehavior workshopsCampaignBehavior = Campaign.Current.GetCampaignBehavior<WorkshopsCampaignBehavior>();
 
             workshopsCampaignBehavior._warehouseRosterPerSettlement = GetWarehouseRosterPerSettlement(playerHeroId, playerHero);
-            WorkshopRepairer.RepairClientWorkshopData(workshopsCampaignBehavior, playerHero);
+            workshopRepairer.RepairClientWorkshopData(workshopsCampaignBehavior, playerHero);
 
             network.SendAll(new NetworkInitializeServerWorkshopDataKeys(playerHeroId));
         }
@@ -76,7 +79,7 @@ namespace GameInterface.Services.Workshops.Handlers
 
             if (!objectManager.TryGetObjectWithLogging(playerHeroId, out Hero playerHero)) return;
 
-            WorkshopRepairer.RepairServerWorkshopData(playerHero, playerHeroId, objectManager, sessionWorkshopPlayerDataInterface);
+            workshopRepairer.RepairServerWorkshopData(playerHero, playerHeroId);
         }
 
         internal static IEnumerable<Workshop> GetWorkshopsOwnedBy(Hero playerHero)

--- a/source/GameInterface/Services/Workshops/Interfaces/SessionWorkshopPlayerDataInterface.cs
+++ b/source/GameInterface/Services/Workshops/Interfaces/SessionWorkshopPlayerDataInterface.cs
@@ -183,31 +183,34 @@ public class SessionWorkshopPlayerDataInterface : ISessionWorkshopPlayerDataInte
 
     public void AddPlayerKeys(string playerHeroId)
     {
-        if (WorkshopPlayerData == null)
+        GameThread.RunSafe(() =>
         {
-            Logger.Error("WorkshopPlayerData was null");
-            return;
-        }
+            if (WorkshopPlayerData == null)
+            {
+                Logger.Error("WorkshopPlayerData was null");
+                return;
+            }
 
-        // A player can own up to MaximumWorkshopsPlayerCanHave workshops (patched to the map-wide
-        // workshop count), so the vanilla-derived MaxClanTier + 1 slot count silently dropped
-        // warehouse data for the settlements past that cap.
-        int slotCapacity = Math.Max(
-            Campaign.Current.Models.ClanTierModel.MaxClanTier + 1,
-            Campaign.Current.Models.WorkshopModel.MaximumWorkshopsPlayerCanHave);
+            // A player can own up to MaximumWorkshopsPlayerCanHave workshops (patched to the map-wide
+            // workshop count), so the vanilla-derived MaxClanTier + 1 slot count silently dropped
+            // warehouse data for the settlements past that cap.
+            int slotCapacity = Math.Max(
+                Campaign.Current.Models.ClanTierModel.MaxClanTier + 1,
+                Campaign.Current.Models.WorkshopModel.MaximumWorkshopsPlayerCanHave);
 
-        if (!WorkshopPlayerData.PlayerWarehouseRosterPerSettlement.TryGetValue(playerHeroId, out var slots))
-        {
-            WorkshopPlayerData.PlayerWarehouseRosterPerSettlement[playerHeroId] = new KeyValuePair<string, List<ItemRosterElementData>>[slotCapacity];
-            return;
-        }
+            if (!WorkshopPlayerData.PlayerWarehouseRosterPerSettlement.TryGetValue(playerHeroId, out var slots))
+            {
+                WorkshopPlayerData.PlayerWarehouseRosterPerSettlement[playerHeroId] = new KeyValuePair<string, List<ItemRosterElementData>>[slotCapacity];
+                return;
+            }
 
-        if (slots.Length < slotCapacity)
-        {
-            var grownSlots = new KeyValuePair<string, List<ItemRosterElementData>>[slotCapacity];
-            Array.Copy(slots, grownSlots, slots.Length);
-            WorkshopPlayerData.PlayerWarehouseRosterPerSettlement[playerHeroId] = grownSlots;
-        }
+            if (slots.Length < slotCapacity)
+            {
+                var grownSlots = new KeyValuePair<string, List<ItemRosterElementData>>[slotCapacity];
+                Array.Copy(slots, grownSlots, slots.Length);
+                WorkshopPlayerData.PlayerWarehouseRosterPerSettlement[playerHeroId] = grownSlots;
+            }
+        });
     }
 
     public ItemRosterElement GetItemRosterElementFromData(ItemRosterElementData itemRosterElementData)

--- a/source/GameInterface/Services/Workshops/Interfaces/SessionWorkshopPlayerDataInterface.cs
+++ b/source/GameInterface/Services/Workshops/Interfaces/SessionWorkshopPlayerDataInterface.cs
@@ -4,6 +4,7 @@ using GameInterface.CoopSessionData;
 using GameInterface.Services.Inventory.Data;
 using GameInterface.Services.ObjectManager;
 using Serilog;
+using System;
 using System.Collections.Generic;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.Core;
@@ -188,9 +189,24 @@ public class SessionWorkshopPlayerDataInterface : ISessionWorkshopPlayerDataInte
             return;
         }
 
-        if (!WorkshopPlayerData.PlayerWarehouseRosterPerSettlement.ContainsKey(playerHeroId))
+        // A player can own up to MaximumWorkshopsPlayerCanHave workshops (patched to the map-wide
+        // workshop count), so the vanilla-derived MaxClanTier + 1 slot count silently dropped
+        // warehouse data for the settlements past that cap.
+        int slotCapacity = Math.Max(
+            Campaign.Current.Models.ClanTierModel.MaxClanTier + 1,
+            Campaign.Current.Models.WorkshopModel.MaximumWorkshopsPlayerCanHave);
+
+        if (!WorkshopPlayerData.PlayerWarehouseRosterPerSettlement.TryGetValue(playerHeroId, out var slots))
         {
-            WorkshopPlayerData.PlayerWarehouseRosterPerSettlement[playerHeroId] = new KeyValuePair<string, List<ItemRosterElementData>>[Campaign.Current.Models.ClanTierModel.MaxClanTier + 1];
+            WorkshopPlayerData.PlayerWarehouseRosterPerSettlement[playerHeroId] = new KeyValuePair<string, List<ItemRosterElementData>>[slotCapacity];
+            return;
+        }
+
+        if (slots.Length < slotCapacity)
+        {
+            var grownSlots = new KeyValuePair<string, List<ItemRosterElementData>>[slotCapacity];
+            Array.Copy(slots, grownSlots, slots.Length);
+            WorkshopPlayerData.PlayerWarehouseRosterPerSettlement[playerHeroId] = grownSlots;
         }
     }
 

--- a/source/GameInterface/Services/Workshops/WorkshopRepairer.cs
+++ b/source/GameInterface/Services/Workshops/WorkshopRepairer.cs
@@ -18,16 +18,41 @@ namespace GameInterface.Services.Workshops;
 /// (GetOutputDailyChange dereferences the missing data) and faults the server's production tick.
 /// </summary>
 /// <remarks>
-/// Temporary; remove this class once poisoned saves are no longer in circulation. Its only call
-/// sites are the two hooks in <see cref="WorkshopsCampaignBehaviorInitializationHandler"/>.
+/// Temporary; remove this file once poisoned saves are no longer in circulation. Its only
+/// consumer is <see cref="WorkshopsCampaignBehaviorInitializationHandler"/> (constructor
+/// injection plus the two repair calls).
 /// </remarks>
-internal static class WorkshopRepairer
+internal interface IWorkshopRepairer : IGameAbstraction
 {
     /// <summary>
     /// Backfills the local behavior storage for every workshop the player hero owns. Runs blocking
     /// so the player cannot open the Clan screen before their own workshops have data again.
     /// </summary>
-    internal static void RepairClientWorkshopData(WorkshopsCampaignBehavior workshopsCampaignBehavior, Hero playerHero)
+    void RepairClientWorkshopData(WorkshopsCampaignBehavior workshopsCampaignBehavior, Hero playerHero);
+
+    /// <summary>
+    /// Backfills the server behavior storage and the session-store warehouse entries for every
+    /// workshop the player hero owns. The AddNewWorkshopData server prefix broadcasts each
+    /// restored entry to every client.
+    /// </summary>
+    void RepairServerWorkshopData(Hero playerHero, string playerHeroId);
+}
+
+/// <inheritdoc cref="IWorkshopRepairer"/>
+internal class WorkshopRepairer : IWorkshopRepairer
+{
+    private readonly IObjectManager objectManager;
+    private readonly ISessionWorkshopPlayerDataInterface sessionWorkshopPlayerDataInterface;
+
+    public WorkshopRepairer(
+        IObjectManager objectManager,
+        ISessionWorkshopPlayerDataInterface sessionWorkshopPlayerDataInterface)
+    {
+        this.objectManager = objectManager;
+        this.sessionWorkshopPlayerDataInterface = sessionWorkshopPlayerDataInterface;
+    }
+
+    public void RepairClientWorkshopData(WorkshopsCampaignBehavior workshopsCampaignBehavior, Hero playerHero)
     {
         GameThread.RunSafe(() =>
         {
@@ -39,16 +64,7 @@ internal static class WorkshopRepairer
         }, blocking: true);
     }
 
-    /// <summary>
-    /// Backfills the server behavior storage and the session-store warehouse entries for every
-    /// workshop the player hero owns. The AddNewWorkshopData server prefix broadcasts each
-    /// restored entry to every client.
-    /// </summary>
-    internal static void RepairServerWorkshopData(
-        Hero playerHero,
-        string playerHeroId,
-        IObjectManager objectManager,
-        ISessionWorkshopPlayerDataInterface sessionWorkshopPlayerDataInterface)
+    public void RepairServerWorkshopData(Hero playerHero, string playerHeroId)
     {
         GameThread.RunSafe(() =>
         {
@@ -72,7 +88,7 @@ internal static class WorkshopRepairer
         }, context: nameof(WorkshopRepairer));
     }
 
-    internal static void AddMissingWorkshopData(WorkshopsCampaignBehavior workshopsCampaignBehavior, IEnumerable<Workshop> ownedWorkshops)
+    private static void AddMissingWorkshopData(WorkshopsCampaignBehavior workshopsCampaignBehavior, IEnumerable<Workshop> ownedWorkshops)
     {
         foreach (Workshop workshop in ownedWorkshops)
         {

--- a/source/GameInterface/Services/Workshops/WorkshopRepairer.cs
+++ b/source/GameInterface/Services/Workshops/WorkshopRepairer.cs
@@ -1,9 +1,12 @@
 using Common;
 using Common.Util;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Players;
+using GameInterface.Services.Players.Data;
 using GameInterface.Services.Workshops.Handlers;
 using GameInterface.Services.Workshops.Interfaces;
 using System.Collections.Generic;
+using System.Linq;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
 using TaleWorlds.CampaignSystem.Settlements.Workshops;
@@ -18,11 +21,12 @@ namespace GameInterface.Services.Workshops;
 /// (GetOutputDailyChange dereferences the missing data) and faults the server's production tick.
 /// </summary>
 /// <remarks>
-/// Temporary; remove this file once poisoned saves are no longer in circulation. Its only
+/// Temporary; remove this file (and its InstancePerDependency registration in
+/// <see cref="GameInterfaceModule"/>) once poisoned saves are no longer in circulation. Its only
 /// consumer is <see cref="WorkshopsCampaignBehaviorInitializationHandler"/> (constructor
 /// injection plus the two repair calls).
 /// </remarks>
-internal interface IWorkshopRepairer : IGameAbstraction
+internal interface IWorkshopRepairer
 {
     /// <summary>
     /// Backfills the local behavior storage for every workshop the player hero owns. Runs blocking
@@ -31,9 +35,11 @@ internal interface IWorkshopRepairer : IGameAbstraction
     void RepairClientWorkshopData(WorkshopsCampaignBehavior workshopsCampaignBehavior, Hero playerHero);
 
     /// <summary>
-    /// Backfills the server behavior storage and the session-store warehouse entries for every
-    /// workshop the player hero owns. The AddNewWorkshopData server prefix broadcasts each
-    /// restored entry to every client.
+    /// Backfills the server behavior storage and the session-store warehouse entries for the
+    /// announcing hero and every other registered player hero. Offline players stay registered
+    /// (the saved session reloads them on server start), so their workshops must repair on any
+    /// player's join rather than waiting for each owner to reconnect. The AddNewWorkshopData
+    /// server prefix broadcasts each restored entry to every client.
     /// </summary>
     void RepairServerWorkshopData(Hero playerHero, string playerHeroId);
 }
@@ -43,13 +49,16 @@ internal class WorkshopRepairer : IWorkshopRepairer
 {
     private readonly IObjectManager objectManager;
     private readonly ISessionWorkshopPlayerDataInterface sessionWorkshopPlayerDataInterface;
+    private readonly IPlayerManager playerManager;
 
     public WorkshopRepairer(
         IObjectManager objectManager,
-        ISessionWorkshopPlayerDataInterface sessionWorkshopPlayerDataInterface)
+        ISessionWorkshopPlayerDataInterface sessionWorkshopPlayerDataInterface,
+        IPlayerManager playerManager)
     {
         this.objectManager = objectManager;
         this.sessionWorkshopPlayerDataInterface = sessionWorkshopPlayerDataInterface;
+        this.playerManager = playerManager;
     }
 
     public void RepairClientWorkshopData(WorkshopsCampaignBehavior workshopsCampaignBehavior, Hero playerHero)
@@ -71,21 +80,50 @@ internal class WorkshopRepairer : IWorkshopRepairer
             WorkshopsCampaignBehavior workshopsCampaignBehavior = Campaign.Current.GetCampaignBehavior<WorkshopsCampaignBehavior>();
             if (workshopsCampaignBehavior == null) return;
 
-            IEnumerable<Workshop> ownedWorkshops = WorkshopsCampaignBehaviorInitializationHandler.GetWorkshopsOwnedBy(playerHero);
-
             workshopsCampaignBehavior.EnsureBehaviorDataSize();
-            AddMissingWorkshopData(workshopsCampaignBehavior, ownedWorkshops);
 
-            // Restore the session-store warehouse entries after every WorkshopData entry is
-            // back, so a session-store failure cannot cost workshop data.
-            foreach (Workshop workshop in ownedWorkshops)
+            foreach ((Hero hero, string heroId) in GetSavedPlayerHeroes(playerHero, playerHeroId))
             {
-                if (workshop.Settlement != null && objectManager.TryGetIdWithLogging(workshop.Settlement, out string settlementId))
-                {
-                    sessionWorkshopPlayerDataInterface.AddNewWarehouseDataIfNeeded(playerHeroId, settlementId);
-                }
+                RepairPlayerWorkshopData(workshopsCampaignBehavior, hero, heroId);
             }
         }, context: nameof(WorkshopRepairer));
+    }
+
+    /// <summary>
+    /// The announcing hero plus every other hero registered as a player, offline ones included.
+    /// </summary>
+    private List<(Hero Hero, string HeroId)> GetSavedPlayerHeroes(Hero playerHero, string playerHeroId)
+    {
+        var savedPlayerHeroes = new List<(Hero, string)> { (playerHero, playerHeroId) };
+
+        foreach (Player player in playerManager.Players.ToArray())
+        {
+            if (string.IsNullOrEmpty(player.HeroId) || player.HeroId == playerHeroId) continue;
+            if (!objectManager.TryGetObjectWithLogging(player.HeroId, out Hero hero)) continue;
+
+            savedPlayerHeroes.Add((hero, player.HeroId));
+        }
+
+        return savedPlayerHeroes;
+    }
+
+    private void RepairPlayerWorkshopData(WorkshopsCampaignBehavior workshopsCampaignBehavior, Hero playerHero, string playerHeroId)
+    {
+        IEnumerable<Workshop> ownedWorkshops = WorkshopsCampaignBehaviorInitializationHandler.GetWorkshopsOwnedBy(playerHero);
+
+        AddMissingWorkshopData(workshopsCampaignBehavior, ownedWorkshops);
+
+        // Grow the player's session-store slots first (poisoned saves sized them at the vanilla
+        // cap), then restore the warehouse entries after every WorkshopData entry is back, so a
+        // session-store failure cannot cost workshop data.
+        sessionWorkshopPlayerDataInterface.AddPlayerKeys(playerHeroId);
+        foreach (Workshop workshop in ownedWorkshops)
+        {
+            if (workshop.Settlement != null && objectManager.TryGetIdWithLogging(workshop.Settlement, out string settlementId))
+            {
+                sessionWorkshopPlayerDataInterface.AddNewWarehouseDataIfNeeded(playerHeroId, settlementId);
+            }
+        }
     }
 
     private static void AddMissingWorkshopData(WorkshopsCampaignBehavior workshopsCampaignBehavior, IEnumerable<Workshop> ownedWorkshops)

--- a/source/GameInterface/Services/Workshops/WorkshopRepairer.cs
+++ b/source/GameInterface/Services/Workshops/WorkshopRepairer.cs
@@ -1,0 +1,87 @@
+using Common;
+using Common.Util;
+using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Workshops.Handlers;
+using GameInterface.Services.Workshops.Interfaces;
+using System.Collections.Generic;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.CampaignBehaviors;
+using TaleWorlds.CampaignSystem.Settlements.Workshops;
+
+namespace GameInterface.Services.Workshops;
+
+/// <summary>
+/// Repairs saves poisoned by issue #2373: while MaximumWorkshopsPlayerCanHave returned the vanilla
+/// value, WorkshopsCampaignBehavior's fixed-size storage capped out and the native
+/// AddNewWorkshopData silently dropped WorkshopData for player-owned workshops. Those saves keep
+/// player ownership without WorkshopData, which black-screens the owner's Clan tab
+/// (GetOutputDailyChange dereferences the missing data) and faults the server's production tick.
+/// </summary>
+/// <remarks>
+/// Temporary; remove this class once poisoned saves are no longer in circulation. Its only call
+/// sites are the two hooks in <see cref="WorkshopsCampaignBehaviorInitializationHandler"/>.
+/// </remarks>
+internal static class WorkshopRepairer
+{
+    /// <summary>
+    /// Backfills the local behavior storage for every workshop the player hero owns. Runs blocking
+    /// so the player cannot open the Clan screen before their own workshops have data again.
+    /// </summary>
+    internal static void RepairClientWorkshopData(WorkshopsCampaignBehavior workshopsCampaignBehavior, Hero playerHero)
+    {
+        GameThread.RunSafe(() =>
+        {
+            using (new AllowedThread())
+            {
+                workshopsCampaignBehavior.EnsureBehaviorDataSize();
+                AddMissingWorkshopData(workshopsCampaignBehavior, WorkshopsCampaignBehaviorInitializationHandler.GetWorkshopsOwnedBy(playerHero));
+            }
+        }, blocking: true);
+    }
+
+    /// <summary>
+    /// Backfills the server behavior storage and the session-store warehouse entries for every
+    /// workshop the player hero owns. The AddNewWorkshopData server prefix broadcasts each
+    /// restored entry to every client.
+    /// </summary>
+    internal static void RepairServerWorkshopData(
+        Hero playerHero,
+        string playerHeroId,
+        IObjectManager objectManager,
+        ISessionWorkshopPlayerDataInterface sessionWorkshopPlayerDataInterface)
+    {
+        GameThread.RunSafe(() =>
+        {
+            WorkshopsCampaignBehavior workshopsCampaignBehavior = Campaign.Current.GetCampaignBehavior<WorkshopsCampaignBehavior>();
+            if (workshopsCampaignBehavior == null) return;
+
+            IEnumerable<Workshop> ownedWorkshops = WorkshopsCampaignBehaviorInitializationHandler.GetWorkshopsOwnedBy(playerHero);
+
+            workshopsCampaignBehavior.EnsureBehaviorDataSize();
+            AddMissingWorkshopData(workshopsCampaignBehavior, ownedWorkshops);
+
+            // Restore the session-store warehouse entries after every WorkshopData entry is
+            // back, so a session-store failure cannot cost workshop data.
+            foreach (Workshop workshop in ownedWorkshops)
+            {
+                if (workshop.Settlement != null && objectManager.TryGetIdWithLogging(workshop.Settlement, out string settlementId))
+                {
+                    sessionWorkshopPlayerDataInterface.AddNewWarehouseDataIfNeeded(playerHeroId, settlementId);
+                }
+            }
+        }, context: nameof(WorkshopRepairer));
+    }
+
+    internal static void AddMissingWorkshopData(WorkshopsCampaignBehavior workshopsCampaignBehavior, IEnumerable<Workshop> ownedWorkshops)
+    {
+        foreach (Workshop workshop in ownedWorkshops)
+        {
+            if (workshop == null) continue;
+
+            if (workshopsCampaignBehavior.GetDataOfWorkshop(workshop) == null)
+            {
+                workshopsCampaignBehavior.AddNewWorkshopData(workshop);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2373

## Root cause

`WorkshopsCampaignBehavior` stores per-workshop state (`_workshopData`) and warehouse rosters in fixed-size arrays sized by `WorkshopModel.MaximumWorkshopsPlayerCanHave`. Until 31aea9386, `MaximumWorkshopsPatch` began with `if (CallOriginalPolicy.IsOriginalAllowed()) return true;` — and every path that sizes those arrays runs where that is true (native `InitializeBehaviorData`/`EnsureBehaviorDataSize` during load, when the server is not yet in `ServerRunningState`; every coop `EnsureBehaviorDataSize` call site, wrapped in `AllowedThread`). So the arrays stayed at the vanilla value, `GetMaxWorkshopCountForClanTier(MaxClanTier)` = 7, on every peer — while holding data for **all** players' workshops combined.

Native `AddNewWorkshopData` silently no-ops when the array is full. From the 8th player workshop onward (the reported session had 15+), a purchase produced a workshop with a player owner but no `WorkshopData`, persisted into the save. For such a workshop:

- The owner's Clan tab builds `ClanFinanceWorkshopItemVM`, whose `RefreshValues` calls `GetOutputDailyChange` → `GetDataOfWorkshop(workshop).StockProductionInWarehouseRatio` → NullReferenceException escapes `GauntletClanScreen.OnInitialize` → black screen.
- The server production tick hits the same null in `TickOneProductionCycleForPlayerWorkshopInternal` and logs "Failed to run TickOneProductionCycleForPlayerWorkshop" every daily tick (the error the reporter attached).

31aea9386 fixed the sizing going forward but does not repair existing saves — nothing recreates the dropped entries, so affected players stay black-screened on every rejoin/restart, matching the follow-up reports that the newest nightly still reproduces it.

## Fix

`WorkshopRepairer` (`IWorkshopRepairer : IGameAbstraction`, auto-registered by the ServiceModule abstraction scan and injected into the initialization handler) — deliberately temporary; delete the file once poisoned saves are out of circulation. Its only consumer is `WorkshopsCampaignBehaviorInitializationHandler`, via two hooks:

- **Client**: when the player's hero is assigned (`PlayerHeroChanged`, i.e. every join), backfill `WorkshopData` for every workshop the hero owns, blocking so the Clan screen cannot open before the data exists again.
- **Server**: when a player announces their hero id (`NetworkInitializeServerWorkshopDataKeys`), backfill the server's `WorkshopData` — the existing `AddNewWorkshopData` server prefix broadcasts each restored entry to every connected client — then reinstate the session-store warehouse entries for the owned settlements.

Two adjacent gaps in the same family are fixed permanently (outside the repairer):

- The warehouse-roster join restore now derives owned workshops from `Hero.OwnedWorkshops` ∪ workshops whose `Workshop.Owner` is the hero (the Clan screen lists by `Workshop.Owner`, and the two can diverge mid-session), so `GetWarehouseItemRosterWeight` cannot iterate a null roster.
- `AddPlayerKeys` sized each player's session-store warehouse slots at `MaxClanTier + 1` = 7 and silently dropped an eighth settlement; it now sizes new arrays (and grows existing ones) to `MaximumWorkshopsPlayerCanHave`.

## Testing

- New `WorkshopDataRepairTests` (E2E): the real `NetworkInitializeServerWorkshopDataKeys` flow restores data on the server and on every client via the broadcast, plus the session-store warehouse entry; the client repair prepares Clan-screen data locally; owner-only-tracked workshops (list/owner divergence) are covered.
- E2E `Services.Workshops` filter: 15 passed (12 pre-existing + 3 new)
- GameInterface.Tests `Services.Workshops` filter: 5 passed
