### PR TITLE
[2541] Keep troop upgrade options open during time progression

### DIFF
--- a/source/E2E.Tests/Util/ObjectBuilders/MobilePartyBuilder.cs
+++ b/source/E2E.Tests/Util/ObjectBuilders/MobilePartyBuilder.cs
@@ -12,6 +12,7 @@ internal class MobilePartyBuilder : IObjectBuilder
         var spawnSettlement = GameObjectCreator.CreateInitializedObject<Settlement>();
         var leaderHero = GameObjectCreator.CreateInitializedObject<Hero>();
         var clan = GameObjectCreator.CreateInitializedObject<Clan>();
+        // Real clans always have a culture; surrender paths read it while building encounter state.
         clan.Culture = GameObjectCreator.CreateInitializedObject<CultureObject>();
         
         leaderHero.Clan = clan;

--- a/source/E2E.Tests/Util/ObjectBuilders/MobilePartyBuilder.cs
+++ b/source/E2E.Tests/Util/ObjectBuilders/MobilePartyBuilder.cs
@@ -12,6 +12,7 @@ internal class MobilePartyBuilder : IObjectBuilder
         var spawnSettlement = GameObjectCreator.CreateInitializedObject<Settlement>();
         var leaderHero = GameObjectCreator.CreateInitializedObject<Hero>();
         var clan = GameObjectCreator.CreateInitializedObject<Clan>();
+        clan.Culture = GameObjectCreator.CreateInitializedObject<CultureObject>();
         
         leaderHero.Clan = clan;
         clan.SetLeader(leaderHero);

--- a/source/GameInterface.Tests/Services/Party/PartyScreenRosterRefresherTests.cs
+++ b/source/GameInterface.Tests/Services/Party/PartyScreenRosterRefresherTests.cs
@@ -1,4 +1,5 @@
 ﻿using GameInterface.Services.Party;
+using System;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Roster;
@@ -129,6 +130,65 @@ public class PartyScreenRosterRefresherTests
     }
 
     [Fact]
+    public void FindSelectionReplacement_MatchesCharacterSideAndType()
+    {
+        var character = new CharacterObject();
+        var expected = new SelectionCandidate(
+            character,
+            PartyScreenLogic.PartyRosterSide.Right,
+            PartyScreenLogic.TroopType.Member);
+        var selection = expected.Identity;
+
+        var replacement = PartyScreenRosterRefresher.FindSelectionReplacement(
+            new[]
+            {
+                new SelectionCandidate(
+                    new CharacterObject(),
+                    PartyScreenLogic.PartyRosterSide.Right,
+                    PartyScreenLogic.TroopType.Member),
+                expected
+            },
+            new[]
+            {
+                new SelectionCandidate(
+                    character,
+                    PartyScreenLogic.PartyRosterSide.Right,
+                    PartyScreenLogic.TroopType.Prisoner)
+            },
+            new[]
+            {
+                new SelectionCandidate(
+                    character,
+                    PartyScreenLogic.PartyRosterSide.Left,
+                    PartyScreenLogic.TroopType.Member)
+            },
+            Array.Empty<SelectionCandidate>(),
+            selection,
+            candidate => candidate.Identity);
+
+        Assert.Same(expected, replacement);
+    }
+
+    [Fact]
+    public void FindSelectionReplacement_ReturnsNullWhenSelectionWasRemoved()
+    {
+        var selection = new PartyScreenSelectionIdentity(
+            new CharacterObject(),
+            PartyScreenLogic.PartyRosterSide.Right,
+            PartyScreenLogic.TroopType.Member);
+
+        var replacement = PartyScreenRosterRefresher.FindSelectionReplacement(
+            Array.Empty<SelectionCandidate>(),
+            Array.Empty<SelectionCandidate>(),
+            Array.Empty<SelectionCandidate>(),
+            Array.Empty<SelectionCandidate>(),
+            selection,
+            candidate => candidate.Identity);
+
+        Assert.Null(replacement);
+    }
+
+    [Fact]
     public void ItemServerUpdate_RefreshesSavedPopupStateWithoutSavingPendingChanges()
     {
         var character = new CharacterObject();
@@ -245,5 +305,18 @@ public class PartyScreenRosterRefresherTests
         public TroopRoster GetBaselineRoster(PartyScreenLogic logic, TroopRoster roster) => baseline;
 
         public ItemRoster GetBaselineRoster(PartyScreenLogic logic, ItemRoster roster) => null!;
+    }
+
+    private sealed class SelectionCandidate
+    {
+        public PartyScreenSelectionIdentity Identity { get; }
+
+        public SelectionCandidate(
+            CharacterObject character,
+            PartyScreenLogic.PartyRosterSide side,
+            PartyScreenLogic.TroopType type)
+        {
+            Identity = new PartyScreenSelectionIdentity(character, side, type);
+        }
     }
 }

