### PR TITLE
Reduce field battle movement receive overhead

### DIFF
--- a/source/Common.Tests/Utils/GameThreadBatchedRunTests.cs
+++ b/source/Common.Tests/Utils/GameThreadBatchedRunTests.cs
@@ -1,0 +1,279 @@
+﻿using Common;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace Common.Tests.Utils;
+
+/// <summary>Covers adjacent game-thread batching without crossing FIFO barriers.</summary>
+[Collection(nameof(GameThreadBatchedRunCollection))]
+public sealed class GameThreadBatchedRunTests : IDisposable
+{
+    public GameThreadBatchedRunTests()
+    {
+        GameThread.Instance.MarkGameThread();
+        GameThread.Instance.Update(TimeSpan.Zero);
+    }
+
+    public void Dispose()
+    {
+        GameThread.Instance.Update(TimeSpan.Zero);
+        GameThread.Instance.UnmarkGameThread();
+    }
+
+    [Fact]
+    public void RunSafeBatched_CollapsesAdjacentItemsIntoOneQueueSlot()
+    {
+        var applied = new List<int>();
+        Action<int> apply = applied.Add;
+
+        RunOffGameThread(() =>
+        {
+            for (int i = 0; i < 134; i++)
+                GameThread.RunSafeBatched(i, apply);
+        });
+
+        Assert.Equal(1, GameThread.Instance.QueueLength);
+        GameThread.Instance.Update(TimeSpan.Zero);
+
+        Assert.Equal(Enumerable.Range(0, 134), applied);
+    }
+
+    [Fact]
+    public void RunSafeBatched_DoesNotCrossAnInterveningAction()
+    {
+        var applied = new List<string>();
+        Action<string> apply = applied.Add;
+
+        RunOffGameThread(() =>
+        {
+            GameThread.RunSafeBatched("first", apply);
+            GameThread.RunSafeBatched("second", apply);
+            GameThread.Run(() => applied.Add("barrier"));
+            GameThread.RunSafeBatched("third", apply);
+        });
+
+        Assert.Equal(3, GameThread.Instance.QueueLength);
+        GameThread.Instance.Update(TimeSpan.Zero);
+
+        Assert.Equal(
+            new[] { "first", "second", "barrier", "third" },
+            applied);
+    }
+
+    [Fact]
+    public void RunSafeBatched_DoesNotJoinDifferentActions()
+    {
+        var applied = new List<string>();
+        Action<int> first = item => applied.Add($"first:{item}");
+        Action<int> second = item => applied.Add($"second:{item}");
+
+        RunOffGameThread(() =>
+        {
+            GameThread.RunSafeBatched(1, first);
+            GameThread.RunSafeBatched(2, second);
+        });
+
+        Assert.Equal(2, GameThread.Instance.QueueLength);
+        GameThread.Instance.Update(TimeSpan.Zero);
+
+        Assert.Equal(new[] { "first:1", "second:2" }, applied);
+    }
+
+    [Fact]
+    public void RunSafeBatched_DoesNotAppendAfterTheQueueSnapshot()
+    {
+        var probe = new SnapshotProbe();
+
+        RunOffGameThread(() =>
+            GameThread.RunSafeBatched(1, probe.Apply));
+
+        GameThread.Instance.Update(TimeSpan.Zero);
+
+        Assert.Equal(new[] { 1 }, probe.Applied);
+        Assert.Equal(1, GameThread.Instance.QueueLength);
+
+        GameThread.Instance.Update(TimeSpan.Zero);
+        Assert.Equal(new[] { 1, 2 }, probe.Applied);
+    }
+
+    [Fact]
+    public void RunSafeBatched_DoesNotJoinDifferentCancellationScopes()
+    {
+        var applied = new List<string>();
+        Action<string> apply = applied.Add;
+        using var firstCancellation = new CancellationTokenSource();
+        using var secondCancellation = new CancellationTokenSource();
+
+        RunOffGameThread(() =>
+        {
+            using (GameThread.ActivateCancellation(firstCancellation.Token))
+                GameThread.RunSafeBatched("first", apply);
+
+            using (GameThread.ActivateCancellation(secondCancellation.Token))
+                GameThread.RunSafeBatched("second", apply);
+        });
+
+        Assert.Equal(2, GameThread.Instance.QueueLength);
+        GameThread.Instance.Update(TimeSpan.Zero);
+
+        Assert.Equal(new[] { "first", "second" }, applied);
+    }
+
+    [Fact]
+    public void RunSafeBatched_IgnoresAnAlreadyCanceledScope()
+    {
+        var applied = new List<int>();
+        Action<int> apply = applied.Add;
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        RunOffGameThread(() =>
+        {
+            using (GameThread.ActivateCancellation(cancellation.Token))
+                GameThread.RunSafeBatched(1, apply);
+        });
+
+        Assert.Equal(0, GameThread.Instance.QueueLength);
+        Assert.Empty(applied);
+    }
+
+    [Fact]
+    public void RunSafeBatched_DiscardsABatchCanceledBeforeDrain()
+    {
+        var applied = new List<int>();
+        Action<int> apply = applied.Add;
+        using var cancellation = new CancellationTokenSource();
+
+        RunOffGameThread(() =>
+        {
+            using (GameThread.ActivateCancellation(cancellation.Token))
+                GameThread.RunSafeBatched(1, apply);
+        });
+
+        cancellation.Cancel();
+        GameThread.Instance.Update(TimeSpan.Zero);
+
+        Assert.Empty(applied);
+        Assert.Equal(0, GameThread.Instance.QueueLength);
+    }
+
+    [Fact]
+    public void RunSafeBatched_DiscardsItemsWhenTheirLifetimeEnds()
+    {
+        var applied = new List<int>();
+        Action<int> apply = applied.Add;
+        var lifetime = new CancellationTokenSource();
+
+        RunOffGameThread(() =>
+        {
+            for (int i = 0; i < 134; i++)
+                GameThread.RunSafeBatched(i, apply, lifetime.Token);
+        });
+
+        Assert.Equal(1, GameThread.Instance.QueueLength);
+        lifetime.Cancel();
+        lifetime.Dispose();
+        GameThread.Instance.Update(TimeSpan.Zero);
+
+        Assert.Empty(applied);
+    }
+
+    [Fact]
+    public void RunSafeBatched_ContinuesAfterAnItemThrows()
+    {
+        var applied = new List<int>();
+        Action<int> apply = item =>
+        {
+            if (item == 1)
+                throw new InvalidOperationException("Expected test failure");
+            applied.Add(item);
+        };
+
+        RunOffGameThread(() =>
+        {
+            for (int i = 0; i < 3; i++)
+                GameThread.RunSafeBatched(i, apply);
+        });
+
+        GameThread.Instance.Update(TimeSpan.Zero);
+
+        Assert.Equal(new[] { 0, 2 }, applied);
+    }
+
+    [Fact]
+    public void RunSafeBatched_StopsWhenItsScopeIsCanceledMidBatch()
+    {
+        var applied = new List<int>();
+        using var cancellation = new CancellationTokenSource();
+        Action<int> apply = item =>
+        {
+            applied.Add(item);
+            cancellation.Cancel();
+        };
+
+        RunOffGameThread(() =>
+        {
+            using (GameThread.ActivateCancellation(cancellation.Token))
+            {
+                GameThread.RunSafeBatched(1, apply);
+                GameThread.RunSafeBatched(2, apply);
+            }
+        });
+
+        GameThread.Instance.Update(TimeSpan.Zero);
+
+        Assert.Equal(new[] { 1 }, applied);
+    }
+
+    private static void RunOffGameThread(Action action)
+    {
+        Exception? failure = null;
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception e)
+            {
+                failure = e;
+            }
+        });
+        thread.Start();
+        thread.Join();
+
+        if (failure != null)
+            throw failure;
+    }
+
+    /// <summary>Queues a second item while the first queue snapshot is draining.</summary>
+    private sealed class SnapshotProbe
+    {
+        public SnapshotProbe()
+        {
+            Apply = ApplyItem;
+        }
+
+        public List<int> Applied { get; } = new List<int>();
+        public Action<int> Apply { get; }
+
+        private void ApplyItem(int item)
+        {
+            Applied.Add(item);
+            if (item != 1) return;
+
+            RunOffGameThread(() =>
+                GameThread.RunSafeBatched(2, Apply));
+        }
+    }
+}
+
+/// <summary>Serializes tests that directly own and drain the global game-thread queue.</summary>
+[CollectionDefinition(
+    nameof(GameThreadBatchedRunCollection),
+    DisableParallelization = true)]
+public sealed class GameThreadBatchedRunCollection
+{
+}

