### PR TITLE
Update README with released-mod info from Steam page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,117 @@
+![Bannerlord Coop](img/Banner.png)
+
 # Bannerlord Coop
 
-## Summary
+**Experience the Mount & Blade II: Bannerlord campaign with your friends.**
 
-***The Bannerlord Coop mod is not playable in its current state. We will make an announcement in Discord/Reddit when we're ready for the community to begin bug hunting.***
+Build armies, manage kingdoms, fight battles, trade, raid settlements, and conquer Calradia together in a shared multiplayer campaign.
 
-Mod to enjoy the original Mount & Blade II: Bannerlord campaign with other players. Our intent is to keep true to the original code as much as possible.
+[Steam Workshop](https://steamcommunity.com/sharedfiles/filedetails/?id=3770450698) &nbsp;•&nbsp;
+[Discord](https://discord.gg/VXqGyT8) &nbsp;•&nbsp;
+[Reddit](https://www.reddit.com/r/BannerlordCoop/) &nbsp;•&nbsp;
+[Support the project](#support-bannerlord-coop)
 
-## Social Links
-[Discord](https://discord.gg/VXqGyT8)
+## About the Mod
 
-[Reddit](https://www.reddit.com/r/BannerlordCoop/)
+Bannerlord Coop transforms Bannerlord's single-player campaign into a cooperative multiplayer experience.
 
-## Current State
-***There is absolutely no gameplay so far***.
+Players share the same persistent campaign world while controlling their own characters, parties, clans, troops, and resources. Travel across the campaign map together, interact with settlements and NPC parties, or fight alongside — and against — other players.
 
-Very early in development.  [Video created on commit d86c24c](https://youtu.be/Y_htoMXQGqU).
+The mod is currently optimized for campaigns with up to **8 players**. Larger groups may work, but could experience reduced performance and stability.
 
-# Contributing
+## Installation
+
+Subscribe on the [Steam Workshop](https://steamcommunity.com/sharedfiles/filedetails/?id=3770450698), then enable the **Coop** module in the Bannerlord launcher.
+
+Join our [Discord](https://discord.gg/VXqGyT8) for installation help, announcements, bug reports, playtests, and community discussion.
+
+## Hosting
+
+For the best performance and stability, we strongly recommend hosting campaigns through the included **dedicated server**. [The hosting instructions can be found in our Discord through this link.](https://discord.gg/2MRuH9fVVV)
+
+Steam hosting does not require traditional port forwarding in most cases. Manual network hosting options are also available.
+
+Server setup walkthrough: https://www.youtube.com/watch?v=laZM967Eals
+
+## Current Features
+
+- Shared campaign map
+- Player and AI movement synchronization
+- Map encounters
+- Party and troop management
+- Character skills and progression
+- Clan and kingdom management
+- Settlement management
+- Recruitment and trading
+- Caravans and villager parties
+- Smithing
+- Player captivity
+- Field battles
+- Village raids
+- PvE and PvP combat
+- Simulated battles
+- Players visible inside locations such as taverns and village scenes
+- Dedicated server support
+- Steam integration
+
+### Experimental Features
+
+- Sieges and sally-outs
+- Armies
+
+### Planned Features
+
+- Additional campaign systems and stability improvements
+- Hideouts
+- War Sails DLC support
+- Quests
+
+Planned items and release priorities may change as development continues.
+
+## Multiplayer Battles
+
+Players can participate in field battles and sieges as allies or opponents. AI parties may also join active battles under supported campaign conditions.
+
+Players who retreat or disconnect are handled by the campaign and battle synchronization systems, allowing the shared game to continue without ending the entire session.
+
+## Compatibility
+
+For the most reliable experience:
+
+- Use the supported Bannerlord game version (currently **v1.4.7**)
+- Disable all other mods
+- Do not enable the War Sails DLC
+- Ensure every player is using the same mod version
+
+Compatibility with other mods is not guaranteed.
+
+## Feedback and Bug Reports
+
+Please share your honest experience with the mod — good or bad. Detailed feedback and reproducible bug reports are extremely valuable and help us improve stability, performance, and gameplay.
+
+Report bugs in our [Discord](https://discord.gg/VXqGyT8) or via [GitHub issues](https://github.com/Bannerlord-Coop-Team/BannerlordCoop/issues), and please include:
+
+- What happened
+- What you expected to happen
+- Steps that reproduce the problem
+- Relevant screenshots, videos, or log files
+- The number of connected players
+
+## Support Bannerlord Coop
+
+Bannerlord Coop is developed by a volunteer team and will always be available for free.
+
+Support helps cover development tools, hosting infrastructure, dedicated servers, distribution costs, and other project expenses. Choose whichever platform works best for you:
+
+- [**Patreon**](https://www.patreon.com/c/bannerlordcoop) — Become a monthly supporter
+- [**Buy Me a Coffee**](https://buymeacoffee.com/bannerlordcoop) — Send a one-time contribution
+- [**PayPal**](https://www.paypal.com/donate/?hosted_button_id=KHBSK4FXQ9GKS) — Donate directly
+- [**Afdian**](https://ifdian.net/a/BannerlordCoop) — Support us from China
+- [**Boosty**](https://boosty.to/bannerlordcoop/donate) — Additional international support option
+
+**Financial support is completely optional.** Playing the mod, reporting bugs, creating content, and sharing Bannerlord Coop also help the project tremendously.
+
+## Contributing
 
 Get started [here!](https://github.com/Bannerlord-Coop-Team/BannerlordCoop/wiki/Getting-Started-as-a-Contributor) Also join our [Discord](https://discord.gg/VXqGyT8) for direct questions and collaboration.
 
@@ -28,9 +123,24 @@ You also confirm that you have the right to submit the contribution and that it
 does not knowingly include code copied from another project without permission.
 
 ## FAQ
+
 Please read through [the #faq channel in our discord server](https://discord.gg/VXqGyT8).
 
-## Acknowledgments
+## License
+
+Bannerlord Coop is source-available, not open source. The code may be viewed and contributed to, but it may not be copied, redistributed, relicensed, or used in another project without written permission from the maintainers. See [LICENSE](LICENSE) and [NOTICE.md](NOTICE.md) for the full terms.
+
+## Credits
+
+- Trailer by [medievalsniper](https://www.youtube.com/@medievalsniper9)
+- Artwork by [timbermold](https://www.instagram.com/timbermold/)
+
+### Acknowledgments
+
 - Zetrith for [Multiplayer](https://github.com/Zetrith/Multiplayer).
 - Salminar for [NoHarmony](https://github.com/Salminar/NoHarmony).
 - ashoulson for [RailgunNet](https://github.com/ashoulson/RailgunNet).
+
+---
+
+**Now go — conquer your friends' castles!**

--- a/README.md
+++ b/README.md
@@ -130,17 +130,5 @@ Please read through [the #faq channel in our discord server](https://discord.gg/
 
 Bannerlord Coop is source-available, not open source. The code may be viewed and contributed to, but it may not be copied, redistributed, relicensed, or used in another project without written permission from the maintainers. See [LICENSE](LICENSE) and [NOTICE.md](NOTICE.md) for the full terms.
 
-## Credits
-
-- Trailer by [medievalsniper](https://www.youtube.com/@medievalsniper9)
-- Artwork by [timbermold](https://www.instagram.com/timbermold/)
-
 ### Acknowledgments
-
-- Zetrith for [Multiplayer](https://github.com/Zetrith/Multiplayer).
 - Salminar for [NoHarmony](https://github.com/Salminar/NoHarmony).
-- ashoulson for [RailgunNet](https://github.com/ashoulson/RailgunNet).
-
----
-
-**Now go — conquer your friends' castles!**


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

<!-- Docs-only change: no new classes, no code to test. -->

## PR Type
What kind of change does this PR introduce?

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?

The README is years out of date. It still leads with "The Bannerlord Coop mod is not playable in its current state" and "There is absolutely no gameplay so far", linking a demo video from commit d86c24c — this is the first thing anyone visiting the repo sees, well after release.


## What is the new behavior?

README rewritten around the Steam Workshop page content:

- About / player count guidance (up to 8 players)
- Installation (Steam Workshop) and Hosting (dedicated server, setup video, Discord hosting link)
- Current / Experimental / Planned features
- Multiplayer Battles, Compatibility, Feedback and Bug Reports
- Support section with all five donation platforms
- Banner image header and quick-links row
- License section (source-available, per `NOTICE.md`) — the README had none
- Contributing / CLA text and third-party acknowledgments kept as-is

Two values came from the repo rather than the Steam text: the supported game version `v1.4.7` (`source/Coop/Coop.csproj`), and the Steam Workshop link `3770450698` — note `Workshop/WorkshopUpdate.xml` still points at the older item `3039085192` and should be updated separately.

Also worth resolving separately: the in-game buttons open Discord invite `ngC4RVb` (`CommunityLinks.cs`), while Steam and the README use `VXqGyT8`.


## Bot Changelog Entry


## Other information
