### PR TITLE
Add credits button and popup

### DIFF
--- a/UIMovies/CoopConnectionUIMovie.xml
+++ b/UIMovies/CoopConnectionUIMovie.xml
@@ -309,7 +309,7 @@
                          VerticalAlignment="Bottom" MarginBottom="44" Command.Click="ActionCancel"/>
 
         <TextWidget WidthSizePolicy="Fixed" SuggestedWidth="256" HeightSizePolicy="Fixed" SuggestedHeight="64"
-                    VerticalAlignment="Bottom" HorizontalAlignment="Right" PositionYOffset="-170" PositionXOffset="-6"
+                    VerticalAlignment="Bottom" HorizontalAlignment="Right" PositionYOffset="-220" PositionXOffset="-6"
                     Brush="ScoreboardPanels_2" Text="@CommunityText"/>
 
         <ListPanel WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren"
@@ -336,6 +336,15 @@
           <Children>
             <Standard.Button HorizontalAlignment="Left" VerticalAlignment="Bottom"
                              Command.Click="ActionDonate" Parameter.Text="@DonateButtonText" PositionXOffset="-20"/>
+          </Children>
+        </ListPanel>
+
+        <ListPanel WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren"
+                   HorizontalAlignment="Right" VerticalAlignment="Bottom" MarginBottom="160"
+                   StackLayout.LayoutMethod="HorizontalLeftToRight">
+          <Children>
+            <Standard.Button HorizontalAlignment="Left" VerticalAlignment="Bottom"
+                             Command.Click="ActionCredits" Parameter.Text="@CreditsButtonText" PositionXOffset="-20"/>
           </Children>
         </ListPanel>
       </Children>

--- a/UIMovies/CoopOptionsUIMovie.xml
+++ b/UIMovies/CoopOptionsUIMovie.xml
@@ -122,7 +122,7 @@
 		<!-- Bottom-right community links (mirrors the connect screen). Lifted higher than the connect
             screen so the lowest button clears the campaign map's bottom HUD/toolbar. -->
 		<TextWidget WidthSizePolicy="Fixed" SuggestedWidth="256" HeightSizePolicy="Fixed" SuggestedHeight="64"
-					VerticalAlignment="Bottom" HorizontalAlignment="Right" PositionYOffset="-270" PositionXOffset="-6"
+					VerticalAlignment="Bottom" HorizontalAlignment="Right" PositionYOffset="-320" PositionXOffset="-6"
 					Brush="ScoreboardPanels_2" Text="@CommunityText"/>
 
 		<ListPanel WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren"
@@ -149,6 +149,15 @@
 			<Children>
 				<Standard.Button HorizontalAlignment="Left" VerticalAlignment="Bottom"
 								Command.Click="ActionDonate" Parameter.Text="@DonateButtonText" PositionXOffset="-20"/>
+			</Children>
+		</ListPanel>
+
+		<ListPanel WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren"
+					HorizontalAlignment="Right" VerticalAlignment="Bottom" MarginBottom="260"
+					StackLayout.LayoutMethod="HorizontalLeftToRight">
+			<Children>
+				<Standard.Button HorizontalAlignment="Left" VerticalAlignment="Bottom"
+								Command.Click="ActionCredits" Parameter.Text="@CreditsButtonText" PositionXOffset="-20"/>
 			</Children>
 		</ListPanel>
       </Children>

