### PR TITLE
Fix bandit party home settlement save corruption

### DIFF
--- a/source/E2E.Tests/Services/PartyComponents/BanditPartyComponentTests.cs
+++ b/source/E2E.Tests/Services/PartyComponents/BanditPartyComponentTests.cs
@@ -1,4 +1,6 @@
 ﻿using E2E.Tests.Util;
+using GameInterface.Services.Bandits;
+using GameInterface.Utils;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Party.PartyComponents;
@@ -61,6 +63,7 @@ public class BanditPartyComponentTests : SyncTestBase
         // Act
         string? partyId = null;
         string? clanId = null;
+        string? settlementId = null;
 
         server.Call(() =>
         {
@@ -76,12 +79,15 @@ public class BanditPartyComponentTests : SyncTestBase
 
             Assert.True(server.ObjectManager.TryGetId(newParty, out partyId));
             Assert.True(server.ObjectManager.TryGetId(clan, out clanId));
+            Assert.True(server.ObjectManager.TryGetId(settlement, out settlementId));
             Assert.Same(clan, newParty.ActualClan);
+            Assert.Same(settlement, newParty.HomeSettlement);
         });
 
         // Assert
         Assert.NotNull(partyId);
         Assert.NotNull(clanId);
+        Assert.NotNull(settlementId);
 
         foreach (var client in TestEnvironment.Clients)
         {
@@ -95,7 +101,53 @@ public class BanditPartyComponentTests : SyncTestBase
             // MapFaction resolves via ActualClan for bandit parties.
             Assert.True(client.ObjectManager.TryGetObject<Clan>(clanId, out var clientClan));
             Assert.Same(clientClan, newParty.ActualClan);
+
+            Assert.True(client.ObjectManager.TryGetObject<Settlement>(settlementId, out var clientSettlement));
+            Assert.Same(clientSettlement, newParty.HomeSettlement);
         }
+    }
+
+    [Fact]
+    public void RepairMissingHomeSettlements_WhenLooterSaveIsCorrupted_UsesNearestTown()
+    {
+        var server = TestEnvironment.Server;
+
+        server.Call(() =>
+        {
+            var nearSettlement = GameObjectCreator.CreateInitializedObject<Settlement>();
+            nearSettlement.Town = GameObjectCreator.CreateInitializedObject<Town>();
+            nearSettlement._position = new CampaignVec2(new Vec2(10, 10), true);
+
+            var farSettlement = GameObjectCreator.CreateInitializedObject<Settlement>();
+            farSettlement.Town = GameObjectCreator.CreateInitializedObject<Town>();
+            farSettlement._position = new CampaignVec2(new Vec2(100, 100), true);
+
+            var clan = GameObjectCreator.CreateInitializedObject<Clan>();
+            var template = GameObjectCreator.CreateInitializedObject<PartyTemplateObject>();
+            var party = BanditPartyComponent.CreateLooterParty(
+                "CorruptedLooter",
+                clan,
+                nearSettlement,
+                false,
+                template,
+                new CampaignVec2(new Vec2(11, 11), true));
+            var component = Assert.IsType<BanditPartyComponent>(party.PartyComponent);
+
+            ReflectionUtils.SetPrivateField(
+                typeof(BanditPartyComponent),
+                nameof(BanditPartyComponent._relatedSettlement),
+                component,
+                null);
+            Assert.Null(party.HomeSettlement);
+
+            int repairedCount = server.Resolve<IBanditPartyHomeSettlementRepairer>()
+                .RepairMissingHomeSettlements(
+                    new[] { party },
+                    new[] { farSettlement, nearSettlement });
+
+            Assert.Equal(1, repairedCount);
+            Assert.Same(nearSettlement, party.HomeSettlement);
+        });
     }
 
     [Fact]

--- a/source/GameInterface/GameInterfaceModule.cs
+++ b/source/GameInterface/GameInterfaceModule.cs
@@ -9,6 +9,7 @@ using GameInterface.Configuration;
 using GameInterface.Registry;
 using GameInterface.Serialization;
 using GameInterface.Services;
+using GameInterface.Services.Bandits;
 using GameInterface.Services.Barters;
 using GameInterface.Services.Entity;
 using GameInterface.Services.GameDebug.Metrics;
@@ -66,6 +67,7 @@ public class GameInterfaceModule : Module
         builder.RegisterType<PlayerRansomReleaseSettlementProvider>().As<IPlayerRansomReleaseSettlementProvider>().InstancePerDependency();
         builder.RegisterType<PrisonerSaleProcessor>().As<IPrisonerSaleProcessor>().InstancePerDependency();
         builder.RegisterType<PartyScreenRosterBaselineProvider>().As<IPartyScreenRosterBaselineProvider>().InstancePerDependency();
