### PR TITLE
Point Patreon link at the membership page

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Bannerlord Coop is developed by a volunteer team and will always be available fo
 
 Support helps cover development tools, hosting infrastructure, dedicated servers, distribution costs, and other project expenses. Choose whichever platform works best for you:
 
-- [**Patreon**](https://www.patreon.com/c/bannerlordcoop) — Become a monthly supporter
+- [**Patreon**](https://www.patreon.com/c/bannerlordcoop/membership) — Become a monthly supporter
 - [**Buy Me a Coffee**](https://buymeacoffee.com/bannerlordcoop) — Send a one-time contribution
 - [**PayPal**](https://www.paypal.com/donate/?hosted_button_id=KHBSK4FXQ9GKS) — Donate directly
 - [**Afdian**](https://ifdian.net/a/BannerlordCoop) — Support us from China

--- a/source/GameInterface/Services/UI/Donate/CommunityLinks.cs
+++ b/source/GameInterface/Services/UI/Donate/CommunityLinks.cs
@@ -10,7 +10,7 @@ namespace GameInterface.Services.UI.Donate;
 internal static class CommunityLinks
 {
     private const string DiscordUrl = "https://discord.gg/ngC4RVb";
-    private const string PatreonUrl = "https://www.patreon.com/c/bannerlordcoop";
+    private const string PatreonUrl = "https://www.patreon.com/c/bannerlordcoop/membership";
 
     public static void OpenDiscord() => Open(DiscordUrl);
 


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [x] Other... Please describe: Link URL update


## What is the current behavior?
The Patreon button and the README support link both point at `https://www.patreon.com/c/bannerlordcoop`, which lands on the page overview rather than the membership tiers.


## What is the new behavior?
Both point at `https://www.patreon.com/c/bannerlordcoop/membership`, so supporters land directly on the membership tiers.

Changed in two places:
- `source/GameInterface/Services/UI/Donate/CommunityLinks.cs` — the in-game Patreon button (shared by the connect menu and coop options screens)
- `README.md` — the support section link


## Bot Changelog Entry

- The Patreon button now opens the membership page directly.


## Other information