--- a/source/GameInterface/Services/Party/Commands/PartyCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/PartyCommands.cs
@@ -139,7 +139,7 @@ internal class PartyCommands
     [CommandLineArgumentFunction("restore_position", "coop.debug.mobileparty")]
     public static string RestorePositionCommand(List<string> strings)
     {
-        if (!ModInformation.IsServer) return "Command can only be run on the server.";
+        if (ModInformation.IsClient) return "Command can only be run on the server.";
         if (strings.Count != 4 ||
             !float.TryParse(strings[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var positionX) ||
             !float.TryParse(strings[2], NumberStyles.Float, CultureInfo.InvariantCulture, out var positionY) ||
@@ -288,6 +288,86 @@ internal class PartyCommands
     }
 
     /// <summary>
+    /// Sets one member-roster troop's exact state and reports the state it replaced.
+    /// </summary>
+    [CommandLineArgumentFunction("set_troop_state", "coop.debug.mobileparty")]
+    public static string SetTroopStateCommand(List<string> strings)
+    {
+        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        if (strings.Count != 6)
+            return "Usage: coop.debug.mobileparty.set_troop_state <party id> <character id> <exists> <number> <wounded count> <xp>";
+
+        if (!bool.TryParse(strings[2], out var shouldExist) ||
+            !int.TryParse(strings[3], out var number) ||
+            !int.TryParse(strings[4], out var woundedCount) ||
+            !int.TryParse(strings[5], out var xp))
+            return "Exists must be true or false, and number, wounded count, and xp must be integers.";
+        if (number < 0 || woundedCount < 0 || woundedCount > number || xp < 0 || (number == 0 && xp != 0) ||
+            (!shouldExist && (number != 0 || woundedCount != 0 || xp != 0)))
+            return "State requires number >= 0, wounded between 0 and number, xp >= 0, zero xp when number is zero, and all zero values when exists is false.";
+
+        if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
+        if (!objectManager.TryGetObject(strings[0], out MobileParty party))
+            return $"Party with id {strings[0]} not found.";
+        if (!objectManager.TryGetObject(strings[1], out CharacterObject character))
+            return $"Character with id {strings[1]} not found.";
+        if (character.IsHero) return "Hero roster elements are not supported by this command.";
+
+        var roster = party.MemberRoster;
+        int index = roster.FindIndexOfTroop(character);
+        bool oldExists = index >= 0;
+        var oldState = oldExists ? roster.GetElementCopyAtIndex(index) : default;
+
+        if (index < 0 && shouldExist)
+        {
+            roster.AddToCounts(character, System.Math.Max(number, 1), removeDepleted: false);
+            index = roster.FindIndexOfTroop(character);
+        }
+
+        if (index >= 0)
+        {
+            int currentWounded = roster.GetElementWoundedNumber(index);
+            if (currentWounded > number) roster.SetElementWoundedNumber(index, number);
+            roster.SetElementNumber(index, number);
+            roster.SetElementWoundedNumber(index, woundedCount);
+            roster.SetElementXp(index, xp);
+            if (!shouldExist) roster.RemoveZeroCounts();
+            roster.InitializeCachedData();
+        }
+
+        return $"TROOP_STATE_SET party={strings[0]} character={strings[1]} " +
+               $"oldExists={oldExists} oldNumber={oldState.Number} oldWounded={oldState.WoundedNumber} oldXp={oldState.Xp} " +
+               $"newExists={shouldExist} newNumber={number} newWounded={woundedCount} newXp={xp}";
+    }
+
+    /// <summary>
+    /// Selects a real right-member row so live tests can observe its inline upgrade choices.
+    /// </summary>
+    [CommandLineArgumentFunction("select_party_screen_troop", "coop.debug.mobileparty")]
+    public static string SelectPartyScreenTroopCommand(List<string> strings)
+    {
+        if (ModInformation.IsServer) return "Command can only be run on a client.";
+        if (strings.Count != 1)
+            return "Usage: coop.debug.mobileparty.select_party_screen_troop <character id>";
+        if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
+        if (!objectManager.TryGetObject(strings[0], out CharacterObject character))
+            return $"Character with id {strings[0]} not found.";
+        if (!(Game.Current?.GameStateManager?.ActiveState is PartyState))
+            return "No active party screen.";
+
+        var partyVm = (ScreenManager.TopScreen as GauntletPartyScreen)?._dataSource;
+        if (partyVm == null) return "No active Party screen view model.";
+
+        var row = partyVm.MainPartyTroops.FirstOrDefault(vm => vm.Character == character);
+        if (row == null) return $"{strings[0]} is not in the right member roster.";
+
+        if (!row.IsSelected) partyVm.ExecuteSelectCharacterTuple(row);
+        return $"PARTY_SCREEN_TROOP_SELECTED character={strings[0]} selected={row.IsSelected} " +
+               $"upgradeTargets={row.Upgrades.Count} ready={row.NumOfReadyToUpgradeTroops} " +
+               $"upgradeable={row.NumOfUpgradeableTroops}";
+    }
+
+    /// <summary>
     /// Creates a real pending Party-screen transfer for live synchronization tests.
     /// </summary>
     [CommandLineArgumentFunction("stage_party_screen_transfer", "coop.debug.mobileparty")]
@@ -335,17 +415,19 @@ internal class PartyCommands
         var partyVm = (ScreenManager.TopScreen as GauntletPartyScreen)?._dataSource;
         var row = partyVm?.MainPartyTroops.FirstOrDefault(vm => vm.Character == character);
         var rendered = row == null
-            ? (number: -1, wounded: -1)
-            : (number: row.Troop.Number, wounded: row.Troop.WoundedNumber);
+            ? (number: -1, wounded: -1, xp: -1)
+            : (number: row.Troop.Number, wounded: row.Troop.WoundedNumber, xp: row.Troop.Xp);
 
         return $"PARTY_SCREEN_TROOP_STATE character={strings[0]} " +
-               $"visibleNumber={visible.number} visibleWounded={visible.wounded} " +
-               $"baselineNumber={baseline.number} baselineWounded={baseline.wounded} " +
-               $"vmNumber={rendered.number} vmWounded={rendered.wounded} " +
+               $"visibleNumber={visible.number} visibleWounded={visible.wounded} visibleXp={visible.xp} " +
+               $"baselineNumber={baseline.number} baselineWounded={baseline.wounded} baselineXp={baseline.xp} " +
+               $"vmNumber={rendered.number} vmWounded={rendered.wounded} vmXp={rendered.xp} " +
+               $"selected={row?.IsSelected == true} upgradeTargets={row?.Upgrades.Count ?? 0} " +
+               $"ready={row?.NumOfReadyToUpgradeTroops ?? 0} upgradeable={row?.NumOfUpgradeableTroops ?? 0} " +
                $"pending={logic.IsThereAnyChanges()}";
     }
 
-    private static (int number, int wounded) GetRosterElement(
+    private static (int number, int wounded, int xp) GetRosterElement(
         TroopRoster roster,
         CharacterObject character)
     {
@@ -353,7 +435,7 @@ internal class PartyCommands
         if (index < 0) return default;
 
         var element = roster.GetElementCopyAtIndex(index);
-        return (element.Number, element.WoundedNumber);
+        return (element.Number, element.WoundedNumber, element.Xp);
     }
 
     /// <summary>

--- a/source/GameInterface/Services/Party/Commands/PartyCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/PartyCommands.cs
@@ -294,17 +294,13 @@ internal class PartyCommands
     public static string SetTroopStateCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";
-        if (strings.Count != 6)
-            return "Usage: coop.debug.mobileparty.set_troop_state <party id> <character id> <exists> <number> <wounded count> <xp>";
-
-        if (!bool.TryParse(strings[2], out var shouldExist) ||
-            !int.TryParse(strings[3], out var number) ||
-            !int.TryParse(strings[4], out var woundedCount) ||
-            !int.TryParse(strings[5], out var xp))
-            return "Exists must be true or false, and number, wounded count, and xp must be integers.";
-        if (number < 0 || woundedCount < 0 || woundedCount > number || xp < 0 || (number == 0 && xp != 0) ||
-            (!shouldExist && (number != 0 || woundedCount != 0 || xp != 0)))
-            return "State requires number >= 0, wounded between 0 and number, xp >= 0, zero xp when number is zero, and all zero values when exists is false.";
+        string validationError = ValidateTroopStateArgs(
+            strings,
+            out var shouldExist,
+            out var number,
+            out var woundedCount,
+            out var xp);
+        if (validationError != null) return validationError;
 
         if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
         if (!objectManager.TryGetObject(strings[0], out MobileParty party))
@@ -343,6 +339,32 @@ internal class PartyCommands
                $"newExists={shouldExist} newNumber={number} newWounded={woundedCount} newXp={xp}";
     }
 
+    private static string ValidateTroopStateArgs(
+        List<string> strings,
+        out bool shouldExist,
+        out int number,
+        out int woundedCount,
+        out int xp)
+    {
+        shouldExist = false;
+        number = 0;
+        woundedCount = 0;
+        xp = 0;
+        if (strings.Count != 6)
+            return "Usage: coop.debug.mobileparty.set_troop_state <party id> <character id> <exists> <number> <wounded count> <xp>";
+
+        if (!bool.TryParse(strings[2], out shouldExist) ||
+            !int.TryParse(strings[3], out number) ||
+            !int.TryParse(strings[4], out woundedCount) ||
+            !int.TryParse(strings[5], out xp))
+            return "Exists must be true or false, and number, wounded count, and xp must be integers.";
+        if (number < 0 || woundedCount < 0 || woundedCount > number || xp < 0 || (number == 0 && xp != 0) ||
+            (!shouldExist && (number != 0 || woundedCount != 0 || xp != 0)))
+            return "State requires number >= 0, wounded between 0 and number, xp >= 0, zero xp when number is zero, and all zero values when exists is false.";
+
+        return null;
+    }
+
     /// <summary>
     /// Selects a real right-member row so live tests can observe its inline upgrade choices.
     /// </summary>
@@ -376,7 +398,7 @@ internal class PartyCommands
     [CommandLineArgumentFunction("stage_party_screen_transfer", "coop.debug.mobileparty")]
     public static string StagePartyScreenTransferCommand(List<string> strings)
     {
-        if (!ModInformation.IsClient) return "Command can only be run on a client.";
+        if (ModInformation.IsServer) return "Command can only be run on a client.";
         if (strings.Count != 1)
             return "Usage: coop.debug.mobileparty.stage_party_screen_transfer <character id>";
         if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
@@ -403,7 +425,7 @@ internal class PartyCommands
     [CommandLineArgumentFunction("party_screen_troop_state", "coop.debug.mobileparty")]
     public static string PartyScreenTroopStateCommand(List<string> strings)
     {
-        if (!ModInformation.IsClient) return "Command can only be run on a client.";
+        if (ModInformation.IsServer) return "Command can only be run on a client.";
         if (strings.Count != 1)
             return "Usage: coop.debug.mobileparty.party_screen_troop_state <character id>";
         if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
@@ -435,7 +457,7 @@ internal class PartyCommands
         CharacterObject character)
     {
         var index = roster.FindIndexOfTroop(character);
-        if (index < 0) return default;
+        if (index < 0) return (-1, -1, -1);
 
         var element = roster.GetElementCopyAtIndex(index);
         return (element.Number, element.WoundedNumber, element.Xp);

--- a/source/GameInterface/Services/Party/Commands/PartyCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/PartyCommands.cs
@@ -317,6 +317,9 @@ internal class PartyCommands
         int index = roster.FindIndexOfTroop(character);
         bool oldExists = index >= 0;
         var oldState = oldExists ? roster.GetElementCopyAtIndex(index) : default;
+        int oldNumber = oldExists ? oldState.Number : 0;
+        int oldWounded = oldExists ? oldState.WoundedNumber : 0;
+        int oldXp = oldExists ? oldState.Xp : 0;
 
         if (index < 0 && shouldExist)
         {
@@ -336,7 +339,7 @@ internal class PartyCommands
         }
 
         return $"TROOP_STATE_SET party={strings[0]} character={strings[1]} " +
-               $"oldExists={oldExists} oldNumber={oldState.Number} oldWounded={oldState.WoundedNumber} oldXp={oldState.Xp} " +
+               $"oldExists={oldExists} oldNumber={oldNumber} oldWounded={oldWounded} oldXp={oldXp} " +
                $"newExists={shouldExist} newNumber={number} newWounded={woundedCount} newXp={xp}";
     }
 

--- a/source/GameInterface/Services/Party/PartyScreenRosterRefresher.cs
+++ b/source/GameInterface/Services/Party/PartyScreenRosterRefresher.cs
@@ -1,12 +1,15 @@
 ﻿using Common.Logging;
+using SandBox.GauntletUI;
 using Serilog;
 using System;
+using System.Linq;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.GameState;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Roster;
 using TaleWorlds.Core;
 using TaleWorlds.Localization;
+using TaleWorlds.ScreenSystem;
 
 namespace GameInterface.Services.Party;
 
@@ -237,7 +240,31 @@ internal class PartyScreenRosterRefresher : IPartyScreenRosterRefresher
 
     private static void RefreshScreen(PartyScreenLogic logic)
     {
+        var partyVm = (ScreenManager.TopScreen as GauntletPartyScreen)?._dataSource;
+        var previousSelection = partyVm != null && ReferenceEquals(partyVm.PartyScreenLogic, logic)
+            ? partyVm.CurrentCharacter
+            : null;
+        bool restoreSelection = previousSelection?.IsSelected == true;
+        var selectedCharacter = previousSelection?.Character;
+        var selectedSide = previousSelection?.Side;
+        var selectedType = previousSelection?.Type;
+
         logic.OnReset(false);
+
+        if (!restoreSelection) return;
+
+        var replacement = partyVm.MainPartyTroops
+            .Concat(partyVm.MainPartyPrisoners)
+            .Concat(partyVm.OtherPartyTroops)
+            .Concat(partyVm.OtherPartyPrisoners)
+            .FirstOrDefault(row =>
+                ReferenceEquals(row.Character, selectedCharacter) &&
+                row.Side == selectedSide &&
+                row.Type == selectedType);
+        if (replacement == null) return;
+
+        partyVm.SetSelectedCharacter(replacement);
+        replacement.IsSelected = true;
     }
 
     private static void NotifyPendingChangesReset()

--- a/source/GameInterface/Services/Party/PartyScreenRosterRefresher.cs
+++ b/source/GameInterface/Services/Party/PartyScreenRosterRefresher.cs
@@ -354,8 +354,10 @@ internal class PartyScreenRosterRefresher : IPartyScreenRosterRefresher
         var sortType = logic.GetActiveSortTypeForSide(identity.Side);
         if (sortType != PartyScreenLogic.TroopSortType.Count) return;
 
+        var troopComparer = logic.GetComparer(sortType);
+        troopComparer.SetIsAscending(logic.GetIsAscendingSortForSide(identity.Side));
         var comparer = new TaleWorlds.CampaignSystem.ViewModelCollection.Party.PartyVM.TroopVMComparer(
-            logic.GetComparer(sortType));
+            troopComparer);
         if (identity.Side == PartyScreenLogic.PartyRosterSide.Right)
         {
             if (identity.Type == PartyScreenLogic.TroopType.Member)

--- a/source/GameInterface/Services/Party/PartyScreenRosterRefresher.cs
+++ b/source/GameInterface/Services/Party/PartyScreenRosterRefresher.cs
@@ -2,6 +2,7 @@
 using SandBox.GauntletUI;
 using Serilog;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.GameState;
@@ -23,6 +24,28 @@ internal interface IPartyScreenRosterRefresher
     bool TryRemoveZeroCounts(TroopRoster authoritativeRoster);
 
     bool TryApply(ItemRoster authoritativeRoster, Action<ItemRoster> applyAuthoritative);
+}
+
+internal readonly struct PartyScreenSelectionIdentity
+{
+    public CharacterObject Character { get; }
+    public PartyScreenLogic.PartyRosterSide Side { get; }
+    public PartyScreenLogic.TroopType Type { get; }
+
+    public PartyScreenSelectionIdentity(
+        CharacterObject character,
+        PartyScreenLogic.PartyRosterSide side,
+        PartyScreenLogic.TroopType type)
+    {
+        Character = character;
+        Side = side;
+        Type = type;
+    }
+
+    public bool Matches(PartyScreenSelectionIdentity other)
+        => ReferenceEquals(Character, other.Character) &&
+           Side == other.Side &&
+           Type == other.Type;
 }
 
 /// <summary>
@@ -109,7 +132,12 @@ internal class PartyScreenRosterRefresher : IPartyScreenRosterRefresher
         rebasedVisible.Write(visible, character);
         if (saved != null) rebasedSaved.Write(saved, character);
         RefreshRecruitablePrisoners(logic);
-        RefreshScreen(logic);
+        RefreshTroop(
+            logic,
+            baseline,
+            character,
+            previousVisible.Number != rebasedVisible.Number,
+            previousVisible.Wounded != rebasedVisible.Wounded);
         return true;
     }
 
