### PR TITLE
Fix food consumption refresh

### DIFF
--- a/source/GameInterface/Services/MobileParties/Interfaces/FoodConsumptionBehaviorInterface.cs
+++ b/source/GameInterface/Services/MobileParties/Interfaces/FoodConsumptionBehaviorInterface.cs
@@ -62,8 +62,7 @@ public class FoodConsumptionBehaviorInterface : IFoodConsumptionBehaviorInterfac
 
             if (doesPartyConsumeFood)
             {
-                // Check for a player party starving here instead of OnTick
-                behavior.PartyConsumeFood(mobileParty, mobileParty.IsPlayerParty() && mobileParty.Party.IsStarving);
+                behavior.PartyConsumeFood(mobileParty, false);
             }
         });
     }

--- a/source/GameInterface/Services/MobileParties/Patches/Disable/DisableFoodConsumptionBehavior.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/Disable/DisableFoodConsumptionBehavior.cs
@@ -5,7 +5,6 @@ using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Services.MobileParties.Interfaces;
 using GameInterface.Services.Players;
 using HarmonyLib;
-using System;
 using System.Collections.Generic;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
@@ -93,6 +92,7 @@ internal class FoodConsumptionBehaviorPatches
     {
         if (!ContainerProvider.TryResolve<IFoodConsumptionBehaviorInterface>(out var foodConsumptionBehaviorInterface)) return false;
 
+        // Custom implementation to handle IsMainParty -> IsPlayerParty replacements and client notifications
         foodConsumptionBehaviorInterface.PartyConsumeFood(__instance, mobileParty, starvingCheck);
 
         return false;
@@ -104,6 +104,7 @@ internal class FoodConsumptionBehaviorPatches
     {
         if (!ContainerProvider.TryResolve<IFoodConsumptionBehaviorInterface>(out var foodConsumptionBehaviorInterface)) return false;
 
+        // Custom implementation to handle IsMainParty -> IsPlayerParty replacement and client notification
         foodConsumptionBehaviorInterface.CheckAnimalBreeding(__instance, party);
 
         return false;

--- a/source/GameInterface/Services/MobileParties/Patches/Disable/DisableFoodConsumptionBehavior.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/Disable/DisableFoodConsumptionBehavior.cs
@@ -66,7 +66,7 @@ internal class FoodConsumptionBehaviorPatches
             var playerPartyId = player.MobilePartyId;
             if (!objectManager.TryGetObjectWithLogging<MobileParty>(playerPartyId, out var playerParty)) continue;
 
-            if (!ShouldTickFoodChange(playerManager, playerParty)) return false;
+            if (!ShouldTickFoodChange(playerManager, playerParty)) continue;
 
             int versionNo = playerParty.Party.ItemRoster.VersionNo;
 

--- a/source/GameInterface/Services/MobileParties/Patches/Disable/DisableFoodConsumptionBehavior.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/Disable/DisableFoodConsumptionBehavior.cs
@@ -3,6 +3,7 @@ using GameInterface.Extentions;
 using GameInterface.Services.MapEvents.Patches;
 using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Services.MobileParties.Interfaces;
+using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
 using HarmonyLib;
 using System.Collections.Generic;
@@ -42,13 +43,7 @@ internal class FoodConsumptionBehaviorPatches
 
         ContainerProvider.TryResolve<IPlayerManager>(out var playerManager);
 
-        // Don't tick food change for disconnected players
-        if (playerManager.IsOwnerOfPartyDisconnected(party)) return false;
-
-        // Use AI join window to determine if a player party should consume food and breed animals.
-        // This way players only have food change at most once during a map event.
-        if (party.MapEvent != null
-            && !InteractionPatches.IsWithinAiJoinWindow(party.MapEvent)) return false;
+        if (!ShouldTickFoodChange(playerManager, party)) return false;
 
         if (!ContainerProvider.TryResolve<IFoodConsumptionBehaviorInterface>(out var foodConsumptionBehaviorInterface)) return false;
 
@@ -63,13 +58,21 @@ internal class FoodConsumptionBehaviorPatches
     [HarmonyPrefix]
     public static bool OnTickPrefix(FoodConsumptionBehavior __instance, float dt)
     {
-        foreach (var playerParty in Campaign.Current.CampaignObjectManager.GetPlayerMobileParties())
+        if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager)) return false;
+        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)) return false;
+
+        foreach (var player in playerManager.Players)
         {
+            var playerPartyId = player.MobilePartyId;
+            if (!objectManager.TryGetObjectWithLogging<MobileParty>(playerPartyId, out var playerParty)) continue;
+
+            if (!ShouldTickFoodChange(playerManager, playerParty)) return false;
+
             int versionNo = playerParty.Party.ItemRoster.VersionNo;
 
             if (!playerPartyLastItemVersions.ContainsKey(playerParty))
             {
-                playerPartyLastItemVersions[playerParty] = versionNo;
+                playerPartyLastItemVersions[playerParty] = -1;
             }
 
             if (playerParty.Party.IsStarving)
@@ -108,5 +111,18 @@ internal class FoodConsumptionBehaviorPatches
         foodConsumptionBehaviorInterface.CheckAnimalBreeding(__instance, party);
 
         return false;
+    }
+
+    private static bool ShouldTickFoodChange(IPlayerManager playerManager, MobileParty playerParty)
+    {
+        // Don't tick food change for disconnected players
+        if (playerManager.IsOwnerOfPartyDisconnected(playerParty)) return false;
+
+        // Use AI join window to determine if a player party should consume food.
+        // This way players only have food change at most once during a map event.
+        if (playerParty.MapEvent != null
+            && !InteractionPatches.IsWithinAiJoinWindow(playerParty.MapEvent)) return false;
+
+        return true;
     }
 }