--- a/source/Common/GameThread.cs
+++ b/source/Common/GameThread.cs
@@ -64,7 +64,7 @@ public class GameThread : IUpdateable
     /// call site needs to change. Off by default; toggle it at runtime on the process you want to
     /// profile (typically the client) with the <c>coop.debug.gamethread.instrument</c> console command.
     /// </summary>
-    public static bool Instrument = false;
+    public static bool Instrument { get; private set; }
 
     /// <summary>How often the drain summary is written to the log.</summary>
     private static readonly TimeSpan ReportInterval = TimeSpan.FromSeconds(1);
@@ -81,6 +81,8 @@ public class GameThread : IUpdateable
     private long m_WorstFrameTicks;
     private int m_WorstFrameActions;
     private int m_WorstBacklog;
+    private int m_WindowBatchItems;
+    private int m_WindowBatchRuns;
 
     private static double ToMs(long ticks) => 1000.0 * ticks / Stopwatch.Frequency;
 
@@ -179,7 +181,8 @@ public class GameThread : IUpdateable
             Logger.Information(
                 "[GameThread] {Frames} frames | {Actions} actions ({Rate:0}/s) | drain {Drain:0.0}ms " +
                 "({PerFrame:0.00}ms/frame) | worst frame {Worst:0.0}ms/{WorstActions} actions | " +
-                "max backlog {Backlog} | top: {Top}",
+                "max backlog {Backlog} | batching {BatchItems} items -> {BatchRuns} runs " +
+                "({AvoidedRuns} avoided, {BatchReduction:0.0}% reduction, {ItemsPerBatch:0.0}/run) | top: {Top}",
                 m_WindowFrames,
                 m_WindowActions,
                 m_WindowActions / seconds,
@@ -188,9 +191,30 @@ public class GameThread : IUpdateable
                 ToMs(m_WorstFrameTicks),
                 m_WorstFrameActions,
                 m_WorstBacklog,
+                m_WindowBatchItems,
+                m_WindowBatchRuns,
+                Math.Max(0, m_WindowBatchItems - m_WindowBatchRuns),
+                m_WindowBatchItems == 0
+                    ? 0
+                    : 100.0 * (m_WindowBatchItems - m_WindowBatchRuns) / m_WindowBatchItems,
+                m_WindowBatchRuns == 0
+                    ? 0
+                    : (double)m_WindowBatchItems / m_WindowBatchRuns,
                 top);
         }
 
