### PR TITLE
[2475] Remove player party from map event when unstucking

### DIFF
--- a/source/E2E.Tests/Services/MobileParties/UnstuckCommandTests.cs
+++ b/source/E2E.Tests/Services/MobileParties/UnstuckCommandTests.cs
@@ -1,12 +1,14 @@
-using Common.Util;
-using E2E.Tests.Environment;
+﻿using Common.Util;
 using E2E.Tests.Environment.Instance;
+using E2E.Tests.Services.MapEvents;
 using E2E.Tests.Util;
 using GameInterface.Services.Armies.Messages;
+using GameInterface.Services.MapEvents.Messages.Leave;
 using GameInterface.Services.MobileParties.Commands;
 using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Services.MobileParties.Messages.Unstuck;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.MapEvents;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Core;
@@ -20,21 +22,11 @@ namespace E2E.Tests.Services.MobileParties;
 /// independently and replies with <see cref="NetworkPlayerUnstuckResult"/>, and the requesting
 /// client runs local cleanup and publishes <see cref="PlayerUnstuckCompleted"/>.
 /// </summary>
-public class UnstuckCommandTests : IDisposable
+public class UnstuckCommandTests : MapEventTestBase
 {
-    private E2ETestEnvironment TestEnvironment { get; }
-    private EnvironmentInstance Server => TestEnvironment.Server;
     private EnvironmentInstance Client => TestEnvironment.Clients.First();
 
-    public UnstuckCommandTests(ITestOutputHelper output)
-    {
-        TestEnvironment = new E2ETestEnvironment(output);
-    }
-
-    public void Dispose()
-    {
-        TestEnvironment.Dispose();
-    }
+    public UnstuckCommandTests(ITestOutputHelper output) : base(output) { }
 
     [Fact]
     public void Unstuck_OnServer_IsRejected()
@@ -151,6 +143,37 @@ public class UnstuckCommandTests : IDisposable
         Assert.Equal(player.PartyId, result.PartyId);
         Assert.NotNull(result.Actions);
         Assert.Contains(result.Actions, action => action.Contains("captivity release"));
+    }
+
+    [Fact]
+    public void ServerUnstuckRequest_WithMapEvent_RemovesPartyAndBroadcastsLeave()
+    {
+        var player = SetupRegisteredMainHeroAndParty();
+        var mapEventContext = CreateServerMapEvent();
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(player.PartyId, out var party));
+            Assert.True(Server.ObjectManager.TryGetObject<MapEvent>(mapEventContext.MapEventId, out var mapEvent));
+
+            party.Party.MapEventSide = mapEvent.AttackerSide;
+
+            Assert.Same(mapEvent, party.MapEvent);
+        }, MapEventDisabledMethods);
+
+        Server.SimulateMessage(this, new NetworkRequestPlayerUnstuck(player.PartyId, player.HeroId));
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(player.PartyId, out var party));
+            Assert.Null(party.MapEvent);
+        });
+
+        var leave = Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkPartyLeftBattle>());
+        Assert.False(leave.LeaveSiege);
+
+        var result = Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkPlayerUnstuckResult>());
+        Assert.Contains(result.Actions, action => action.Contains("map event"));
     }
 
     [Fact]

--- a/source/GameInterface/Services/MobileParties/Commands/UnstuckCommand.cs
+++ b/source/GameInterface/Services/MobileParties/Commands/UnstuckCommand.cs
@@ -1,4 +1,4 @@
-using Common;
+﻿using Common;
 using Common.Messaging;
 using GameInterface.Services.MobileParties.Messages.Unstuck;
 using System.Collections.Generic;
@@ -10,10 +10,10 @@ namespace GameInterface.Services.MobileParties.Commands;
 
 /// <summary>
 /// Client-side recovery command that forces the local player party out of stuck states —