--- a/UIMovies/CreditsPopupUIMovie.xml
+++ b/UIMovies/CreditsPopupUIMovie.xml
@@ -1,0 +1,104 @@
+<Prefab>
+  <Window>
+    <Widget WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent">
+      <Children>
+        <!-- Dim backdrop. A plain Widget tints correctly; a ButtonWidget renders the raw white
+             sprite (ignores Color), which whited-out the whole screen. Input to the screen below is
+             already blocked by the focus layer, so the backdrop needs no click handling. -->
+        <Widget WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent"
+                Sprite="BlankWhiteSquare_9" Color="#000000FF" AlphaFactor="0.7"/>
+
+        <!-- Dialog border. -->
+        <Widget WidthSizePolicy="Fixed" SuggestedWidth="600" HeightSizePolicy="CoverChildren"
+                HorizontalAlignment="Center" VerticalAlignment="Center"
+                Sprite="BlankWhiteSquare_9" Color="#6E5A3AFF">
+          <Children>
+            <!-- Dialog body. -->
+            <ListPanel WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
+                       MarginTop="3" MarginBottom="3" MarginLeft="3" MarginRight="3"
+                       Sprite="BlankWhiteSquare_9" Color="#1C1712FF"
+                       StackLayout.LayoutMethod="VerticalTopToBottom">
+              <Children>
+                <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
+                            MarginTop="24" MarginLeft="34" MarginRight="34" MarginBottom="10"
+                            Brush="Clan.TabControl.Text" Brush.FontSize="40"
+                            Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
+                            Text="@TitleText"/>
+
+                <!-- Scrollable name sections. -->
+                <Widget WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="520"
+                        MarginLeft="34" MarginRight="24">
+                  <Children>
+                    <ScrollablePanel Id="CreditsScrollablePanel" WidthSizePolicy="StretchToParent"
+                                     HeightSizePolicy="StretchToParent" MarginRight="18"
+                                     AutoHideScrollBars="true" ClipRect="CreditsClipRect"
+                                     InnerPanel="CreditsClipRect\CreditsSections" VerticalScrollbar="..\CreditsScrollbar">
+                      <Children>
+                        <Widget Id="CreditsClipRect" WidthSizePolicy="StretchToParent"
+                                HeightSizePolicy="StretchToParent" ClipContents="true">
+                          <Children>
+                            <ListPanel Id="CreditsSections" WidthSizePolicy="StretchToParent"
+                                       HeightSizePolicy="CoverChildren"
+                                       StackLayout.LayoutMethod="VerticalTopToBottom">
+                              <Children>
+                                <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
+                                            MarginBottom="8" Brush="Clan.TabControl.Text" Brush.FontSize="32"
+                                            Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
+                                            Text="@ContributorsHeaderText"/>
+                                <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
+                                            MarginBottom="24" Brush="Clan.TabControl.Text" Brush.FontSize="23"
+                                            Brush.FontColor="#B8B8B8FF"
+                                            Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
+                                            Text="@ContributorsText"/>
+
+                                <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
+                                            MarginBottom="8" Brush="Clan.TabControl.Text" Brush.FontSize="32"
+                                            Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
+                                            Text="@CommunityHeaderText"/>
+                                <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
+                                            MarginBottom="24" Brush="Clan.TabControl.Text" Brush.FontSize="23"
+                                            Brush.FontColor="#B8B8B8FF"
+                                            Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
+                                            Text="@CommunityText"/>
+
+                                <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
+                                            MarginBottom="8" Brush="Clan.TabControl.Text" Brush.FontSize="32"
+                                            Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
+                                            Text="@SupportersHeaderText"/>
+                                <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
+                                            MarginBottom="8" Brush="Clan.TabControl.Text" Brush.FontSize="23"
+                                            Brush.FontColor="#B8B8B8FF"
+                                            Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
+                                            Text="@SupportersText"/>
+                              </Children>
+                            </ListPanel>
+                          </Children>
+                        </Widget>
+                      </Children>
+                    </ScrollablePanel>
+
+                    <ScrollbarWidget Id="CreditsScrollbar" WidthSizePolicy="Fixed" SuggestedWidth="8"
+                                     HeightSizePolicy="StretchToParent" HorizontalAlignment="Right"
+                                     AlignmentAxis="Vertical" Handle="CreditsScrollbarHandle" MaxValue="100" MinValue="0">
+                      <Children>
+                        <Widget WidthSizePolicy="Fixed" SuggestedWidth="2" HeightSizePolicy="StretchToParent"
+                                HorizontalAlignment="Center" Sprite="BlankWhiteSquare_9" Color="#5A4033FF" AlphaFactor="0.2"/>
+                        <ImageWidget Id="CreditsScrollbarHandle" WidthSizePolicy="Fixed" SuggestedWidth="4"
+                                     HeightSizePolicy="Fixed" SuggestedHeight="10" HorizontalAlignment="Center"
+                                     Brush="FaceGen.Scrollbar.Handle" Brush.AlphaFactor="0.7"/>
+                      </Children>
+                    </ScrollbarWidget>
+                  </Children>
+                </Widget>
+
+                <Standard.Button WidthSizePolicy="Fixed" SuggestedWidth="168" HeightSizePolicy="Fixed" SuggestedHeight="56"
+                                 HorizontalAlignment="Center" MarginTop="16" MarginBottom="24"
+                                 Command.Click="ActionClose" Parameter.Text="@CloseButtonText"/>
+              </Children>
+            </ListPanel>
+          </Children>
+        </Widget>
+      </Children>
+    </Widget>
+  </Window>
+</Prefab>

