### PR TITLE
Enforce exact co-op build compatibility

### DIFF
--- a/.github/scripts/run-e2e-local-docker.sh
+++ b/.github/scripts/run-e2e-local-docker.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+source_revision=$(git -C "$repo_root" rev-parse HEAD)
 docker_image=${E2E_IMAGE:-garrettluskey/bannerlordcoop:latest}
 shard_count=${E2E_SHARDS:-8}
 run_id="bannerlordcoop-e2e-$(date +%s)-$$"
@@ -45,10 +46,10 @@ docker exec "$seed_container" /bin/sh -c 'mkdir -p /workspace'
 docker cp "$repo_root/source" "$seed_container:/workspace/source"
 docker cp "$repo_root/deploy" "$seed_container:/workspace/deploy"
 docker cp "$repo_root/.github/scripts/run-e2e-shard.sh" "$seed_container:/workspace/run-e2e-shard.sh"
-docker exec "$seed_container" /bin/sh -eu -c '
+docker exec -e COOP_SOURCE_REVISION="$source_revision" "$seed_container" /bin/sh -eu -c '
     find /workspace/source -type d \( -name bin -o -name obj \) -prune -exec rm -rf {} +
     ln -s /home/mb2 /workspace/mb2
-    dotnet build /workspace/source/CoopTests.slnf -c Release
+    dotnet build /workspace/source/CoopTests.slnf -c Release -p:SourceRevisionId="$COOP_SOURCE_REVISION"
 '
 docker commit "$seed_container" "$local_image" >/dev/null
 docker rm --force "$seed_container" >/dev/null

--- a/source/Common/Common.csproj
+++ b/source/Common/Common.csproj
@@ -6,6 +6,7 @@
     <Platforms>x64</Platforms>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <InformationalVersion>$(CoopVersion)</InformationalVersion>
+    <IncludeSourceRevisionInInformationalVersion>true</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
@@ -42,5 +43,21 @@
     <PackageReference Include="System.Text.Json" Version="9.0.2" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
   </ItemGroup>
+
+  <Target Name="ResolveCoopSourceRevision" BeforeTargets="AddSourceRevisionToInformationalVersion">
+    <Exec Command="git -C &quot;$(MSBuildThisFileDirectory)../..&quot; rev-parse HEAD"
+          ConsoleToMSBuild="true"
+          IgnoreExitCode="true"
+          StandardOutputImportance="Low"
+          Condition="'$(SourceRevisionId)' == ''">
+      <Output TaskParameter="ConsoleOutput" ItemName="_CoopSourceRevisionOutput" />
+      <Output TaskParameter="ExitCode" PropertyName="_CoopSourceRevisionExitCode" />
+    </Exec>
+    <PropertyGroup Condition="'$(SourceRevisionId)' == '' and '$(_CoopSourceRevisionExitCode)' == '0'">
+      <SourceRevisionId>@(_CoopSourceRevisionOutput)</SourceRevisionId>
+    </PropertyGroup>
+    <Error Condition="$([System.String]::Copy('$(SourceRevisionId)').Length) != 40"
+           Text="Common requires a 40-character Git SourceRevisionId so co-op build compatibility cannot collapse to the semantic module version." />
+  </Target>
 
 </Project>

--- a/source/Coop.Core/Server/Connections/Messages/NetworkModuleVersionsValidate.cs
+++ b/source/Coop.Core/Server/Connections/Messages/NetworkModuleVersionsValidate.cs
@@ -1,4 +1,5 @@
-﻿using Common.Messaging;
+﻿using Common;
+using Common.Messaging;
 using GameInterface.Services.Modules;
 using ProtoBuf;
 using System;
@@ -11,15 +12,24 @@ namespace Coop.Core.Server.Connections.Messages;
 /// Message from Client to Server for validating the module versions.
 /// Responsibilities
 /// 1. Make sure that all active modules have the same version as on the server
