### PR TITLE
[2501] Allow players to join AI-led siege assaults

### DIFF
--- a/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
+++ b/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
@@ -408,16 +408,40 @@ public class SiegeDebugCommand
         }
         else
         {
+            var connectedPlayerFactions = new List<IFaction>();
+            if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager))
+            {
+                return "Unable to resolve PlayerManager";
+            }
+
+            foreach (var player in playerManager.Players.Where(playerManager.IsConnected))
+            {
+                if (!objectManager.TryGetObjectWithLogging<MobileParty>(player.MobilePartyId, out var playerParty))
+                {
+                    return $"Unable to resolve player party {player.MobilePartyId}";
+                }
+
+                if (playerParty.MapFaction == null)
+                {
+                    return $"Player party {player.MobilePartyId} has no map faction";
+                }
+
+                connectedPlayerFactions.Add(playerParty.MapFaction);
+            }
+
             besieger = MobileParty.AllLordParties
                 .Where(party => !party.IsPlayerParty()
                     && party.MapFaction?.IsAtWarWith(settlement.MapFaction) == true
+                    && connectedPlayerFactions.All(playerFaction =>
+                        !party.MapFaction.IsAtWarWith(playerFaction))
                     && party.LeaderHero != null && party.CurrentSettlement == null
                     && party.MapEvent == null && party.BesiegerCamp == null && party.Army == null)
                 .OrderByDescending(party => party.Party.CalculateCurrentStrength())
                 .FirstOrDefault();
             if (besieger == null)
             {
-                return $"No hostile lord party available to besiege {settlement.Name}; pass a partyId explicitly";
+                return $"No hostile lord party compatible with the connected players is available to besiege " +
+                    $"{settlement.Name}; pass a partyId explicitly";
             }
         }
 

--- a/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
+++ b/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
@@ -20,8 +20,10 @@ using System.Linq;
 using System.Text;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Actions;
+using TaleWorlds.CampaignSystem.CampaignBehaviors;
 using TaleWorlds.CampaignSystem.Encounters;
 using TaleWorlds.CampaignSystem.GameMenus;
+using TaleWorlds.CampaignSystem.GameState;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.CampaignSystem.Siege;
@@ -268,6 +270,41 @@ public class SiegeDebugCommand
         GameMenu.SwitchToMenu("menu_siege_strategies");
         MobileParty.MainParty.SetMoveModeHold();
         return $"Joined the active siege assault at {settlement.Name}";
+    }
+
+    [CommandLineArgumentFunction("assault_entry_state", "coop.debug.siege")]
+    public static string AssaultEntryState(List<string> args)
+    {
+        if (args.Count != 0)
+        {
+            return "Usage: coop.debug.siege.assault_entry_state";
+        }
+
+        if (ModInformation.IsServer)
+        {
+            return "This command can only be used by a client";
+        }
+
+        if (Campaign.Current == null || PlayerEncounter.Current == null || MobileParty.MainParty == null)
+        {
+            return "The local player encounter is unavailable";
+        }
+
+        var callbackArgs = new MenuCallbackArgs((MenuContext)null, null);
+        bool conditionShown = new EncounterGameMenuBehavior()
+            .game_menu_encounter_attack_on_condition(callbackArgs);
+        var menu = Campaign.Current?.CurrentMenuContext?.GameMenu;
+        var renderedOption = menu?.MenuOptions
+            .FirstOrDefault(option => option.IdString == "attack");
+        var settlement = MobileParty.MainParty?.BesiegedSettlement;
+        var leader = settlement?.SiegeEvent?.BesiegerCamp?.LeaderParty;
+
+        return $"menu={menu?.StringId ?? "none"} settlement={settlement?.StringId ?? "none"} " +
+            $"leader={leader?.StringId ?? "none"} localLeader={leader == MobileParty.MainParty} " +
+            $"conditionShown={conditionShown} conditionEnabled={callbackArgs.IsEnabled} " +
+            $"conditionTooltip={callbackArgs.Tooltip?.ToString() ?? "none"} " +
+            $"renderedRegistered={renderedOption != null} renderedEnabled={renderedOption?.IsEnabled ?? false} " +
+            $"renderedTooltip={renderedOption?.Tooltip?.ToString() ?? "none"}";
     }
 
     [CommandLineArgumentFunction("leave", "coop.debug.siege")]

