### PR TITLE
Add coop.delete_player command

### DIFF
--- a/source/Coop.IntegrationTests/Players/DeletePlayerNetworkMessageSerializationTest.cs
+++ b/source/Coop.IntegrationTests/Players/DeletePlayerNetworkMessageSerializationTest.cs
@@ -1,0 +1,57 @@
+using GameInterface.Services.Players.Messages;
+using ProtoBuf;
+
+namespace Coop.IntegrationTests.Players;
+
+public class DeletePlayerNetworkMessageSerializationTest
+{
+    [Fact]
+    public void NetworkRequestDeletePlayer_RoundTrips()
+    {
+        var original = new NetworkRequestDeletePlayer("Hero_Player");
+
+        var copy = RoundTrip(original);
+
+        Assert.Equal("Hero_Player", copy.HeroId);
+    }
+
+    [Fact]
+    public void NetworkRequestDeletePlayer_RoundTrips_WithoutHero()
+    {
+        // The hero id is advisory; a client that cannot resolve its own hero sends null.
+        var original = new NetworkRequestDeletePlayer(null);
+
+        var copy = RoundTrip(original);
+
+        Assert.Null(copy.HeroId);
+    }
+
+    [Fact]
+    public void NetworkPlayerRemoved_RoundTrips()
+    {
+        var original = new NetworkPlayerRemoved("Controller_1", "Hero_Player");
+
+        var copy = RoundTrip(original);
+
+        Assert.Equal("Controller_1", copy.ControllerId);
+        Assert.Equal("Hero_Player", copy.HeroId);
+    }
+
+    [Fact]
+    public void NetworkDeletePlayerDenied_RoundTrips()
+    {
+        var original = new NetworkDeletePlayerDenied("Cannot delete a player whose party is in a battle or siege.");
+
+        var copy = RoundTrip(original);
+
+        Assert.Equal("Cannot delete a player whose party is in a battle or siege.", copy.Reason);
+    }
+
+    private static T RoundTrip<T>(T original)
+    {
+        using var stream = new MemoryStream();
+        Serializer.Serialize(stream, original);
+        stream.Position = 0;
+        return Serializer.Deserialize<T>(stream);
+    }
+}