+/// 2. Make sure the client and server use the same exact co-op build
 /// </summary>
 [ProtoContract(SkipConstructor = true)]
 public record NetworkModuleVersionsValidate : ICommand
 {
     [ProtoMember(1)]
     public NetworkModuleInfo[] Modules { get; }
+    [ProtoMember(2)]
+    public string BuildVersion { get; }
 
     public NetworkModuleVersionsValidate(IEnumerable<ModuleInfo> modules)
+        : this(modules, ModInformation.BuildVersion)
     {
+    }
+
+    public NetworkModuleVersionsValidate(IEnumerable<ModuleInfo> modules, string buildVersion)
+    {
+        BuildVersion = buildVersion;
         if (modules is null)
         {
             Modules = Array.Empty<NetworkModuleInfo>();

--- a/source/Coop.Core/Server/Connections/States/ResolveCharacterState.cs
+++ b/source/Coop.Core/Server/Connections/States/ResolveCharacterState.cs
@@ -1,3 +1,4 @@
+﻿using Common;
 using Common.Logging;
 using Common.Messaging;
 using Common.Network;
@@ -71,10 +72,19 @@ public class ResolveCharacterState : ConnectionStateBase
         string error;
         try
         {
-            var clientModules = obj.What.Modules;
-            var serverModules = moduleInfoProvider.GetModuleInfos();
+            if (!ModInformation.MatchesBuildVersion(obj.What.BuildVersion))
+            {
+                result = false;
+                error = $"Wrong co-op build detected. Server uses '{ModInformation.BuildVersion}', " +
+                    $"client uses '{obj.What.BuildVersion ?? "unknown"}'.";
+            }
+            else
+            {
+                var clientModules = obj.What.Modules;
+                var serverModules = moduleInfoProvider.GetModuleInfos();
 
-            result = moduleValidator.Validate(serverModules, clientModules.Select(ConvertToModuleInfo), out error);
+                result = moduleValidator.Validate(serverModules, clientModules.Select(ConvertToModuleInfo), out error);
+            }
         }
         catch (Exception e)
         {

--- a/source/Coop.Tests/Client/States/ValidateModuleStateTests.cs
+++ b/source/Coop.Tests/Client/States/ValidateModuleStateTests.cs
@@ -1,4 +1,5 @@
 ﻿using Autofac;
+using Common;
 using Common.Messaging;
 using Coop.Core.Client;
 using Coop.Core.Client.States;
@@ -50,7 +51,8 @@ namespace Coop.Tests.Client.States
             Assert.NotEmpty(clientComponent.TestNetwork.Peers);
 
             var message = Assert.Single(clientComponent.TestNetwork.GetPeerMessages(serverPeer));
-            Assert.IsType<NetworkModuleVersionsValidate>(message);
+            var validateMessage = Assert.IsType<NetworkModuleVersionsValidate>(message);
+            Assert.Equal(ModInformation.BuildVersion, validateMessage.BuildVersion);
         }
 
         [Fact]

--- a/source/Coop.Tests/Server/Connections/Messages/NetworkModuleVersionsValidateTests.cs
+++ b/source/Coop.Tests/Server/Connections/Messages/NetworkModuleVersionsValidateTests.cs
@@ -1,0 +1,33 @@
+﻿using Coop.Core.Server.Connections.Messages;
+using GameInterface.Services.Modules;
+using ProtoBuf;
+using System.Collections.Generic;
+using System.IO;
+using TaleWorlds.Library;
+using Xunit;
+
+namespace Coop.Tests.Server.Connections.Messages
+{
+    public class NetworkModuleVersionsValidateTests
+    {
+        [Fact]
+        public void Serialize_RoundTripsBuildVersion()
+        {
+            var original = new NetworkModuleVersionsValidate(
+                new List<ModuleInfo>
+                {
+                    new ModuleInfo("Coop", false, false, new ApplicationVersion()),
+                },
+                "0.1.1+0123456789012345678901234567890123456789");
+
+            using var stream = new MemoryStream();
+            Serializer.Serialize(stream, original);
+            stream.Position = 0;
+
+            var deserialized = Serializer.Deserialize<NetworkModuleVersionsValidate>(stream);
+
+            Assert.Equal(original.BuildVersion, deserialized.BuildVersion);
+            Assert.Single(deserialized.Modules);
+        }
+    }
+}

--- a/source/Coop.Tests/Server/Connections/States/ResolveCharacterStateTests.cs
+++ b/source/Coop.Tests/Server/Connections/States/ResolveCharacterStateTests.cs
@@ -1,4 +1,5 @@
 ﻿using Autofac;
+using Common;
 using Common.Messaging;
 using Coop.Core.Server.Connections;
 using Coop.Core.Server.Connections.Messages;
@@ -137,6 +138,28 @@ namespace Coop.Tests.Server.Connections.States
 
             var castedMessage = (NetworkModuleVersionsValidated)message;
             Assert.False(castedMessage.Matches);
+        }
+
+        [Fact]
+        public void NetworkModuleVersionsValidate_BuildMismatch()
+        {
+            // Arrange
+            var currentState = connectionLogic.SetState<ResolveCharacterState>();
+            var moduleInfoProvider = serverComponent.Container.Resolve<Mock<IModuleInfoProvider>>();
+
+            // Act
+            var payload = new MessagePayload<NetworkModuleVersionsValidate>(
+                playerPeer,
+                new NetworkModuleVersionsValidate(System.Array.Empty<ModuleInfo>(), "different-build"));
+            currentState.Handle_ModuleVersionsValidate(payload);
+
+            // Assert
+            var message = Assert.Single(serverComponent.TestNetwork.GetPeerMessages(playerPeer));
+            var castedMessage = Assert.IsType<NetworkModuleVersionsValidated>(message);
+            Assert.False(castedMessage.Matches);
+            Assert.Contains(ModInformation.BuildVersion, castedMessage.Reason);
+            Assert.Contains("different-build", castedMessage.Reason);
+            moduleInfoProvider.Verify(mip => mip.GetModuleInfos(), Times.Never);
         }
 
         [Fact]

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <!-- Bannerlord requires a dotted numeric module version. This also seeds the exact build label
-         advertised through Steam; the SDK may append source-revision metadata to that label. -->
+    <!-- Bannerlord requires a dotted numeric module version. Common appends the required Git
+         revision to form the exact build label used for compatibility checks. -->
     <CoopVersion>0.1.1</CoopVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## PR Type

- [x] Bug fix
- [x] Build related changes

## What is the current behavior?

local and playtest builds can lose the Git revision and advertise only the shared semantic version, so servers built from different commits can appear compatible. direct connections also only compare module manifest versions.

## What is the new behavior?

builds require the exact Git revision in the co-op build version. the client sends that build version during connection validation and the server rejects a mismatch before module validation.

## Bot Changelog Entry

- Servers running a different co-op build now show as incompatible and reject connections.