### PR TITLE
[2431] Stop recalculating player party AI every client frame

### DIFF
--- a/source/GameInterface/Services/MobileParties/Commands/MobilePartyDebugCommand.cs
+++ b/source/GameInterface/Services/MobileParties/Commands/MobilePartyDebugCommand.cs
@@ -1,7 +1,9 @@
-
-using Common;
+﻿using Common;
 using Common.Logging;
 using GameInterface.Services.MobileParties.Audit;
+#if DEBUG
+using GameInterface.Services.MobilePartyAIs.Patches;
+#endif
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
 using Helpers;
@@ -23,6 +25,25 @@ namespace GameInterface.Services.MobileParties.Commands;
 internal class MobilePartyDebugCommand
 {
     private static readonly ILogger Logger = LogManager.GetLogger<MobilePartyDebugCommand>();
+
+#if DEBUG
+    [CommandLineArgumentFunction("ai_behavior_calculation_count", "coop.debug.mobileparty")]
+    public static string AiBehaviorCalculationCount(List<string> args)
+    {
+        if (args.Count != 0)
+            return "Usage: coop.debug.mobileparty.ai_behavior_calculation_count";
+
+        if (ModInformation.IsServer)
+            return "ai_behavior_calculation_count is client-only";
+
+        var mainParty = MobileParty.MainParty;
+        return
+            $"MainPartyId={mainParty?.StringId ?? "none"}\n" +
+            $"MainPartyActive={mainParty?.IsActive.ToString() ?? "none"}\n" +
+            $"DefaultBehaviorNeedsUpdate={mainParty?.Ai?.DefaultBehaviorNeedsUpdate.ToString() ?? "none"}\n" +
+            $"GetBehaviorsCount={MobilePartyAIPatches.MainPartyBehaviorCalculationCount}";
+    }
+#endif
 
     [CommandLineArgumentFunction("info", "coop.debug.mobileparty")]
     public static string Info(List<string> args)

--- a/source/GameInterface/Services/MobileParties/Commands/MobilePartyDebugCommand.cs
+++ b/source/GameInterface/Services/MobileParties/Commands/MobilePartyDebugCommand.cs
@@ -1,9 +1,6 @@
 ﻿using Common;
 using Common.Logging;
 using GameInterface.Services.MobileParties.Audit;
-#if DEBUG
-using GameInterface.Services.MobilePartyAIs.Patches;
-#endif
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
 using Helpers;
@@ -25,25 +22,6 @@ namespace GameInterface.Services.MobileParties.Commands;
 internal class MobilePartyDebugCommand
 {
     private static readonly ILogger Logger = LogManager.GetLogger<MobilePartyDebugCommand>();
-
-#if DEBUG
-    [CommandLineArgumentFunction("ai_behavior_calculation_count", "coop.debug.mobileparty")]
-    public static string AiBehaviorCalculationCount(List<string> args)
-    {
-        if (args.Count != 0)
-            return "Usage: coop.debug.mobileparty.ai_behavior_calculation_count";
-
-        if (ModInformation.IsServer)
-            return "ai_behavior_calculation_count is client-only";
-
-        var mainParty = MobileParty.MainParty;
-        return
-            $"MainPartyId={mainParty?.StringId ?? "none"}\n" +
-            $"MainPartyActive={mainParty?.IsActive.ToString() ?? "none"}\n" +
-            $"DefaultBehaviorNeedsUpdate={mainParty?.Ai?.DefaultBehaviorNeedsUpdate.ToString() ?? "none"}\n" +
-            $"GetBehaviorsCount={MobilePartyAIPatches.MainPartyBehaviorCalculationCount}";
-    }
-#endif
 
     [CommandLineArgumentFunction("info", "coop.debug.mobileparty")]
     public static string Info(List<string> args)

--- a/source/GameInterface/Services/MobilePartyAIs/Patches/MobilePartyAIPatches.cs
+++ b/source/GameInterface/Services/MobilePartyAIs/Patches/MobilePartyAIPatches.cs
@@ -31,21 +31,6 @@ internal class MobilePartyAIPatches
             EncounterManager.HandleEncounterForMobileParty(__instance._mobileParty, 0f);
     }
 
-#if DEBUG
-    private static long mainPartyBehaviorCalculationCount;
-
-    internal static long MainPartyBehaviorCalculationCount =>
-        System.Threading.Interlocked.Read(ref mainPartyBehaviorCalculationCount);
-
-    [HarmonyPatch(nameof(MobilePartyAi.GetBehaviors))]
-    [HarmonyPrefix]
-    private static void GetBehaviorsPrefix(MobilePartyAi __instance)
-    {
-        if (ModInformation.IsClient && __instance._mobileParty == MobileParty.MainParty)
-            System.Threading.Interlocked.Increment(ref mainPartyBehaviorCalculationCount);
-    }
-#endif
-
     [HarmonyPatch(nameof(MobilePartyAi.AiBehaviorInteractable), MethodType.Setter), HarmonyPrefix]
     private static void AiBehaviorInteractablePrefix(MobilePartyAi __instance, IInteractablePoint value, out bool __state) =>
         __state = ModInformation.IsServer &&

--- a/source/GameInterface/Services/MobilePartyAIs/Patches/MobilePartyAIPatches.cs
+++ b/source/GameInterface/Services/MobilePartyAIs/Patches/MobilePartyAIPatches.cs
@@ -3,6 +3,7 @@ using Common.Messaging;
 using GameInterface.Policies;
 using GameInterface.Services.MobileParties.Messages.Behavior;
 using HarmonyLib;
+using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Map;
 using TaleWorlds.CampaignSystem.Party;
 
@@ -13,7 +14,7 @@ internal class MobilePartyAIPatches
 {
     [HarmonyPatch(nameof(MobilePartyAi.CheckPartyNeedsUpdate))]
     [HarmonyPrefix]
-    static void Prefix(ref MobilePartyAi __instance)
+    private static void CheckPartyNeedsUpdatePrefix(MobilePartyAi __instance)
     {
         // Default path on server
         if (ModInformation.IsServer) return;
@@ -25,8 +26,25 @@ internal class MobilePartyAIPatches
             return;
         }
 
-        __instance.DefaultBehaviorNeedsUpdate = true;
+        // Client encounter polling must continue even when vanilla has no AI update to apply.
+        if (!__instance.DefaultBehaviorNeedsUpdate)
+            EncounterManager.HandleEncounterForMobileParty(__instance._mobileParty, 0f);
     }
+
+#if DEBUG
+    private static long mainPartyBehaviorCalculationCount;
+
+    internal static long MainPartyBehaviorCalculationCount =>
+        System.Threading.Interlocked.Read(ref mainPartyBehaviorCalculationCount);
+
+    [HarmonyPatch(nameof(MobilePartyAi.GetBehaviors))]
+    [HarmonyPrefix]
+    private static void GetBehaviorsPrefix(MobilePartyAi __instance)
+    {
+        if (ModInformation.IsClient && __instance._mobileParty == MobileParty.MainParty)
+            System.Threading.Interlocked.Increment(ref mainPartyBehaviorCalculationCount);
+    }
+#endif
 
     [HarmonyPatch(nameof(MobilePartyAi.AiBehaviorInteractable), MethodType.Setter), HarmonyPrefix]
     private static void AiBehaviorInteractablePrefix(MobilePartyAi __instance, IInteractablePoint value, out bool __state) =>

--- a/source/GameInterface/Services/Party/Commands/PartyCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/PartyCommands.cs
@@ -1,4 +1,4 @@
-using Autofac;
+﻿using Autofac;
 using Common;
 using Common.Logging;
 using Common.Messaging;
@@ -159,6 +159,44 @@ internal class PartyCommands
 
         return $"Restored {party.StringId} to {party.Position.X:R},{party.Position.Y:R} in Hold mode.";
     }