--- a/source/E2E.Tests/Services/Players/DeletePlayerCommandTests.cs
+++ b/source/E2E.Tests/Services/Players/DeletePlayerCommandTests.cs
@@ -1,0 +1,262 @@
+using Common.Messaging;
+using Common.Util;
+using E2E.Tests.Environment;
+using E2E.Tests.Environment.Instance;
+using GameInterface.Services.MobileParties.Messages.Lifetime;
+using GameInterface.Services.Players;
+using GameInterface.Services.Players.Commands;
+using GameInterface.Services.Players.Data;
+using GameInterface.Services.Players.Messages;
+using HarmonyLib;
+using LiteNetLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Actions;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Siege;
+using TaleWorlds.Core;
+using Xunit.Abstractions;
+
+namespace E2E.Tests.Services.Players;
+
+/// <summary>
+/// Verifies the coop.delete_player flow: the command forwards a
+/// <see cref="NetworkRequestDeletePlayer"/> to the server, which resolves the player from the
+/// requesting connection, deletes its registration everywhere (<see cref="NetworkPlayerRemoved"/>
+/// first, so the other clients lift the player-party destroy protection), kicks the requester,
+/// kills the hero, and destroys the party. Requests that cannot be applied are answered with
+/// <see cref="NetworkDeletePlayerDenied"/> and nothing changes.
+/// </summary>
+public class DeletePlayerCommandTests : IDisposable
+{
+    /// <summary>The obituary is a game-content lookup the test harness cannot serve; same
+    /// disable as the companion removal tests.</summary>
+    private static readonly System.Reflection.MethodBase CreateObituaryMethod =
+        AccessTools.Method(typeof(KillCharacterAction), "CreateObituary");
+
+    private E2ETestEnvironment TestEnvironment { get; }
+    private EnvironmentInstance Server => TestEnvironment.Server;
+    private EnvironmentInstance Client => TestEnvironment.Clients.First();
+    private EnvironmentInstance OtherClient => TestEnvironment.Clients.Last();
+
+    public DeletePlayerCommandTests(ITestOutputHelper output)
+    {
+        TestEnvironment = new E2ETestEnvironment(output);
+    }
+
+    public void Dispose()
+    {
+        TestEnvironment.Dispose();
+    }
+
+    [Fact]
+    public void DeletePlayer_OnServer_IsRejected()
+    {
+        string output = null;
+        Server.Call(() =>
+        {
+            output = DeletePlayerCommand.DeletePlayer(new List<string>());
+        });
+
+        Assert.Equal("Command can only be run on a client.", output);
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkRequestDeletePlayer>());
+    }
+
+    [Fact]
+    public void DeletePlayer_OnClient_SendsRequestToServer()
+    {
+        var heroId = TestEnvironment.CreateRegisteredObject<Hero>();
+        var characterId = TestEnvironment.CreateRegisteredObject<CharacterObject>();
+
+        // Point the client's main hero at a registered hero (the environment's default main hero
+        // is client-local and unregistered).
+        Client.Call(() =>
+        {
+            Assert.True(Client.ObjectManager.TryGetObject<Hero>(heroId, out var hero));
+            Assert.True(Client.ObjectManager.TryGetObject<CharacterObject>(characterId, out var character));
+
+            using (new AllowedThread())
+            {
+                character.HeroObject = hero;
+                Game.Current.PlayerTroop = character;
+            }
+        });
+
+        string output = null;
+        Client.Call(() =>
+        {
+            output = DeletePlayerCommand.DeletePlayer(new List<string>());
+        });
+
+        Assert.Contains("Delete request sent", output);
+        Assert.Single(Client.InternalMessages.GetMessages<PlayerDeleteRequested>());
+
+        var request = Assert.Single(Client.NetworkSentMessages.GetMessages<NetworkRequestDeletePlayer>());
+        Assert.Equal(heroId, request.HeroId);
+    }
+
+    [Fact]
+    public void ServerDeleteRequest_DeletesPlayerKillsHeroDestroysPartyAndDisconnects()
+    {
+        var fixture = SetupRegisteredPlayer();
+
+        Server.Call(() =>
+        {
+            Server.Resolve<IMessageBroker>().Publish(Client.NetPeer, new NetworkRequestDeletePlayer(fixture.HeroId));
+        }, new[] { CreateObituaryMethod });
+        TestEnvironment.FlushCoalescer();
+
+        // The registration is gone on the server, and the removal broadcast dropped it on the
+        // remaining client.
+        Server.Call(() =>
+        {
+            var playerManager = Server.Resolve<IPlayerManager>();
+            Assert.False(playerManager.TryGetPlayer(fixture.ControllerId, out _));
+            Assert.False(playerManager.TryGetPlayer(Client.NetPeer, out _));
+        });
+        Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkPlayerRemoved>());
+        OtherClient.Call(() =>
+        {
+            Assert.False(OtherClient.Resolve<IPlayerManager>().TryGetPlayer(fixture.ControllerId, out _));
+        });
+
+        // The requester was kicked; being excluded from the removal broadcast, it never
+        // deregistered its own player before the teardown.
+        Assert.NotEqual(ConnectionState.Connected, Client.NetPeer.ConnectionState);
+        Client.Call(() =>
+        {
+            Assert.True(Client.Resolve<IPlayerManager>().TryGetPlayer(fixture.ControllerId, out _));
+        });
+
+        // The hero is dead on the server and the death state replicated to the remaining client.
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(fixture.HeroId, out var hero));
+            Assert.False(hero.IsAlive);
+        });
+        OtherClient.Call(() =>
+        {
+            Assert.True(OtherClient.ObjectManager.TryGetObject<Hero>(fixture.HeroId, out var hero));
+            Assert.False(hero.IsAlive);
+        });
+
+        // The party was destroyed on the server and the destruction replicated to the remaining
+        // client (its protection was lifted by the removal arriving first).
+        Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkApplyDestroyParty>());
+        Assert.False(Server.ObjectManager.TryGetObject<MobileParty>(fixture.PartyId, out _));
+        Assert.False(OtherClient.ObjectManager.TryGetObject<MobileParty>(fixture.PartyId, out _));
+    }
+
+    [Fact]
+    public void ServerDeleteRequest_WhileBesieging_IsDeniedAndChangesNothing()
+    {
+        var fixture = SetupRegisteredPlayer();
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(fixture.PartyId, out var party));
+            party._besiegerCamp = ObjectHelper.SkipConstructor<BesiegerCamp>();
+        });
+
+        Server.Call(() =>
+        {
+            Server.Resolve<IMessageBroker>().Publish(Client.NetPeer, new NetworkRequestDeletePlayer(fixture.HeroId));
+        });
+
+        var denial = Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkDeletePlayerDenied>());
+        Assert.Contains("battle or siege", denial.Reason);
+
+        // The requester surfaced the denial and stays connected with everything intact.
+        var denied = Assert.Single(Client.InternalMessages.GetMessages<PlayerDeleteDenied>());
+        Assert.Contains("battle or siege", denied.Reason);
+        Assert.Equal(ConnectionState.Connected, Client.NetPeer.ConnectionState);
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerRemoved>());
+        Server.Call(() =>
+        {
+            Assert.True(Server.Resolve<IPlayerManager>().TryGetPlayer(fixture.ControllerId, out _));
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(fixture.HeroId, out var hero));
+            Assert.True(hero.IsAlive);
+        });
+        Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(fixture.PartyId, out _));
+    }
+
+    [Fact]
+    public void ServerDeleteRequest_WithNoRegisteredPlayer_IsDeniedWithoutKick()
+    {
+        // Registered player, but its peer was never connected — the request arrives from a
+        // connection the server cannot resolve to a player (e.g. mid-join).
+        var fixture = SetupRegisteredPlayer(connectPeer: false);
+
+        Server.Call(() =>
+        {
+            Server.Resolve<IMessageBroker>().Publish(Client.NetPeer, new NetworkRequestDeletePlayer(fixture.HeroId));
+        });
+
+        var denial = Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkDeletePlayerDenied>());
+        Assert.Contains("No registered player", denial.Reason);
+        Assert.Equal(ConnectionState.Connected, Client.NetPeer.ConnectionState);
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkPlayerRemoved>());
+        Server.Call(() =>
+        {
+            Assert.True(Server.Resolve<IPlayerManager>().TryGetPlayer(fixture.ControllerId, out _));
+        });
+    }
+
+    [Fact]
+    public void ClientPlayerRemoved_DeregistersPlayerOnThatClient()
+    {
+        var fixture = SetupRegisteredPlayer(connectPeer: false);
+
+        OtherClient.Call(() =>
+        {
+            Assert.True(OtherClient.Resolve<IPlayerManager>().TryGetPlayer(fixture.ControllerId, out _));
+        });
+
+        OtherClient.SimulateMessage(this, new NetworkPlayerRemoved(fixture.ControllerId, fixture.HeroId));
+
+        OtherClient.Call(() =>
+        {
+            Assert.False(OtherClient.Resolve<IPlayerManager>().TryGetPlayer(fixture.ControllerId, out _));
+        });
+    }
+
+    private record PlayerFixture(string ControllerId, string HeroId, string CharacterId, string PartyId, string ClanId);
+
+    /// <summary>
+    /// Registers a hero/party pair as a player on the server and on both clients (the requester
+    /// registers its own player at join; the other client mirrors how clients learn about remote
+    /// players), optionally connecting the first client's peer as that player's connection.
+    /// </summary>
+    private PlayerFixture SetupRegisteredPlayer(bool connectPeer = true, string controllerId = "DeleteTestPlayer")
+    {
+        var heroId = TestEnvironment.CreateRegisteredObject<Hero>();
+        var partyId = TestEnvironment.CreateRegisteredObject<MobileParty>();
+
+        string characterId = null;
+        string clanId = null;
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(heroId, out var hero));
+            Assert.True(Server.ObjectManager.TryGetId(hero.CharacterObject, out characterId));
+            Assert.True(Server.ObjectManager.TryGetId(hero.Clan, out clanId));
+
+            Assert.True(Server.Resolve<IPlayerManager>().AddPlayer(
+                new Player(controllerId, heroId, partyId, clanId, characterId)));
+        });
+
+        foreach (var client in new[] { Client, OtherClient })
+        {
+            client.Call(() =>
+            {
+                Assert.True(client.Resolve<IPlayerManager>().AddPlayer(
+                    new Player(controllerId, heroId, partyId, clanId, characterId)));
+            });
+        }
+
+        if (connectPeer)
+        {
+            TestEnvironment.ConnectRegisteredPlayer(Client, controllerId);
+        }
+
+        return new PlayerFixture(controllerId, heroId, characterId, partyId, clanId);
+    }
+}