+        ResetInstrumentationWindow();
+    }
+
+    /// <summary>Changes instrumentation state and starts a fresh measurement window.</summary>
+    public static void SetInstrumentation(bool enabled)
+    {
+        Instrument = enabled;
+        Instance.ResetInstrumentationWindow();
+    }
+
+    private void ResetInstrumentationWindow()
+    {
         m_PerLabel.Clear();
         m_WindowFrames = 0;
         m_WindowActions = 0;
@@ -198,6 +222,8 @@ public class GameThread : IUpdateable
         m_WorstFrameTicks = 0;
         m_WorstFrameActions = 0;
         m_WorstBacklog = 0;
+        m_WindowBatchItems = 0;
+        m_WindowBatchRuns = 0;
         m_ReportTimer.Restart();
     }
 
@@ -446,6 +472,14 @@ public class GameThread : IUpdateable
         {
             Logger.Error(e, "Failed to run action on the game thread: {Context}", context ?? "(none)");
         }
+    }
+
+    internal static void RecordBatchRun(int itemCount)
+    {
+        if (!Instrument) return;
+
+        Instance.m_WindowBatchItems += itemCount;
+        Instance.m_WindowBatchRuns++;
     }
 
     private void EnqueueLocked(

--- a/source/Common/GameThread.cs
+++ b/source/Common/GameThread.cs
@@ -22,6 +22,7 @@ public class GameThread : IUpdateable
         new Queue<(Action, EventWaitHandle, string, CancellationToken)>();
 
     private readonly object m_QueueLock = new object();
+    private object m_QueueTailBatch;
     private static readonly AsyncLocal<CancellationToken> m_AmbientCancellation =
         new AsyncLocal<CancellationToken>();
     private int m_GameLoopThreadId;
@@ -103,6 +104,7 @@ public class GameThread : IUpdateable
             {
                 toBeRun.Add(m_Queue.Dequeue());
             }
+            m_QueueTailBatch = null;
         }
 
         if (!Instrument)
@@ -248,7 +250,7 @@ public class GameThread : IUpdateable
             string resolved = label ?? BuildLabel(callerFile, callerMember);
             lock (Instance.m_QueueLock)
             {
-                Instance.m_Queue.Enqueue((action, ewh, resolved, cancellation));
+                Instance.EnqueueLocked((action, ewh, resolved, cancellation));
             }
 
             if (ewh == null) return;
@@ -309,7 +311,60 @@ public class GameThread : IUpdateable
         string label = context ?? BuildLabel(callerFile, callerMember);
         lock (Instance.m_QueueLock)
         {
-            Instance.m_Queue.Enqueue((WrapSafe(action, context), null, label, cancellation));
+            Instance.EnqueueLocked((WrapSafe(action, context), null, label, cancellation));
+        }
+    }
+
+    /// <summary>
+    /// Runs one item on the game thread. Adjacent calls using the same action instance and cancellation
+    /// scope share one queue entry while every item is still applied in FIFO order. Any other queued
+    /// action starts a new batch. Canceling <paramref name="lifetime"/> discards its pending items.
+    /// </summary>
+    public static void RunSafeBatched<T>(
+        T item,
+        Action<T> action,
+        CancellationToken lifetime = default,
+        string context = null,
+        [CallerFilePath] string callerFile = null,
+        [CallerMemberName] string callerMember = null)
+    {
+        if (action == null)
+            throw new ArgumentNullException(nameof(action));
+
+        CancellationToken cancellation = m_AmbientCancellation.Value;
+        if (cancellation.IsCancellationRequested ||
+            lifetime.IsCancellationRequested) return;
+
+        if (Instance.IsGameThread)
+        {
+            InvokeSafe(action, item, context);
+            return;
+        }
+
+        lock (Instance.m_QueueLock)
+        {
+            if (cancellation.IsCancellationRequested ||
+                lifetime.IsCancellationRequested) return;
+
+            if (Instance.m_QueueTailBatch is QueuedBatch<T> batch &&
+                batch.TryAdd(action, cancellation, lifetime, item))
+            {
+                return;
+            }
+
+            if (cancellation.IsCancellationRequested ||
+                lifetime.IsCancellationRequested) return;
+
+            string label = context ?? BuildLabel(callerFile, callerMember);
+            batch = new QueuedBatch<T>(
+                action,
+                cancellation,
+                lifetime,
+                context,
+                item);
+            Instance.EnqueueLocked(
+                (batch.Run, null, label, cancellation),
+                batch);
         }
     }
 
@@ -381,6 +436,27 @@ public class GameThread : IUpdateable
         }
     };
 
