### PR TITLE
Respect player damage difficulty for routed hits

### DIFF
--- a/source/E2E.Tests/Environment/MockEngine/MissionEngineFixture.cs
+++ b/source/E2E.Tests/Environment/MockEngine/MissionEngineFixture.cs
@@ -33,6 +33,7 @@ public sealed class MissionEngineFixture : IDisposable
         // Mission statics / members
         Prefix(typeof(Mission), "get_Current", nameof(Mission_get_Current));
         Prefix(typeof(Mission), "get_CurrentTime", nameof(Mission_get_CurrentTime));
+        Prefix(typeof(Mission), "get_DamageToPlayerMultiplier", nameof(Mission_get_DamageToPlayerMultiplier));
         Prefix(typeof(Mission), nameof(Mission.EndMission), nameof(Mission_EndMission));
         Prefix(typeof(Mission), nameof(Mission.OnAgentFleeing), nameof(Mission_OnAgentFleeing));
         Prefix(typeof(Mission), nameof(Mission.SpawnAgent), nameof(Mission_SpawnAgent));
@@ -214,6 +215,13 @@ public sealed class MissionEngineFixture : IDisposable
     {
         if (!MockMission.ForShell(__instance, out _)) return true;
         __result = 0f;
+        return false;
+    }
+
+    private static bool Mission_get_DamageToPlayerMultiplier(Mission __instance, ref float __result)
+    {
+        if (!MockMission.ForShell(__instance, out var mock)) return true;
+        __result = mock.DamageToPlayerMultiplier;
         return false;
     }
 

--- a/source/E2E.Tests/Environment/MockEngine/MockMission.cs
+++ b/source/E2E.Tests/Environment/MockEngine/MockMission.cs
@@ -20,6 +20,7 @@ public sealed class MockMission
     public Mission Shell { get; }
 
     public Agent MainAgent { get; set; }
+    public float DamageToPlayerMultiplier { get; set; } = 1f;
     public bool EndMissionCalled { get; set; }
     public int AgentFleeingCalls { get; set; }
     public Agent LastFleeingAgent { get; set; }

--- a/source/E2E.Tests/Services/Missions/BattleDamageMirrorTests.cs
+++ b/source/E2E.Tests/Services/Missions/BattleDamageMirrorTests.cs
@@ -26,13 +26,13 @@ public class BattleDamageMirrorTests : MissionTestEnvironment
     public BattleDamageMirrorTests(ITestOutputHelper output) : base(output) { }
 
     [Theory]