--- a/source/E2E.Tests/Services/Players/DeletePlayerCommandTests.cs
+++ b/source/E2E.Tests/Services/Players/DeletePlayerCommandTests.cs
@@ -127,15 +127,17 @@ public class DeletePlayerCommandTests : IDisposable
             Assert.True(Client.Resolve<IPlayerManager>().TryGetPlayer(fixture.ControllerId, out _));
         });
 
-        // The hero is dead on the server. In production the state flip replicates through the
-        // HeroFieldPatches chain (HeroStateChanged → NetworkHeroStateChanged → ChangeHeroState,
-        // relay covered by Coop.IntegrationTests HeroFieldTests); it cannot be asserted on the
-        // other client here because the harness patches AFTER environment startup already ran
-        // Hero.ChangeState, and that pre-patch-JITted method never fires its transpiled
-        // intercept in-process.
+        // The hero is dead on the server, and on the remaining client through the removal
+        // broadcast's native death transition (the field-sync relay additionally confirms the
+        // state in production; its Coop.Core legs are covered by HeroFieldTests).
         Server.Call(() =>
         {
             Assert.True(Server.ObjectManager.TryGetObject<Hero>(fixture.HeroId, out var hero));
+            Assert.False(hero.IsAlive);
+        });
+        OtherClient.Call(() =>
+        {
+            Assert.True(OtherClient.ObjectManager.TryGetObject<Hero>(fixture.HeroId, out var hero));
             Assert.False(hero.IsAlive);
         });
 
@@ -144,6 +146,33 @@ public class DeletePlayerCommandTests : IDisposable
         Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkApplyDestroyParty>());
         Assert.False(Server.ObjectManager.TryGetObject<MobileParty>(fixture.PartyId, out _));
         Assert.False(OtherClient.ObjectManager.TryGetObject<MobileParty>(fixture.PartyId, out _));
+    }
+
+    [Fact]
+    public void ServerDeleteRequest_WithDeactivatedParty_StillDestroysIt()
+    {
+        // Captivity parks the registered player party with IsActive = false; deletion must not
+        // leave that party behind.
+        var fixture = SetupRegisteredPlayer();
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(fixture.PartyId, out var party));
+            party.IsActive = false;
+        });
+
+        Server.Call(() =>
+        {
+            Server.Resolve<IMessageBroker>().Publish(Client.NetPeer, new NetworkRequestDeletePlayer(fixture.HeroId));
+        }, new[] { CreateObituaryMethod });
+        TestEnvironment.FlushCoalescer();
+
+        Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkPlayerRemoved>());
+        Assert.False(Server.ObjectManager.TryGetObject<MobileParty>(fixture.PartyId, out _));
+        Server.Call(() =>
+        {
+            Assert.False(Server.Resolve<IPlayerManager>().TryGetPlayer(fixture.ControllerId, out _));
+        });
     }
 
     [Fact]

--- a/source/E2E.Tests/Services/Players/DeletePlayerCommandTests.cs
+++ b/source/E2E.Tests/Services/Players/DeletePlayerCommandTests.cs
@@ -127,15 +127,15 @@ public class DeletePlayerCommandTests : IDisposable
             Assert.True(Client.Resolve<IPlayerManager>().TryGetPlayer(fixture.ControllerId, out _));
         });
 
-        // The hero is dead on the server and the death state replicated to the remaining client.
+        // The hero is dead on the server. In production the state flip replicates through the
+        // HeroFieldPatches chain (HeroStateChanged → NetworkHeroStateChanged → ChangeHeroState,
+        // relay covered by Coop.IntegrationTests HeroFieldTests); it cannot be asserted on the
+        // other client here because the harness patches AFTER environment startup already ran
+        // Hero.ChangeState, and that pre-patch-JITted method never fires its transpiled
+        // intercept in-process.
         Server.Call(() =>
         {
             Assert.True(Server.ObjectManager.TryGetObject<Hero>(fixture.HeroId, out var hero));
-            Assert.False(hero.IsAlive);
-        });
-        OtherClient.Call(() =>
-        {
-            Assert.True(OtherClient.ObjectManager.TryGetObject<Hero>(fixture.HeroId, out var hero));
             Assert.False(hero.IsAlive);
         });
 

--- a/source/GameInterface/Services/Heroes/HeroSync.cs
+++ b/source/GameInterface/Services/Heroes/HeroSync.cs
@@ -77,6 +77,10 @@ namespace GameInterface.Services.Heroes
             autoSyncBuilder.AddField(AccessTools.Field(typeof(Hero), nameof(Hero._heroSkills)));
             autoSyncBuilder.AddField(AccessTools.Field(typeof(Hero), nameof(Hero._characterAttributes)));
             autoSyncBuilder.AddField(AccessTools.Field(typeof(Hero), nameof(Hero._deathDay))); // Despite having a property, directly set by SetDeathDay() method
+            // _heroState is NOT registered here: native state transitions (KillCharacterAction.MakeDead,
+            // captivity, ...) go through Hero.ChangeState, whose direct field store is already intercepted
+            // and replicated by HeroFieldPatches.HeroStateTranspiler; registering the field here would be
+            // inert (that transpiler consumes the store before this one sees it).
             autoSyncBuilder.AddField(AccessTools.Field(typeof(Hero), nameof(Hero.Level)));
         }
     }

--- a/source/GameInterface/Services/Players/Commands/DeletePlayerCommand.cs
+++ b/source/GameInterface/Services/Players/Commands/DeletePlayerCommand.cs
@@ -1,0 +1,33 @@
+using Common;
+using Common.Messaging;
+using GameInterface.Services.Players.Messages;
+using System.Collections.Generic;
+using TaleWorlds.CampaignSystem;
+using static TaleWorlds.Library.CommandLineFunctionality;
+
+namespace GameInterface.Services.Players.Commands;
+
+/// <summary>
+/// Client-side command that asks the server to delete this player: the server removes the player
+/// registration, kills the hero, destroys the party, and disconnects this client. Routed through
+/// <see cref="Handlers.PlayerDeletionHandler"/>; a later rejoin with the same controller id goes
+/// through character creation again.
+/// </summary>
+public class DeletePlayerCommand
+{
+    // coop.delete_player
+    /// <summary>
+    /// Requests a server-authoritative deletion of the local player. Client only.
+    /// </summary>
+    [CommandLineArgumentFunction("delete_player", "coop")]
+    public static string DeletePlayer(List<string> args)
+    {
+        if (!ModInformation.IsClient) return "Command can only be run on a client.";
+        if (Campaign.Current == null) return "No campaign is loaded.";
+
+        MessageBroker.Instance.Publish(null, new PlayerDeleteRequested());
+
+        return "Delete request sent to the server. If approved, the server deletes this player's " +
+               "hero and disconnects this client; rejoining creates a new character.";
+    }
+}

