### PR TITLE
Compile protobuf contracts individually on Wine-Mono

### DIFF
--- a/source/Common.Tests/Serialization/ProtoBufSerializerTests.cs
+++ b/source/Common.Tests/Serialization/ProtoBufSerializerTests.cs
@@ -35,13 +35,15 @@ public class ProtoBufSerializerTests
     }
 
     [Fact]
-    public void ConfigureRuntimeModel_KeepsCompilationAndUsesDefaultInitializationForStructs()
+    public void ConfigureRuntimeModel_DisablesAutoCompileOnMonoAndUsesDefaultInitializationForStructs()
     {
         var model = RuntimeTypeModel.Create();
         ProtoBufSerializer.ConfigureRuntimeModel(model, isMonoRuntime: true);
         var metaType = model.Add(typeof(SkipConstructorStruct), applyDefaultBehaviour: true);
 
-        Assert.True(model.AutoCompile);
+        // Auto-compile is off on Mono so no contract is emitted implicitly; compilation is then
+        // attempted per type, and a runtime that rejects the IL simply keeps the reflection path.
+        Assert.False(model.AutoCompile);
         Assert.True(metaType.UseConstructor);
 
         var expected = new SkipConstructorStruct(42, "linux");
@@ -66,6 +68,31 @@ public class ProtoBufSerializerTests
         var metaType = model.Add(typeof(SkipConstructorClass), applyDefaultBehaviour: true);
 
         Assert.False(metaType.UseConstructor);
+    }
+
+    [Fact]
+    public void TryCompilePending_LeavesContractUsableWhenCompilationIsRejected()
+    {
+        // Wine-Mono rejects the IL protobuf-net emits for some contracts. TryCompilePending
+        // swallows that rejection, and the contract must still serialize on the reflection path.
+        var model = RuntimeTypeModel.Create();
+        ProtoBufSerializer.ConfigureRuntimeModel(model, isMonoRuntime: true);
+        model.Add(typeof(SkipConstructorStruct), applyDefaultBehaviour: true);
+
+        ProtoBufSerializer.TryCompilePending();
+
+        var expected = new SkipConstructorStruct(7, "fallback");
+        using var stream = new MemoryStream();
+        model.Serialize(stream, expected);
+        stream.Position = 0;
+
+        var actual = (SkipConstructorStruct)model.Deserialize(
+            stream,
+            value: null,
+            typeof(SkipConstructorStruct));
+
+        Assert.Equal(expected.Number, actual.Number);
+        Assert.Equal(expected.Text, actual.Text);
     }
 
     [Fact]

--- a/source/Common/Serialization/ProtoBufSerializer.cs
+++ b/source/Common/Serialization/ProtoBufSerializer.cs
@@ -1,6 +1,7 @@
 ﻿using ProtoBuf;
 using ProtoBuf.Meta;
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace Common.Serialization;
@@ -26,20 +27,86 @@ public class ProtoBufSerializer : ICommonSerializer
         ConfigureRuntimeModel(RuntimeTypeModel.Default, IsMonoRuntime);
     }
 
+    /// <summary>
+    /// Contracts registered on Mono that have not yet had a compilation attempt. Compilation is
+    /// deferred rather than performed inside
+    /// <see cref="RuntimeTypeModel.AfterApplyDefaultBehaviour"/> because compiling a contract also
+    /// builds serializers for its nested types, which would run ahead of those nested types' own
+    /// configuration and make protobuf-net throw "The type cannot be changed once a serializer has
+    /// been generated for &lt;T&gt;".
+    /// </summary>
+    private static readonly List<MetaType> PendingCompilation = new List<MetaType>();
+
     internal static void ConfigureRuntimeModel(RuntimeTypeModel model, bool isMonoRuntime)
     {
         model.AfterApplyDefaultBehaviour -= ConfigureMonoValueType;
         if (isMonoRuntime) model.AfterApplyDefaultBehaviour += ConfigureMonoValueType;
-        model.AutoCompile = true;
+
+        // Wine-Mono's JIT rejects some of the IL protobuf-net emits when it compiles a
+        // TypeSerializer, throwing InvalidProgramException ("Invalid IL code in (wrapper
+        // dynamic-method)") the first time such a contract is serialized. Repeatedly sent messages
+        // survive it, because the failed attempt leaves the MetaType resolvable and the next send
+        // succeeds on the non-compiled path. One-shot messages do not: NetworkTransferNewHero is
+        // published exactly once, from CharacterCreationState.Handle_CharacterCreationFinished, so
+        // a single throw leaves both peers waiting on "Join Coop Campaign" until the tunnel times
+        // out. ConfigureMonoValueType only replaces the uninitialized-object factory; the compiled
+        // serializer is still emitted and still rejected.
+        //
+        // Leaving auto-compile off keeps protobuf-net on its reflection path, which emits no IL.
+        // Rather than accept that cost for every contract, TryCompilePending gives each type one
+        // opportunistic compilation attempt: whatever this runtime accepts keeps the emitted fast
+        // path and only the contracts it rejects stay interpreted. If a runtime rejects all of
+        // them, behaviour is exactly that of a plain AutoCompile=false.
+        model.AutoCompile = !isMonoRuntime;
     }
 
     private static void ConfigureMonoValueType(object sender, TypeAddedEventArgs args)
     {
+        lock (PendingCompilation) PendingCompilation.Add(args.MetaType);
+
         if (!args.Type.IsValueType || args.MetaType.UseConstructor) return;
 
-        // Wine-Mono rejects protobuf-net's uninitialized-object factory IL for value types.
-        // Its no-factory path returns the same zero-initialized default value.
-        args.MetaType.UseConstructor = true;
+        try
+        {
+            // Wine-Mono rejects protobuf-net's uninitialized-object factory IL for value types.
+            // Its no-factory path returns the same zero-initialized default value.
+            args.MetaType.UseConstructor = true;
+        }
+        catch (InvalidOperationException)
+        {
+            // A containing contract was compiled first and has already generated a serializer for
+            // this type, so its factory choice is fixed and there is nothing left to change.
+        }
+    }
+
+    /// <summary>
+    /// Gives each newly registered contract one attempt at the compiled serializer. Runs before
+    /// serializing rather than during registration so the model has settled first. A rejection is
+    /// swallowed and leaves that contract on protobuf-net's reflection path, which is slower but
+    /// emits no IL and is therefore always accepted.
+    /// </summary>
+    internal static void TryCompilePending()
+    {
+        MetaType[] pending;
+        lock (PendingCompilation)
+        {
+            if (PendingCompilation.Count == 0) return;
+            pending = PendingCompilation.ToArray();
+            PendingCompilation.Clear();
+        }
+
+        for (var index = 0; index < pending.Length; index++)
+        {
+            try
+            {
+                pending[index].CompileInPlace();
+            }
+            catch
+            {
+                // This runtime rejected the emitted IL for this contract; the interpreted
+                // serializer stays in place and remains fully functional.
+            }
+        }
     }
 
     public ProtoBufSerializer(ISerializableTypeMapper typeMapper)
