### PR TITLE
Disable Save And Exit on clients - 2515

### DIFF
--- a/source/GameInterface/Services/UI/Patches/EscapeMenuDisableSavePatch.cs
+++ b/source/GameInterface/Services/UI/Patches/EscapeMenuDisableSavePatch.cs
@@ -9,7 +9,7 @@ using TaleWorlds.MountAndBlade.ViewModelCollection.EscapeMenu;
 namespace GameInterface.Services.UI.Patches
 {
     /// <summary>
-    /// Greys out the "Save" and "Save As" buttons in the client's campaign-map escape menu.
+    /// Greys out the "Save" and "Save As" and "Save and Exit" buttons in the client's campaign-map escape menu.
     /// </summary>
     [HarmonyPatch(typeof(MapScreen), "GetEscapeMenuItems")]
     internal class EscapeMenuDisableSavePatch
@@ -19,6 +19,7 @@ namespace GameInterface.Services.UI.Patches
         // the item is replaced with a clone whose func always reports disabled.
         private static readonly TextObject SaveButtonText = new TextObject("{=bV75iwKa}Save");
         private static readonly TextObject SaveAsButtonText = new TextObject("{=e0KdfaNe}Save As");
+        private static readonly TextObject SaveAndExitButtonText = new TextObject("{=AbEh2y8o}Save And Exit");
         private static readonly TextObject DisabledReason =
             new TextObject("Saving is disabled on clients; the host saves the campaign.");
 
@@ -29,6 +30,7 @@ namespace GameInterface.Services.UI.Patches
 
             DisableItem(__result, SaveButtonText);
             DisableItem(__result, SaveAsButtonText);
+            DisableItem(__result, SaveAndExitButtonText);
         }
 
         private static void DisableItem(List<EscapeMenuItemVM> items, TextObject buttonText)


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [X] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
Clients cannot use `Save` or `Save As` from the campaign-map escape menu, but `Save And Exit` remains available.


## What is the new behavior?
Resolves #2515

Clients can no longer use `Save And Exit` from the campaign-map escape menu. The host remains responsible for saving the campaign.


## Bot Changelog Entry
- Disabled `Save And Exit` for clients in co-op sessions.


## Other information
Manually tested in a host/client session and confirmed that `Save`, `Save As`, and `Save And Exit` are disabled on the client.