+    internal static void InvokeSafe<T>(Action<T> action, T item, string context)
+    {
+        try
+        {
+            action(item);
+        }
+        catch (Exception e)
+        {
+            Logger.Error(e, "Failed to run action on the game thread: {Context}", context ?? "(none)");
+        }
+    }
+
+    private void EnqueueLocked(
+        (Action Act, EventWaitHandle Wait, string Label, CancellationToken Cancellation) task,
+        object tailBatch = null)
+    {
+        m_Queue.Enqueue(task);
+        // An ordinary queue entry is a FIFO barrier between adjacent batches.
+        m_QueueTailBatch = tailBatch;
+    }
+
     public void MarkGameThread()
     {
         m_GameLoopThreadId = Thread.CurrentThread.ManagedThreadId;
@@ -434,4 +510,5 @@ public class GameThread : IUpdateable
             m_AmbientCancellation.Value = previous;
         }
     }
+
 }

--- a/source/Common/GameThread.cs
+++ b/source/Common/GameThread.cs
@@ -544,5 +544,4 @@ public class GameThread : IUpdateable
             m_AmbientCancellation.Value = previous;
         }
     }
-
 }

--- a/source/Common/QueuedBatch.cs
+++ b/source/Common/QueuedBatch.cs
@@ -74,6 +74,7 @@ internal sealed class QueuedBatch<T>
                 items.Clear();
             }
 
+            GameThread.RecordBatchRun(snapshot.Length);
             foreach (T item in snapshot)
             {
                 if (cancellation.IsCancellationRequested ||

--- a/source/Common/QueuedBatch.cs
+++ b/source/Common/QueuedBatch.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Common;
+
+/// <summary>Items owned by one adjacent game-thread queue segment.</summary>
+internal sealed class QueuedBatch<T>
+{
+    private readonly Action<T> action;
+    private readonly CancellationToken cancellation;
+    private readonly CancellationToken lifetime;
+    private readonly string context;
+    private readonly object itemsLock = new object();
+    private readonly List<T> items = new List<T>();
+    private readonly CancellationTokenRegistration lifetimeRegistration;
+
+    public QueuedBatch(
+        Action<T> action,
+        CancellationToken cancellation,
+        CancellationToken lifetime,
+        string context,
+        T firstItem)
+    {
+        this.action = action;
+        this.cancellation = cancellation;
+        this.lifetime = lifetime;
+        this.context = context;
+        items.Add(firstItem);
+        lifetimeRegistration = lifetime.CanBeCanceled
+            ? lifetime.Register(Clear)
+            : default;
+    }
+
+    public bool TryAdd(
+        Action<T> candidateAction,
+        CancellationToken candidateCancellation,
+        CancellationToken candidateLifetime,
+        T item)
+    {
+        if (!ReferenceEquals(action, candidateAction) ||
+            cancellation != candidateCancellation ||
+            lifetime != candidateLifetime)
+        {
+            return false;
+        }
+
+        lock (itemsLock)
+        {
+            if (!cancellation.IsCancellationRequested &&
+                !lifetime.IsCancellationRequested)
+            {
+                items.Add(item);
+            }
+        }
+        return true;
+    }
+
+    public void Run()
+    {
+        try
+        {
+            T[] snapshot;
+            lock (itemsLock)
+            {
+                if (cancellation.IsCancellationRequested ||
+                    lifetime.IsCancellationRequested)
+                {
+                    items.Clear();
+                    return;
+                }
+
+                snapshot = items.ToArray();
+                items.Clear();
+            }
+
+            foreach (T item in snapshot)
+            {
+                if (cancellation.IsCancellationRequested ||
+                    lifetime.IsCancellationRequested) return;
+                GameThread.InvokeSafe(action, item, context);
+            }
+        }
+        finally
+        {
+            lifetimeRegistration.Dispose();
+        }
+    }
+
+    private void Clear()
+    {
+        lock (itemsLock)
+        {
+            items.Clear();
+        }
+    }
+}

--- a/source/E2E.Tests/Services/Missions/MovementTrafficTests.cs
+++ b/source/E2E.Tests/Services/Missions/MovementTrafficTests.cs
@@ -1,5 +1,7 @@
-using System;
+﻿using System;
 using System.Linq;
+using System.Threading;
+using Common;
 using Common.Messaging;
 using Common.Network;
 using Common.Network.Session;
@@ -176,6 +178,62 @@ public class MovementTrafficTests : MissionTestEnvironment
             Assert.Equal(movementIds.Count, sentAgents.Length);
             Assert.Equal(sentAgents.Length, sentAgents.Distinct().Count());
             Assert.All(movementIds, id => Assert.Contains(id, sentAgents));
+        });
+    }
+
+    [Fact]
+    public void HandlePacket_CoalescesAdjacentReceivesWithoutDroppingUpdates()
+    {
+        using var fixture = new MissionEngineFixture();
+        var peer = Clients.First();
+        SetControllerId(peer, "peer");
+
+        peer.Call(() =>
+        {
+            var mock = fixture.CreateMission(peer);
+            var registry = peer.Resolve<INetworkAgentRegistry>();
+            var component = peer.Resolve<ICoopMissionComponent>();
+            Guid puppetId = Guid.NewGuid();
+            Agent puppet = SpawnRider(mock);
+            Agent source = SpawnRider(mock);
+            Assert.True(AgentMirror.TryGet(puppet, out var puppetMirror));
+            Assert.True(AgentMirror.TryGet(source, out var sourceMirror));
+            Assert.True(registry.TryRegisterAgent("owner", puppetId, puppet));
+
+            GameThread.Instance.Update(TimeSpan.Zero);
+            int initialMovementFlagCalls = puppetMirror.SetMovementFlagsCalls;
+            const int packetCount = 134;
+            var packets = new MovementPacket[packetCount];
+            for (int i = 0; i < packets.Length; i++)
+            {
+                sourceMirror.MovementFlags = i % 2 == 0
+                    ? Agent.MovementControlFlag.Forward
+                    : Agent.MovementControlFlag.Backward;
+                sourceMirror.MovementDirection = new Vec2(i, -i);
+                packets[i] = new MovementPacket(
+                    new[] { puppetId },
+                    new[] { new AgentData(source) });
+            }
+
+            RunOffGameThread(() =>
+            {
+                foreach (MovementPacket packet in packets)
+                    component.AgentMovementHandler.HandlePacket(null, packet);
+            });
+
+            Assert.Equal(1, GameThread.Instance.QueueLength);
+            GameThread.Instance.Update(TimeSpan.Zero);
+
+            Assert.Equal(
+                packets.Length,
+                puppetMirror.SetMovementFlagsCalls - initialMovementFlagCalls);
+            Assert.Equal(
+                Agent.MovementControlFlag.Backward,
+                puppetMirror.MovementFlags & Agent.MovementControlFlag.MoveMask);
+            int finalPacketIndex = packetCount - 1;
+            Assert.Equal(
+                new Vec2(finalPacketIndex, -finalPacketIndex),
+                puppetMirror.MovementDirection);
         });
     }
 