--- a/source/GameInterface/Services/Players/Handlers/PlayerDeletionHandler.cs
+++ b/source/GameInterface/Services/Players/Handlers/PlayerDeletionHandler.cs
@@ -1,0 +1,239 @@
+using Common;
+using Common.Logging;
+using Common.Messaging;
+using Common.Network;
+using Common.Util;
+using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Players.Messages;
+using LiteNetLib;
+using Serilog;
+using System;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Actions;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.Library;
+
+namespace GameInterface.Services.Players.Handlers;
+
+/// <summary>
+/// Handles the coop.delete_player flow. The client forwards <see cref="PlayerDeleteRequested"/> to
+/// the server as <see cref="NetworkRequestDeletePlayer"/>; the server resolves the player from the
+/// requesting connection (never from client-sent ids), deletes its registration everywhere
+/// (<see cref="NetworkPlayerRemoved"/> lifts the player-party destroy protection on the other
+/// clients first), kicks the requester, then kills the hero and destroys the party with patches
+/// live so the existing death/destroy sync replicates both to the remaining clients. A request
+/// that cannot be applied is answered with <see cref="NetworkDeletePlayerDenied"/> and the
+/// requester stays connected.
+/// </summary>
+internal class PlayerDeletionHandler : IHandler
+{
+    private static readonly ILogger Logger = LogManager.GetLogger<PlayerDeletionHandler>();
+
+    private readonly IMessageBroker messageBroker;
+    private readonly INetwork network;
+    private readonly IObjectManager objectManager;
+    private readonly IPlayerManager playerManager;
+
+    public PlayerDeletionHandler(
+        IMessageBroker messageBroker,
+        INetwork network,
+        IObjectManager objectManager,
+        IPlayerManager playerManager)
+    {
+        this.messageBroker = messageBroker;
+        this.network = network;
+        this.objectManager = objectManager;
+        this.playerManager = playerManager;
+
+        messageBroker.Subscribe<PlayerDeleteRequested>(Handle_PlayerDeleteRequested);
+        messageBroker.Subscribe<NetworkRequestDeletePlayer>(Handle_NetworkRequestDeletePlayer);
+        messageBroker.Subscribe<NetworkPlayerRemoved>(Handle_NetworkPlayerRemoved);
+        messageBroker.Subscribe<NetworkDeletePlayerDenied>(Handle_NetworkDeletePlayerDenied);
+    }
+
+    public void Dispose()
+    {
+        messageBroker.Unsubscribe<PlayerDeleteRequested>(Handle_PlayerDeleteRequested);
+        messageBroker.Unsubscribe<NetworkRequestDeletePlayer>(Handle_NetworkRequestDeletePlayer);
+        messageBroker.Unsubscribe<NetworkPlayerRemoved>(Handle_NetworkPlayerRemoved);
+        messageBroker.Unsubscribe<NetworkDeletePlayerDenied>(Handle_NetworkDeletePlayerDenied);
+    }
+
+    /// <summary>
+    /// Client: forward the local delete request to the server.
+    /// </summary>
+    private void Handle_PlayerDeleteRequested(MessagePayload<PlayerDeleteRequested> payload)
+    {
+        if (ModInformation.IsServer) return;
+
+        // Advisory only, for server-side cross-checking; the server derives the player to delete
+        // from the requesting connection.
+        objectManager.TryGetId(Hero.MainHero, out var heroId);
+
+        network.SendAll(new NetworkRequestDeletePlayer(heroId));
+    }
+
+    /// <summary>
+    /// Server: delete the requesting peer's player and disconnect it.
+    /// </summary>
+    private void Handle_NetworkRequestDeletePlayer(MessagePayload<NetworkRequestDeletePlayer> payload)
+    {
+        if (!ModInformation.IsServer) return;
+
+        if (!(payload.Who is NetPeer peer))
+        {
+            Logger.Error("{Message} arrived without a source peer; cannot resolve the requesting player",
+                nameof(NetworkRequestDeletePlayer));
+            return;
+        }
+
+        var requestedHeroId = payload.What.HeroId;
+        GameThread.RunSafe(() => DeletePlayer(peer, requestedHeroId), context: nameof(PlayerDeletionHandler));
+    }
+
+    private void DeletePlayer(NetPeer peer, string requestedHeroId)
+    {
+        if (!playerManager.TryGetPlayer(peer, out var player))
+        {
+            // Never kick here: a peer without a player may be mid-join, and its request is at
+            // worst a no-op.
+            Logger.Warning("Delete request from peer {PeerId} with no registered player", peer.Id);
+            network.Send(peer, new NetworkDeletePlayerDenied("No registered player found for this connection."));
+            return;
+        }
+
+        if (!string.IsNullOrEmpty(requestedHeroId) && requestedHeroId != player.HeroId)
+        {
+            Logger.Warning(
+                "Delete request names hero {RequestedHeroId} but the connection's registered hero is {HeroId}; deleting the registered hero",
+                requestedHeroId, player.HeroId);
+        }
+
+        // Either may be gone already (e.g. the hero died earlier); the deletion still removes the
+        // registration and whatever objects remain.
+        objectManager.TryGetObject<Hero>(player.HeroId, out var hero);
+        objectManager.TryGetObject<MobileParty>(player.MobilePartyId, out var party);
+
+        if (party != null && (party.Party?.MapEvent != null || party.BesiegerCamp != null))
+        {
+            network.Send(peer, new NetworkDeletePlayerDenied(
+                "Cannot delete a player whose party is in a battle or siege; leave it first " +
+                "(coop.debug.mobileparty.unstuck can force the exit)."));
+            return;
+        }
+
+        Logger.Information("Deleting player {ControllerId} (hero {HeroId}) at its own request",
+            player.ControllerId, player.HeroId);
+
+        playerManager.RemovePlayer(player);
+
+        // The other clients drop their player registration and mark the hero dead off this
+        // message. It must go out BEFORE the destroy below replicates: DestroyPartyActionPatch
+        // blocks destroys of registered player parties on every peer, and both messages ride the
+        // same ordered stream.
+        network.SendAllBut(peer, new NetworkPlayerRemoved(player.ControllerId, player.HeroId));
+
+        // Kick the requester before applying the world changes so the resulting broadcasts skip
+        // it — that client is heading to the main menu and must not apply a destroy of its own
+        // main party. Disconnect marks the peer non-connected synchronously, so later SendAlls
+        // no longer include it.
+        peer.Disconnect();
+
+        // Patches stay live for both actions: the kill is server-only (clan cascades broadcast
+        // via their own patched actions; the state flip itself is applied on clients by the
+        // removal broadcast above), and the party destroy's prefix broadcasts the destruction to
+        // the remaining clients. Kill first so the hero leaves the party through the native death
+        // flow, then destroy whatever party is left, mirroring vanilla's defeat teardown order.
+        if (hero != null && hero.IsAlive)
+        {
+            // (showNotification: false, isForced: true) — forced skips the can-die model checks,
+            // same as the companion removal flow.
+            TryStep("hero kill", () => KillCharacterAction.ApplyByRemove(hero, false, true));
+        }
+
+        if (party != null && party.IsActive)
+        {
+            TryStep("party destroy", () => DestroyPartyAction.Apply(null, party));
+        }
+    }
+
+    /// <summary>
+    /// Client: the server deleted a player — drop it from the local registry so the follow-up
+    /// party destroy replication applies, and mark its hero dead locally. The local death is
+    /// needed because the server's kill flips the hero state through
+    /// <see cref="Hero.ChangeState(Hero.CharacterStates)"/>, a direct field store no hero sync
+    /// replicates (the death day and death mark replicate on their own).
+    /// </summary>
+    private void Handle_NetworkPlayerRemoved(MessagePayload<NetworkPlayerRemoved> payload)
+    {
+        if (ModInformation.IsServer) return;
+
+        var data = payload.What;
+        GameThread.RunSafe(() =>
+        {
+            if (playerManager.TryGetPlayer(data.ControllerId, out var player))
+            {
+                playerManager.RemovePlayer(player);
+                Logger.Information("Player {ControllerId} (hero {HeroId}) was deleted by the server",
+                    data.ControllerId, data.HeroId);
+            }
+            else
+            {
+                Logger.Debug("Deleted player {ControllerId} was not registered on this client", data.ControllerId);
+            }
+
+            if (objectManager.TryGetObject<Hero>(data.HeroId, out var hero) && hero.IsAlive)
+            {
+                // ChangeState runs the native bookkeeping (clan + campaign object manager lists);
+                // the kill's cascades happened on the server and replicate via their own syncs.
+                using (new AllowedThread())
+                {
+                    hero.ChangeState(Hero.CharacterStates.Dead);
+                }
+            }
+        }, context: nameof(PlayerDeletionHandler));
+    }
+
+    /// <summary>
+    /// Requesting client: the server denied the delete; surface the reason.
+    /// </summary>
+    private void Handle_NetworkDeletePlayerDenied(MessagePayload<NetworkDeletePlayerDenied> payload)
+    {
+        if (ModInformation.IsServer) return;
+
+        var reason = payload.What.Reason ?? "The server denied the delete request.";
+
+        // Network handlers run on the poller thread; the display is UI work.
+        GameThread.RunSafe(() =>
+        {
+            messageBroker.Publish(this, new PlayerDeleteDenied(reason));
+            ShowMessage($"[DeletePlayer] {reason}");
+        }, context: nameof(PlayerDeletionHandler));
+    }
+
+    private static void TryStep(string step, Action apply)
+    {
+        try
+        {
+            apply();
+        }
+        catch (Exception e)
+        {
+            // The registration is already gone and the peer kicked; a failed world-side step must
+            // not abort the rest of the teardown.
+            Logger.Error(e, "Delete player step {Step} failed", step);
+        }
+    }
+
+    private static void ShowMessage(string text)
+    {
+        try
+        {
+            InformationManager.DisplayMessage(new InformationMessage(text));
+        }
+        catch (Exception e)
+        {
+            Logger.Error(e, "Failed to display the delete player message");
+        }
+    }
+}