+
+#if DEBUG
+    [CommandLineArgumentFunction("move_to_settlement", "coop.debug.mobileparty")]
+    public static string MoveToSettlementCommand(List<string> strings)
+    {
+        if (!ModInformation.IsServer)
+            return "Command can only be run on the server.";
+
+        if (strings.Count != 2)
+            return "Usage: coop.debug.mobileparty.move_to_settlement <partyId> <settlementId>";
+
+        if (!TryGetObjectManager(out var objectManager))
+            return "Unable to resolve ObjectManager.";
+
+        if (!objectManager.TryGetObject(strings[0], out MobileParty party))
+            return $"Party with id {strings[0]} not found";
+
+        if (!party.IsPlayerParty())
+            return $"Party {party.StringId} is not a player party.";
+
+        var settlement = Settlement.Find(strings[1]);
+        if (settlement == null)
+            return $"Settlement with id {strings[1]} not found";
+
+        if (!party.IsActive)
+            return $"Party {party.StringId} is not active.";
+
+        if (party.CurrentSettlement != null)
+            return $"Party {party.StringId} is already in {party.CurrentSettlement.StringId}.";
+
+        var navigationType = party.IsCurrentlyAtSea
+            ? MobileParty.NavigationType.Naval
+            : MobileParty.NavigationType.Default;
+        party.SetMoveGoToSettlement(settlement, navigationType, isTargetingThePort: false);
+
+        return $"Ordered {party.StringId} to {settlement.StringId}.";
+    }
+#endif
 
     /// <summary>
     /// View character ids in a hero's party

--- a/source/GameInterface/Services/Party/Commands/PartyCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/PartyCommands.cs
@@ -160,7 +160,6 @@ internal class PartyCommands
         return $"Restored {party.StringId} to {party.Position.X:R},{party.Position.Y:R} in Hold mode.";
     }
 
-#if DEBUG
     [CommandLineArgumentFunction("move_to_settlement", "coop.debug.mobileparty")]
     public static string MoveToSettlementCommand(List<string> strings)
     {
@@ -196,7 +195,6 @@ internal class PartyCommands
 
         return $"Ordered {party.StringId} to {settlement.StringId}.";
     }
-#endif
 
     /// <summary>
     /// View character ids in a hero's party


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Active player parties recalculate their campaign-map behavior every rendered client frame, which can cause stuttering while moving. The repeated work stops during captivity because the party is inactive, then resumes after release.

## What is the new behavior?

Resolves #2431

Active player parties no longer recalculate campaign-map behavior every rendered frame. Movement and target changes still refresh their behavior, and entering or leaving settlements still works normally.

## Bot Changelog Entry

- Player parties no longer repeat campaign-map behavior calculations every frame and still enter and leave settlements normally.