@@ -879,6 +937,27 @@ public class MovementTrafficTests : MissionTestEnvironment
         for (int i = 0; i < characters.Length; i++)
             characters[i] = (char)('!' + (Next(ref state) % 94));
         return new string(characters);
+    }
+
+    private static void RunOffGameThread(Action action)
+    {
+        Exception? failure = null;
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception e)
+            {
+                failure = e;
+            }
+        });
+        thread.Start();
+        thread.Join();
+
+        if (failure != null)
+            throw failure;
     }
 
     private sealed class CountingMovementPacketCompressor : IMovementPacketCompressor

--- a/source/GameInterface/Services/GameDebug/Commands/GameThreadDebugCommand.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/GameThreadDebugCommand.cs
@@ -27,15 +27,15 @@ public class GameThreadDebugCommand
             case "on":
             case "true":
             case "1":
-                GameThread.Instrument = true;
+                GameThread.SetInstrumentation(true);
                 break;
             case "off":
             case "false":
             case "0":
-                GameThread.Instrument = false;
+                GameThread.SetInstrumentation(false);
                 break;
             case "toggle":
-                GameThread.Instrument = !GameThread.Instrument;
+                GameThread.SetInstrumentation(!GameThread.Instrument);
                 break;
             case "status":
                 break;
@@ -44,7 +44,7 @@ public class GameThreadDebugCommand
         }
 
         return $"GameThread drain instrumentation is {(GameThread.Instrument ? "ON" : "OFF")}. " +
-               "When ON, a per-second [GameThread] summary (drain ms, worst frame, backlog, top handlers) is written to the log.";
+               "When ON, a per-second [GameThread] summary (drain ms, worst frame, backlog, batching, top handlers) is written to the log.";
     }
 
     [CommandLineArgumentFunction("stall", "coop.debug.gamethread")]