+        builder.RegisterType<BanditPartyHomeSettlementRepairer>().As<IBanditPartyHomeSettlementRepairer>().InstancePerDependency();
         builder.RegisterType<WorkshopRepairer>().As<IWorkshopRepairer>().InstancePerDependency();
         builder.RegisterType<MapEventLogger>().As<IMapEventLogger>().InstancePerLifetimeScope();
         builder.RegisterType<TroopRosterLogger>().As<ITroopRosterLogger>().InstancePerLifetimeScope();

--- a/source/GameInterface/Services/Bandits/BanditPartyHomeSettlementRepairer.cs
+++ b/source/GameInterface/Services/Bandits/BanditPartyHomeSettlementRepairer.cs
@@ -1,0 +1,87 @@
+﻿using Common.Logging;
+using GameInterface.Utils;
+using Serilog;
+using System.Collections.Generic;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Party.PartyComponents;
+using TaleWorlds.CampaignSystem.Settlements;
+
+namespace GameInterface.Services.Bandits;
+
+internal interface IBanditPartyHomeSettlementRepairer
+{
+    int RepairMissingHomeSettlements(
+        IEnumerable<MobileParty> banditParties,
+        IEnumerable<Settlement> settlements);
+}
+
+internal class BanditPartyHomeSettlementRepairer : IBanditPartyHomeSettlementRepairer
+{
+    private static readonly ILogger Logger = LogManager.GetLogger<BanditPartyHomeSettlementRepairer>();
+
+    public int RepairMissingHomeSettlements(
+        IEnumerable<MobileParty> banditParties,
+        IEnumerable<Settlement> settlements)
+    {
+        var homeSettlements = new List<Settlement>();
+        foreach (Settlement settlement in settlements)
+        {
+            if (settlement.IsTown || settlement.IsVillage)
+            {
+                homeSettlements.Add(settlement);
+            }
+        }
+
+        var repairedCount = 0;
+        foreach (MobileParty party in banditParties)
+        {
+            if (!(party.PartyComponent is BanditPartyComponent component) ||
+                component.HomeSettlement != null)
+            {
+                continue;
+            }
+
+            Settlement nearestSettlement = FindNearestSettlement(party, homeSettlements);
+            if (nearestSettlement == null)
+            {
+                Logger.Error("Could not repair missing home settlement for bandit party {PartyId}", party.StringId);
+                continue;
+            }
+
+            // Vanilla exposes no setter for its readonly saveable _relatedSettlement field.
+            ReflectionUtils.SetPrivateField(
+                typeof(BanditPartyComponent),
+                nameof(BanditPartyComponent._relatedSettlement),
+                component,
+                nearestSettlement);
+            repairedCount++;
+        }
+
+        if (repairedCount > 0)
+        {
+            Logger.Warning("Repaired missing home settlements for {Count} bandit parties", repairedCount);
+        }
+
+        return repairedCount;
+    }
+
+    private static Settlement FindNearestSettlement(
+        MobileParty party,
+        IEnumerable<Settlement> settlements)
+    {
+        Settlement nearestSettlement = null;
+        float nearestDistanceSquared = float.MaxValue;
+
+        foreach (Settlement settlement in settlements)
+        {
+            float distanceSquared = settlement.Position.DistanceSquared(party.Position);
+            if (distanceSquared < nearestDistanceSquared)
+            {
+                nearestSettlement = settlement;
+                nearestDistanceSquared = distanceSquared;
+            }
+        }
+
+        return nearestSettlement;
+    }
+}

--- a/source/GameInterface/Services/Bandits/Patches/BanditPartyHomeSettlementRepairPatch.cs
+++ b/source/GameInterface/Services/Bandits/Patches/BanditPartyHomeSettlementRepairPatch.cs
@@ -1,0 +1,27 @@
+﻿using Common.Logging;
+using Common.Util;
+using HarmonyLib;
+using Serilog;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Settlements;
+
+namespace GameInterface.Services.Bandits.Patches;
+
+[HarmonyPatch(typeof(CampaignEventDispatcher), nameof(CampaignEventDispatcher.OnGameLoaded))]
+internal class BanditPartyHomeSettlementRepairPatch
+{
+    private static readonly ILogger Logger = LogManager.GetLogger<BanditPartyHomeSettlementRepairPatch>();
+
+    [HarmonyPrefix]
+    private static void RepairMissingHomeSettlements()
+    {
+        if (!ContainerProvider.TryResolve<IBanditPartyHomeSettlementRepairer>(out var repairer))
+        {
+            Logger.Error("Unable to resolve {Repairer}", nameof(IBanditPartyHomeSettlementRepairer));
+            return;
+        }
+
+        repairer.RepairMissingHomeSettlements(MobileParty.AllBanditParties, Settlement.All);
+    }
+}

