### PR TITLE
More logging for corrupted saves

### DIFF
--- a/source/Coop.Core/Server/Services/MobileParties/JoinCampaignBaselineSender.cs
+++ b/source/Coop.Core/Server/Services/MobileParties/JoinCampaignBaselineSender.cs
@@ -51,9 +51,15 @@ internal sealed class JoinCampaignBaselineSender : IJoinCampaignBaselineSender
         for (int i = 0; i < parties.Count; i++)
         {
             MobileParty party = parties[i];
-            if (!mobilePartyBehaviorSnapshot.TryCreateJoinState(party, out MobilePartyJoinState state))
+            if (!mobilePartyBehaviorSnapshot.TryCreateJoinState(
+                party,
+                out MobilePartyJoinState state,
+                out string failure))
             {
-                Logger.Warning("Could not capture a complete join baseline for party {Party}", party?.StringId);
+                Logger.Warning(
+                    "Could not capture a complete join baseline for party {Party}: {Failure}",
+                    party?.StringId,
+                    failure);
                 isComplete = false;
                 break;
             }

--- a/source/GameInterface.Tests/Services/MobileParties/MobilePartyBehaviorSnapshotTests.cs
+++ b/source/GameInterface.Tests/Services/MobileParties/MobilePartyBehaviorSnapshotTests.cs
@@ -2,13 +2,16 @@
 using GameInterface.Services.MobileParties.Data;
 using GameInterface.Services.ObjectManager;
 using Moq;
+using System.Collections.Generic;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Library;
 using Xunit;
 
 namespace GameInterface.Tests.Services.MobileParties;
 
+[Collection("CampaignCurrentCollection")]
 public class MobilePartyBehaviorSnapshotTests
 {
     [Fact]
@@ -51,6 +54,77 @@ public class MobilePartyBehaviorSnapshotTests
         Assert.Equal(MoveModeType.Point, data.PartyMoveMode);
         Assert.Null(data.MoveTargetPartyId);
         Assert.Equal(removedMoveTarget.Position, data.MoveTargetPoint);
+    }
+
+    [Fact]
+    public void TryCreateJoinState_MissingAi_ReportsFailure()
+    {
+        var party = ObjectHelper.SkipConstructor<MobileParty>();
+        var snapshot = new MobilePartyBehaviorSnapshot(Mock.Of<IObjectManager>());
+
+        bool created = snapshot.TryCreateJoinState(party, out _, out string failure);
+
+        Assert.False(created);
+        Assert.Equal("party AI is unavailable", failure);
+    }
+
+    [Fact]
+    public void TryApplyJoinBaseline_MismatchedPartyCount_ReportsCounts()
+    {
+        Campaign previousCampaign = Campaign.Current;
+        try
+        {
+            var campaign = ObjectHelper.SkipConstructor<Campaign>();
+            var campaignObjectManager = new CampaignObjectManager
+            {
+                Settlements = new MBReadOnlyList<Settlement>(new List<Settlement>()),
+            };
+            campaign.CampaignObjectManager = campaignObjectManager;
+            Campaign.Current = campaign;
+            var snapshot = new MobilePartyBehaviorSnapshot(Mock.Of<IObjectManager>());
+
+            bool applied = snapshot.TryApplyJoinBaseline(
+                new MobilePartyJoinState[1],
+                () => { });
+
+            Assert.False(applied);
+            Assert.Equal(
+                "party count mismatch (baseline=1, client=0)",
+                snapshot.LastJoinBaselineFailure);
+        }
+        finally
+        {
+            Campaign.Current = previousCampaign;
+        }
+    }
+
+    [Fact]
+    public void TryApplyJoinBaseline_MissingPartyId_ReportsStateIndex()
+    {
+        Campaign previousCampaign = Campaign.Current;
+        try
+        {
+            var campaign = ObjectHelper.SkipConstructor<Campaign>();
+            var campaignObjectManager = new CampaignObjectManager
+            {
+                Settlements = new MBReadOnlyList<Settlement>(new List<Settlement>()),
+            };
+            campaignObjectManager._mobileParties.Add(CreateParty());
+            campaign.CampaignObjectManager = campaignObjectManager;
+            Campaign.Current = campaign;
+            var snapshot = new MobilePartyBehaviorSnapshot(Mock.Of<IObjectManager>());
+
+            bool applied = snapshot.TryApplyJoinBaseline(
+                new[] { new MobilePartyJoinState() },
+                () => { });
+
+            Assert.False(applied);
+            Assert.Equal("state 0 has no mobile-party id", snapshot.LastJoinBaselineFailure);
+        }
+        finally
+        {
+            Campaign.Current = previousCampaign;
+        }
     }
 
     private static MobileParty CreateParty()

--- a/source/GameInterface.Tests/Services/MobileParties/MobilePartyBehaviorSnapshotTests.cs
+++ b/source/GameInterface.Tests/Services/MobileParties/MobilePartyBehaviorSnapshotTests.cs
@@ -2,16 +2,13 @@
 using GameInterface.Services.MobileParties.Data;
 using GameInterface.Services.ObjectManager;
 using Moq;
-using System.Collections.Generic;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
-using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Library;
 using Xunit;
 
 namespace GameInterface.Tests.Services.MobileParties;
 
-[Collection("CampaignCurrentCollection")]
 public class MobilePartyBehaviorSnapshotTests
 {
     [Fact]
@@ -66,65 +63,6 @@ public class MobilePartyBehaviorSnapshotTests
 
         Assert.False(created);
         Assert.Equal("party AI is unavailable", failure);
-    }
-
-    [Fact]
-    public void TryApplyJoinBaseline_MismatchedPartyCount_ReportsCounts()
-    {
-        Campaign previousCampaign = Campaign.Current;
-        try
-        {
-            var campaign = ObjectHelper.SkipConstructor<Campaign>();
-            var campaignObjectManager = new CampaignObjectManager
-            {
-                Settlements = new MBReadOnlyList<Settlement>(new List<Settlement>()),
-            };
-            campaign.CampaignObjectManager = campaignObjectManager;
-            Campaign.Current = campaign;
-            var snapshot = new MobilePartyBehaviorSnapshot(Mock.Of<IObjectManager>());
-
-            bool applied = snapshot.TryApplyJoinBaseline(
-                new MobilePartyJoinState[1],
-                () => { });
-
-            Assert.False(applied);
-            Assert.Equal(
-                "party count mismatch (baseline=1, client=0)",
-                snapshot.LastJoinBaselineFailure);
-        }
-        finally
-        {
-            Campaign.Current = previousCampaign;
-        }
-    }
-
-    [Fact]
-    public void TryApplyJoinBaseline_MissingPartyId_ReportsStateIndex()
-    {
-        Campaign previousCampaign = Campaign.Current;
-        try
-        {
-            var campaign = ObjectHelper.SkipConstructor<Campaign>();
-            var campaignObjectManager = new CampaignObjectManager
-            {
-                Settlements = new MBReadOnlyList<Settlement>(new List<Settlement>()),
-            };
-            campaignObjectManager._mobileParties.Add(CreateParty());
-            campaign.CampaignObjectManager = campaignObjectManager;
-            Campaign.Current = campaign;
-            var snapshot = new MobilePartyBehaviorSnapshot(Mock.Of<IObjectManager>());
-
-            bool applied = snapshot.TryApplyJoinBaseline(
-                new[] { new MobilePartyJoinState() },
-                () => { });
-
-            Assert.False(applied);
-            Assert.Equal("state 0 has no mobile-party id", snapshot.LastJoinBaselineFailure);
-        }
-        finally
-        {
-            Campaign.Current = previousCampaign;
-        }
     }
 
     private static MobileParty CreateParty()

--- a/source/GameInterface/Services/MobileParties/Data/MobilePartyBehaviorSnapshot.cs
+++ b/source/GameInterface/Services/MobileParties/Data/MobilePartyBehaviorSnapshot.cs
@@ -19,7 +19,10 @@ public interface IMobilePartyBehaviorSnapshot
 {
     bool TryCreate(MobileParty party, out PartyBehaviorUpdateData data);
     bool CanApply(MobileParty party, PartyBehaviorUpdateData data);
-    bool TryCreateJoinState(MobileParty party, out MobilePartyJoinState state);
+    bool TryCreateJoinState(
+        MobileParty party,
+        out MobilePartyJoinState state,
+        out string failure);
     bool TryApply(MobileParty party, PartyBehaviorUpdateData data, out IInteractablePoint interactable);
     bool TryApplyJoinBaseline(MobilePartyJoinState[] states, Action beforeApply);
 }
@@ -29,24 +32,51 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
     private static readonly ILogger Logger = LogManager.GetLogger<MobilePartyBehaviorSnapshot>();
 
     private readonly IObjectManager objectManager;
+    private string lastJoinBaselineFailure;
+
+    internal string LastJoinBaselineFailure => lastJoinBaselineFailure;
 
     public MobilePartyBehaviorSnapshot(IObjectManager objectManager) => this.objectManager = objectManager;
 
     public bool TryCreate(
         MobileParty party,
-        out PartyBehaviorUpdateData data)
+        out PartyBehaviorUpdateData data) =>
+        TryCreate(party, out data, out _);
+
+    private bool TryCreate(
+        MobileParty party,
+        out PartyBehaviorUpdateData data,
+        out string failure)
     {
         data = default;
-        if (party?.Ai == null)
-            return false;
-        if (!TryGetCompactId(party, out string partyId) ||
-            !TryGetInteractableReference(
-                party.Ai.AiBehaviorInteractable,
-                out string interactablePointId,
-                out bool isInteractableAnchor) ||
-            !TryGetCompactId(party.TargetParty, out string targetPartyId) ||
-            !TryGetCompactId(party.TargetSettlement, out string targetSettlementId))
-            return false;
+        failure = null;
+        if (party == null)
+            return FailCreation("party is null", out failure);
+        if (party.Ai == null)
+            return FailCreation("party AI is unavailable", out failure);
+        if (!TryGetCompactId(party, out string partyId))
+            return FailCreation("party is not registered", out failure);
+        if (!TryGetInteractableReference(
+            party.Ai.AiBehaviorInteractable,
+            out string interactablePointId,
+            out bool isInteractableAnchor))
+        {
+            return FailCreation(
+                $"AI interactable '{party.Ai.AiBehaviorInteractable?.GetType().Name}' is not registered",
+                out failure);
+        }
+        if (!TryGetCompactId(party.TargetParty, out string targetPartyId))
+        {
+            return FailCreation(
+                $"target party '{party.TargetParty?.StringId}' is not registered",
+                out failure);
+        }
+        if (!TryGetCompactId(party.TargetSettlement, out string targetSettlementId))
+        {
+            return FailCreation(
+                $"target settlement '{party.TargetSettlement?.StringId}' is not registered",
+                out failure);
+        }
 
         MoveModeType partyMoveMode = party.PartyMoveMode;
         CampaignVec2 moveTargetPoint = party.MoveTargetPoint;
@@ -91,10 +121,13 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
         TryResolve(data.TargetSettlementId, out Settlement _) &&
         TryResolve(data.MoveTargetPartyId, out MobileParty _);
 
-    public bool TryCreateJoinState(MobileParty party, out MobilePartyJoinState state)
+    public bool TryCreateJoinState(
+        MobileParty party,
+        out MobilePartyJoinState state,
+        out string failure)
     {
         state = default;
-        if (!TryCreate(party, out PartyBehaviorUpdateData behavior))
+        if (!TryCreate(party, out PartyBehaviorUpdateData behavior, out failure))
             return false;
 
         state = new MobilePartyJoinState
@@ -109,7 +142,14 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
             StartTransitionNextFrameToExitFromPort = party.StartTransitionNextFrameToExitFromPort,
             ForceAiNoPathMode = party.ForceAiNoPathMode,
         };
+        failure = null;
         return true;
+    }
+
+    private static bool FailCreation(string reason, out string failure)
+    {
+        failure = reason;
+        return false;
     }
 
     public bool TryApply(MobileParty party, PartyBehaviorUpdateData data, out IInteractablePoint interactable)