--- a/UIMovies/DonatePopupUIMovie.xml
+++ b/UIMovies/DonatePopupUIMovie.xml
@@ -35,7 +35,7 @@
                     <Standard.Button WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="60"
                                      MarginBottom="14" Command.Click="ActionBuyMeACoffee" Parameter.Text="@BuyMeACoffeeButtonText"/>
                     <Standard.Button WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="60"
-                                     MarginBottom="14" Command.Click="ActionIfdian" Parameter.Text="@IfdianButtonText"/>
+                                     MarginBottom="14" Command.Click="ActionAfdian" Parameter.Text="@AfdianButtonText"/>
                     <Standard.Button WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="60"
                                      MarginBottom="14" Command.Click="ActionBoosty" Parameter.Text="@BoostyButtonText"/>
                   </Children>

--- a/source/GameInterface.Tests/Services/UI/CreditsPopupVMTests.cs
+++ b/source/GameInterface.Tests/Services/UI/CreditsPopupVMTests.cs
@@ -1,0 +1,51 @@
+using GameInterface.Services.UI.Credits;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace GameInterface.Tests.Services.UI;
+
+public class CreditsPopupVMTests
+{
+    [Fact]
+    public void Constructor_RequiresCloseAction()
+    {
+        Assert.Throws<ArgumentNullException>(() => new CreditsPopupVM(null!));
+    }
+
+    [Fact]
+    public void ActionClose_InvokesCloseOnce()
+    {
+        int closeCount = 0;
+        var viewModel = new CreditsPopupVM(() => closeCount++);
+
+        viewModel.ActionClose();
+
+        Assert.Equal(1, closeCount);
+    }
+
+    [Fact]
+    public void SectionTexts_ListRosterNamesOrFallBackWhenEmpty()
+    {
+        var viewModel = new CreditsPopupVM(() => { });
+
+        Assert.Equal(ExpectedSectionText(CreditsRoster.Contributors), viewModel.ContributorsText);
+        Assert.Equal(ExpectedSectionText(CreditsRoster.Community), viewModel.CommunityText);
+        Assert.Equal(ExpectedSectionText(CreditsRoster.Supporters), viewModel.SupportersText);
+    }
+
+    [Fact]
+    public void ContributorsRoster_HasCleanDistinctNames()
+    {
+        Assert.NotEmpty(CreditsRoster.Contributors);
+        Assert.All(CreditsRoster.Contributors, name => Assert.False(string.IsNullOrWhiteSpace(name)));
+        Assert.Equal(CreditsRoster.Contributors.Count, CreditsRoster.Contributors
+            .Distinct(StringComparer.OrdinalIgnoreCase).Count());
+    }
+
+    private static string ExpectedSectionText(IReadOnlyList<string> names)
+    {
+        return names.Count == 0 ? CreditsPopupVM.EmptySectionText : string.Join("\n", names);
+    }
+}

