### PR TITLE
[2177] Hold parties and pause world map time during conversations and trade

### DIFF
--- a/source/Coop.Tests/GameInterface/Services/MapEvents/ConversationPartyTrackerTests.cs
+++ b/source/Coop.Tests/GameInterface/Services/MapEvents/ConversationPartyTrackerTests.cs
@@ -1,14 +1,22 @@
-﻿using GameInterface.Services.MapEvents;
+﻿using Common.Messaging;
+using GameInterface.Services.MapEvents;
+using GameInterface.Services.MapEvents.Messages.Conversation;
 using Xunit;
 
 namespace Coop.Tests.GameInterface.Services.MapEvents;
 
 public class ConversationPartyTrackerTests
 {
-    private readonly ConversationPartyTracker tracker = new ConversationPartyTracker(objectManager: null);
+    private readonly MessageBroker messageBroker = new MessageBroker();
+    private readonly ConversationPartyTracker tracker;
 
     private readonly object firstPlayer = new object();
     private readonly object secondPlayer = new object();
+
+    public ConversationPartyTrackerTests()
+    {
+        tracker = new ConversationPartyTracker(objectManager: null, messageBroker: messageBroker);
+    }
 
     [Fact]
     public void TryBeginEngagement_WhenPartyUnengaged_BeginsEngagement()
@@ -119,6 +127,43 @@ public class ConversationPartyTrackerTests
         Assert.False(tracker.IsEngagedByOther("lord1", firstPlayer));
         Assert.True(tracker.IsEngagedByOther("lord1", secondPlayer));
         Assert.False(tracker.IsEngagedByOther("lord2", secondPlayer));
+    }
+
+    [Fact]
+    public void IsPlayerPartyEngaged_TracksAiAndPvpConversationParticipants()
+    {
+        tracker.TryBeginEngagement(firstPlayer, "player1", "lord1", wasAiDisabled: false);
+        tracker.BeginPvpConversation("player2", "player3");
+
+        Assert.True(tracker.IsPlayerPartyEngaged("player1"));
+        Assert.True(tracker.IsPlayerPartyEngaged("player2"));
+        Assert.True(tracker.IsPlayerPartyEngaged("player3"));
+        Assert.False(tracker.IsPlayerPartyEngaged("lord1"));
+
+        tracker.TryEndEngagement(firstPlayer, out _, out _);
+        tracker.EndPvpConversation("player2");
+
+        Assert.False(tracker.IsPlayerPartyEngaged("player1"));
+        Assert.False(tracker.IsPlayerPartyEngaged("player2"));
+        Assert.False(tracker.IsPlayerPartyEngaged("player3"));
+    }
+
+    [Fact]
+    public void ConversationStateChanges_PublishOnlyForTransitions()
+    {
+        var changes = 0;
+        messageBroker.Subscribe<PlayerConversationChanged>(_ => changes++);
+
+        Assert.True(tracker.TryBeginEngagement(firstPlayer, "player1", "lord1", wasAiDisabled: false));
+        Assert.True(tracker.TryBeginEngagement(firstPlayer, "player1", "lord1", wasAiDisabled: true));
+        tracker.BeginPvpConversation("player2", "player3");
+        tracker.BeginPvpConversation("player2", "player3");
+        Assert.True(tracker.TryEndEngagement(firstPlayer, out _, out _));
+        Assert.False(tracker.TryEndEngagement(firstPlayer, out _, out _));
+        tracker.EndPvpConversation("player2");
+        tracker.EndPvpConversation("player2");
+
+        Assert.Equal(4, changes);
     }
 
     [Fact]

--- a/source/E2E.Tests/Services/MapEvents/PlayerPartyInteractionFlowTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/PlayerPartyInteractionFlowTests.cs
@@ -1,13 +1,17 @@
 ﻿using Coop.Core.Server.Services.Stances.Messages;
 using Common.Messaging;
 using Common.Network;
+using Common.Network.Messages;
 using Common.Util;
+using Coop.Core.Server.Services.Time.Messages;
 using E2E.Tests.Environment.Instance;
 using E2E.Tests.Util;
 using GameInterface.Services.Barters.Messages;
 using GameInterface.CoopSessionData;
 using GameInterface.Services.Bandits.Messages;
 using GameInterface.Services.Entity;