@@ -125,13 +165,23 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
 
     public bool TryApplyJoinBaseline(MobilePartyJoinState[] states, Action beforeApply)
     {
-        if (states == null || beforeApply == null) return false;
+        if (states == null)
+            return RejectJoinBaseline("the baseline party-state array is null");
+        if (beforeApply == null)
+            return RejectJoinBaseline("the before-apply callback is null");
 
         var objectManager = Campaign.Current?.CampaignObjectManager;
         var parties = objectManager?.MobileParties;
         var settlements = objectManager?.Settlements;
-        if (parties == null || settlements == null || states.Length != parties.Count)
-            return false;
+        if (parties == null)
+            return RejectJoinBaseline("the client campaign mobile-party collection is unavailable");
+        if (settlements == null)
+            return RejectJoinBaseline("the client campaign settlement collection is unavailable");
+        if (states.Length != parties.Count)
+        {
+            return RejectJoinBaseline(
+                $"party count mismatch (baseline={states.Length}, client={parties.Count})");
+        }
 
         var liveParties = new HashSet<MobileParty>(parties);
         var liveSettlements = new HashSet<Settlement>(settlements);
@@ -141,17 +191,43 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
         for (int i = 0; i < states.Length; i++)
         {
             PartyBehaviorUpdateData behavior = states[i].Behavior;
-            if (string.IsNullOrEmpty(behavior.MobilePartyId) ||
-                !this.objectManager.TryGetObjectWithLogging(behavior.MobilePartyId, out MobileParty party) ||
-                !liveParties.Contains(party) ||
-                !seenParties.Add(party) ||
-                !TryPrepare(party, behavior, liveParties, liveSettlements, out resolved[i]))
+            if (string.IsNullOrEmpty(behavior.MobilePartyId))
+                return RejectJoinBaseline($"state {i} has no mobile-party id");
+            if (!this.objectManager.TryGetObjectWithLogging(
+                behavior.MobilePartyId,
+                out MobileParty party))
             {
-                return false;
+                return RejectJoinBaseline(
+                    $"state {i} references missing mobile party '{behavior.MobilePartyId}'");
+            }
+            if (!liveParties.Contains(party))
+            {
+                return RejectJoinBaseline(
+                    $"state {i} party '{behavior.MobilePartyId}' is not in the client campaign collection");
+            }
+            if (!seenParties.Add(party))
+                return RejectJoinBaseline($"state {i} duplicates party '{behavior.MobilePartyId}'");
+            if (!TryPrepare(
+                party,
+                behavior,
+                liveParties,
+                liveSettlements,
+                out resolved[i]))
+            {
+                return RejectJoinBaseline(
+                    $"state {i} party '{behavior.MobilePartyId}' failed dependency validation " +
+                    $"(interactable='{behavior.InteractablePointId}', " +
+                    $"targetParty='{behavior.TargetPartyId}', " +
+                    $"targetSettlement='{behavior.TargetSettlementId}', " +
+                    $"moveTargetParty='{behavior.MoveTargetPartyId}')");
             }
         }
 
-        if (seenParties.Count != liveParties.Count) return false;
+        if (seenParties.Count != liveParties.Count)
+        {
+            return RejectJoinBaseline(
+                $"party coverage mismatch (baseline={seenParties.Count}, client={liveParties.Count})");
+        }
 
         try
         {
@@ -165,13 +241,27 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
                 }
             }
 