--- a/source/GameInterface/Services/Players/Handlers/PlayerDeletionHandler.cs
+++ b/source/GameInterface/Services/Players/Handlers/PlayerDeletionHandler.cs
@@ -2,7 +2,6 @@ using Common;
 using Common.Logging;
 using Common.Messaging;
 using Common.Network;
-using Common.Util;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players.Messages;
 using LiteNetLib;
@@ -127,10 +126,10 @@ internal class PlayerDeletionHandler : IHandler
 
         playerManager.RemovePlayer(player);
 
-        // The other clients drop their player registration and mark the hero dead off this
-        // message. It must go out BEFORE the destroy below replicates: DestroyPartyActionPatch
-        // blocks destroys of registered player parties on every peer, and both messages ride the
-        // same ordered stream.
+        // The other clients drop their player registration off this message. It must go out
+        // BEFORE the kill/destroy below replicate: DestroyPartyActionPatch blocks destroys of
+        // registered player parties on every peer, and all these messages ride the same ordered
+        // stream.
         network.SendAllBut(peer, new NetworkPlayerRemoved(player.ControllerId, player.HeroId));
 
         // Kick the requester before applying the world changes so the resulting broadcasts skip
@@ -139,11 +138,12 @@ internal class PlayerDeletionHandler : IHandler
         // no longer include it.
         peer.Disconnect();
 
