### PR TITLE
Fix unprofitable player caravans

### DIFF
--- a/source/GameInterface/Services/Caravans/Patches/DefaultCaravanModelPatches.cs
+++ b/source/GameInterface/Services/Caravans/Patches/DefaultCaravanModelPatches.cs
@@ -14,13 +14,17 @@ namespace GameInterface.Services.Caravans.Patches;
 internal class DefaultCaravanModelPatches
 {
     [HarmonyPatch(nameof(DefaultCaravanModel.GetInitialTradeGold))]
-    [HarmonyPostfix]
-    public static void GetInitialTradeGoldPrefix(ref int __result, Hero owner)
+    [HarmonyPrefix]
+    public static bool GetInitialTradeGoldPrefix(ref int __result, Hero owner, bool navalCaravan, bool largeCaravan)
     {
-        // Add the same 5000 extra for any player hero as vanilla does for Hero.MainHero
-        if (owner != null && owner.IsPlayerHero())
+        int fromType = 10000;
+        int fromPlayerOwner = (owner.IsPlayerHero()) ? 5000 : 0;
+        if (largeCaravan)
         {
-            __result += 5000;
+            fromType = 17500;
         }
+        __result = fromType + fromPlayerOwner;
+
+        return false;
     }
 }

--- a/source/GameInterface/Services/Caravans/Patches/DefaultCaravanModelPatches.cs
+++ b/source/GameInterface/Services/Caravans/Patches/DefaultCaravanModelPatches.cs
@@ -1,0 +1,26 @@
+﻿using GameInterface.Services.Heroes.Extensions;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.GameComponents;
+
+namespace GameInterface.Services.Caravans.Patches;
+
+/// <summary>
+/// Vanilla uses a Hero.MainHero check for the caravan's owner to give it extra money when forming.
+/// Without this patch, player caravans are treated as AI caravans in terms of their starting balance.
+/// This takes a lot longer to build up to being profitable as they have less money to build up a roster of trade goods.
+/// </summary>
+[HarmonyPatch(typeof(DefaultCaravanModel))]
+internal class DefaultCaravanModelPatches
+{
+    [HarmonyPatch(nameof(DefaultCaravanModel.GetInitialTradeGold))]
+    [HarmonyPostfix]
+    public static void GetInitialTradeGoldPrefix(ref int __result, Hero owner)
+    {
+        // Add the same 5000 extra for any player hero as vanilla does for Hero.MainHero
+        if (owner != null && owner.IsPlayerHero())
+        {
+            __result += 5000;
+        }
+    }
+}


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Vanilla uses a `Hero.MainHero` check on the caravan's owner to give it extra money when forming. Without this, a player caravan spawns with the same money as an AI caravan. The result being that it takes longer to build up to being profitable than in vanilla with less starting capital.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #2513
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Newly formed player caravans are now profitable like vanilla.