--- a/source/GameInterface.Tests/Services/UI/PopupUIMovieBindingTests.cs
+++ b/source/GameInterface.Tests/Services/UI/PopupUIMovieBindingTests.cs
@@ -1,0 +1,88 @@
+using GameInterface.Services.UI.Credits;
+using GameInterface.Services.UI.Donate;
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Xml.Linq;
+using Xunit;
+
+namespace GameInterface.Tests.Services.UI;
+
+/// <summary>
+/// Cross-checks the popup movies against their view models so a renamed VM member cannot leave
+/// a dead "@Property" or "Command.Click" binding behind in the XML. Only valid for popups whose
+/// widgets all bind against the root data source (no DataSource scopes).
+/// </summary>
+public class PopupUIMovieBindingTests
+{
+    public static TheoryData<string, Type> PopupMovies => new()
+    {
+        { "DonatePopupUIMovie.xml", typeof(DonatePopupVM) },
+        { "CreditsPopupUIMovie.xml", typeof(CreditsPopupVM) },
+    };
+
+    [Theory]
+    [MemberData(nameof(PopupMovies))]
+    public void PopupMovies_BindOnlyAgainstTheRootDataSource(string movieFile, Type viewModelType)
+    {
+        _ = viewModelType;
+        var document = XDocument.Load(FindMoviePath(movieFile));
+
+        Assert.DoesNotContain(document.Descendants().SelectMany(element => element.Attributes()),
+            attribute => attribute.Name.LocalName == "DataSource");
+    }
+
+    [Theory]
+    [MemberData(nameof(PopupMovies))]
+    public void PropertyBindings_ResolveToViewModelProperties(string movieFile, Type viewModelType)
+    {
+        var document = XDocument.Load(FindMoviePath(movieFile));
+
+        var propertyNames = document.Descendants()
+            .SelectMany(element => element.Attributes())
+            .Where(attribute => attribute.Value.StartsWith("@", StringComparison.Ordinal))
+            .Select(attribute => attribute.Value.Substring(1))
+            .Distinct()
+            .ToList();
+
+        Assert.NotEmpty(propertyNames);
+        foreach (var propertyName in propertyNames)
+        {
+            var property = viewModelType.GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance);
+            Assert.True(property?.GetMethod != null,
+                $"{movieFile} binds '@{propertyName}' but {viewModelType.Name} has no readable public property '{propertyName}'.");
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(PopupMovies))]
+    public void CommandBindings_ResolveToViewModelMethods(string movieFile, Type viewModelType)
+    {
+        var document = XDocument.Load(FindMoviePath(movieFile));
+
+        var methodNames = document.Descendants()
+            .SelectMany(element => element.Attributes())
+            .Where(attribute => attribute.Name.LocalName.StartsWith("Command.", StringComparison.Ordinal))
+            .Select(attribute => attribute.Value)
+            .Distinct()
+            .ToList();
+
+        Assert.NotEmpty(methodNames);
+        foreach (var methodName in methodNames)
+        {
+            var method = viewModelType.GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance,
+                binder: null, types: Type.EmptyTypes, modifiers: null);
+            Assert.True(method != null,
+                $"{movieFile} invokes '{methodName}' but {viewModelType.Name} has no parameterless public method '{methodName}'.");
+        }
+    }
+
+    private static string FindMoviePath(string movieFile, [CallerFilePath] string sourceFile = "")
+    {
+        var sourceDirectory = Path.GetDirectoryName(sourceFile);
+        return Path.GetFullPath(Path.Combine(sourceDirectory!,
+            "..", "..", "..", "..", "UIMovies", movieFile));
+    }
+}

--- a/source/GameInterface/Services/UI/CoopConnectMenuVM.cs
+++ b/source/GameInterface/Services/UI/CoopConnectMenuVM.cs
@@ -46,6 +46,7 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
     public string DiscordButtonText => "Discord";
     public string PatreonButtonText => "Patreon";
     public string DonateButtonText => "Donate";
+    public string CreditsButtonText => "Credits";
     public string MovieTextHeader => "Join Co-op Sandbox";
     public string CommunityText => "Join the Community";
     public string SteamLobbiesHeaderText => $"Hosted Steam Servers ({filteredSteamLobbyCount})";
@@ -346,6 +347,9 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
 
     // Opens a popup listing the individual donation platforms above a close button.
     public void ActionDonate() => CommunityLinks.ShowDonatePopup();