--- a/source/GameInterface/Services/MobileParties/Patches/Disable/DisableFoodConsumptionBehavior.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/Disable/DisableFoodConsumptionBehavior.cs
@@ -1,9 +1,12 @@
 ﻿using Common;
+using GameInterface.Extentions;
 using GameInterface.Services.MapEvents.Patches;
 using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Services.MobileParties.Interfaces;
 using GameInterface.Services.Players;
 using HarmonyLib;
+using System;
+using System.Collections.Generic;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
 using TaleWorlds.CampaignSystem.Party;
@@ -50,18 +53,37 @@ internal class FoodConsumptionBehaviorPatches
 
         if (!ContainerProvider.TryResolve<IFoodConsumptionBehaviorInterface>(out var foodConsumptionBehaviorInterface)) return false;
 
-        // Custom implementation to move check for starving player parties into daily tick from OnTick
         foodConsumptionBehaviorInterface.DailyTickParty(__instance, party);
 
         return false;
     }
 
+    private static Dictionary<MobileParty, int> playerPartyLastItemVersions = new();
+
     [HarmonyPatch(nameof(FoodConsumptionBehavior.OnTick))]
     [HarmonyPrefix]
     public static bool OnTickPrefix(FoodConsumptionBehavior __instance, float dt)
     {
-        // Moved to be part of the daily tick.
-        // Avoids tying the server hero's item roster version number to the behavior's version number 
+        foreach (var playerParty in Campaign.Current.CampaignObjectManager.GetPlayerMobileParties())
+        {
+            int versionNo = playerParty.Party.ItemRoster.VersionNo;
+
+            if (!playerPartyLastItemVersions.ContainsKey(playerParty))
+            {
+                playerPartyLastItemVersions[playerParty] = versionNo;
+            }
+
+            if (playerParty.Party.IsStarving)
+            {
+                if (playerPartyLastItemVersions[playerParty] != versionNo)
+                {
+                    playerPartyLastItemVersions[playerParty] = versionNo;
+
+                    __instance.PartyConsumeFood(playerParty, true);
+                }
+            }
+        }
+
         return false;
     }
 
@@ -71,7 +93,6 @@ internal class FoodConsumptionBehaviorPatches
     {
         if (!ContainerProvider.TryResolve<IFoodConsumptionBehaviorInterface>(out var foodConsumptionBehaviorInterface)) return false;
 
-        // Custom implementation to handle IsMainParty -> IsPlayerParty replacements and client notifications
         foodConsumptionBehaviorInterface.PartyConsumeFood(__instance, mobileParty, starvingCheck);
 
         return false;
@@ -83,7 +104,6 @@ internal class FoodConsumptionBehaviorPatches
     {
         if (!ContainerProvider.TryResolve<IFoodConsumptionBehaviorInterface>(out var foodConsumptionBehaviorInterface)) return false;
 
-        // Custom implementation to handle IsMainParty -> IsPlayerParty replacement and client notification
         foodConsumptionBehaviorInterface.CheckAnimalBreeding(__instance, party);
 
         return false;

--- a/source/GameInterface/Services/MobileParties/Patches/Disable/DisableFoodConsumptionBehavior.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/Disable/DisableFoodConsumptionBehavior.cs
@@ -7,6 +7,7 @@ using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
 using HarmonyLib;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
 using TaleWorlds.CampaignSystem.Party;
@@ -52,7 +53,7 @@ internal class FoodConsumptionBehaviorPatches
         return false;
     }
 
-    private static Dictionary<MobileParty, int> playerPartyLastItemVersions = new();
+    private static readonly ConditionalWeakTable<FoodConsumptionBehavior, Dictionary<MobileParty, int>> campaignPlayerPartyLastItemVersions = new();
 
     [HarmonyPatch(nameof(FoodConsumptionBehavior.OnTick))]
     [HarmonyPrefix]
@@ -60,6 +61,8 @@ internal class FoodConsumptionBehaviorPatches
     {
         if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager)) return false;
         if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)) return false;
+
+        var playerPartyLastItemVersions = campaignPlayerPartyLastItemVersions.GetOrCreateValue(__instance);
 
         foreach (var player in playerManager.Players)
         {


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Starving player parties buying food don't update their starving status until the next daily tick. This doesn't match vanilla and was originally implemented this way to avoid tying the campaign behavior's version number to the player parties.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Created a dictionary to store last checked roster versions to keep the check in line with vanilla. Now when a starving player party gets food morale penalties etc. will update much sooner.

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