-        // Patches stay live for both actions: the kill is server-only (clan cascades broadcast
-        // via their own patched actions; the state flip itself is applied on clients by the
-        // removal broadcast above), and the party destroy's prefix broadcasts the destruction to
-        // the remaining clients. Kill first so the hero leaves the party through the native death
-        // flow, then destroy whatever party is left, mirroring vanilla's defeat teardown order.
+        // Patches stay live for both actions so the server-side apply is what replicates: the
+        // kill is server-only and its state flip broadcasts through the hero field sync (clan
+        // cascades via their own patched actions), and the party destroy's prefix broadcasts the
+        // destruction to the remaining clients. Kill first so the hero leaves the party through
+        // the native death flow, then destroy whatever party is left, mirroring vanilla's defeat
+        // teardown order.
         if (hero != null && hero.IsAlive)
         {
             // (showNotification: false, isForced: true) — forced skips the can-die model checks,
@@ -159,10 +159,10 @@ internal class PlayerDeletionHandler : IHandler
 
     /// <summary>
     /// Client: the server deleted a player — drop it from the local registry so the follow-up
-    /// party destroy replication applies, and mark its hero dead locally. The local death is
-    /// needed because the server's kill flips the hero state through
-    /// <see cref="Hero.ChangeState(Hero.CharacterStates)"/>, a direct field store no hero sync
-    /// replicates (the death day and death mark replicate on their own).
+    /// kill/destroy replication applies. The world-side changes themselves arrive through the
+    /// normal sync flows (the hero state via the hero field sync, the party via the destroy
+    /// broadcast); this message only carries the session-level registration, which no game-state
+    /// sync can.
     /// </summary>
     private void Handle_NetworkPlayerRemoved(MessagePayload<NetworkPlayerRemoved> payload)
     {
@@ -171,26 +171,15 @@ internal class PlayerDeletionHandler : IHandler
         var data = payload.What;
         GameThread.RunSafe(() =>
         {
-            if (playerManager.TryGetPlayer(data.ControllerId, out var player))
-            {
-                playerManager.RemovePlayer(player);
-                Logger.Information("Player {ControllerId} (hero {HeroId}) was deleted by the server",
-                    data.ControllerId, data.HeroId);
-            }
-            else
+            if (!playerManager.TryGetPlayer(data.ControllerId, out var player))
             {
                 Logger.Debug("Deleted player {ControllerId} was not registered on this client", data.ControllerId);
+                return;
             }
 
-            if (objectManager.TryGetObject<Hero>(data.HeroId, out var hero) && hero.IsAlive)
-            {
-                // ChangeState runs the native bookkeeping (clan + campaign object manager lists);
-                // the kill's cascades happened on the server and replicate via their own syncs.
-                using (new AllowedThread())
-                {
-                    hero.ChangeState(Hero.CharacterStates.Dead);
-                }
-            }
+            playerManager.RemovePlayer(player);
+            Logger.Information("Player {ControllerId} (hero {HeroId}) was deleted by the server",
+                data.ControllerId, data.HeroId);
         }, context: nameof(PlayerDeletionHandler));
     }
 

--- a/source/GameInterface/Services/Players/Handlers/PlayerDeletionHandler.cs
+++ b/source/GameInterface/Services/Players/Handlers/PlayerDeletionHandler.cs
@@ -2,6 +2,7 @@ using Common;
 using Common.Logging;
 using Common.Messaging;
 using Common.Network;
+using Common.Util;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players.Messages;
 using LiteNetLib;
@@ -151,36 +152,51 @@ internal class PlayerDeletionHandler : IHandler
             TryStep("hero kill", () => KillCharacterAction.ApplyByRemove(hero, false, true));
         }
 
-        if (party != null && party.IsActive)
+        // Re-resolved because the kill can cascade into destroying the party itself. Inactive
+        // parties are destroyed too: captivity parks the registered player party deactivated,
+        // and it must not outlive the deleted player.
+        if (objectManager.TryGetObject<MobileParty>(player.MobilePartyId, out MobileParty remainingParty))
         {
-            TryStep("party destroy", () => DestroyPartyAction.Apply(null, party));
+            TryStep("party destroy", () => DestroyPartyAction.Apply(null, remainingParty));
         }
     }
 
     /// <summary>
     /// Client: the server deleted a player — drop it from the local registry so the follow-up
-    /// kill/destroy replication applies. The world-side changes themselves arrive through the
-    /// normal sync flows (the hero state via the hero field sync, the party via the destroy
-    /// broadcast); this message only carries the session-level registration, which no game-state
-    /// sync can.
+    /// kill/destroy replication applies, and run the native death transition for its hero. The
+    /// hero state itself also arrives through the hero field sync, but that wire application
+    /// only assigns the field; ChangeState here keeps the clan alive-lord caches and
+    /// CampaignObjectManager's alive/dead lists correct too.
     /// </summary>
     private void Handle_NetworkPlayerRemoved(MessagePayload<NetworkPlayerRemoved> payload)
     {
         if (ModInformation.IsServer) return;
 
         var data = payload.What;
+        // Blocking: a client still loading in can replay [player created, player removed, player
+        // created again] back to back, and RemotePlayerHeroHandler's duplicate check reads the
+        // registry on this thread — the removal must be applied before the next message.
         GameThread.RunSafe(() =>
         {
-            if (!playerManager.TryGetPlayer(data.ControllerId, out var player))
+            if (playerManager.TryGetPlayer(data.ControllerId, out var player))
+            {
+                playerManager.RemovePlayer(player);
+                Logger.Information("Player {ControllerId} (hero {HeroId}) was deleted by the server",
+                    data.ControllerId, data.HeroId);
+            }
+            else
             {
                 Logger.Debug("Deleted player {ControllerId} was not registered on this client", data.ControllerId);
-                return;
             }
 
-            playerManager.RemovePlayer(player);
-            Logger.Information("Player {ControllerId} (hero {HeroId}) was deleted by the server",
-                data.ControllerId, data.HeroId);
-        }, context: nameof(PlayerDeletionHandler));
+            if (objectManager.TryGetObject<Hero>(data.HeroId, out var hero) && hero.IsAlive)
+            {
+                using (new AllowedThread())
+                {
+                    hero.ChangeState(Hero.CharacterStates.Dead);
+                }
+            }
+        }, blocking: true, context: nameof(PlayerDeletionHandler));
     }
 
     /// <summary>

--- a/source/GameInterface/Services/Players/Messages/NetworkDeletePlayerDenied.cs
+++ b/source/GameInterface/Services/Players/Messages/NetworkDeletePlayerDenied.cs
@@ -1,0 +1,20 @@
+using Common.Messaging;
+using ProtoBuf;
+
+namespace GameInterface.Services.Players.Messages;
+
+/// <summary>
+/// Server reply to the requesting client only: the delete request was not applied. The client
+/// stays connected and surfaces the reason.
+/// </summary>
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkDeletePlayerDenied : IEvent
+{
+    [ProtoMember(1)]
+    public string Reason { get; }
+
+    public NetworkDeletePlayerDenied(string reason)
+    {
+        Reason = reason;
+    }
+}

