### PR TITLE
Stop the campaign-time heartbeat in the E2E harness

### DIFF
--- a/source/E2E.Tests/Environment/E2ETestEnvironment.cs
+++ b/source/E2E.Tests/Environment/E2ETestEnvironment.cs
@@ -79,22 +79,6 @@ public class E2ETestEnvironment : IDisposable
     /// <summary>
     /// Stops the server's authoritative campaign-time heartbeat for the lifetime of this environment.
     /// </summary>
-    /// <remarks>
-    /// <see cref="CampaignTimeSyncHandler"/> starts a 250 ms <see cref="System.Timers.Timer"/> in its
-    /// constructor and is AutoActivate'd into the server container, so in the harness it fires on a
-    /// thread-pool thread straight into <c>TestNetworkRouter</c> → <c>EnvironmentInstance.SimulatePacket</c>.
-    /// That runs client packet handling — and the Harmony-patched game code behind it — CONCURRENTLY with the
-    /// test thread, which patches and unpatches those same methods in <c>EnvironmentInstance.PatchScope</c>
-    /// (outside <c>GameInstance.@lock</c>, and <c>SimulatePacket</c> never takes <c>EnvironmentInstance._lock</c>
-    /// at all). Rewriting a detour while another thread executes it makes interception intermittently not fire,
-    /// which surfaces as a server change silently never replicating — the shared signature of a long-running
-    /// family of CI-only E2E failures. It also leaves the game statics pointing at a client at arbitrary
-    /// moments, since StaticScope.Dispose does not restore them.
-    ///
-    /// E2E drives campaign time explicitly, so no test needs the heartbeat; the handler's own coverage lives in
-    /// Coop.Tests, a separate assembly and process. Disposing is idempotent (the handler guards on a disposed
-    /// flag), so the container's later disposal stays valid.
-    /// </remarks>
     private void StopCampaignTimeHeartbeat()
         => Server.Resolve<CampaignTimeSyncHandler>().Dispose();
 

--- a/source/E2E.Tests/Environment/E2ETestEnvironment.cs
+++ b/source/E2E.Tests/Environment/E2ETestEnvironment.cs
@@ -4,6 +4,7 @@ using Common.Network;
 using Common.Network.Coalescing;
 using Common.Tests.Utils;
 using Common.Util;
+using Coop.Core.Server.Services.Time.Handlers;
 using E2E.Tests.Environment.Instance;
 using E2E.Tests.Util;
 using GameInterface;
@@ -59,6 +60,8 @@ public class E2ETestEnvironment : IDisposable
 
         IntegrationEnvironment = new TestEnvironment(output, numClients, registerGameInterface: true);
 
+        StopCampaignTimeHeartbeat();
+
         SetupMainHero();
 
         Server.Resolve<TestMessageBroker>().SetStaticInstance();
@@ -72,6 +75,28 @@ public class E2ETestEnvironment : IDisposable
             Server.ObjectManager.AddExisting(settlement.StringId, settlement);
         }
     }
+
+    /// <summary>
+    /// Stops the server's authoritative campaign-time heartbeat for the lifetime of this environment.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="CampaignTimeSyncHandler"/> starts a 250 ms <see cref="System.Timers.Timer"/> in its
+    /// constructor and is AutoActivate'd into the server container, so in the harness it fires on a
+    /// thread-pool thread straight into <c>TestNetworkRouter</c> → <c>EnvironmentInstance.SimulatePacket</c>.
+    /// That runs client packet handling — and the Harmony-patched game code behind it — CONCURRENTLY with the
+    /// test thread, which patches and unpatches those same methods in <c>EnvironmentInstance.PatchScope</c>
+    /// (outside <c>GameInstance.@lock</c>, and <c>SimulatePacket</c> never takes <c>EnvironmentInstance._lock</c>
+    /// at all). Rewriting a detour while another thread executes it makes interception intermittently not fire,
+    /// which surfaces as a server change silently never replicating — the shared signature of a long-running
+    /// family of CI-only E2E failures. It also leaves the game statics pointing at a client at arbitrary
+    /// moments, since StaticScope.Dispose does not restore them.
+    ///
+    /// E2E drives campaign time explicitly, so no test needs the heartbeat; the handler's own coverage lives in
+    /// Coop.Tests, a separate assembly and process. Disposing is idempotent (the handler guards on a disposed
+    /// flag), so the container's later disposal stays valid.
+    /// </remarks>
+    private void StopCampaignTimeHeartbeat()
+        => Server.Resolve<CampaignTimeSyncHandler>().Dispose();
 
     /// <summary>
     /// Associates an already registered player with a connected E2E client peer.


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Roughly half of recent `Build and Test` runs — on every branch — have 1-10 failing E2E tests in one or more shards. The failing test names differ every run (~40 distinct ones collected across 5 runs), but they all share one signature: **server state silently never reaches the client**. Examples:

- `Assert.NotNull(MobileParty.MainParty.Party.MapEventSide)` in the various `SetMainPartyInBattle` helpers
- `MapEventLifetimeTests.ServerCreate_MapEvent_SyncAllClients`
- `Server_<Type>_Fields` / `_Properties` AutoSync tests (the replica was never created, so no field can land)

Root cause:

`CampaignTimeSyncHandler` starts a 250 ms `System.Timers.Timer` **in its constructor**, and as an `IHandler` in `Coop.Core.Server` it is `.AutoActivate()`d into every E2E server container. So every test runs with a live background timer whose callback reaches straight into the harness:

```
CampaignTimeSyncHandler.PublishCampaignTime   <- thread-pool timer thread
 -> MockNetworkBase.Send
 -> TestNetworkRouter.Send
 -> EnvironmentInstance.SimulatePacket
 -> new StaticScope(client)
```

That executes client packet handling — and the Harmony-patched game code behind it — concurrently with the test thread. Meanwhile `EnvironmentInstance.Call` patches and unpatches those same methods in `PatchScope` **outside** `GameInstance.@lock`, and `SimulatePacket` never takes `EnvironmentInstance._lock` at all:

```csharp
lock (_lock)
{
    using (new PatchScope(disabledMethods))   // Harmony patch/unpatch - NOT under GameInstance.@lock
    {
        using (new StaticScope(this))          // takes GameInstance.@lock
```

Rewriting a detour while another thread is executing it makes interception intermittently not fire, so a server-side change never publishes and nothing replicates. Being a load-dependent race, it shows up on a 4-core CI runner and not on a dev box. It also leaves `Campaign.Current` / `Game.Current` / `MBObjectManager.Instance` pointing at a client at arbitrary moments, since `StaticScope.Dispose` does not restore those.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->

The E2E harness stops that heartbeat right after building the environment. E2E drives campaign time explicitly, so no test needs it, and the handler's own coverage lives in `Coop.Tests` (separate assembly and process). Disposing is idempotent, so the container's later disposal stays valid.

Verified in the CI container image (`garrettluskey/bannerlordcoop:latest`, .NET 6.0.36, `--cpus=1`), by instrumenting `StaticScope` to dump a stack trace whenever a non-game thread enters it — same shard, same container, same CPU limit:

| | background reentries | shard result |
|---|---|---|
| before | 2 | 138 passed / 1 skipped |
| after | **0** | 138 passed / 1 skipped |

Full E2E suite on Windows is green with the change: 1113 passed / 4 skipped / 0 failed.

Note the failure itself does not reproduce locally (shard 6 was green 6x at 4 CPUs and 3x at 1 CPU), which is why this was diagnosed by probing for the hazard rather than by forcing a red run.

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->


## Other information

This branch is based on `development`, which does not yet have #2567, so `SiegeAssaultLeaveTests.WoundedNonInitiator_WhenSiegeMissionStarts_LeavesSiege` can still fail here on its own (unrelated) ~1-in-23 dice roll until that merges.

This removes one instance of the race rather than the race class. Two follow-ups would close it properly:

- have `SimulatePacket` / `SimulateMessage` take the same `_lock` as `Call`, so no background path can ever interleave with `PatchScope`
- move `PatchScope` inside `StaticScope`, so Harmony patching happens under `GameInstance.@lock`

Separately, in production the heartbeat broadcasts 4x/second even with zero connections; starting the timer on the first connection instead of in the constructor would be a reasonable tidy-up, but is deliberately out of scope here.
