### PR TITLE
Wait for Bannerlord crash dumps

### DIFF
--- a/source/Coop.CrashReporter.Tests/Coop.CrashReporter.Tests.csproj
+++ b/source/Coop.CrashReporter.Tests/Coop.CrashReporter.Tests.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Coop.CrashReporter\Coop.CrashReporter.csproj" />
+  </ItemGroup>
+</Project>

--- a/source/Coop.CrashReporter.Tests/Coop.CrashReporter.Tests.csproj
+++ b/source/Coop.CrashReporter.Tests/Coop.CrashReporter.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -14,6 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Coop.CrashReporter\Coop.CrashReporter.csproj" />
+    <Compile Include="..\Coop.CrashReporter\CrashReportCollector.cs" Link="CrashReporter\CrashReportCollector.cs" />
+    <Compile Include="..\Coop.CrashReporter\CrashReporterOptions.cs" Link="CrashReporter\CrashReporterOptions.cs" />
+    <Compile Include="..\Coop.CrashReporter\MinidumpProcessIdReader.cs" Link="CrashReporter\MinidumpProcessIdReader.cs" />
   </ItemGroup>
 </Project>

--- a/source/Coop.CrashReporter.Tests/CrashReportCollectorTests.cs
+++ b/source/Coop.CrashReporter.Tests/CrashReportCollectorTests.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Coop.CrashReporter.Tests
+{
+    public sealed class CrashReportCollectorTests : IDisposable
+    {
+        private readonly string tempRoot = Path.Combine(
+            Path.GetTempPath(),
+            "CoopCrashReporterTests_" + Guid.NewGuid().ToString("N"));
+
+        [Fact]
+        public async Task WaitForMatchingDump_RetriesPastTwentyIntervals()
+        {
+            int processId = Process.GetCurrentProcess().Id;
+            CrashReporterOptions options = CreateOptions(processId);
+            var collector = new CrashReportCollector(
+                options,
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromMilliseconds(10));
+
+            Task<string> waitTask = Task.Run(
+                () => collector.WaitForMatchingDump(TimeSpan.FromSeconds(2)));
+
+            await Task.Delay(300);
+            string dumpPath = Path.Combine(options.BannerlordDataRoot, "crashes", "dump.dmp");
+            WriteMinidump(dumpPath, processId);
+
+            Assert.Equal(dumpPath, await waitTask);
+        }
+
+        [Fact]
+        public void TryCopyDump_RetriesPastTwentyIntervals()
+        {
+            int processId = Process.GetCurrentProcess().Id;
+            CrashReporterOptions options = CreateOptions(processId);
+            var attempts = 0;
+            var collector = new CrashReportCollector(
+                options,
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromMilliseconds(10),
+                (source, destination) => Interlocked.Increment(ref attempts) > 25);
+
+            Assert.True(collector.TryCopyDump(
+                Path.Combine(tempRoot, "source.dmp"),
+                Path.Combine(tempRoot, "destination.dmp")));
+            Assert.True(attempts > 20);
+        }
+
+        [Fact]
+        public void TryCopyDump_CopiesAndValidatesMatchingDump()
+        {
+            int processId = Process.GetCurrentProcess().Id;
+            CrashReporterOptions options = CreateOptions(processId);
+            var collector = new CrashReportCollector(
+                options,
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromMilliseconds(10));
+            string sourcePath = Path.Combine(tempRoot, "source.dmp");
+            string destinationPath = Path.Combine(tempRoot, "copied.dmp");
+            WriteMinidump(sourcePath, processId);
+
+            Assert.True(collector.TryCopyDump(sourcePath, destinationPath));
+            int copiedProcessId;
+            Assert.True(MinidumpProcessIdReader.TryReadProcessId(
+                destinationPath,
+                out copiedProcessId));
+            Assert.Equal(processId, copiedProcessId);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(tempRoot, true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+
+        private CrashReporterOptions CreateOptions(int processId)
+        {
+            Directory.CreateDirectory(tempRoot);
+            return new CrashReporterOptions(
+                processId,
+                DateTime.UtcNow.AddMinutes(-1).Ticks,
+                Path.Combine(tempRoot, "coop.log"),
+                "client",
+                "test",
+                tempRoot,
+                Path.Combine(tempRoot, "reports"));
+        }
+
+        private static void WriteMinidump(string path, int processId)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
+            using (var stream = new FileStream(path, FileMode.Create, FileAccess.Write))
+            using (var writer = new BinaryWriter(stream))
+            {
+                writer.Write(0x504D444D);
+                writer.Write(0);
+                writer.Write(1);
+                writer.Write(32);
+                writer.Write(0);
+                writer.Write(0);
+                writer.Write(0L);
+
+                writer.Write(15);
+                writer.Write(12);
+                writer.Write(44);
+
+                writer.Write(12);
+                writer.Write(1);
+                writer.Write(processId);
+            }
+        }
+    }
+}

--- a/source/Coop.CrashReporter/CrashReportCollector.cs
+++ b/source/Coop.CrashReporter/CrashReportCollector.cs
@@ -13,7 +13,6 @@ namespace Coop.CrashReporter
     internal sealed class CrashReportCollector
     {
         private const string RuntimeArgumentsMarker = "#TW#Runtime#TW#Arguments#TW#";
-        private static readonly TimeSpan CleanExitDumpDiscoveryTimeout = TimeSpan.FromSeconds(5);
         private static readonly TimeSpan CrashDumpDiscoveryTimeout = TimeSpan.FromSeconds(30);
         private static readonly TimeSpan DumpCompletionTimeout = TimeSpan.FromMinutes(15);
         private static readonly TimeSpan RetryInterval = TimeSpan.FromMilliseconds(250);
@@ -58,7 +57,7 @@ namespace Coop.CrashReporter
             process.WaitForExit();
             int exitCode = process.ExitCode;
             string dumpPath = exitCode == 0
-                ? WaitForMatchingDump(CleanExitDumpDiscoveryTimeout)
+                ? WaitForMatchingDump(CrashDumpDiscoveryTimeout)
                 : null;
             if (exitCode == 0 && dumpPath == null)
                 return 0;

--- a/source/Coop.CrashReporter/CrashReportCollector.cs
+++ b/source/Coop.CrashReporter/CrashReportCollector.cs
@@ -13,33 +13,78 @@ namespace Coop.CrashReporter
     internal sealed class CrashReportCollector
     {
         private const string RuntimeArgumentsMarker = "#TW#Runtime#TW#Arguments#TW#";
+        private static readonly TimeSpan CleanExitDumpDiscoveryTimeout = TimeSpan.FromSeconds(5);
+        private static readonly TimeSpan CrashDumpDiscoveryTimeout = TimeSpan.FromSeconds(30);
+        private static readonly TimeSpan DumpCompletionTimeout = TimeSpan.FromMinutes(15);
+        private static readonly TimeSpan RetryInterval = TimeSpan.FromMilliseconds(250);
         private readonly CrashReporterOptions options;
+        private readonly TimeSpan dumpCompletionTimeout;
+        private readonly TimeSpan retryInterval;
+        private readonly Func<string, string, bool> tryCopyDumpAttempt;
 
         public CrashReportCollector(CrashReporterOptions options)
+            : this(options, DumpCompletionTimeout, RetryInterval, null)
         {
+        }
+
+        internal CrashReportCollector(
+            CrashReporterOptions options,
+            TimeSpan dumpCompletionTimeout,
+            TimeSpan retryInterval)
+            : this(options, dumpCompletionTimeout, retryInterval, null)
+        {
+        }
+
+        internal CrashReportCollector(
+            CrashReporterOptions options,
+            TimeSpan dumpCompletionTimeout,
+            TimeSpan retryInterval,
+            Func<string, string, bool> tryCopyDumpAttempt)
+        {
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            if (dumpCompletionTimeout <= TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(dumpCompletionTimeout));
+            if (retryInterval <= TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(retryInterval));
+
             this.options = options;
+            this.dumpCompletionTimeout = dumpCompletionTimeout;
+            this.retryInterval = retryInterval;
+            this.tryCopyDumpAttempt = tryCopyDumpAttempt ?? TryCopyDumpOnce;
         }
 
         public int Run(Process process)
         {
             process.WaitForExit();
             int exitCode = process.ExitCode;
-            string dumpPath = WaitForMatchingDump();
+            string dumpPath = exitCode == 0
+                ? WaitForMatchingDump(CleanExitDumpDiscoveryTimeout)
+                : null;
             if (exitCode == 0 && dumpPath == null)
                 return 0;
 
             string reportDirectory = CreateReportDirectory();
             string logsDirectory = Path.Combine(reportDirectory, "logs");
             Directory.CreateDirectory(logsDirectory);
+            List<string> copiedLogs = CopyLogs(logsDirectory);
+
+            if (dumpPath == null)
+                dumpPath = WaitForMatchingDump(CrashDumpDiscoveryTimeout);
 
             string copiedDumpPath = Path.Combine(reportDirectory, "dump.dmp");
             bool dumpCopied = dumpPath != null &&
                               TryCopyDump(dumpPath, copiedDumpPath);
-            List<string> copiedLogs = CopyLogs(logsDirectory);
+            string dumpCaptureDetails = GetDumpCaptureDetails(dumpPath, dumpCopied);
+            RefreshLogs(logsDirectory, copiedLogs);
 
             string reportPath = Path.Combine(reportDirectory, "report.txt");
             string readmePath = Path.Combine(reportDirectory, "README.txt");
-            WriteReport(reportPath, exitCode, dumpCopied, copiedLogs);
+            WriteReport(
+                reportPath,
+                exitCode,
+                dumpCopied,
+                dumpCaptureDetails,
+                copiedLogs);
             WriteReadme(readmePath, dumpCopied);
             CreateShareableZip(
                 Path.Combine(reportDirectory, "shareable.zip"),
@@ -72,26 +117,32 @@ namespace Coop.CrashReporter
             }
         }
 
-        private string WaitForMatchingDump()
+        internal string WaitForMatchingDump(TimeSpan initialTimeout)
         {
             DateTime processStartUtc =
                 new DateTime(options.ProcessStartUtcTicks, DateTimeKind.Utc)
                     .AddSeconds(-1);
-            for (var attempt = 0; attempt < 20; attempt++)
+            var stopwatch = Stopwatch.StartNew();
+            do
             {
                 foreach (string dumpPath in FindDumps())
                 {
                     int dumpProcessId;
-                    if (File.GetLastWriteTimeUtc(dumpPath) >= processStartUtc &&
-                        MinidumpProcessIdReader.TryReadProcessId(dumpPath, out dumpProcessId) &&
+                    if (File.GetLastWriteTimeUtc(dumpPath) < processStartUtc)
+                        continue;
+
+                    if (MinidumpProcessIdReader.TryReadProcessId(
+                            dumpPath,
+                            out dumpProcessId) &&
                         dumpProcessId == options.ProcessId)
                     {
                         return dumpPath;
                     }
                 }
 
-                Thread.Sleep(250);
+                WaitForRetry(stopwatch, initialTimeout);
             }
+            while (stopwatch.Elapsed < initialTimeout);
 
             return null;
         }
@@ -135,6 +186,15 @@ namespace Coop.CrashReporter
             return copied;
         }
 
+        private void RefreshLogs(string destinationRoot, ICollection<string> copiedLogs)
+        {
+            foreach (string refreshedLog in CopyLogs(destinationRoot))
+            {
+                if (!copiedLogs.Contains(refreshedLog, StringComparer.OrdinalIgnoreCase))
+                    copiedLogs.Add(refreshedLog);
+            }
+        }
+
         private static void CopyLog(
             string sourcePath,
             string destinationRoot,
@@ -147,52 +207,78 @@ namespace Coop.CrashReporter
                 copied.Add(destinationPath);
         }
 
-        private bool TryCopyDump(string sourcePath, string destinationPath)
+        internal bool TryCopyDump(string sourcePath, string destinationPath)
         {
-            for (var attempt = 0; attempt < 20; attempt++)
+            var stopwatch = Stopwatch.StartNew();
+            do
             {
-                try
-                {
-                    long sourceLength;
-                    using (var source = new FileStream(
-                        sourcePath,
-                        FileMode.Open,
-                        FileAccess.Read,
-                        FileShare.Read))
-                    using (var destination = new FileStream(
-                        destinationPath,
-                        FileMode.Create,
-                        FileAccess.Write,
-                        FileShare.Read))
-                    {
-                        source.CopyTo(destination);
-                        sourceLength = source.Length;
-                    }
-
-                    int copiedProcessId;
-                    if (sourceLength > 0 &&
-                        new FileInfo(destinationPath).Length == sourceLength &&
-                        MinidumpProcessIdReader.TryReadProcessId(
-                            destinationPath,
-                            out copiedProcessId) &&
-                        copiedProcessId == options.ProcessId)
-                    {
-                        return true;
-                    }
-                }
-                catch (IOException)
-                {
-                }
-                catch (UnauthorizedAccessException)
-                {
-                }
+                if (tryCopyDumpAttempt(sourcePath, destinationPath))
+                    return true;
 
                 TryDelete(destinationPath);
-                Thread.Sleep(250);
+                WaitForRetry(stopwatch, dumpCompletionTimeout);
             }
+            while (stopwatch.Elapsed < dumpCompletionTimeout);
 
             TryDelete(destinationPath);
             return false;
+        }
+
+        private bool TryCopyDumpOnce(string sourcePath, string destinationPath)
+        {
+            try
+            {
+                long sourceLength;
+                using (var source = new FileStream(
+                    sourcePath,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.Read))
+                using (var destination = new FileStream(
+                    destinationPath,
+                    FileMode.Create,
+                    FileAccess.Write,
+                    FileShare.Read))
+                {
+                    source.CopyTo(destination);
+                    sourceLength = source.Length;
+                }
+
+                int copiedProcessId;
+                return sourceLength > 0 &&
+                       new FileInfo(destinationPath).Length == sourceLength &&
+                       MinidumpProcessIdReader.TryReadProcessId(
+                           destinationPath,
+                           out copiedProcessId) &&
+                       copiedProcessId == options.ProcessId;
+            }
+            catch (IOException)
+            {
+                return false;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return false;
+            }
+        }
+
+        private void WaitForRetry(Stopwatch stopwatch, TimeSpan timeout)
+        {
+            TimeSpan remaining = timeout - stopwatch.Elapsed;
+            if (remaining <= TimeSpan.Zero)
+                return;
+
+            Thread.Sleep(remaining < retryInterval ? remaining : retryInterval);
+        }
+
+        private static string GetDumpCaptureDetails(string dumpPath, bool dumpCopied)
+        {
+            if (dumpCopied)
+                return "matching dump copied and validated";
+
+            return dumpPath == null
+                ? "no matching readable dump appeared before the discovery timeout"
+                : "matching dump did not become copyable before the completion timeout";
         }
 
         private static bool TryCopyFile(string sourcePath, string destinationPath)
@@ -243,6 +329,7 @@ namespace Coop.CrashReporter
             string reportPath,
             int exitCode,
             bool dumpCopied,
+            string dumpCaptureDetails,
             IEnumerable<string> copiedLogs)
         {
             var lines = new[]
@@ -254,6 +341,7 @@ namespace Coop.CrashReporter
                 "Build: " + options.Build,
                 "Exit code: " + exitCode.ToString(CultureInfo.InvariantCulture),
                 "Dump captured: " + (dumpCopied ? "yes" : "no"),
+                "Dump capture details: " + dumpCaptureDetails,
                 "Logs captured: " + copiedLogs.Count().ToString(CultureInfo.InvariantCulture),
             };
             File.WriteAllLines(reportPath, lines, new UTF8Encoding(false));

--- a/source/Coop.CrashReporter/CrashReportCollector.cs
+++ b/source/Coop.CrashReporter/CrashReportCollector.cs
@@ -41,10 +41,12 @@ namespace Coop.CrashReporter
             Func<string, string, bool> tryCopyDumpAttempt)
         {
             if (options == null) throw new ArgumentNullException(nameof(options));
+#pragma warning disable CA1512 // ThrowIfLessThanOrEqual is unavailable on .NET Framework 4.7.2.
             if (dumpCompletionTimeout <= TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(nameof(dumpCompletionTimeout));
             if (retryInterval <= TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(nameof(retryInterval));
+#pragma warning restore CA1512
 
             this.options = options;
             this.dumpCompletionTimeout = dumpCompletionTimeout;

--- a/source/Coop.CrashReporter/CrashReporterOptions.cs
+++ b/source/Coop.CrashReporter/CrashReporterOptions.cs
@@ -8,7 +8,7 @@ namespace Coop.CrashReporter
     {
         private const string BannerlordDirectoryName = "Mount and Blade II Bannerlord";
 
-        private CrashReporterOptions(
+        internal CrashReporterOptions(
             int processId,
             long processStartUtcTicks,
             string coopLogPath,

--- a/source/Coop.CrashReporter/Properties/AssemblyInfo.cs
+++ b/source/Coop.CrashReporter/Properties/AssemblyInfo.cs
@@ -1,8 +1,6 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: InternalsVisibleTo("Coop.CrashReporter.Tests")]
 [assembly: AssemblyTitle("Coop Crash Reporter")]
 [assembly: AssemblyDescription("Preserves local Bannerlord crash diagnostics for BannerlordCoop.")]
 [assembly: AssemblyCompany("")]

--- a/source/Coop.CrashReporter/Properties/AssemblyInfo.cs
+++ b/source/Coop.CrashReporter/Properties/AssemblyInfo.cs
@@ -1,6 +1,8 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+[assembly: InternalsVisibleTo("Coop.CrashReporter.Tests")]
 [assembly: AssemblyTitle("Coop Crash Reporter")]
 [assembly: AssemblyDescription("Preserves local Bannerlord crash diagnostics for BannerlordCoop.")]
 [assembly: AssemblyCompany("")]

--- a/source/Coop.sln
+++ b/source/Coop.sln
@@ -30,6 +30,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Coop", "Coop\Coop.csproj", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Coop.CrashReporter", "Coop.CrashReporter\Coop.CrashReporter.csproj", "{8D983480-E9ED-4850-AB2B-E089109AC1DF}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Coop.CrashReporter.Tests", "Coop.CrashReporter.Tests\Coop.CrashReporter.Tests.csproj", "{F0D0158E-A4BC-494E-856E-58103944648B}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClientDebug", "ClientDebug\ClientDebug.csproj", "{470498AB-91E4-419A-9E59-5E9E97264D99}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Coop.IntegrationTests", "Coop.IntegrationTests\Coop.IntegrationTests.csproj", "{DF3D47B3-487A-48AE-A10B-FDCE9D46D782}"
@@ -256,6 +258,18 @@ Global
 		{52680E0F-F98F-4A85-B80B-3AC75C474FAF}.Release|Any CPU.Build.0 = Release|Any CPU
 		{52680E0F-F98F-4A85-B80B-3AC75C474FAF}.Release|x64.ActiveCfg = Release|Any CPU
 		{52680E0F-F98F-4A85-B80B-3AC75C474FAF}.Release|x64.Build.0 = Release|Any CPU
+		{F0D0158E-A4BC-494E-856E-58103944648B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F0D0158E-A4BC-494E-856E-58103944648B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F0D0158E-A4BC-494E-856E-58103944648B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F0D0158E-A4BC-494E-856E-58103944648B}.Debug|x64.Build.0 = Debug|Any CPU
+		{F0D0158E-A4BC-494E-856E-58103944648B}.DebugAutoConnect|Any CPU.ActiveCfg = Debug|Any CPU
+		{F0D0158E-A4BC-494E-856E-58103944648B}.DebugAutoConnect|Any CPU.Build.0 = Debug|Any CPU
+		{F0D0158E-A4BC-494E-856E-58103944648B}.DebugAutoConnect|x64.ActiveCfg = Debug|Any CPU
+		{F0D0158E-A4BC-494E-856E-58103944648B}.DebugAutoConnect|x64.Build.0 = Debug|Any CPU
+		{F0D0158E-A4BC-494E-856E-58103944648B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F0D0158E-A4BC-494E-856E-58103944648B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F0D0158E-A4BC-494E-856E-58103944648B}.Release|x64.ActiveCfg = Release|Any CPU
+		{F0D0158E-A4BC-494E-856E-58103944648B}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/source/CoopTests.slnf
+++ b/source/CoopTests.slnf
@@ -3,6 +3,7 @@
     "path": "Coop.sln",
     "projects": [
       "Common.Tests\\Common.Tests.csproj",
+      "Coop.CrashReporter.Tests\\Coop.CrashReporter.Tests.csproj",
       "Coop.Tests\\Coop.Tests.csproj",
       "Coop.IntegrationTests\\Coop.IntegrationTests.csproj",
       "GameInterface.Tests\\GameInterface.Tests.csproj",

--- a/source/CoopUnitTests.slnf
+++ b/source/CoopUnitTests.slnf
@@ -3,6 +3,7 @@
     "path": "Coop.sln",
     "projects": [
       "Common.Tests\\Common.Tests.csproj",
+      "Coop.CrashReporter.Tests\\Coop.CrashReporter.Tests.csproj",
       "Coop.Tests\\Coop.Tests.csproj",
       "Coop.IntegrationTests\\Coop.IntegrationTests.csproj",
       "GameInterface.Tests\\GameInterface.Tests.csproj"


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

The crash reporter gives Bannerlord five seconds to expose and unlock its dump. Large dumps can still be writing when it gives up, so the co-op report only contains logs even though the normal Bannerlord dump appears later.

## What is the new behavior?

Unexpected exits get 30 seconds for dump discovery and matching dumps get up to 15 minutes to become copyable. Logs are preserved before the wait and refreshed afterward, and `report.txt` now identifies which dump stage timed out.

## Bot Changelog Entry

- Crash reports now wait for large Bannerlord dumps to finish before packaging them.