--- a/source/GameInterface/Services/Players/Messages/NetworkPlayerRemoved.cs
+++ b/source/GameInterface/Services/Players/Messages/NetworkPlayerRemoved.cs
@@ -1,0 +1,27 @@
+using Common.Messaging;
+using ProtoBuf;
+
+namespace GameInterface.Services.Players.Messages;
+
+/// <summary>
+/// Server broadcast: the given player's registration was deleted. Clients drop the player from
+/// their own registry and mark its hero dead locally (the server-side kill's state flip does not
+/// replicate on its own). Sent BEFORE the party destroy replicates on the same ordered stream,
+/// so every client lifts the player-party destroy protection
+/// (<see cref="MobileParties.Patches.DestroyPartyActionPatch"/>) before applying it.
+/// </summary>
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkPlayerRemoved : IEvent
+{
+    [ProtoMember(1)]
+    public string ControllerId { get; }
+
+    [ProtoMember(2)]
+    public string HeroId { get; }
+
+    public NetworkPlayerRemoved(string controllerId, string heroId)
+    {
+        ControllerId = controllerId;
+        HeroId = heroId;
+    }
+}

--- a/source/GameInterface/Services/Players/Messages/NetworkPlayerRemoved.cs
+++ b/source/GameInterface/Services/Players/Messages/NetworkPlayerRemoved.cs
@@ -5,10 +5,10 @@ namespace GameInterface.Services.Players.Messages;
 
 /// <summary>
 /// Server broadcast: the given player's registration was deleted. Clients drop the player from
-/// their own registry and mark its hero dead locally (the server-side kill's state flip does not
-/// replicate on its own). Sent BEFORE the party destroy replicates on the same ordered stream,
-/// so every client lifts the player-party destroy protection
-/// (<see cref="MobileParties.Patches.DestroyPartyActionPatch"/>) before applying it.
+/// their own registry; the hero death and party destruction arrive separately through the normal
+/// sync flows. Sent BEFORE those replicate on the same ordered stream, so every client lifts the
+/// player-party destroy protection
+/// (<see cref="MobileParties.Patches.DestroyPartyActionPatch"/>) before applying them.
 /// </summary>
 [ProtoContract(SkipConstructor = true)]
 internal readonly struct NetworkPlayerRemoved : IEvent

--- a/source/GameInterface/Services/Players/Messages/NetworkPlayerRemoved.cs
+++ b/source/GameInterface/Services/Players/Messages/NetworkPlayerRemoved.cs
@@ -5,9 +5,10 @@ namespace GameInterface.Services.Players.Messages;
 
 /// <summary>
 /// Server broadcast: the given player's registration was deleted. Clients drop the player from
-/// their own registry; the hero death and party destruction arrive separately through the normal
-/// sync flows. Sent BEFORE those replicate on the same ordered stream, so every client lifts the
-/// player-party destroy protection
+/// their own registry and run the native death transition for its hero (the field-sync wire
+/// application alone skips the clan/campaign bookkeeping); the party destruction arrives
+/// separately through the destroy broadcast. Sent BEFORE the kill/destroy replicate on the same
+/// ordered stream, so every client lifts the player-party destroy protection
 /// (<see cref="MobileParties.Patches.DestroyPartyActionPatch"/>) before applying them.
 /// </summary>
 [ProtoContract(SkipConstructor = true)]

--- a/source/GameInterface/Services/Players/Messages/NetworkRequestDeletePlayer.cs
+++ b/source/GameInterface/Services/Players/Messages/NetworkRequestDeletePlayer.cs
@@ -1,0 +1,22 @@
+using Common.Messaging;
+using ProtoBuf;
+
+namespace GameInterface.Services.Players.Messages;
+
+/// <summary>
+/// Client request to delete the requesting player: the server removes the player registration,
+/// kills the hero, destroys the party, and disconnects the requesting client.
+/// </summary>
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkRequestDeletePlayer : ICommand
+{
+    /// <summary>The requesting client's own hero, for cross-checking and logging only; the server
+    /// resolves the player to delete from the requesting connection, never from this id.</summary>
+    [ProtoMember(1)]
+    public string HeroId { get; }
+
+    public NetworkRequestDeletePlayer(string heroId)
+    {
+        HeroId = heroId;
+    }
+}

--- a/source/GameInterface/Services/Players/Messages/PlayerDeleteDenied.cs
+++ b/source/GameInterface/Services/Players/Messages/PlayerDeleteDenied.cs
@@ -1,0 +1,17 @@
+using Common.Messaging;
+
+namespace GameInterface.Services.Players.Messages;
+
+/// <summary>
+/// Client-local event: the server denied this client's delete request
+/// (<see cref="NetworkDeletePlayerDenied"/>). Carries the server's reason.
+/// </summary>
+public record PlayerDeleteDenied : IEvent
+{
+    public string Reason { get; }
+
+    public PlayerDeleteDenied(string reason)
+    {
+        Reason = reason;
+    }
+}

--- a/source/GameInterface/Services/Players/Messages/PlayerDeleteRequested.cs
+++ b/source/GameInterface/Services/Players/Messages/PlayerDeleteRequested.cs
@@ -1,0 +1,12 @@
+using Common.Messaging;
+
+namespace GameInterface.Services.Players.Messages;
+
+/// <summary>
+/// Client-local request (from the coop.delete_player command) to have the server delete this
+/// player's hero and disconnect the client. Forwarded to the server as
+/// <see cref="NetworkRequestDeletePlayer"/>.
+/// </summary>
+public record PlayerDeleteRequested : IEvent
+{
+}

--- a/source/GameInterface/Services/Players/PlayerManager.cs
+++ b/source/GameInterface/Services/Players/PlayerManager.cs
@@ -94,9 +94,21 @@ public class PlayerManager : IPlayerManager
     private readonly IControllerIdProvider controllerIdProvider;
     private readonly ConcurrentDictionary<NetPeer, Player> peerToPlayer = new();
     private readonly Dictionary<string, NetPeer> controllerToPeer = new();
-    private readonly object peerSync = new();
 
-    public IReadOnlyCollection<Player> Players => _players;
+    // Guards _players and controllerToPeer: registrations mutate on the game thread (e.g. a
+    // player deletion) while join handlers read them on the network thread.
+    private readonly object registrySync = new();
+
+    public IReadOnlyCollection<Player> Players
+    {
+        get
+        {
+            lock (registrySync)
+            {
+                return _players.ToArray();
+            }
+        }
+    }
     private readonly HashSet<Player> _players = new HashSet<Player>();
 
     public PlayerManager(ILogger logger, IObjectManager objectManager, IControllerIdProvider controllerIdProvider)