+
+    // Opens a popup listing contributor, community, and supporter names.
+    public void ActionCredits() => CommunityLinks.ShowCreditsPopup();
 
     public void Dispose()
     {

--- a/source/GameInterface/Services/UI/CoopOptions/CoopOptionsUIMovie.template.xml
+++ b/source/GameInterface/Services/UI/CoopOptions/CoopOptionsUIMovie.template.xml
@@ -43,7 +43,7 @@
 		<!-- Bottom-right community links (mirrors the connect screen). Lifted higher than the connect
             screen so the lowest button clears the campaign map's bottom HUD/toolbar. -->
 		<TextWidget WidthSizePolicy="Fixed" SuggestedWidth="256" HeightSizePolicy="Fixed" SuggestedHeight="64"
-					VerticalAlignment="Bottom" HorizontalAlignment="Right" PositionYOffset="-270" PositionXOffset="-6"
+					VerticalAlignment="Bottom" HorizontalAlignment="Right" PositionYOffset="-320" PositionXOffset="-6"
 					Brush="ScoreboardPanels_2" Text="@CommunityText"/>
 
 		<ListPanel WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren"
@@ -70,6 +70,15 @@
 			<Children>
 				<Standard.Button HorizontalAlignment="Left" VerticalAlignment="Bottom"
 								Command.Click="ActionDonate" Parameter.Text="@DonateButtonText" PositionXOffset="-20"/>
+			</Children>
+		</ListPanel>
+
+		<ListPanel WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren"
+					HorizontalAlignment="Right" VerticalAlignment="Bottom" MarginBottom="260"
+					StackLayout.LayoutMethod="HorizontalLeftToRight">
+			<Children>
+				<Standard.Button HorizontalAlignment="Left" VerticalAlignment="Bottom"
+								Command.Click="ActionCredits" Parameter.Text="@CreditsButtonText" PositionXOffset="-20"/>
 			</Children>
 		</ListPanel>
       </Children>

--- a/source/GameInterface/Services/UI/CoopOptions/CoopOptionsVM.cs
+++ b/source/GameInterface/Services/UI/CoopOptions/CoopOptionsVM.cs
@@ -25,6 +25,7 @@ public class CoopOptionsVM : ViewModel
     public string MovieTextHeader => "Coop Options";
     public string ApplyButtonText => "Apply";
     public string CommunityText => "Join the Community";
+    public string CreditsButtonText => "Credits";
     public string DonateButtonText => "Donate";
     public string PatreonButtonText => "Patreon";
     public string DiscordButtonText => "Discord";
@@ -105,6 +106,8 @@ public class CoopOptionsVM : ViewModel
     }
 
     public void ActionDonate() => CommunityLinks.ShowDonatePopup();
+
+    public void ActionCredits() => CommunityLinks.ShowCreditsPopup();
 
     public void ActionPatreon() => CommunityLinks.OpenPatreon();
 

--- a/source/GameInterface/Services/UI/Credits/CreditsPopupOverlay.cs
+++ b/source/GameInterface/Services/UI/Credits/CreditsPopupOverlay.cs
@@ -1,0 +1,51 @@
+using TaleWorlds.Engine.GauntletUI;
+using TaleWorlds.ScreenSystem;
+
+namespace GameInterface.Services.UI.Credits;
+
+/// <summary>
+/// Shows the credits popup as a focus layer over the given screen. Mirrors
+/// <see cref="Donate.DonatePopupOverlay"/>: add a layer, load the movie, remove it on close.
+/// </summary>
+internal sealed class CreditsPopupOverlay
+{
+    private readonly ScreenBase owner;
+    private CreditsPopupVM dataSource;
+    private GauntletLayer gauntletLayer;
+
+    private CreditsPopupOverlay(ScreenBase owner)
+    {
+        this.owner = owner;
+    }
+
+    public static void Show(ScreenBase owner)
+    {
+        if (owner == null) return;
+
+        new CreditsPopupOverlay(owner).Show();
+    }
+
+    private void Show()
+    {
+        dataSource = new CreditsPopupVM(Close);
+        gauntletLayer = new GauntletLayer("CreditsPopupUI", 200)
+        {
+            IsFocusLayer = true
+        };
+        owner.AddLayer(gauntletLayer);
+        gauntletLayer.InputRestrictions.SetInputRestrictions();
+        gauntletLayer.LoadMovie("CreditsPopupUIMovie", dataSource);
+        ScreenManager.TrySetFocus(gauntletLayer);
+    }
+
+    private void Close()
+    {
+        if (gauntletLayer == null) return;
+
+        gauntletLayer.IsFocusLayer = false;
+        ScreenManager.TryLoseFocus(gauntletLayer);
+        owner.RemoveLayer(gauntletLayer);
+        dataSource = null;
+        gauntletLayer = null;
+    }
+}