+using GameInterface.Services.Heroes.Enum;
+using GameInterface.Services.Heroes.Interaces;
 using GameInterface.Services.Inventory.Data;
 using GameInterface.Services.Locations.Conversations;
 using GameInterface.Services.Locations.Messages.Conversation;
@@ -59,9 +63,15 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
     [Fact]
     public void ClientRequest_PlayerPartyInteraction_StartsServerDrivenDialogStates()
     {
-        var (client1, _, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+        var (client1, client2, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+        Server.Resolve<IPlayerManager>().SetPeer("PlayerOne", client1.NetPeer);
+        Server.Resolve<IPlayerManager>().SetPeer("PlayerTwo", client2.NetPeer);
+        Server.NetworkSentMessages.Clear();
 
         RequestInteraction(client1, initiatorPartyId, responderPartyId);
+
+        var timeControlChange = Server.NetworkSentMessages.GetMessages<NetworkChangeTimeControlMode>().Single();
+        Assert.Equal(TimeControlEnum.Pause, timeControlChange.NewControlMode);
 
         var started = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>().Single();
         Assert.Equal(initiatorPartyId, started.InitiatorPartyId);
@@ -160,7 +170,13 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
     public void TradeProposal_AcceptedByResponder_EntersTradeActiveForBothParties()
     {
         var (client1, client2, initiatorPartyId, responderPartyId) = CreateTwoPlayerParties();
+        Server.Resolve<IPlayerManager>().SetPeer("PlayerOne", client1.NetPeer);
+        Server.Resolve<IPlayerManager>().SetPeer("PlayerTwo", client2.NetPeer);
+        Server.NetworkSentMessages.Clear();
         RequestInteraction(client1, initiatorPartyId, responderPartyId);
+        Assert.Equal(
+            TimeControlEnum.Pause,
+            Server.NetworkSentMessages.GetMessages<NetworkChangeTimeControlMode>().Single().NewControlMode);
         var sessionId = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>().Single().SessionId;
         var initiatorInitialState = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionState>().Single(s =>
             s.SessionId == sessionId &&
@@ -204,6 +220,9 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
         var tradeStates = Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionState>().ToArray();
         Assert.Contains(tradeStates, s => s.PartyId == initiatorPartyId && s.Phase == PlayerPartyInteractionPhase.TradeActive);
         Assert.Contains(tradeStates, s => s.PartyId == responderPartyId && s.Phase == PlayerPartyInteractionPhase.TradeActive);
+        Server.Call(() => Assert.Equal(
+            TimeControlEnum.Pause,
+            Server.Resolve<ITimeControlInterface>().GetTimeControl()));
     }
 
     [Fact]
@@ -1373,10 +1392,15 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
     }
 
     [Fact]
-    public void AiPartyConversation_UsesExistingAllowPath()
+    public void AiPartyConversation_HoldsTargetWhileOtherPlayerKeepsTimeRunning_ThenPausesWhenFreePlayerDisconnects()
     {
-        var (client1, _, initiatorPartyId, _) = CreateTwoPlayerParties();
+        var (client1, client2, initiatorPartyId, _) = CreateTwoPlayerParties();
         var aiPartyId = CreateMobilePartyBase();
+
+        Server.Resolve<IPlayerManager>().SetPeer("PlayerOne", client1.NetPeer);
+        Server.Resolve<IPlayerManager>().SetPeer("PlayerTwo", client2.NetPeer);
+        Server.Call(() => Server.Resolve<ITimeControlInterface>().ServerSetTimeControl(TimeControlEnum.Play_1x));
+        Server.NetworkSentMessages.Clear();
 
         RequestInteraction(client1, initiatorPartyId, aiPartyId);
 
@@ -1385,8 +1409,33 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
         Assert.Equal(aiPartyId, allowed.DefenderId);
         Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerPartyInteractionStarted>());
         AssertInteractionStateCleared(client1);
+        Server.Call(() =>
+        {
+            Assert.Equal(TimeControlEnum.Play_1x, Server.Resolve<ITimeControlInterface>().GetTimeControl());
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(aiPartyId, out var aiParty));
+            Assert.Equal(MoveModeType.Hold, aiParty.MobileParty.PartyMoveMode);
+            Assert.True(aiParty.MobileParty.Ai.IsDisabled);
+            Assert.True(aiParty.MobileParty.Ai.DoNotMakeNewDecisions);
+        });
+
+        Server.NetworkSentMessages.Clear();
+        Server.Call(() =>
+        {
+            Server.Resolve<IPlayerManager>().ClearPeer(client2.NetPeer);
+            Server.Resolve<IMessageBroker>().Publish(this, new PlayerDisconnected(client2.NetPeer, default));
+        });
+
+        var timeControlChange = Server.NetworkSentMessages.GetMessages<NetworkChangeTimeControlMode>().Single();
+        Assert.Equal(TimeControlEnum.Pause, timeControlChange.NewControlMode);
 
         client1.Call(() => client1.Resolve<INetwork>().SendAll(new NetworkConversationEnded()));
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(aiPartyId, out var aiParty));
+            Assert.False(aiParty.MobileParty.Ai.IsDisabled);
+            Assert.False(aiParty.MobileParty.Ai.DoNotMakeNewDecisions);
+        });
     }
 
     [Fact]