+            lastJoinBaselineFailure = null;
             return true;
         }
         catch (Exception ex)
         {
+            lastJoinBaselineFailure = $"application threw {ex.GetType().Name}: {ex.Message}";
             Logger.Error(ex, "Failed to apply a complete mobile-party join baseline");
             return false;
         }
+    }
+
+    private bool RejectJoinBaseline(string failure)
+    {
+        if (string.Equals(lastJoinBaselineFailure, failure, StringComparison.Ordinal))
+            return false;
+
+        lastJoinBaselineFailure = failure;
+        Logger.Warning(
+            "Could not apply mobile-party join baseline: {Failure}. Identical retries will not be logged",
+            failure);
+        return false;
     }
 
     private bool TryPrepare(

--- a/source/GameInterface/Services/MobileParties/Data/MobilePartyBehaviorSnapshot.cs
+++ b/source/GameInterface/Services/MobileParties/Data/MobilePartyBehaviorSnapshot.cs
@@ -32,9 +32,6 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
     private static readonly ILogger Logger = LogManager.GetLogger<MobilePartyBehaviorSnapshot>();
 
     private readonly IObjectManager objectManager;
-    private string lastJoinBaselineFailure;
-
-    internal string LastJoinBaselineFailure => lastJoinBaselineFailure;
 
     public MobilePartyBehaviorSnapshot(IObjectManager objectManager) => this.objectManager = objectManager;
 
@@ -165,23 +162,13 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
 
     public bool TryApplyJoinBaseline(MobilePartyJoinState[] states, Action beforeApply)
     {
-        if (states == null)
-            return RejectJoinBaseline("the baseline party-state array is null");
-        if (beforeApply == null)
-            return RejectJoinBaseline("the before-apply callback is null");
+        if (states == null || beforeApply == null) return false;
 
         var objectManager = Campaign.Current?.CampaignObjectManager;
         var parties = objectManager?.MobileParties;
         var settlements = objectManager?.Settlements;
-        if (parties == null)
-            return RejectJoinBaseline("the client campaign mobile-party collection is unavailable");
-        if (settlements == null)
-            return RejectJoinBaseline("the client campaign settlement collection is unavailable");
-        if (states.Length != parties.Count)
-        {
-            return RejectJoinBaseline(
-                $"party count mismatch (baseline={states.Length}, client={parties.Count})");
-        }
+        if (parties == null || settlements == null || states.Length != parties.Count)
+            return false;
 
         var liveParties = new HashSet<MobileParty>(parties);
         var liveSettlements = new HashSet<Settlement>(settlements);
@@ -191,43 +178,17 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
         for (int i = 0; i < states.Length; i++)
         {
             PartyBehaviorUpdateData behavior = states[i].Behavior;
-            if (string.IsNullOrEmpty(behavior.MobilePartyId))
-                return RejectJoinBaseline($"state {i} has no mobile-party id");
-            if (!this.objectManager.TryGetObjectWithLogging(
-                behavior.MobilePartyId,
-                out MobileParty party))
+            if (string.IsNullOrEmpty(behavior.MobilePartyId) ||
+                !this.objectManager.TryGetObjectWithLogging(behavior.MobilePartyId, out MobileParty party) ||
+                !liveParties.Contains(party) ||
+                !seenParties.Add(party) ||
+                !TryPrepare(party, behavior, liveParties, liveSettlements, out resolved[i]))
             {
-                return RejectJoinBaseline(
-                    $"state {i} references missing mobile party '{behavior.MobilePartyId}'");
-            }
-            if (!liveParties.Contains(party))
-            {
-                return RejectJoinBaseline(
-                    $"state {i} party '{behavior.MobilePartyId}' is not in the client campaign collection");
-            }
-            if (!seenParties.Add(party))
-                return RejectJoinBaseline($"state {i} duplicates party '{behavior.MobilePartyId}'");
-            if (!TryPrepare(
-                party,
-                behavior,
-                liveParties,
-                liveSettlements,
-                out resolved[i]))
-            {
-                return RejectJoinBaseline(
-                    $"state {i} party '{behavior.MobilePartyId}' failed dependency validation " +
-                    $"(interactable='{behavior.InteractablePointId}', " +
-                    $"targetParty='{behavior.TargetPartyId}', " +
-                    $"targetSettlement='{behavior.TargetSettlementId}', " +
-                    $"moveTargetParty='{behavior.MoveTargetPartyId}')");
+                return false;
             }
         }
 
-        if (seenParties.Count != liveParties.Count)
-        {
-            return RejectJoinBaseline(
-                $"party coverage mismatch (baseline={seenParties.Count}, client={liveParties.Count})");
-        }
+        if (seenParties.Count != liveParties.Count) return false;
 
         try
         {
@@ -241,27 +202,13 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
                 }
             }
 
-            lastJoinBaselineFailure = null;
             return true;
         }
         catch (Exception ex)
         {
-            lastJoinBaselineFailure = $"application threw {ex.GetType().Name}: {ex.Message}";
             Logger.Error(ex, "Failed to apply a complete mobile-party join baseline");
             return false;
         }
-    }
-
-    private bool RejectJoinBaseline(string failure)
-    {
-        if (string.Equals(lastJoinBaselineFailure, failure, StringComparison.Ordinal))
-            return false;
-
-        lastJoinBaselineFailure = failure;
-        Logger.Warning(
-            "Could not apply mobile-party join baseline: {Failure}. Identical retries will not be logged",
-            failure);
-        return false;
     }
 
     private bool TryPrepare(


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [x] Other... Diagnostics

## What is the current behavior?

An incomplete server baseline only identifies the party, not the failed capture check.

## What is the new behavior?

Server-side capture failures log the party and exact failed capture check without adding anything to the network message or client log.

## Bot Changelog Entry

Add additional logging to help debug corrupted saves that are no longer joinable