-/// captivity, army membership, siege camp, settlement, and player encounter. Routed through the
-/// dedicated unstuck flow (<see cref="Handlers.PlayerUnstuckHandler"/>): the server force-applies
-/// the synced exits and its reply clears the local encounter/menu state, so recovery works even
-/// when a normal exit request flow is what is wedged.
+/// captivity, map event, army membership, siege camp, settlement, and player encounter. Routed
+/// through the dedicated unstuck flow (<see cref="Handlers.PlayerUnstuckHandler"/>): the server
+/// force-applies the synced exits and its reply clears the local encounter/menu state, so
+/// recovery works even when a normal exit request flow is what is wedged.
 /// </summary>
 public class UnstuckCommand
 {
@@ -32,7 +32,7 @@ public class UnstuckCommand
 
         MessageBroker.Instance.Publish(mainParty, new PlayerUnstuckRequested(mainParty));
 
-        return "Unstuck request sent to the server. Captivity, army, siege camp, and settlement exits " +
-               "apply on the server; the local encounter and menu state clear when its reply arrives.";
+        return "Unstuck request sent to the server. Captivity, map event, army, siege camp, and " +
+               "settlement exits apply on the server; the local encounter and menu state clear when its reply arrives.";
     }
 }

--- a/source/GameInterface/Services/MobileParties/Handlers/PlayerUnstuckHandler.cs
+++ b/source/GameInterface/Services/MobileParties/Handlers/PlayerUnstuckHandler.cs
@@ -1,10 +1,11 @@
-using Common;
+﻿using Common;
 using Common.Logging;
 using Common.Messaging;
 using Common.Network;
 using Common.Util;
 using GameInterface.Services.Armies.Messages;
 using GameInterface.Services.Armies.Patches;
+using GameInterface.Services.MapEvents.Messages.Leave;
 using GameInterface.Services.MobileParties.Messages.Unstuck;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
@@ -28,8 +29,9 @@ namespace GameInterface.Services.MobileParties.Handlers;
 /// <summary>
 /// Dedicated recovery flow behind coop.debug.mobileparty.unstuck. The client forwards
 /// <see cref="PlayerUnstuckRequested"/> to the server as <see cref="NetworkRequestPlayerUnstuck"/>;
-/// the server force-applies every applicable exit (captivity, army, siege camp, settlement) with
-/// each step guarded independently, so one broken exit flow cannot block the others; the
+/// the server force-applies every applicable exit (captivity, map event, army, siege camp,
+/// settlement) with each step guarded independently, so one broken exit flow cannot block the
+/// others; the
 /// <see cref="NetworkPlayerUnstuckResult"/> reply then lets the requesting client clear the
 /// local-only encounter and menu state the server cannot see. Intentionally separate from the
 /// normal exit request flows — those carry gating state that may be exactly what is stuck.
@@ -161,12 +163,20 @@ internal class PlayerUnstuckHandler : IHandler
 
         if (party.Party?.MapEvent != null)
         {
-            actions.Add("Warning: the party is in a map event; battle state was not touched (retreat from the battle instead).");
+            TryStep(actions, "map event removal", () =>
+            {
+                // Reuse the normal authoritative leave flow so the removal and client cleanup are broadcast.
+                messageBroker.Publish(party, new PlayerLeaveBattleAttempted(party.Party));
+                if (party.Party.MapEvent != null)
+                    throw new InvalidOperationException("The battle leave flow did not remove the party from its map event.");
+
+                return "Removed the party from its map event.";
+            });
         }
 
         if (actions.Count == 0)
         {
-            actions.Add("No server-side stuck state found (captivity, army, siege camp, settlement).");
+            actions.Add("No server-side stuck state found (captivity, map event, army, siege camp, settlement).");
         }
 
         network.SendAll(new NetworkPlayerUnstuckResult(partyId, actions.ToArray()));


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Requesting unstuck while the player party is in a map event leaves it attached and reports that battle state was not touched.

## What is the new behavior?

Resolves #2475

Requesting unstuck now removes the player party from its active map event and returns it to the campaign map.

## Bot Changelog Entry

- Unstuck now removes the player party from an active map event.