-    [InlineData(true, 0, 90f)]
-    [InlineData(true, 1, 80f)]
-    [InlineData(true, 2, 60f)]
-    [InlineData(false, 0, 60f)]
-    public void RoutedDamage_UsesPlayerReceivedDamageDifficultyOnlyForMainAgent(
+    [InlineData(true, 0.25f, 90f)]
+    [InlineData(true, 0.5f, 80f)]
+    [InlineData(true, 1f, 60f)]
+    [InlineData(false, 0.25f, 60f)]
+    public void RoutedDamage_UsesPlayerDamageMultiplierOnlyForMainAgent(
         bool isMainAgent,
-        int difficulty,
+        float damageToPlayerMultiplier,
         float expectedHealth)
     {
         using var fixture = new MissionEngineFixture();
@@ -41,37 +41,28 @@ public class BattleDamageMirrorTests : MissionTestEnvironment
 
         client.Call(() =>
         {
-            int previousDifficulty = BannerlordConfig.PlayerReceivedDamageDifficulty;
-            try
-            {
-                BannerlordConfig.PlayerReceivedDamageDifficulty = difficulty;
+            var mock = fixture.CreateMission(client);
+            mock.DamageToPlayerMultiplier = damageToPlayerMultiplier;
+            var controller = client.Resolve<CoopBattleController>();
+            var registry = client.Resolve<INetworkAgentRegistry>();
 
-                var mock = fixture.CreateMission(client);
-                var controller = client.Resolve<CoopBattleController>();
-                var registry = client.Resolve<INetworkAgentRegistry>();
+            var agent = mock.SpawnAgent(new AgentBuildData(Game.Current.PlayerTroop)
+                .Controller(isMainAgent ? AgentControllerType.Player : AgentControllerType.AI));
+            if (isMainAgent)
+                mock.MainAgent = agent;
 
-                var agent = mock.SpawnAgent(new AgentBuildData(Game.Current.PlayerTroop)
-                    .Controller(isMainAgent ? AgentControllerType.Player : AgentControllerType.AI));
-                if (isMainAgent)
-                    mock.MainAgent = agent;
+            var victimId = Guid.NewGuid();
+            Assert.True(registry.TryRegisterAgent("owner", victimId, agent));
 
-                var victimId = Guid.NewGuid();
-                Assert.True(registry.TryRegisterAgent("owner", victimId, agent));
+            var blow = new Blow(0) { InflictedDamage = 40, DamageType = DamageTypes.Pierce };
+            var collisionData = new AttackCollisionData { InflictedDamage = 40 };
+            client.Resolve<IMessageBroker>().Publish(
+                this,
+                new NetworkApplyBattleDamage(victimId, Guid.Empty, blow, collisionData));
 
-                var blow = new Blow(0) { InflictedDamage = 40, DamageType = DamageTypes.Pierce };
-                var collisionData = new AttackCollisionData { InflictedDamage = 40 };
-                client.Resolve<IMessageBroker>().Publish(
-                    this,
-                    new NetworkApplyBattleDamage(victimId, Guid.Empty, blow, collisionData));
-
-                Assert.True(AgentMirror.TryGet(agent, out var mirror));
-                Assert.Equal(expectedHealth, mirror.Health);
-                GC.KeepAlive(controller);
-            }
-            finally
-            {
-                BannerlordConfig.PlayerReceivedDamageDifficulty = previousDifficulty;
-            }
+            Assert.True(AgentMirror.TryGet(agent, out var mirror));
+            Assert.Equal(expectedHealth, mirror.Health);
+            GC.KeepAlive(controller);
         });
     }
 

--- a/source/E2E.Tests/Services/Missions/BattleDamageMirrorTests.cs
+++ b/source/E2E.Tests/Services/Missions/BattleDamageMirrorTests.cs
@@ -25,6 +25,56 @@ public class BattleDamageMirrorTests : MissionTestEnvironment
 {
     public BattleDamageMirrorTests(ITestOutputHelper output) : base(output) { }
 
+    [Theory]
+    [InlineData(true, 0, 90f)]
+    [InlineData(true, 1, 80f)]
+    [InlineData(true, 2, 60f)]
+    [InlineData(false, 0, 60f)]
+    public void RoutedDamage_UsesPlayerReceivedDamageDifficultyOnlyForMainAgent(
+        bool isMainAgent,
+        int difficulty,
+        float expectedHealth)
+    {
+        using var fixture = new MissionEngineFixture();
+        var client = Clients.First();
+        SetControllerId(client, "owner");
+
+        client.Call(() =>
+        {
+            int previousDifficulty = BannerlordConfig.PlayerReceivedDamageDifficulty;
+            try
+            {
+                BannerlordConfig.PlayerReceivedDamageDifficulty = difficulty;
+
+                var mock = fixture.CreateMission(client);
+                var controller = client.Resolve<CoopBattleController>();
+                var registry = client.Resolve<INetworkAgentRegistry>();
+
+                var agent = mock.SpawnAgent(new AgentBuildData(Game.Current.PlayerTroop)
+                    .Controller(isMainAgent ? AgentControllerType.Player : AgentControllerType.AI));
+                if (isMainAgent)
+                    mock.MainAgent = agent;
+
+                var victimId = Guid.NewGuid();
+                Assert.True(registry.TryRegisterAgent("owner", victimId, agent));
+
+                var blow = new Blow(0) { InflictedDamage = 40, DamageType = DamageTypes.Pierce };
+                var collisionData = new AttackCollisionData { InflictedDamage = 40 };
+                client.Resolve<IMessageBroker>().Publish(
+                    this,
+                    new NetworkApplyBattleDamage(victimId, Guid.Empty, blow, collisionData));
+
+                Assert.True(AgentMirror.TryGet(agent, out var mirror));
+                Assert.Equal(expectedHealth, mirror.Health);
+                GC.KeepAlive(controller);
+            }
+            finally
+            {
+                BannerlordConfig.PlayerReceivedDamageDifficulty = previousDifficulty;
+            }
+        });
+    }
+
     [Fact]
     public void RoutedMissileBlow_AppliesToOwner_WithoutMissilesDictionaryThrow()
     {

--- a/source/Missions/Battles/BattleDamageRouter.cs
+++ b/source/Missions/Battles/BattleDamageRouter.cs
@@ -522,6 +522,9 @@ public class BattleDamageRouter : IBattleDamageRouter
             blow.OwnerId = -1;
         }
 
+        // The source calculated this blow against a puppet, so vanilla could not apply its main-agent multiplier.
+        ApplyPlayerReceivedDamageMultiplier(victim, ref blow, ref collisionData);
+
         bool wasMissile = IsMissileDamage(damage);
         // The victim owner relays blood so a fatal effect stays ordered before its death broadcast.
         coopMissionComponent.CombatHitPresentationHandler.PresentRoutedMeleeBlood(
@@ -546,5 +549,19 @@ public class BattleDamageRouter : IBattleDamageRouter
         {
             hero.HitPoints = Math.Max(1, (int)victim.Health);
         }
+    }
+
+    private static void ApplyPlayerReceivedDamageMultiplier(
+        Agent victim,
+        ref Blow blow,
+        ref AttackCollisionData collisionData)
+    {
+        if (!victim.IsMainAgent)
+            return;
+
+        int scaledDamage = TaleWorlds.Library.MathF.Round(
+            blow.InflictedDamage * Mission.Current.DamageToPlayerMultiplier);
+        blow.InflictedDamage = scaledDamage;
+        collisionData.InflictedDamage = scaledDamage;
     }
 }


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

Hits routed from another client's puppet use the already-calculated damage, so the victim's player received damage setting is never applied.

## What is the new behavior?

Routed hits apply the victim owner's player damage multiplier when the victim is the main agent. Routed troop and mount damage stays unchanged.

## Bot Changelog Entry

- Player received damage difficulty now applies to hits routed from other clients.