--- a/source/GameInterface.Tests/Services/MapEvents/ConversationPartyTrackerTests.cs
+++ b/source/GameInterface.Tests/Services/MapEvents/ConversationPartyTrackerTests.cs
@@ -1,3 +1,4 @@
+﻿using Common.Messaging;
 using GameInterface.Services.MapEvents;
 using GameInterface.Services.ObjectManager;
 using Moq;
@@ -10,7 +11,9 @@ public class ConversationPartyTrackerTests
     [Fact]
     public void RefreshingSameEngagement_RecordsServerDetectedDefender()
     {
-        var tracker = new ConversationPartyTracker(new Mock<IObjectManager>().Object);
+        var tracker = new ConversationPartyTracker(
+            new Mock<IObjectManager>().Object,
+            new MessageBroker());
         var peer = new object();
 
         Assert.True(tracker.TryBeginEngagement(peer, "player-party", "bandit-party", false));

--- a/source/GameInterface/Services/MapEvents/Commands/ConversationDebugCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/ConversationDebugCommands.cs
@@ -1,6 +1,7 @@
 ﻿using Common;
 using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Villages.Commands;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -17,21 +18,27 @@ internal class ConversationDebugCommands
     [CommandLineArgumentFunction("start_nearest_ai", "coop.debug.conversation")]
     public static string StartNearestAi(List<string> args)
     {
-        if (ModInformation.IsServer)
-            return "Run coop.debug.conversation.start_nearest_ai on a client only";
-        if (args.Count != 0)
-            return "Usage: coop.debug.conversation.start_nearest_ai";
+        if (ModInformation.IsClient)
+            return "Run coop.debug.conversation.start_nearest_ai on the server only";
+        if (args.Count < 1 || args.Count > 2)
+            return "Usage: coop.debug.conversation.start_nearest_ai <controllerId> [excludedPartyId]";
 
-        var playerParty = MobileParty.MainParty;
-        if (playerParty == null)
-            return "The local player has no party";
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
-            return $"Unable to get {nameof(IObjectManager)}";
+        if (!MapEventDebugCommands.TryGetPlayerParty(
+                args[0],
+                requireReady: true,
+                out var objectManager,
+                out var playerParty,
+                out var error))
+            return error;
+        if (playerParty.CurrentSettlement != null)
+            return $"Player {args[0]} must be outside a settlement";
 
+        var excludedPartyId = args.Count == 2 ? args[1] : null;
         var playerPosition = playerParty.Position.ToVec2();
         var target = MobileParty.All
             .Where(party => party.IsActive &&
                 !party.IsPlayerParty() &&
+                !MapEventDebugCommands.MatchesPartyId(objectManager, party, excludedPartyId) &&
                 party.LeaderHero != null &&
                 party.MapEvent == null &&
                 party.CurrentSettlement == null &&
@@ -42,11 +49,13 @@ internal class ConversationDebugCommands
             .FirstOrDefault();
         if (target == null)
             return "No active AI lord party is available";
-        if (!objectManager.TryGetId(target.Party, out var partyId))
-            return "Unable to get the AI party id";
+        if (!objectManager.TryGetId(target, out var mobilePartyId) ||
+            !objectManager.TryGetId(target.Party, out var partyBaseId))
+            return "Unable to get the AI party ids";
 
         EncounterManager.StartPartyEncounter(playerParty.Party, target.Party);
-        return $"Started AI conversation with {target.StringId}; PartyId={partyId}";
+        return $"Started AI conversation with {target.Name} (StringId {target.StringId}, " +
+            $"registry id {mobilePartyId}, PartyBase id {partyBaseId}) against player {args[0]}";
     }
 
     [CommandLineArgumentFunction("state", "coop.debug.conversation")]

--- a/source/GameInterface/Services/MapEvents/Commands/ConversationDebugCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/ConversationDebugCommands.cs
@@ -73,5 +73,4 @@ internal class ConversationDebugCommands
             $"DoNotMakeNewDecisions={party.Ai?.DoNotMakeNewDecisions == true}\n" +
             $"InConversation={ConversationPartyHold.IsInPlayerConversation(party)}";
     }
-
 }