--- a/source/GameInterface/Services/UI/Credits/CreditsPopupVM.cs
+++ b/source/GameInterface/Services/UI/Credits/CreditsPopupVM.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using TaleWorlds.Library;
+
+namespace GameInterface.Services.UI.Credits;
+
+/// <summary>
+/// Backs the credits popup: a title above named sections (contributors, community, supporters)
+/// and a close button. Section names come from <see cref="CreditsRoster"/>.
+/// </summary>
+public class CreditsPopupVM : ViewModel
+{
+    internal const string EmptySectionText = "Coming soon";
+
+    private readonly Action close;
+
+    public CreditsPopupVM(Action close)
+    {
+        this.close = close ?? throw new ArgumentNullException(nameof(close));
+    }
+
+    public string TitleText => "Credits";
+    public string ContributorsHeaderText => "Contributors";
+    public string CommunityHeaderText => "Community";
+    public string SupportersHeaderText => "Supporters";
+    public string ContributorsText => FormatNames(CreditsRoster.Contributors);
+    public string CommunityText => FormatNames(CreditsRoster.Community);
+    public string SupportersText => FormatNames(CreditsRoster.Supporters);
+    public string CloseButtonText => "Close";
+
+    public void ActionClose()
+    {
+        close();
+    }
+
+    private static string FormatNames(IReadOnlyList<string> names)
+    {
+        return names.Count == 0 ? EmptySectionText : string.Join("\n", names);
+    }
+}