--- a/source/GameInterface/Services/Party/Commands/LargeBattleRosterFixtureCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/LargeBattleRosterFixtureCommands.cs
@@ -1,0 +1,253 @@
+﻿#if DEBUG
+using Autofac;
+using Common;
+using GameInterface.Services.ObjectManager;
+using GameInterface.Utils.Commands;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Roster;
+using static TaleWorlds.Library.CommandLineFunctionality;
+
+namespace GameInterface.Services.Party.Commands;
+
+internal static class LargeBattleRosterFixtureCommands
+{
+    private const string FixtureTroopId = "imperial_recruit";
+    private static LargeBattleRosterFixture fixture;
+
+    private sealed class LargeBattleRosterFixture
+    {
+        public PartySnapshot FirstParty;
+        public PartySnapshot SecondParty;
+    }
+
+    private sealed class PartySnapshot
+    {
+        public MobileParty Party;
+        public TroopRosterElement[] MemberRoster;
+        public string Fingerprint;
+    }
+
+    [CommandLineArgumentFunction("large_battle_roster_begin", "coop.debug.mobileparty")]
+    public static string Begin(List<string> args)
+    {
+        if (!ModInformation.IsServer)
+            return "Run this command on the server.";
+        if (args.Count != 3 ||
+            !int.TryParse(args[2], out var addedPerParty) ||
+            addedPerParty < 1 ||
+            addedPerParty > 500)
+            return "Usage: coop.debug.mobileparty.large_battle_roster_begin " +
+                   "<firstPartyId> <secondPartyId> <troopsPerParty:1-500>";
+        if (fixture != null)
+            return "A large-battle roster fixture is already pending restoration.";
+        if (!TryGetObjectManager(out var objectManager))
+            return "Unable to resolve ObjectManager.";
+        if (!TryResolveParty(objectManager, args[0], out var firstParty, out var firstError))
+            return firstError;
+        if (!TryResolveParty(objectManager, args[1], out var secondParty, out var secondError))
+            return secondError;
+        if (firstParty == secondParty)
+            return "The fixture requires two distinct parties.";
+        if (!objectManager.TryGetObject(FixtureTroopId, out CharacterObject fixtureTroop))
+            return $"Unable to resolve fixture troop {FixtureTroopId}.";
+
+        var activeFixture = new LargeBattleRosterFixture
+        {
+            FirstParty = Capture(firstParty),
+            SecondParty = Capture(secondParty),
+        };
+        fixture = activeFixture;
+
+        firstParty.MemberRoster.AddToCounts(fixtureTroop, addedPerParty);
+        secondParty.MemberRoster.AddToCounts(fixtureTroop, addedPerParty);
+
+        return
+            $"LARGE_BATTLE_ROSTER_FIXTURE_STARTED troop={FixtureTroopId} addedPerParty={addedPerParty}\n" +
+            FormatState("active", firstParty, secondParty);
+    }
+
+    [CommandLineArgumentFunction("large_battle_roster_status", "coop.debug.mobileparty")]
+    public static string Status(List<string> args)
+    {
+        if (args.Count != 2)
+            return "Usage: coop.debug.mobileparty.large_battle_roster_status " +
+                   "<firstPartyId> <secondPartyId>";
+        if (!TryGetObjectManager(out var objectManager))
+            return "Unable to resolve ObjectManager.";
+        if (!TryResolveParty(objectManager, args[0], out var firstParty, out var firstError))
+            return firstError;
+        if (!TryResolveParty(objectManager, args[1], out var secondParty, out var secondError))
+            return secondError;
+
+        return FormatState(fixture == null ? "none" : "active", firstParty, secondParty);
+    }
+
+    [CommandLineArgumentFunction("large_battle_roster_restore", "coop.debug.mobileparty")]
+    public static string Restore(List<string> args)
+    {
+        if (!ModInformation.IsServer)
+            return "Run this command on the server.";
+        if (args.Count != 0)
+            return "Usage: coop.debug.mobileparty.large_battle_roster_restore";
+        if (fixture == null)
+            return "No large-battle roster fixture is pending restoration.";
+
+        var activeFixture = fixture;
+        Restore(activeFixture.FirstParty);
+        Restore(activeFixture.SecondParty);
+
+        string firstFingerprint = Fingerprint(activeFixture.FirstParty.Party.MemberRoster);
+        string secondFingerprint = Fingerprint(activeFixture.SecondParty.Party.MemberRoster);
+        if (firstFingerprint != activeFixture.FirstParty.Fingerprint ||
+            secondFingerprint != activeFixture.SecondParty.Fingerprint)
+        {
+            return "Large-battle roster restoration did not reproduce the original fingerprints.\n" +
+                   FormatState(
+                       "restore-failed",
+                       activeFixture.FirstParty.Party,
+                       activeFixture.SecondParty.Party);
+        }
+
+        fixture = null;
+        return
+            "LARGE_BATTLE_ROSTER_FIXTURE_RESTORED\n" +
+            FormatState(
+                "none",
+                activeFixture.FirstParty.Party,
+                activeFixture.SecondParty.Party);
+    }
+
+    private static bool TryGetObjectManager(out IObjectManager objectManager)
+    {
+        objectManager = null;
+        if (!ContainerProvider.TryGetContainer(out var container)) return false;
+
+        return container.TryResolve(out objectManager);
+    }
+
+    private static bool TryResolveParty(
+        IObjectManager objectManager,
+        string id,
+        out MobileParty party,
+        out string error)
+    {
+        if (objectManager.TryGetObject(id, out party) ||
+            CommandHelpers.TryGetMobileParty(id, out party, out _))
+        {
+            error = null;
+            return true;
+        }
+
+        error = $"Unable to resolve party {id}.";
+        return false;
+    }
+
+    private static PartySnapshot Capture(MobileParty party) => new PartySnapshot
+    {
+        Party = party,
+        MemberRoster = CopyRoster(party.MemberRoster),
+        Fingerprint = Fingerprint(party.MemberRoster),
+    };
+
+    private static TroopRosterElement[] CopyRoster(TroopRoster roster)
+    {
+        var copy = new TroopRosterElement[roster.Count];
+        for (int index = 0; index < roster.Count; index++)
+            copy[index] = roster.GetElementCopyAtIndex(index);
+
+        return copy;
+    }
+
+    private static void Restore(PartySnapshot snapshot)
+    {
+        var roster = snapshot.Party.MemberRoster;
+        for (int index = roster.Count - 1; index >= 0; index--)
+        {
+            TroopRosterElement element = roster.GetElementCopyAtIndex(index);
+            roster.AddToCountsAtIndex(
+                index,
+                -element.Number,
+                -element.WoundedNumber,
+                0,
+                false);
+        }
+        roster.RemoveZeroCounts();
+
+        foreach (TroopRosterElement element in snapshot.MemberRoster)
+        {
+            roster.AddToCounts(
+                element.Character,
+                element.Number,
+                false,
+                element.WoundedNumber,
+                element.Xp,
+                true);
+        }
+    }
+
+    private static string FormatState(
+        string state,
+        MobileParty firstParty,
+        MobileParty secondParty)
+    {
+        var output = new StringBuilder();
+        output.AppendLine($"LARGE_BATTLE_ROSTER_FIXTURE state={state}");
+        AppendPartyState(output, firstParty);
+        AppendPartyState(output, secondParty);
+        return output.ToString().TrimEnd();
+    }
+
+    private static void AppendPartyState(StringBuilder output, MobileParty party)
+    {
+        TroopRoster roster = party.MemberRoster;
+        int total = 0;
+        int wounded = 0;
+        for (int index = 0; index < roster.Count; index++)
+        {
+            TroopRosterElement element = roster.GetElementCopyAtIndex(index);
+            total += element.Number;
+            wounded += element.WoundedNumber;
+        }
+
+        output.AppendLine(
+            $"party={party.StringId}|total={total}|wounded={wounded}|healthy={total - wounded}|" +
+            $"fingerprint={Fingerprint(roster)}");
+    }
+
+    private static string Fingerprint(TroopRoster roster)
+    {
+        var content = new StringBuilder();
+        var elements = new List<TroopRosterElement>();
+        for (int index = 0; index < roster.Count; index++)
+            elements.Add(roster.GetElementCopyAtIndex(index));
+
+        foreach (TroopRosterElement element in elements
+                     .OrderBy(value => value.Character.StringId, StringComparer.Ordinal))
+        {
+            content.Append(element.Character.StringId);
+            content.Append('|');
+            content.Append(element.Number);
+            content.Append('|');
+            content.Append(element.WoundedNumber);
+            content.Append('|');
+            content.Append(element.Xp);
+            content.AppendLine();
+        }
+
+        using (SHA256 sha256 = SHA256.Create())
+        {
+            byte[] hash = sha256.ComputeHash(Encoding.UTF8.GetBytes(content.ToString()));
+            var result = new StringBuilder(hash.Length * 2);
+            foreach (byte value in hash)
+                result.Append(value.ToString("x2"));
+            return result.ToString();
+        }
+    }
+}
+#endif