--- a/source/GameInterface/Services/MapEvents/Commands/ConversationDebugCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/ConversationDebugCommands.cs
@@ -1,0 +1,77 @@
+﻿using Common;
+using GameInterface.Services.MobileParties.Extensions;
+using GameInterface.Services.ObjectManager;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Encounters;
+using TaleWorlds.CampaignSystem.Party;
+using static TaleWorlds.Library.CommandLineFunctionality;
+
+namespace GameInterface.Services.MapEvents.Commands;
+
+/// <summary>Debug-only commands for driving and inspecting AI party conversations during live tests.</summary>
+internal class ConversationDebugCommands
+{
+    [CommandLineArgumentFunction("start_nearest_ai", "coop.debug.conversation")]
+    public static string StartNearestAi(List<string> args)
+    {
+        if (ModInformation.IsServer)
+            return "Run coop.debug.conversation.start_nearest_ai on a client only";
+        if (args.Count != 0)
+            return "Usage: coop.debug.conversation.start_nearest_ai";
+
+        var playerParty = MobileParty.MainParty;
+        if (playerParty == null)
+            return "The local player has no party";
+        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
+            return $"Unable to get {nameof(IObjectManager)}";
+
+        var playerPosition = playerParty.Position.ToVec2();
+        var target = MobileParty.All
+            .Where(party => party.IsActive &&
+                !party.IsPlayerParty() &&
+                party.LeaderHero != null &&
+                party.MapEvent == null &&
+                party.CurrentSettlement == null &&
+                party.BesiegerCamp == null &&
+                party.Ai?.IsDisabled == false &&
+                party.MemberRoster.TotalManCount > 0)
+            .OrderBy(party => party.Position.ToVec2().DistanceSquared(playerPosition))
+            .FirstOrDefault();
+        if (target == null)
+            return "No active AI lord party is available";
+        if (!objectManager.TryGetId(target.Party, out var partyId))
+            return "Unable to get the AI party id";
+
+        EncounterManager.StartPartyEncounter(playerParty.Party, target.Party);
+        return $"Started AI conversation with {target.StringId}; PartyId={partyId}";
+    }
+
+    [CommandLineArgumentFunction("state", "coop.debug.conversation")]
+    public static string State(List<string> args)
+    {
+        if (ModInformation.IsClient)
+            return "Run coop.debug.conversation.state on the server only";
+        if (args.Count != 1)
+            return "Usage: coop.debug.conversation.state <partyId>";
+        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
+            return $"Unable to get {nameof(IObjectManager)}";
+        if (!objectManager.TryGetObjectWithLogging<PartyBase>(args[0], out var partyBase) ||
+            partyBase.MobileParty == null)
+            return $"Unable to resolve mobile party '{args[0]}'";
+
+        var party = partyBase.MobileParty;
+        return
+            $"PartyId={args[0]}\n" +
+            $"StringId={party.StringId}\n" +
+            $"PositionX={party.Position.X.ToString("R", CultureInfo.InvariantCulture)}\n" +
+            $"PositionY={party.Position.Y.ToString("R", CultureInfo.InvariantCulture)}\n" +
+            $"MoveMode={party.PartyMoveMode}\n" +
+            $"AiDisabled={party.Ai?.IsDisabled == true}\n" +
+            $"DoNotMakeNewDecisions={party.Ai?.DoNotMakeNewDecisions == true}\n" +
+            $"InConversation={ConversationPartyHold.IsInPlayerConversation(party)}";
+    }
+
+}

