### PR TITLE
Fix settlement gold after transaction

### DIFF
--- a/source/GameInterface/Services/Inventory/Interfaces/InventoryLogicInterface.cs
+++ b/source/GameInterface/Services/Inventory/Interfaces/InventoryLogicInterface.cs
@@ -154,7 +154,7 @@ namespace GameInterface.Services.Inventory.Interfaces
             if (currentSettlementComponent != null && isTrading)
             {
                 // Sets the gold of the other party
-                currentSettlementComponent.Gold += totalAmount;
+                currentSettlementComponent.ChangeGold(totalAmount);
             }
             else if (((currentMobileParty != null) ? currentMobileParty.Party.LeaderHero : null) != null && isTrading)
             {


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently `InventoryLogicInterface` sets the gold of a settlement directly which can allow it to become negative when selling more than the settlement has. Negative gold causes a lot of issues, namely messing with the balance of future trades in the same settlement.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #2448
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Use the same call as vanilla instead of assigning the gold directly to guard against negative settlement gold.

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Fixed an issue with selling more to a settlement than it has gold for.