@@ -178,7 +206,7 @@ internal class PartyScreenRosterRefresher : IPartyScreenRosterRefresher
             applyAuthoritative(saved);
         }
 
-        RefreshScreen(logic);
+        RefreshUpgrades(logic);
         return true;
     }
 
@@ -240,31 +268,176 @@ internal class PartyScreenRosterRefresher : IPartyScreenRosterRefresher
 
     private static void RefreshScreen(PartyScreenLogic logic)
     {
-        var partyVm = (ScreenManager.TopScreen as GauntletPartyScreen)?._dataSource;
-        var previousSelection = partyVm != null && ReferenceEquals(partyVm.PartyScreenLogic, logic)
-            ? partyVm.CurrentCharacter
-            : null;
+        var partyVm = GetPartyVm(logic);
+        var previousSelection = partyVm?.CurrentCharacter;
         bool restoreSelection = previousSelection?.IsSelected == true;
-        var selectedCharacter = previousSelection?.Character;
-        var selectedSide = previousSelection?.Side;
-        var selectedType = previousSelection?.Type;
+        var selection = restoreSelection
+            ? GetIdentity(previousSelection)
+            : default;
 
         logic.OnReset(false);
 
         if (!restoreSelection) return;
 
-        var replacement = partyVm.MainPartyTroops
-            .Concat(partyVm.MainPartyPrisoners)
-            .Concat(partyVm.OtherPartyTroops)
-            .Concat(partyVm.OtherPartyPrisoners)
-            .FirstOrDefault(row =>
-                ReferenceEquals(row.Character, selectedCharacter) &&
-                row.Side == selectedSide &&
-                row.Type == selectedType);
+        var replacement = FindSelectionReplacement(
+            partyVm.MainPartyTroops,
+            partyVm.MainPartyPrisoners,
+            partyVm.OtherPartyTroops,
+            partyVm.OtherPartyPrisoners,
+            selection,
+            GetIdentity);
         if (replacement == null) return;
 
-        partyVm.SetSelectedCharacter(replacement);
+        partyVm._currentCharacter = replacement;
+        partyVm.RefreshCurrentCharacterInformation();
+        partyVm.OnPropertyChangedWithValue(replacement, nameof(partyVm.CurrentCharacter));
         replacement.IsSelected = true;
+        replacement.UpdateRecruitable();
+    }
+
+    private static void RefreshTroop(
+        PartyScreenLogic logic,
+        TroopRoster baseline,
+        CharacterObject character,
+        bool numberChanged,
+        bool woundedChanged)
+    {
+        var partyVm = GetPartyVm(logic);
+        if (partyVm == null) return;
+
+        var identity = GetIdentity(logic, baseline, character);
+        var row = FindSelectionReplacement(
+            partyVm.MainPartyTroops,
+            partyVm.MainPartyPrisoners,
+            partyVm.OtherPartyTroops,
+            partyVm.OtherPartyPrisoners,
+            identity,
+            GetIdentity);
+        var visible = GetVisibleRoster(logic, baseline);
+        int index = visible.FindIndexOfTroop(character);
+        if (row == null || index < 0)
+        {
+            RefreshScreen(logic);
+            return;
+        }
+
+        row.Troop = visible.GetElementCopyAtIndex(index);
+        row.InitializeUpgrades();
+        row.UpdateRecruitable();
+        row.UpdateTradeData();
+        row.ThrowOnPropertyChanged();
+        partyVm.UpdateTroopManagerPopUpCounts();
+        if (numberChanged)
+        {
+            partyVm.RefreshPartyInformation();
+            partyVm.IsDoneDisabled = !logic.IsDoneActive();
+            partyVm.DoneHint.HintText = new TextObject("{=!}" + logic.DoneReasonString);
+            partyVm.IsCancelDisabled = !logic.IsCancelActive();
+            RefreshSort(logic, partyVm, identity);
+
+            if (identity.Side == PartyScreenLogic.PartyRosterSide.Right)
+                partyVm.MainPartyComposition.RefreshCounts(partyVm.MainPartyTroops);
+            else
+                partyVm.OtherPartyComposition.RefreshCounts(partyVm.OtherPartyTroops);
+        }
+
+        if ((numberChanged || woundedChanged) &&
+            identity.Side == PartyScreenLogic.PartyRosterSide.Right)
+            partyVm.RefreshTopInformation();
+    }
+
+    private static void RefreshSort(
+        PartyScreenLogic logic,
+        TaleWorlds.CampaignSystem.ViewModelCollection.Party.PartyVM partyVm,
+        PartyScreenSelectionIdentity identity)
+    {
+        var sortType = logic.GetActiveSortTypeForSide(identity.Side);
+        if (sortType != PartyScreenLogic.TroopSortType.Count) return;
+
+        var comparer = new TaleWorlds.CampaignSystem.ViewModelCollection.Party.PartyVM.TroopVMComparer(
+            logic.GetComparer(sortType));
+        if (identity.Side == PartyScreenLogic.PartyRosterSide.Right)
+        {
+            if (identity.Type == PartyScreenLogic.TroopType.Member)
+                partyVm.MainPartyTroops.Sort(comparer);
+            else
+                partyVm.MainPartyPrisoners.Sort(comparer);
+        }
+        else if (identity.Type == PartyScreenLogic.TroopType.Member)
+        {
+            partyVm.OtherPartyTroops.Sort(comparer);
+        }
+        else
+        {
+            partyVm.OtherPartyPrisoners.Sort(comparer);
+        }
+    }
+
+    private static void RefreshUpgrades(PartyScreenLogic logic)
+    {
+        var partyVm = GetPartyVm(logic);
+        if (partyVm == null) return;
+
+        foreach (var row in partyVm.MainPartyTroops)
+        {
+            row.InitializeUpgrades();
+        }
+        partyVm.UpdateTroopManagerPopUpCounts();
+    }
+
+    private static TaleWorlds.CampaignSystem.ViewModelCollection.Party.PartyVM GetPartyVm(
+        PartyScreenLogic logic)
+    {
+        var partyVm = (ScreenManager.TopScreen as GauntletPartyScreen)?._dataSource;
+        return partyVm != null && ReferenceEquals(partyVm.PartyScreenLogic, logic)
+            ? partyVm
+            : null;
+    }
+
+    private static PartyScreenSelectionIdentity GetIdentity(
+        PartyScreenLogic logic,
+        TroopRoster baseline,
+        CharacterObject character)
+    {
+        if (ReferenceEquals(baseline, logic._initialData.RightMemberRoster))
+            return new PartyScreenSelectionIdentity(
+                character,
+                PartyScreenLogic.PartyRosterSide.Right,
+                PartyScreenLogic.TroopType.Member);
+        if (ReferenceEquals(baseline, logic._initialData.LeftMemberRoster))
+            return new PartyScreenSelectionIdentity(
+                character,
+                PartyScreenLogic.PartyRosterSide.Left,
+                PartyScreenLogic.TroopType.Member);
+        if (ReferenceEquals(baseline, logic._initialData.RightPrisonerRoster))
+            return new PartyScreenSelectionIdentity(
+                character,
+                PartyScreenLogic.PartyRosterSide.Right,
+                PartyScreenLogic.TroopType.Prisoner);
+        return new PartyScreenSelectionIdentity(
+            character,
+            PartyScreenLogic.PartyRosterSide.Left,
+            PartyScreenLogic.TroopType.Prisoner);
+    }
+
+    private static PartyScreenSelectionIdentity GetIdentity(
+        TaleWorlds.CampaignSystem.ViewModelCollection.Party.PartyCharacterVM row)
+        => new PartyScreenSelectionIdentity(row.Character, row.Side, row.Type);
+
+    internal static T FindSelectionReplacement<T>(
+        IEnumerable<T> mainPartyTroops,
+        IEnumerable<T> mainPartyPrisoners,
+        IEnumerable<T> otherPartyTroops,
+        IEnumerable<T> otherPartyPrisoners,
+        PartyScreenSelectionIdentity selection,
+        Func<T, PartyScreenSelectionIdentity> getIdentity)
+        where T : class
+    {
+        return mainPartyTroops
+            .Concat(mainPartyPrisoners)
+            .Concat(otherPartyTroops)
+            .Concat(otherPartyPrisoners)
+            .FirstOrDefault(row => getIdentity(row).Matches(selection));
     }
 
     private static void NotifyPendingChangesReset()


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Opening a troop's upgrade choices while campaign time is progressing causes the choices to close when an authoritative roster update refreshes the Party screen, preventing the player from completing an upgrade.

## What is the new behavior?

Resolves #2541

The selected troop row and its upgrade choices now remain open through authoritative Party-screen roster refreshes, while the normal fallback remains when that troop is no longer present.

## Bot Changelog Entry

- Fixed troop upgrade choices closing while campaign time progresses.