--- a/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
@@ -110,7 +110,7 @@ public class MapEventDebugCommands
         return container.TryResolve(out objectManager);
     }
 
-    private static bool MatchesPartyId(IObjectManager objectManager, MobileParty party, string id)
+    internal static bool MatchesPartyId(IObjectManager objectManager, MobileParty party, string id)
     {
         if (party == null || string.IsNullOrEmpty(id)) return false;
         if (party.StringId == id) return true;
@@ -1511,7 +1511,7 @@ public class MapEventDebugCommands
             playerParty);
     }
 
-    private static bool TryGetPlayerParty(
+    internal static bool TryGetPlayerParty(
         string controllerId,
         bool requireReady,
         out IObjectManager objectManager,

--- a/source/GameInterface/Services/MapEvents/ConversationPartyTracker.cs
+++ b/source/GameInterface/Services/MapEvents/ConversationPartyTracker.cs
@@ -1,6 +1,7 @@
 ﻿using Common;
 using Common.Messaging;
 using Common.Util;
+using GameInterface.Services.MapEvents.Messages.Conversation;
 using GameInterface.Services.ObjectManager;
 using System.Collections.Generic;
 using System.Linq;
@@ -24,6 +25,7 @@ internal sealed class ConversationPartyTracker : IHandler
     internal static ConversationPartyTracker Instance { get; private set; }
 
     private readonly object stateLock = new object();
+    private readonly IMessageBroker messageBroker;
     private readonly Dictionary<object, Engagement> engagements =
         new Dictionary<object, Engagement>(ReferenceObjectComparer.Instance);
 
@@ -50,9 +52,10 @@ internal sealed class ConversationPartyTracker : IHandler
     /// </summary>
     internal IObjectManager ObjectManager { get; }
 
-    public ConversationPartyTracker(IObjectManager objectManager)
+    public ConversationPartyTracker(IObjectManager objectManager, IMessageBroker messageBroker)
     {
         ObjectManager = objectManager;
+        this.messageBroker = messageBroker;
         Instance = this;
     }
 
@@ -156,8 +159,10 @@ internal sealed class ConversationPartyTracker : IHandler
                 engagerIsDefender,
                 wasAiDisabled));
             isEmpty = false;
-            return true;
         }
+
+        PublishConversationChanged();
+        return true;
     }
 
     /// <summary>Gets the engagement owned by the given player, if any.</summary>
@@ -192,8 +197,10 @@ internal sealed class ConversationPartyTracker : IHandler
             engagements.Remove(engagerKey);
             shouldReleaseParty = !engagements.Values.Any(x => x.PartyId == endedPartyId);
             isEmpty = engagements.Count == 0;
-            return true;
         }
+
+        PublishConversationChanged();
+        return true;
     }
 
     public bool TryEndEngagement(object engagerKey, out string partyId, out Engagement engagement) =>
@@ -223,6 +230,18 @@ internal sealed class ConversationPartyTracker : IHandler
         }
     }
 
+    /// <summary>True when a player party is participating in an AI or player conversation.</summary>
+    public bool IsPlayerPartyEngaged(string partyId)
+    {
+        if (partyId == null) return false;
+
+        lock (stateLock)
+        {
+            return engagements.Values.Any(x => x.EngagerPartyId == partyId) ||
+                pvpPartnersByPartyId.ContainsKey(partyId);
+        }
+    }
+
     /// <summary>True when the party is engaged by a player other than <paramref name="engagerKey"/>.</summary>
     public bool IsEngagedByOther(string partyId, object engagerKey)
     {
@@ -243,10 +262,16 @@ internal sealed class ConversationPartyTracker : IHandler
         lock (stateLock)
         {
             if (disposed) return;
+            if (pvpPartnersByPartyId.TryGetValue(partyIdA, out var partnerId) && partnerId == partyIdB &&
+                pvpPartnersByPartyId.TryGetValue(partyIdB, out partnerId) && partnerId == partyIdA)
+                return;
+
             pvpPartnersByPartyId[partyIdA] = partyIdB;
             pvpPartnersByPartyId[partyIdB] = partyIdA;
             pvpIsEmpty = false;
         }
+
+        PublishConversationChanged();
     }
 
     /// <summary>Ends the PvP conversation containing the given party, releasing both it and its partner.</summary>