@@ -109,7 +121,10 @@ public class PlayerManager : IPlayerManager
     /// <inheritdoc cref="IPlayerManager.AddPlayer(Player)"/>
     public bool AddPlayer(Player player)
     {
-        if (!_players.Add(player)) return false;
+        lock (registrySync)
+        {
+            if (!_players.Add(player)) return false;
+        }
 
         // Add player objects for IsPlayer extension (i.e. MobilePartyExtensions)
         AddPlayerObject<MobileParty>(player.ControllerId, player.MobilePartyId);
@@ -153,7 +168,10 @@ public class PlayerManager : IPlayerManager
 
     public bool TryGetPlayer(string controllerId, out Player player)
     {
-        player = _players.SingleOrDefault(player => player.ControllerId == controllerId);
+        lock (registrySync)
+        {
+            player = _players.SingleOrDefault(player => player.ControllerId == controllerId);
+        }
 
         return player != null;
     }
@@ -176,7 +194,7 @@ public class PlayerManager : IPlayerManager
             return;
         }
 
-        lock (peerSync)
+        lock (registrySync)
         {
             peerToPlayer[peer] = player;
             controllerToPeer[controllerId] = peer;
@@ -185,7 +203,7 @@ public class PlayerManager : IPlayerManager
 
     public bool TryGetPeer(string controllerId, out NetPeer peer)
     {
-        lock (peerSync)
+        lock (registrySync)
         {
             return controllerToPeer.TryGetValue(controllerId, out peer);
         }
@@ -193,7 +211,7 @@ public class PlayerManager : IPlayerManager
 
     public void ClearPeer(NetPeer peer)
     {
-        lock (peerSync)
+        lock (registrySync)
         {
             if (!peerToPlayer.TryRemove(peer, out var player)) return;
 
@@ -206,10 +224,12 @@ public class PlayerManager : IPlayerManager
     /// <inheritdoc cref="IPlayerManager.RemovePlayer(Player)"/>
     public bool RemovePlayer(Player player)
     {
-        if (player == null || !_players.Remove(player)) return false;
+        if (player == null) return false;
 
-        lock (peerSync)
+        lock (registrySync)
         {
+            if (!_players.Remove(player)) return false;
+
             controllerToPeer.Remove(player.ControllerId);
 
             // A rejoin adds a fresh peer link without clearing the old one, so sweep every peer

--- a/source/GameInterface/Services/Players/PlayerManager.cs
+++ b/source/GameInterface/Services/Players/PlayerManager.cs
@@ -54,6 +54,16 @@ public interface IPlayerManager
     void ClearPeer(NetPeer peer);
 
     /// <summary>
+    /// Deletes a player's registration entirely: the Player entry, every peer link, and the
+    /// controlled-object markers on its hero/party/clan. The game objects themselves are
+    /// untouched. Used when a player's character is deleted; afterwards a rejoin with the same
+    /// controller id goes through character creation again.
+    /// </summary>
+    /// <param name="player">The player to delete from the registry</param>
+    /// <returns>true if the player was registered and is now removed</returns>
+    bool RemovePlayer(Player player);
+
+    /// <summary>
     /// Resolves the Player currently controlled by a connected peer.
     /// </summary>
     bool TryGetPlayer(NetPeer peer, out Player player);
@@ -190,6 +200,47 @@ public class PlayerManager : IPlayerManager
             if (controllerToPeer.TryGetValue(player.ControllerId, out var currentPeer) &&
                 ReferenceEquals(currentPeer, peer))
                 controllerToPeer.Remove(player.ControllerId);
+        }
+    }
+
+    /// <inheritdoc cref="IPlayerManager.RemovePlayer(Player)"/>
+    public bool RemovePlayer(Player player)
+    {
+        if (player == null || !_players.Remove(player)) return false;
+
+        lock (peerSync)
+        {
+            controllerToPeer.Remove(player.ControllerId);
+
+            // A rejoin adds a fresh peer link without clearing the old one, so sweep every peer
+            // still mapped to this player, not just the current one.
+            foreach (var stalePeer in peerToPlayer
+                         .Where(kvp => ReferenceEquals(kvp.Value, player))
+                         .Select(kvp => kvp.Key).ToArray())
+            {
+                peerToPlayer.TryRemove(stalePeer, out _);
+            }
+        }
+
+        RemovePlayerObject<MobileParty>(player.MobilePartyId);
+        RemovePlayerObject<Hero>(player.HeroId);
+        RemovePlayerObject<Clan>(player.ClanId);
+
+        return true;
+    }
+
+    private void RemovePlayerObject<T>(string networkId)
+    {
+        if (string.IsNullOrEmpty(networkId)) return;
+
+        // The object may already be gone (e.g. a destroyed party); nothing to unmark then.
+        if (!objectManager.TryGetObject<T>(networkId, out var obj)) return;
+
+        PlayerObjects.Remove(obj);
+
+        if (obj is MobileParty mobileParty)
+        {
+            InvalidatePlayerPartySpeedCache(mobileParty);
         }
     }
 


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

There is no way to delete a player. A registered player's hero and party live forever, and rejoining with the same controller id always resumes the existing character.

## What is the new behavior?

Adds a client-only `coop.delete_player` console command. The client sends the request to the server; the server resolves the player from the requesting connection (client-sent ids are advisory only), removes the registration everywhere (`NetworkPlayerRemoved` goes out first so other clients lift the player-party destroy protection), disconnects the requester, then kills the hero and destroys the party with patches live so the existing sync flows (hero field sync, party destroy broadcast, clan cascades) replicate the results. Requests that cannot be applied (unknown connection, party in a battle or siege) are denied with a reason and nothing changes. Rejoining after deletion goes through character creation again.

Also adds `IPlayerManager.RemovePlayer` (the inverse of `AddPlayer`) and a note in `HeroSync` documenting that `_heroState` must not be registered there (the `HeroFieldPatches` transpiler already owns that store).

## Bot Changelog Entry

- Added a `coop.delete_player` console command: deletes your character on the server and disconnects you, so you can rejoin and create a new one.

## Other information

The E2E flow test does not assert the other client's hero death: the harness runs `Hero.ChangeState` during environment startup before `PatchAll`, so that method's transpiled intercept never fires in-process (production patches before any campaign code runs and is unaffected; the relay itself is covered by `HeroFieldTests`).