--- a/source/GameInterface/Services/SiegeEvents/Patches/SiegeAssaultCommandGatePatch.cs
+++ b/source/GameInterface/Services/SiegeEvents/Patches/SiegeAssaultCommandGatePatch.cs
@@ -7,31 +7,23 @@ using TaleWorlds.Localization;
 namespace GameInterface.Services.SiegeEvents.Patches;
 
 /// <summary>
-/// A co-besieger (a party besieging a settlement it does not lead) must not command the assault; only the
-/// BesiegerCamp leader leads or orders it. The vanilla encounter-menu command conditions can't tell leader from
-/// follower in co-op (the local leader lookup resolves to the local main party on every machine), so both
-/// besiegers get the enabled command options. Grey them out here for a non-leader besieger, keyed on the synced
-/// BesiegerCamp.LeaderParty which resolves identically on every machine. Non-siege encounters and the actual
-/// leader are untouched, and single-player is unaffected since a player leads its own siege.
+/// Restricts starting an assault to the synced BesiegerCamp leader. Participation in an active assault
+/// remains on the vanilla encounter flow.
 /// </summary>
-[HarmonyPatch(typeof(EncounterGameMenuBehavior))]
+[HarmonyPatch(typeof(SiegeEventCampaignBehavior))]
 internal static class SiegeAssaultCommandGatePatch
 {
-    [HarmonyPatch("game_menu_encounter_attack_on_condition")]
+    [HarmonyPatch(nameof(SiegeEventCampaignBehavior.game_menu_siege_strategies_lead_assault_on_condition))]
     [HarmonyPostfix]
-    private static void AttackConditionPostfix(MenuCallbackArgs args, ref bool __result) => DisableForCoBesieger(args, ref __result);
+    private static void LeadAssaultConditionPostfix(MenuCallbackArgs args, bool __result) => DisableForCoBesieger(args, __result);
 
-    [HarmonyPatch("game_menu_encounter_order_attack_on_condition")]
+    [HarmonyPatch(nameof(SiegeEventCampaignBehavior.game_menu_siege_strategies_order_assault_on_condition))]
     [HarmonyPostfix]
-    private static void OrderAttackConditionPostfix(MenuCallbackArgs args, ref bool __result) => DisableForCoBesieger(args, ref __result);
+    private static void OrderAssaultConditionPostfix(MenuCallbackArgs args, bool __result) => DisableForCoBesieger(args, __result);
 
-    [HarmonyPatch("game_menu_town_besiege_continue_siege_on_condition")]
-    [HarmonyPostfix]
-    private static void ContinueSiegeConditionPostfix(MenuCallbackArgs args, ref bool __result) => DisableForCoBesieger(args, ref __result);
-
-    private static void DisableForCoBesieger(MenuCallbackArgs args, ref bool __result)
+    private static void DisableForCoBesieger(MenuCallbackArgs args, bool result)
     {
-        if (!__result) return;
+        if (!result) return;
 
         var settlement = MobileParty.MainParty?.BesiegedSettlement;
         if (settlement == null) return;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Joining an AI-led siege camp before or during an assault disables the participation actions and tells the player they are not the siege leader, preventing them from entering the battle.

## What is the new behavior?

Resolves #2501

Players who join an AI-led siege can use the normal Attack action to participate after the AI leader starts the assault, while only the siege leader can choose when the assault begins.

## Bot Changelog Entry

- Fixed players being unable to join assaults led by an AI siege leader.