@@ -254,6 +279,7 @@ internal sealed class ConversationPartyTracker : IHandler
     {
         if (partyId == null) return;
 
+        var changed = false;
         lock (stateLock)
         {
             if (pvpPartnersByPartyId.TryGetValue(partyId, out var partnerId))
@@ -262,10 +288,13 @@ internal sealed class ConversationPartyTracker : IHandler
                 pvpPartnersByPartyId.Remove(partnerId);
                 RemovePvpPeer(partyId);
                 RemovePvpPeer(partnerId);
+                changed = true;
             }
 
             pvpIsEmpty = pvpPartnersByPartyId.Count == 0;
         }
+
+        if (changed) PublishConversationChanged();
     }
 
     /// <summary>Gets the conversation partner of a party in a PvP conversation, if any.</summary>
@@ -313,6 +342,11 @@ internal sealed class ConversationPartyTracker : IHandler
             pvpPeerByPartyId.Remove(partyId);
             pvpPartyIdByPeer.Remove(peer);
         }
+    }
+
+    private void PublishConversationChanged()
+    {
+        messageBroker.Publish(this, new PlayerConversationChanged());
     }
 
     private sealed class ReferenceObjectComparer : IEqualityComparer<object>

--- a/source/GameInterface/Services/MapEvents/Handlers/PlayerOccupancyPauseHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/PlayerOccupancyPauseHandler.cs
@@ -1,8 +1,10 @@
-using Common;
+﻿using Common;
 using Common.Messaging;
+using Common.Network.Messages;
 using GameInterface.Services.Heroes.Enum;
 using GameInterface.Services.Heroes.Interaces;
 using GameInterface.Services.MapEvents;
+using GameInterface.Services.MapEvents.Messages.Conversation;
 using GameInterface.Services.MobileParties.Messages.Behavior;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
@@ -12,11 +14,9 @@ using TaleWorlds.CampaignSystem.Party;
 namespace GameInterface.Services.MapEvents.Handlers;
 
 /// <summary>
-/// [Server] Pauses the campaign once every player is "occupied" — in a map event OR a settlement — so time stops
-/// when nobody is free on the map. Driven by <see cref="PartyOccupancyChanged"/>, which the setter postfixes
-/// (<see cref="MobileParties.Patches.PartyOccupancyPatches"/>) raise whenever any party's map-event or settlement
-/// membership changes. There is no unpause here (that is left to the players / other policies); it only sends the
-/// pause when the occupancy condition becomes true.
+/// [Server] Pauses the campaign once every player is occupied by a map event, settlement, or conversation, so time
+/// stops when nobody is free on the map. There is no unpause here (that is left to the players / other policies); it
+/// only sends the pause when the occupancy condition becomes true.
 /// </summary>
 internal class PlayerOccupancyPauseHandler : IHandler
 {
@@ -24,27 +24,53 @@ internal class PlayerOccupancyPauseHandler : IHandler
     private readonly IObjectManager objectManager;
     private readonly IPlayerManager playerManager;
     private readonly ITimeControlInterface timeControlInterface;
+    private readonly ConversationPartyTracker conversationPartyTracker;
 
     public PlayerOccupancyPauseHandler(
         IMessageBroker messageBroker,
         IObjectManager objectManager,
         IPlayerManager playerManager,
-        ITimeControlInterface timeControlInterface)
+        ITimeControlInterface timeControlInterface,
+        ConversationPartyTracker conversationPartyTracker)
     {
         this.messageBroker = messageBroker;
         this.objectManager = objectManager;
         this.playerManager = playerManager;
         this.timeControlInterface = timeControlInterface;
+        this.conversationPartyTracker = conversationPartyTracker;
 
         messageBroker.Subscribe<PartyOccupancyChanged>(Handle_PartyOccupancyChanged);
+        messageBroker.Subscribe<PlayerConversationChanged>(Handle_PlayerConversationChanged);
+        messageBroker.Subscribe<PlayerDisconnected>(Handle_PlayerDisconnected);
     }
 
     public void Dispose()
     {
         messageBroker.Unsubscribe<PartyOccupancyChanged>(Handle_PartyOccupancyChanged);
+        messageBroker.Unsubscribe<PlayerConversationChanged>(Handle_PlayerConversationChanged);
+        messageBroker.Unsubscribe<PlayerDisconnected>(Handle_PlayerDisconnected);
     }
 
     private void Handle_PartyOccupancyChanged(MessagePayload<PartyOccupancyChanged> payload)
