### PR TITLE
Fix auto creating parties

### DIFF
--- a/source/GameInterface/Services/Heroes/Patches/Disable/DisableHeroSpawnCampaignBehavior.cs
+++ b/source/GameInterface/Services/Heroes/Patches/Disable/DisableHeroSpawnCampaignBehavior.cs
@@ -1,8 +1,10 @@
 ﻿using Common;
 using GameInterface.Policies;
+using GameInterface.Services.Clans.Extensions;
 using HarmonyLib;
 using System.Collections.Generic;
 using System.Reflection;
+using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
 
 namespace GameInterface.Services.Heroes.Patches.Disable;
@@ -17,4 +19,52 @@ internal class DisableHeroSpawnCampaignBehavior
 
     [HarmonyPrefix]
     static bool Prefix() => ModInformation.IsServer || CallOriginalPolicy.IsOriginalAllowed();
+}
+
+[HarmonyPatch(typeof(HeroSpawnCampaignBehavior))]
+internal class HeroSpawnCampaignBehaviorPatches
+{
+    [HarmonyPatch(nameof(HeroSpawnCampaignBehavior.TrySpawnHeroesAndParties))]
+    [HarmonyPrefix]
+    public static bool TrySpawnHeroesAndPartiesPrefix(Clan clan, bool isNewGame)
+    {
+        return clan == null || !clan.IsPlayerClan();
+    }
+
+    [HarmonyPatch(nameof(HeroSpawnCampaignBehavior.CanHeroMoveToAnotherSettlement))]
+    [HarmonyPrefix]
+    public static bool CanHeroMoveToAnotherSettlementPrefix(Hero hero)
+    {
+        return hero?.Clan == null || !hero.Clan.IsPlayerClan();
+    }
+
+    [HarmonyPatch(nameof(HeroSpawnCampaignBehavior.GetBestAvailableCommander))]
+    [HarmonyPrefix]
+    public static bool GetBestAvailableCommanderPrefix(HeroSpawnCampaignBehavior __instance, ref Hero __result, Clan clan)
+    {
+        if (clan == null || !clan.IsPlayerClan()) return true;
+
+        // Replace check to not use Clan.PlayerClan check for player clans
+        Hero hero = null;
+        float num = 0f;
+        foreach (Hero hero2 in clan.Heroes)
+        {
+            if (hero2.IsActive && hero2.IsAlive && hero2.PartyBelongedTo == null && hero2.PartyBelongedToAsPrisoner == null && hero2.CanLeadParty() && hero2.Age > (float)Campaign.Current.Models.AgeModel.HeroComesOfAge && hero2.CharacterObject.Occupation == Occupation.Lord)
+            {
+                float heroPartyCommandScore = __instance.GetHeroPartyCommandScore(hero2);
+                if (heroPartyCommandScore > num)
+                {
+                    num = heroPartyCommandScore;
+                    hero = hero2;
+                }
+            }
+        }
+        if (hero != null)
+        {
+            __result = hero;
+            return false;
+        }
+
+        return false;
+    }
 }

--- a/source/GameInterface/Services/Heroes/Patches/Disable/DisableHeroSpawnCampaignBehavior.cs
+++ b/source/GameInterface/Services/Heroes/Patches/Disable/DisableHeroSpawnCampaignBehavior.cs
@@ -37,34 +37,4 @@ internal class HeroSpawnCampaignBehaviorPatches
     {
         return hero?.Clan == null || !hero.Clan.IsPlayerClan();
     }
-
-    [HarmonyPatch(nameof(HeroSpawnCampaignBehavior.GetBestAvailableCommander))]
-    [HarmonyPrefix]
-    public static bool GetBestAvailableCommanderPrefix(HeroSpawnCampaignBehavior __instance, ref Hero __result, Clan clan)
-    {
-        if (clan == null || !clan.IsPlayerClan()) return true;
-
-        // Replace check to not use Clan.PlayerClan check for player clans
-        Hero hero = null;
-        float num = 0f;
-        foreach (Hero hero2 in clan.Heroes)
-        {
-            if (hero2.IsActive && hero2.IsAlive && hero2.PartyBelongedTo == null && hero2.PartyBelongedToAsPrisoner == null && hero2.CanLeadParty() && hero2.Age > (float)Campaign.Current.Models.AgeModel.HeroComesOfAge && hero2.CharacterObject.Occupation == Occupation.Lord)
-            {
-                float heroPartyCommandScore = __instance.GetHeroPartyCommandScore(hero2);
-                if (heroPartyCommandScore > num)
-                {
-                    num = heroPartyCommandScore;
-                    hero = hero2;
-                }
-            }
-        }
-        if (hero != null)
-        {
-            __result = hero;
-            return false;
-        }
-
-        return false;
-    }
 }


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Clan.PlayerClan checks are used to spawn new parties for clans. This doesn't include player clans so the server automatically creates parties for players when it shouldn't.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #2587
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Fixed spouses automatically creating parties on their own.