--- a/source/Missions/Agents/Handlers/AgentMovementHandler.cs
+++ b/source/Missions/Agents/Handlers/AgentMovementHandler.cs
@@ -12,6 +12,7 @@ using Missions.Messages;
 using Serilog;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
 using AgentControllerType = TaleWorlds.Core.AgentControllerType;
@@ -54,6 +55,10 @@ public class AgentMovementHandler : IAgentMovementHandler
     private readonly IMovementBatchSender movementBatchSender;
     private readonly IPuppetMountStateRepairer puppetMountStateRepairer;
     private readonly Dictionary<Guid, AgentEquipmentData> lastEquipment = new Dictionary<Guid, AgentEquipmentData>();
+    private readonly CancellationTokenSource movementReceiveCancellation = new CancellationTokenSource();
+    private readonly CancellationToken movementReceiveLifetime;
+    // The cached delegate is also the queue-batch identity for adjacent movement packets.
+    private readonly Action<MovementPacket> applyMovement;
 
     // A puppet's horse, remembered when its owner dismounts, so a later re-mount can put it back on the
     // same one. Touched only on the game thread (inside HandlePacket's apply), so no lock; per-mission
@@ -105,6 +110,8 @@ public class AgentMovementHandler : IAgentMovementHandler
         this.equipmentApplier = equipmentApplier;
         this.movementBatchSender = movementBatchSender;
         this.puppetMountStateRepairer = puppetMountStateRepairer;
+        movementReceiveLifetime = movementReceiveCancellation.Token;
+        applyMovement = ApplyMovement;
 
         // Server-mediated membership. A peer entering is the cue to clear any STALE party it left behind
         // on a missed disconnect (so its rejoin re-spawns clean); a leave/disconnect releases its party.