+    {
+        PauseIfAllPlayersOccupied();
+    }
+
+    private void Handle_PlayerConversationChanged(MessagePayload<PlayerConversationChanged> payload)
+    {
+        GameThread.RunSafe(
+            PauseIfAllPlayersOccupied,
+            context: nameof(PlayerOccupancyPauseHandler));
+    }
+
+    private void Handle_PlayerDisconnected(MessagePayload<PlayerDisconnected> payload)
+    {
+        GameThread.RunSafe(
+            PauseIfAllPlayersOccupied,
+            context: nameof(PlayerOccupancyPauseHandler));
+    }
+
+    private void PauseIfAllPlayersOccupied()
     {
         if (ModInformation.IsClient)
             return;
@@ -55,8 +81,7 @@ internal class PlayerOccupancyPauseHandler : IHandler
         timeControlInterface.ServerSetTimeControl(TimeControlEnum.Pause);
     }
 
-    // Every player's party is in a map event or a settlement (i.e. none is free on the campaign map). An empty
-    // session is not "all occupied", so it never pauses with no players.
+    // An empty session is not "all occupied", so it never pauses with no players.
     private bool AllPlayersOccupied()
     {
         var connectedPlayers = playerManager.Players.Where(playerManager.IsConnected).ToList();
@@ -69,11 +94,15 @@ internal class PlayerOccupancyPauseHandler : IHandler
         });
     }
 