@@ -54,6 +121,8 @@ public class ProtoBufSerializer : ICommonSerializer
 
     public object Deserialize(byte[] data)
     {
+        if (IsMonoRuntime) TryCompilePending();
+
         using(var ms = new MemoryStream(data))
         {
             ProtoMessageWrapper wrapper = Serializer.Deserialize<ProtoMessageWrapper>(ms);
@@ -72,6 +141,8 @@ public class ProtoBufSerializer : ICommonSerializer
         {
             throw new InvalidOperationException($"Type {obj.GetType().FullName} is not registered with the serialization type mapper");
         }
+
+        if (IsMonoRuntime) TryCompilePending();
         
         using (MemoryStream memoryStream = new MemoryStream())
         {


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

On Wine-Mono the join never completes. Both peers sit on Join Coop Campaign until the tunnel times
out.

protobuf-net compiles a serializer for each contract via Reflection.Emit on first use and Wine-Mono
rejects some of that IL with InvalidProgramException, "Invalid IL code in (wrapper dynamic-method)".
A failed attempt leaves the MetaType resolvable so anything sent repeatedly recovers on its next
send, which is why CampaignTimePacket throws once and then streams normally and the problem is easy
to miss. One-shot handshake messages get no second chance, and NetworkTransferNewHero is published
exactly once from CharacterCreationState.Handle_CharacterCreationFinished.

It stops the whole session rather than one client because the throw aborts
JoinCampaignBaselineSender.Send partway, leaving queued packets with nothing driving them, and
OverloadedPeerManager then pauses campaign time for every peer while it waits for one that can never
catch up.

#2430 handles Wine-Mono by keeping compiled serializers and replacing the uninitialized-object
factory for value types. The factory is not the only thing being rejected. The emitted TypeSerializer
is rejected too, so UseConstructor does not help these contracts.

## What is the new behavior?

Opened at Seras's suggestion from discord said that ShoT_UP has been working on this in internal builds, so this may just be a second data point rather than the fix you want.

Auto-compile stays off on Mono so nothing is emitted implicitly, then each registered contract gets
one CompileInPlace attempt. Contracts the runtime accepts keep compiled serializers, contracts it
rejects stay on the reflection path, and Windows is untouched. This keeps the intent of "Keep
protobuf compiled on Wine-Mono" from #2430 rather than reverting to interpreted everywhere: a runtime
that accepts the IL loses nothing, and one that rejects all of it degrades to what auto-compile off
would have done anyway.

The attempt is deferred until after registration rather than run from AfterApplyDefaultBehaviour.
Compiling a contract also builds serializers for its nested types, which outruns their own
configuration and makes protobuf-net throw "The type cannot be changed once a serializer has been
generated". ConfigureMonoValueType now tolerates that for types whose serializer already exists.

Verified against Mono 6.4.0, the runtime Bannerlord bundles, with contracts mirroring the ones that
failed in game (PartyBehaviorUpdateData, MobilePartyJoinState, RomanceStateData[] and the messages
wrapping them). Stock settings throw Unable to wrap on 6 of 8 contracts on the first attempt. With
this change all pass on the first attempt, 32 contracts compiled and none fell back on that runtime.
Wire output is identical between the compiled and reflection paths in both directions, so this is not
a format change and a patched client still talks to an unpatched one.

In game two Linux players, one CachyOS and one SteamOS, went from a permanent hang to a completed
join with hero transfer, NetworkJoinSync and the usual tournament, mercenary, romance and siege
traffic. No Unable to wrap in either log and no catch-up pauses.

Common.Tests passes, 102/102.

One thing worth flagging separately: the published Workshop build never calls ConfigureRuntimeModel.
Its only call site is CoopMod.NoHarmonyInit from 0285b453 and the shipped Coop.dll predates it, so
Linux players will not see any of this until a build containing that call site goes out.

## Bot Changelog Entry

- Fixed multiplayer joins hanging forever on Linux, Steam Deck and SteamOS.

## Other information

Contracts that do fall back serialize more slowly than compiled ones. That is limited to Mono and
only to contracts the runtime actually rejects, so Windows is unaffected. live two-player traffic
peaked around 440 messages a second, roughly 78 KB/s, with queues draining and no catch-up pauses. I
have not tested 8 players or large battles.