@@ -134,6 +141,8 @@ public class AgentMovementHandler : IAgentMovementHandler
     {
         if (_disposed) return;
         _disposed = true;
+        movementReceiveCancellation.Cancel();
+        movementReceiveCancellation.Dispose();
 
         Logger.Verbose("Disposing {handlerType}", typeof(AgentMovementHandler));
 
@@ -454,71 +463,75 @@ public class AgentMovementHandler : IAgentMovementHandler
         {
             return;
         }
+        if (_disposed) return;
 
-        // Resolve and apply the whole batch in ONE game-thread action. Resolving here keeps this ordered behind
-        // earlier game-thread spawn/register work that may have been queued by reliable messages.
-        GameThread.RunSafe(() =>
+        GameThread.RunSafeBatched(
+            movement,
+            applyMovement,
+            movementReceiveLifetime);
+    }
+
+    private void ApplyMovement(MovementPacket movement)
+    {
+        if (_disposed || Mission.Current == null) return;
+
+        using (new AllowedThread())
         {
-            if (Mission.Current == null) return;
-
-            using (new AllowedThread())
+            for (int i = 0; i < movement.Agents.Length; i++)
             {
-                for (int i = 0; i < idCount; i++)
+                CoopAgentInfo agentInfo;
+                bool found = movement.AgentIds != null
+                    ? agentRegistry.TryGetAgentInfo(
+                        movement.IdentityScopeId, movement.AgentIds[i], out agentInfo)
+                    : agentRegistry.TryGetAgentInfo(
+                        movement.AgentGuids[i], out agentInfo);
+                if (!found) continue;
+
+                Agent agent = agentInfo.Agent;
+                AgentData data = movement.Agents[i];
+
+                // The agent may have become invalid (player left, mission torn down) between queueing
+                // and running; only apply while it is still active in the current mission.
+                if (agent == null || agent.Mission != Mission.Current || agent.IsActive() == false)
+                    continue;
+
+                // Re-check authority ON the game thread: a packet from the previous owner can be queued
+                // behind a host-migration adoption (both are game-thread actions queued from the network
+                // thread), and applying it after the transfer would re-pin the freshly adopted agent to a
+                // stale position/input snapshot the AI then fights.
+                if (agentRegistry.IsLocallyControlled(agent))
+                    continue;
+
+                SyncMountState(
+                    agent,
+                    movement.IdentityScopeId ?? agentInfo.MovementScopeId,
+                    data);
+
+                // A puppet horse must not run local AI between owner snapshots and fight their heading/input.
+                if (agent.MountAgent is Agent puppetMount && puppetMount.Controller != AgentControllerType.None)
                 {
-                    CoopAgentInfo agentInfo;
-                    bool found = movement.AgentIds != null
-                        ? agentRegistry.TryGetAgentInfo(
-                            movement.IdentityScopeId, movement.AgentIds[i], out agentInfo)
-                        : agentRegistry.TryGetAgentInfo(
-                            movement.AgentGuids[i], out agentInfo);
-                    if (!found) continue;
+                    puppetMount.Controller = AgentControllerType.None;
+                    puppetMountStateRepairer.PreserveRiderlessPuppet(puppetMount);
+                }
 
-                    Agent agent = agentInfo.Agent;
-                    AgentData data = movement.Agents[i];
+                data.Apply(agent);
 
-                    // The agent may have become invalid (player left, mission torn down) between queueing
-                    // and running; only apply while it is still active in the current mission.
-                    if (agent == null || agent.Mission != Mission.Current || agent.IsActive() == false)
-                        continue;
-
-                    // Re-check authority ON the game thread: a packet from the previous owner can be queued
-                    // behind a host-migration adoption (both are game-thread actions queued from the network
-                    // thread), and applying it after the transfer would re-pin the freshly adopted agent to a
-                    // stale position/input snapshot the AI then fights.
-                    if (agentRegistry.IsLocallyControlled(agent))
-                        continue;
-
-                    SyncMountState(
-                        agent,
-                        movement.IdentityScopeId ?? agentInfo.MovementScopeId,
-                        data);
-
-                    // A puppet horse must not run local AI between owner snapshots and fight their heading/input.
-                    if (agent.MountAgent is Agent puppetMount && puppetMount.Controller != AgentControllerType.None)
-                    {
-                        puppetMount.Controller = AgentControllerType.None;
-                        puppetMountStateRepairer.PreserveRiderlessPuppet(puppetMount);
-                    }
-
-                    data.Apply(agent);
-
-                    // Position is reconciled per-frame by the interpolator (smoother than a per-packet
-                    // correction bound to the ~10ms poll cadence); push the latest targets it eases toward.
-                    if (agent.HasMount && data.MountData != null)
-                    {
-                        // Mounted: feed target frames to the rider, since the mount is driven through its rider.
-                        // Keep the mount position only for rare large-gap snaps and drop any stale direct-horse
-                        // target from before the puppet mounted.
-                        _interpolator.Forget(agent.MountAgent);
-                        _interpolator.SetMountedRiderTarget(agent, data);
-                    }
-                    else
-                    {
-                        _interpolator.SetRiderTarget(agent, data);
-                    }
+                // Position is reconciled per-frame by the interpolator (smoother than a per-packet
+                // correction bound to the ~10ms poll cadence); push the latest targets it eases toward.
+                if (agent.HasMount && data.MountData != null)
+                {
+                    // Mounted: feed target frames to the rider, since the mount is driven through its rider.
+                    // Keep the mount position only for rare large-gap snaps and drop any stale direct-horse
+                    // target from before the puppet mounted.
+                    _interpolator.Forget(agent.MountAgent);
+                    _interpolator.SetMountedRiderTarget(agent, data);
+                }
+                else
+                {
+                    _interpolator.SetRiderTarget(agent, data);
                 }
             }
-        });
+        }
     }
 
     // [Game thread] Replicate the owner's mount/dismount onto its puppet. The per-tick AgentData reports


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

Each received movement packet queues a separate game-thread action. Large field battles can produce thousands of these actions per second and consume substantial client CPU.

## What is the new behavior?

Adjacent movement packets share one game-thread queue entry while every packet is still applied in receive order. Intervening spawn and authority work remains an ordering barrier, and movement network traffic is unchanged.

## Bot Changelog Entry

- Reduced client CPU overhead in large field battles.