--- a/source/GameInterface/Services/PartyComponents/BanditPartyComponents/Lifetime/BanditPartyComponentLifetimePatches.cs
+++ b/source/GameInterface/Services/PartyComponents/BanditPartyComponents/Lifetime/BanditPartyComponentLifetimePatches.cs
@@ -1,4 +1,4 @@
-using Common;
+﻿using Common;
 using Common.Logging;
 using Common.Messaging;
 using GameInterface.Policies;
@@ -8,6 +8,7 @@ using Serilog;
 using System.Collections.Generic;
 using System.Reflection;
 using TaleWorlds.CampaignSystem.Party.PartyComponents;
+using TaleWorlds.CampaignSystem.Settlements;
 
 namespace GameInterface.Services.PartyComponents.BanditPartyComponents.Lifetime;
 
@@ -22,7 +23,7 @@ internal class BanditPartyComponentLifetimePatches
 
     private static IEnumerable<MethodBase> TargetMethods() => AccessTools.GetDeclaredConstructors(typeof(BanditPartyComponent));
 
-    private static bool Prefix(BanditPartyComponent __instance)
+    private static bool Prefix(BanditPartyComponent __instance, object[] __args)
     {
         // Call original if we call this function
         if (CallOriginalPolicy.IsOriginalAllowed()) return true;
@@ -33,7 +34,9 @@ internal class BanditPartyComponentLifetimePatches
             return false;
         }
 
-        var message = new PartyComponentCreated(__instance);
+        // The first argument is either a Hideout or the Settlement stored in _relatedSettlement.
+        var relatedSettlement = __args[0] as Settlement;
+        var message = new PartyComponentCreated(__instance, relatedSettlement?.StringId);
 
         MessageBroker.Instance.Publish(__instance, message);
 

--- a/source/GameInterface/Services/PartyComponents/Data/PartyComponentData.cs
+++ b/source/GameInterface/Services/PartyComponents/Data/PartyComponentData.cs
@@ -12,10 +12,8 @@ public record PartyComponentData(int TypeIndex, string Id)
     public string Id { get; } = Id;
 
     /// <summary>
-    /// Optional: the StringId of the home Settlement for a <c>PatrolPartyComponent</c>.
-    /// Null for all other component types. Bundled with creation so the client can call
-    /// <c>InitializePartyComponentProperties</c> immediately without waiting for a
-    /// separate AutoSync field message (which may arrive in any order).
+    /// Optional constructor Settlement for party components whose home is stored in a field.
+    /// Bundled with creation so the client can restore the field before the component is used.
     /// </summary>
     [ProtoMember(3)]
     public string HomeSettlementId { get; set; } = null;

--- a/source/GameInterface/Services/PartyComponents/Handlers/PartyComponentHandler.cs
+++ b/source/GameInterface/Services/PartyComponents/Handlers/PartyComponentHandler.cs
@@ -96,7 +96,7 @@ internal class PartyComponentHandler : IHandler
         {
             try
             {
-                var obj = (PartyComponent)ObjectHelper.SkipConstructor(partyTypes[data.TypeIndex]);
+                var obj = CreatePartyComponent(data);
 
                 switch (data.TypeIndex)
                 {
@@ -221,6 +221,24 @@ internal class PartyComponentHandler : IHandler
                 Logger.Error(e, "Failed to apply {Message}", nameof(NetworkCreatePartyComponent));
             }
         });
+    }
+
+    private PartyComponent CreatePartyComponent(PartyComponentData data)
+    {
+        if (data.TypeIndex != 0 || data.HomeSettlementId is null)
+        {
+            return (PartyComponent)ObjectHelper.SkipConstructor(partyTypes[data.TypeIndex]);
+        }
+
+        if (!objectManager.TryGetObjectWithLogging(data.HomeSettlementId, out Settlement relatedSettlement))
+        {
+            return (PartyComponent)ObjectHelper.SkipConstructor(partyTypes[data.TypeIndex]);
+        }
+
+        using (new AllowedThread())
+        {
+            return new BanditPartyComponent(relatedSettlement, null);
+        }
     }
 
     private void Handle_PartyComponentMobilePartyUpdated(MessagePayload<PartyComponentMobilePartyUpdated> payload)


### PR DESCRIPTION
## PR Checklist

- [ ] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added

## PR Type

- [x] Bug fix

## What is the current behavior?

Coop-created looter and deserter components can be saved without their constructor settlement. Vanilla crashes in `BanditSpawnCampaignBehavior.CacheBanditCounts` when loading these parties because `HomeSettlement` is null.

## What is the new behavior?

Sync the constructor settlement when creating bandit party components and reconstruct them through the vanilla constructor on clients.

Existing affected saves are repaired before vanilla load listeners run by assigning each corrupted bandit party to its nearest town or village.

## Bot Changelog Entry

- Fixed a crash when loading saves containing corrupted looter or deserter parties.