--- a/source/GameInterface/Services/UI/Credits/CreditsRoster.cs
+++ b/source/GameInterface/Services/UI/Credits/CreditsRoster.cs
@@ -15,9 +15,9 @@ internal static class CreditsRoster
     public static readonly IReadOnlyList<string> Contributors = new[]
     {
         "Joke (Garrett)",
-        "ShoT-UPfps",
+        "Andrew.Orlowski (ShoT-UP)",
         "EgardA (Hasted)",
-        "jordanbrymora",
+        "Jordan Brymora (Curzek)",
         "araex",
         "MaxDorob",
         "samuelzurowski",

--- a/source/GameInterface/Services/UI/Credits/CreditsRoster.cs
+++ b/source/GameInterface/Services/UI/Credits/CreditsRoster.cs
@@ -14,9 +14,9 @@ internal static class CreditsRoster
     /// </summary>
     public static readonly IReadOnlyList<string> Contributors = new[]
     {
-        "garrettluskey",
+        "Joke (Garrett)",
         "ShoT-UPfps",
-        "EgardA",
+        "EgardA (Hasted)",
         "jordanbrymora",
         "araex",
         "MaxDorob",
@@ -48,7 +48,6 @@ internal static class CreditsRoster
         "GitEiko",
         "AndreasOhmer",
         "Magenstor",
-        "code-factor",
         "Cytraen",
         "ac-jurd",
         "jacksonamartin",

--- a/source/GameInterface/Services/UI/Credits/CreditsRoster.cs
+++ b/source/GameInterface/Services/UI/Credits/CreditsRoster.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+
+namespace GameInterface.Services.UI.Credits;
+
+/// <summary>
+/// Names shown in the credits popup, one section per list. Add new names here; sections render
+/// in roster order and an empty list shows a "coming soon" line instead of names.
+/// </summary>
+internal static class CreditsRoster
+{
+    /// <summary>
+    /// GitHub contributors ordered by contribution count
+    /// (github.com/Bannerlord-Coop-Team/BannerlordCoop/graphs/contributors).
+    /// </summary>
+    public static readonly IReadOnlyList<string> Contributors = new[]
+    {
+        "garrettluskey",
+        "ShoT-UPfps",
+        "EgardA",
+        "jordanbrymora",
+        "araex",
+        "MaxDorob",
+        "samuelzurowski",
+        "NatteTosti69",
+        "zzzzzzzzott",
+        "WakooMan",
+        "georgyrudnev",
+        "Gerseras",
+        "thomas-soutif",
+        "masesk",
+        "orfolei",
+        "martinprejsa",
+        "brodrigz",
+        "Gears321",
+        "evorios",
+        "thomasDelaporte",
+        "spk-berthel",
+        "Allen-Glass",
+        "dennispost99",
+        "MaxBosse",
+        "smudge202",
+        "DiMiGi",
+        "techratTV",
+        "phong-nnguyen",
+        "wesley-krug",
+        "tristanka",
+        "ignaciofernandezsoto",
+        "GitEiko",
+        "AndreasOhmer",
+        "Magenstor",
+        "code-factor",
+        "Cytraen",
+        "ac-jurd",
+        "jacksonamartin",
+        "hakanyildizhan",
+        "Hollo1001",
+        "Ceron257",
+        "WesKrug",
+        "BetterAtBrewing",
+        "Anziverov",
+        "kaefoody",
+        "NicodemusU",
+        "richlander",
+    };
+
+    /// <summary>Community members: moderators, translators, testers, and other helpers.</summary>
+    public static readonly IReadOnlyList<string> Community = new string[0];
+
+    /// <summary>People who supported the project financially (donations, Patreon).</summary>
+    public static readonly IReadOnlyList<string> Supporters = new string[0];
+}

--- a/source/GameInterface/Services/UI/Donate/CommunityLinks.cs
+++ b/source/GameInterface/Services/UI/Donate/CommunityLinks.cs
@@ -1,10 +1,11 @@
+using GameInterface.Services.UI.Credits;
 using TaleWorlds.ScreenSystem;
 
 namespace GameInterface.Services.UI.Donate;
 
 /// <summary>
-/// Shared community / donation link actions used by the co-op menus (connect menu, coop options).
-/// Keeps the platform URLs and the donate-popup launch in one place so screens stay in sync.
+/// Shared community / donation / credits actions used by the co-op menus (connect menu, coop options).
+/// Keeps the platform URLs and the popup launches in one place so screens stay in sync.
 /// </summary>
 internal static class CommunityLinks
 {
@@ -21,6 +22,15 @@ internal static class CommunityLinks
         if (ScreenManager.TopScreen is ScreenBase owner)
         {
             DonatePopupOverlay.Show(owner);
+        }
+    }
+
+    /// <summary>Shows the credits popup layered over whichever screen is currently on top.</summary>
+    public static void ShowCreditsPopup()
+    {
+        if (ScreenManager.TopScreen is ScreenBase owner)
+        {
+            CreditsPopupOverlay.Show(owner);
         }
     }
 


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?

The connect and coop options screens have Discord / Patreon / Donate buttons in the bottom-right stack, but there is no way to see who built and supports the mod.

Additionally, the third button in the donate popup was dead: `DonatePopupUIMovie.xml` still bound `ActionIfdian` / `@IfdianButtonText` after the view model members were renamed to `ActionAfdian` / `AfdianButtonText`, so the button rendered with a blank label and clicking it did nothing.

## What is the new behavior?

- A **Credits** button sits above Donate in the bottom-right button stack on both the connect screen and the coop options screen (options screen updated through `CoopOptionsUIMovie.template.xml` + generator).
- Clicking it opens a credits popup (same dialog style as the donate popup) with a scrollable list of three sections: **Contributors**, **Community**, and **Supporters**.
- Names live in `CreditsRoster.cs`. Contributors is seeded with all 47 GitHub contributors in contribution order. Community and Supporters are empty for now and show a "Coming soon" line; add names to the arrays and the UI picks them up.
- The Afdian donate button binding is fixed, and a new `PopupUIMovieBindingTests` reflects every `@Property` / `Command.*` binding in both popup movies against their view models so renamed VM members can no longer leave dead bindings behind.

## Bot Changelog Entry

- Added a Credits button to the co-op connect and options screens that lists the mod's contributors, community members, and supporters.
- Fixed the Afdian button in the donate popup showing no label and doing nothing when clicked.

## Other information

- Went with **"Supporters"** instead of "Donators": "Donators" is non-standard English (the standard word is "Donors"), and "Supporters" is the usual game-credits term and also covers Patreon subscribers. One-line change in `CreditsPopupVM` if a different label is preferred.
- Layout follows existing movies (donate popup chrome, Steam-lobby scroll pattern), but the popup has not had an in-game visual pass yet.