-    private static bool IsPlayerOccupied(MobileParty playerParty)
+    private bool IsPlayerOccupied(MobileParty playerParty)
     {
         var mapEvent = playerParty.MapEvent;
         if (mapEvent != null && mapEvent.IsActiveSlowVillageRaid())
             return false;
+
+        if (objectManager.TryGetId(playerParty.Party, out var partyId) &&
+            conversationPartyTracker.IsPlayerPartyEngaged(partyId))
+            return true;
 
         if (playerParty.CurrentSettlement != null)
             return true;

--- a/source/GameInterface/Services/MapEvents/Messages/Conversation/PlayerConversationChanged.cs
+++ b/source/GameInterface/Services/MapEvents/Messages/Conversation/PlayerConversationChanged.cs
@@ -1,0 +1,10 @@
+﻿using Common.Messaging;
+
+namespace GameInterface.Services.MapEvents.Messages.Conversation;
+
+/// <summary>
+/// [Server] Raised after a player party enters or leaves an AI or player conversation.
+/// </summary>
+public readonly struct PlayerConversationChanged : IEvent
+{
+}

--- a/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/Commands/PlayerPartyInteractionDebugCommands.cs
+++ b/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/Commands/PlayerPartyInteractionDebugCommands.cs
@@ -1,0 +1,85 @@
+﻿using Common;
+using GameInterface.Services.MapEvents.Messages.Conversation;
+using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Players;
+using System.Collections.Generic;
+using TaleWorlds.CampaignSystem.Party;
+using static TaleWorlds.Library.CommandLineFunctionality;
+
+namespace GameInterface.Services.MapEvents.PlayerPartyInteractions.Commands;
+
+/// <summary>Debug-only commands for driving player-party interactions during live tests.</summary>
+internal class PlayerPartyInteractionDebugCommands
+{
+    [CommandLineArgumentFunction("start", "coop.debug.player_interaction")]
+    public static string Start(List<string> args)
+    {
+        if (ModInformation.IsClient)
+            return "Run coop.debug.player_interaction.start on the server only";
+        if (args.Count != 2)
+            return "Usage: coop.debug.player_interaction.start <initiatorControllerId> <responderControllerId>";
+
+        if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager))
+            return $"Unable to get {nameof(IPlayerManager)}";
+        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
+            return $"Unable to get {nameof(IObjectManager)}";
+        if (!ContainerProvider.TryResolve<PlayerPartyInteractionHandler>(out var interactionHandler))
+            return $"Unable to get {nameof(PlayerPartyInteractionHandler)}";
+
+        if (!playerManager.TryGetPlayer(args[0], out var initiator))
+            return $"Player '{args[0]}' is not registered";
+        if (!playerManager.TryGetPlayer(args[1], out var responder))
+            return $"Player '{args[1]}' is not registered";
+        if (!playerManager.TryGetPeer(initiator.ControllerId, out var initiatorPeer))
+            return $"Player '{initiator.ControllerId}' is not connected";
+        if (!playerManager.TryGetPeer(responder.ControllerId, out _))
+            return $"Player '{responder.ControllerId}' is not connected";
+        if (!objectManager.TryGetObjectWithLogging<MobileParty>(initiator.MobilePartyId, out var initiatorParty))
+            return $"Player '{initiator.ControllerId}' has no resolved party";
+        if (!objectManager.TryGetObjectWithLogging<MobileParty>(responder.MobilePartyId, out var responderParty))
+            return $"Player '{responder.ControllerId}' has no resolved party";
+        if (!objectManager.TryGetId(initiatorParty.Party, out var initiatorPartyId) ||
+            !objectManager.TryGetId(responderParty.Party, out var responderPartyId))
+            return "Unable to get player party ids";
+
+        var request = new NetworkRequestConversation(
+            responderPartyId,
+            initiatorPartyId,
+            forcePlayerOutFromSettlement: false,
+            ConversationRestartSource.PlayerEncounter,
+            armyTalkEncounter: false);
+
+        return interactionHandler.TryStartSession(
+            initiatorPeer,
+            request,
+            initiatorParty.Party,
+            responderParty.Party)
+            ? $"Started player interaction between {initiator.ControllerId} and {responder.ControllerId}"
+            : "Unable to start player interaction";
+    }
+
+    [CommandLineArgumentFunction("end", "coop.debug.player_interaction")]
+    public static string End(List<string> args)
+    {
+        if (ModInformation.IsClient)
+            return "Run coop.debug.player_interaction.end on the server only";
+        if (args.Count != 1)
+            return "Usage: coop.debug.player_interaction.end <controllerId>";
+
+        if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager))
+            return $"Unable to get {nameof(IPlayerManager)}";
+        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
+            return $"Unable to get {nameof(IObjectManager)}";
+        if (!ContainerProvider.TryResolve<PlayerPartyInteractionHandler>(out var interactionHandler))
+            return $"Unable to get {nameof(PlayerPartyInteractionHandler)}";
+        if (!playerManager.TryGetPlayer(args[0], out var player))
+            return $"Player '{args[0]}' is not registered";
+        if (!objectManager.TryGetObjectWithLogging<MobileParty>(player.MobilePartyId, out var party) ||
+            !objectManager.TryGetId(party.Party, out var partyId))
+            return $"Player '{player.ControllerId}' has no resolved party";
+
+        return interactionHandler.TryEndSessionForDebug(partyId)
+            ? $"Ended player interaction for {player.ControllerId}"
+            : $"Player '{player.ControllerId}' has no active interaction";
+    }
+}

--- a/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyInteractionHandler.cs
+++ b/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyInteractionHandler.cs
@@ -175,6 +175,15 @@ internal class PlayerPartyInteractionHandler : IHandler
         return true;
     }
 
+    internal bool TryEndSessionForDebug(string partyId)
+    {
+        var session = FindExistingSession(partyId);
+        if (session == null) return false;
+
+        EndSession(session, PlayerPartyInteractionOutcomeType.Left);
+        return true;
+    }
+
     private void Handle_NetworkPlayerPartyInteractionStarted(MessagePayload<NetworkPlayerPartyInteractionStarted> payload)
     {
         if (ModInformation.IsServer) return;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

AI parties continue traveling while a player is talking or trading with them, and world-map time can keep running even after every connected player is occupied by a conversation or trade.

## What is the new behavior?

Resolves #2177

Conversation and trade now count as player occupancy: the contacted AI party stays held even while another free player keeps time running, and world-map time pauses once every connected player is occupied. Player-to-player interactions occupy both parties, and AI parties resume their previous behavior when the interaction ends.

## Bot Changelog Entry

- Keep conversation and trade parties stationary, and pause world-map time when every connected player is occupied.
