### PR TITLE
Fix joins breaking permanently when a player's hero goes missing

### DIFF
--- a/source/Coop.Core/Server/Connections/States/CreateCharacterState.cs
+++ b/source/Coop.Core/Server/Connections/States/CreateCharacterState.cs
@@ -72,7 +72,18 @@ public class CreateCharacterState : ConnectionStateBase
         }
 
         if (!playerManager.AddPlayer(player))
-            Logger.Error("Player has been already added.");
+        {
+            // The controller already holds a registration — two joins for it raced into character
+            // creation before either finished. Everything below assumes this peer owns the player
+            // it just created, so continuing would bind the peer to the *other* registration and
+            // announce this refused one to the joiner and every other client. Drop the connection
+            // instead, exactly as a failed create does above.
+            Logger.Error(
+                "Controller {ControllerId} is already registered; disconnecting the joining peer",
+                controllerId);
+            ConnectionLogic.Peer.Disconnect();
+            return;
+        }
 
         // First join: associate this peer with the player it just created.
         playerManager.SetPeer(controllerId, netPeer);

--- a/source/Coop.Core/Server/Connections/States/ResolveCharacterState.cs
+++ b/source/Coop.Core/Server/Connections/States/ResolveCharacterState.cs
@@ -96,22 +96,61 @@ public class ResolveCharacterState : ConnectionStateBase
         var peer = obj.Who as NetPeer;
         if (peer != ConnectionLogic.Peer) return;
 
-        if (playerManager.TryGetPlayer(obj.What.PlayerId, out var player) &&
-            objectManager.TryGetObjectWithLogging(player.HeroId, out Hero _)) // If new save, player hero will not exist
+        try
         {
-            // This peer is a new NetPeer for an already registered player, so the
-            // peer-Player link must be established here
-            playerManager.SetPeer(obj.What.PlayerId, peer);
-            network.SendImmediate(peer, new NetworkClientValidated(true, player));
-            ConnectionLogic.TransferSave();
+            ResolveCharacter(peer, obj.What.PlayerId);
+        }
+        catch (Exception e)
+        {
+            // Same reasoning as Handle_ModuleVersionsValidate: a throw here dies in the network
+            // poller with no answer sent, so the joiner sits on the loading screen until its
+            // validation deadline expires. NetworkClientValidated carries no reason, and
+            // answering "no hero" would push the player into creating a second character, so
+            // drop the connection instead — the client surfaces a disconnect immediately.
+            Logger.Error(e, "Resolving the character for peer {Peer} failed; disconnecting the joiner", peer?.Id);
 
-            existingPlayerSender.SendExistingPlayers(peer, obj.What.PlayerId);
+            // Nothing may escape into the poller, including the teardown itself.
+            try
+            {
+                peer?.Disconnect();
+            }
+            catch (Exception disconnectFailure)
+            {
+                Logger.Error(disconnectFailure, "Disconnecting peer {Peer} failed", peer?.Id);
+            }
         }
-        else
+    }
+
+    private void ResolveCharacter(NetPeer peer, string controllerId)
+    {
+        if (playerManager.TryGetPlayer(controllerId, out var player))
         {
-            network.SendImmediate(peer, new NetworkClientValidated(false, null));
-            ConnectionLogic.CreateCharacter();
+            if (objectManager.TryGetObjectWithLogging(player.HeroId, out Hero _)) // If new save, player hero will not exist
+            {
+                // This peer is a new NetPeer for an already registered player, so the
+                // peer-Player link must be established here
+                playerManager.SetPeer(controllerId, peer);
+                network.SendImmediate(peer, new NetworkClientValidated(true, player));
+                ConnectionLogic.TransferSave();
+
+                existingPlayerSender.SendExistingPlayers(peer, controllerId);
+                return;
+            }
+
+            // Registered, but the hero it names is not in the campaign — a registration that
+            // outlived its objects. Deregister it before routing to character creation: the
+            // character created next registers this same controller id, and leaving the dead
+            // entry behind would make the controller ambiguous for the rest of the session.
+            Logger.Warning(
+                "Controller {ControllerId} is registered to hero {HeroId}, which no longer exists; " +
+                "dropping the stale registration and creating a new character",
+                controllerId, player.HeroId);
+
+            playerManager.RemovePlayer(player);
         }
+
+        network.SendImmediate(peer, new NetworkClientValidated(false, null));
+        ConnectionLogic.CreateCharacter();
     }
 
     public override void CreateCharacter()

--- a/source/Coop.Core/Server/Services/Save/Handlers/SaveGameHandler.cs
+++ b/source/Coop.Core/Server/Services/Save/Handlers/SaveGameHandler.cs
@@ -1,4 +1,5 @@
-﻿using Common.Messaging;
+﻿using Common.Logging;
+using Common.Messaging;
 using Common.Network;
 using Coop.Core.Server.Services.Save.Messages;
 using GameInterface.CoopSessionData;
@@ -7,6 +8,7 @@ using GameInterface.Registry.Messages;
 using GameInterface.Services.Heroes.Messages;
 using GameInterface.Services.Players;
 using GameInterface.Services.Save.Messages;
+using Serilog;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -17,6 +19,8 @@ namespace Coop.Core.Server.Services.Save.Handlers;
 /// </summary>
 internal class SaveGameHandler : IHandler
 {
+    private static readonly ILogger Logger = LogManager.GetLogger<SaveGameHandler>();
+
     private readonly IMessageBroker messageBroker;
     private readonly ICoopSaveManager saveManager;
     private readonly ICoopSessionProvider coopSessionProvider;
@@ -121,7 +125,15 @@ internal class SaveGameHandler : IHandler
 
         foreach (var player in savedSession.Players)
         {
-            playerRegistry.AddPlayer(player);
+            // A save written before controller ids were made unique can carry two entries for one
+            // controller; AddPlayer keeps the first. The owner heals the leftover by joining — a
+            // registration naming a missing hero is dropped in ResolveCharacterState — but say so,
+            // because a silently skipped registration is exactly what made this hard to diagnose.
+            if (!playerRegistry.AddPlayer(player))
+                Logger.Warning(
+                    "Skipped saved registration for controller {ControllerId} (hero {HeroId}): " +
+                    "that controller is already registered",
+                    player?.ControllerId, player?.HeroId);
         }
     }
 }

--- a/source/Coop.Core/Server/Services/Save/Handlers/SaveGameHandler.cs
+++ b/source/Coop.Core/Server/Services/Save/Handlers/SaveGameHandler.cs
@@ -6,11 +6,14 @@ using GameInterface.CoopSessionData;
 using GameInterface.CoopSessionData.Save.Data;
 using GameInterface.Registry.Messages;
 using GameInterface.Services.Heroes.Messages;
+using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
+using GameInterface.Services.Players.Data;
 using GameInterface.Services.Save.Messages;
 using Serilog;
 using System.Collections.Generic;
 using System.Linq;
+using TaleWorlds.CampaignSystem;
 
 namespace Coop.Core.Server.Services.Save.Handlers;
 
@@ -26,6 +29,7 @@ internal class SaveGameHandler : IHandler
     private readonly ICoopSessionProvider coopSessionProvider;
     private readonly IPlayerManager playerRegistry;
     private readonly INetwork network;
+    private readonly IObjectManager objectManager;
     private readonly HashSet<object> activeSaveSources = new HashSet<object>();
 
     public SaveGameHandler(
@@ -33,13 +37,15 @@ internal class SaveGameHandler : IHandler
         ICoopSaveManager saveManager,
         ICoopSessionProvider coopSessionProvider,
         IPlayerManager playerRegistry,
-        INetwork network)
+        INetwork network,
+        IObjectManager objectManager)
     {
         this.messageBroker = messageBroker;
         this.saveManager = saveManager;
         this.coopSessionProvider = coopSessionProvider;
         this.playerRegistry = playerRegistry;
         this.network = network;
+        this.objectManager = objectManager;
 
         messageBroker.Subscribe<GameSaved>(Handle_GameSaved);
         messageBroker.Subscribe<GameLoaded>(Handle_GameLoaded);
@@ -123,12 +129,8 @@ internal class SaveGameHandler : IHandler
         // there is no previous session (and no players) to restore.
         if (savedSession?.Players == null) return;
 
-        foreach (var player in savedSession.Players)
+        foreach (var player in SelectOneRegistrationPerController(savedSession.Players))
         {
-            // A save written before controller ids were made unique can carry two entries for one
-            // controller; AddPlayer keeps the first. The owner heals the leftover by joining — a
-            // registration naming a missing hero is dropped in ResolveCharacterState — but say so,
-            // because a silently skipped registration is exactly what made this hard to diagnose.
             if (!playerRegistry.AddPlayer(player))
                 Logger.Warning(
                     "Skipped saved registration for controller {ControllerId} (hero {HeroId}): " +
@@ -136,4 +138,41 @@ internal class SaveGameHandler : IHandler
                     player?.ControllerId, player?.HeroId);
         }
     }
+
+    /// <summary>
+    /// Picks the single registration to restore per controller. A save written before controller
+    /// ids were unique can carry more than one, in either order, so keep the one whose hero still
+    /// exists rather than the one that happens to come first: the campaign decides which
+    /// registration is real. Keeping the first would as often keep the dead one, which leaves the
+    /// live hero unregistered and sends its owner off to build yet another character.
+    /// </summary>
+    private IEnumerable<Player> SelectOneRegistrationPerController(IEnumerable<Player> players)
+    {
+        // AllGameObjectsRegistered means the campaign's objects are resolvable, so a hero lookup
+        // here is authoritative about which registration still has something behind it.
+        foreach (var group in players.Where(player => player != null).GroupBy(player => player.ControllerId))
+        {
+            var registrations = group.ToArray();
+            if (registrations.Length == 1)
+            {
+                yield return registrations[0];
+                continue;
+            }
+
+            var live = registrations.FirstOrDefault(HeroExists) ?? registrations[0];
+
+            Logger.Warning(
+                "Save carries {Count} registrations for controller {ControllerId} (heroes {HeroIds}); " +
+                "restoring {KeptHeroId} and dropping the rest",
+                registrations.Length,
+                group.Key,
+                string.Join(", ", registrations.Select(registration => registration.HeroId)),
+                live.HeroId);
+
+            yield return live;
+        }
+    }
+
+    private bool HeroExists(Player player) =>
+        !string.IsNullOrEmpty(player.HeroId) && objectManager.TryGetObject<Hero>(player.HeroId, out _);
 }

--- a/source/Coop.Tests/Server/Connections/States/CreateCharacterStateTests.cs
+++ b/source/Coop.Tests/Server/Connections/States/CreateCharacterStateTests.cs
@@ -168,6 +168,34 @@ namespace Coop.Tests.Server.Connections.States
             Assert.Empty(serverComponent.TestNetwork.SentNetworkMessages);
         }
 
+        [Fact]
+        public void NetworkTransferNewHero_ControllerAlreadyRegistered_DisconnectsWithoutAnnouncing()
+        {
+            // Arrange — two joins for one controller reached character creation before either
+            // finished, so the registry refuses the second registration.
+            SetupUnpackedHero();
+            var playerRegistryMock = serverComponent.Container.Resolve<Mock<IPlayerManager>>();
+            playerRegistryMock
+                .Setup(p => p.AddPlayer(It.IsAny<Player>()))
+                .Returns(false);
+            var currentState = connectionLogic.SetState<CreateCharacterState>();
+
+            // Act
+            var payload = new MessagePayload<NetworkTransferNewHero>(
+                playerPeer, new NetworkTransferNewHero("MyId", Array.Empty<byte>()));
+            currentState.Handle_NetworkTransferNewHero(payload);
+
+            // Assert — everything after AddPlayer assumes this peer owns the player it just
+            // created. Carrying on would bind the peer to the registration that already holds the
+            // controller and announce the refused one to the joiner and every other client, so
+            // only this peer is ejected and nothing is sent.
+            Assert.Equal(ConnectionState.ShutdownRequested, playerPeer.ConnectionState);
+            Assert.NotEqual(ConnectionState.ShutdownRequested, differentPeer.ConnectionState);
+            playerRegistryMock.Verify(p => p.SetPeer(It.IsAny<string>(), It.IsAny<NetPeer>()), Times.Never);
+            Assert.Empty(serverComponent.TestNetwork.SentNetworkMessages);
+            Assert.IsType<CreateCharacterState>(connectionLogic.State);
+        }
+
         /// <summary>
         /// Configures the mocked <see cref="IHeroInterface.ServerUnpackHero"/> to return a hero whose
         /// hero/party/clan/character-object are registered in the (real) object manager, so

--- a/source/Coop.Tests/Server/Connections/States/ResolveCharacterStateTests.cs
+++ b/source/Coop.Tests/Server/Connections/States/ResolveCharacterStateTests.cs
@@ -10,6 +10,7 @@ using GameInterface.Services.Players;
 using GameInterface.Services.Players.Data;
 using LiteNetLib;
 using Moq;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -225,6 +226,71 @@ namespace Coop.Tests.Server.Connections.States
 
             Assert.True(message.HeroExists);
             Assert.Equal(player, message.Player);
+        }
+
+        [Fact]
+        public void NetworkClientValidate_RegisteredPlayerWithMissingHero_DropsStaleRegistration()
+        {
+            // Arrange
+            var currentState = connectionLogic.SetState<ResolveCharacterState>();
+
+            // Registered, but its hero is never added to the object manager — the shape a save
+            // carries when a registration outlives the objects it names.
+            var player = new Player("MyPlayer", "MissingHero", "MyParty", "MyClan", "MyCharacter");
+
+            var playerManagerMock = serverComponent.Container.Resolve<Mock<IPlayerManager>>();
+            playerManagerMock
+                .Setup(i => i.TryGetPlayer(player.ControllerId, out It.Ref<Player>.IsAny))
+                .Callback((string id, out Player returnedPlayer) =>
+                {
+                    returnedPlayer = player;
+                })
+                .Returns(true);
+
+            // Act
+            var payload = new MessagePayload<NetworkClientValidate>(
+                playerPeer, new NetworkClientValidate(player.ControllerId));
+            currentState.Handle_ClientValidate(payload);
+
+            // Assert — the dead registration must be dropped before character creation, otherwise
+            // the character created next registers this controller a second time and every later
+            // lookup for it is ambiguous.
+            playerManagerMock.Verify(i => i.RemovePlayer(player), Times.Once);
+            playerManagerMock.Verify(i => i.SetPeer(It.IsAny<string>(), It.IsAny<NetPeer>()), Times.Never);
+
+            var message = Assert.Single(
+                serverComponent.TestNetwork.GetPeerMessages(playerPeer).OfType<NetworkClientValidated>());
+            Assert.False(message.HeroExists);
+
+            Assert.IsType<CreateCharacterState>(connectionLogic.State);
+        }
+
+        [Fact]
+        public void NetworkClientValidate_ResolutionThrows_DoesNotAnswerOrAdvance()
+        {
+            // Arrange
+            var currentState = connectionLogic.SetState<ResolveCharacterState>();
+
+            const string playerId = "MyPlayer";
+            serverComponent.Container
+                .Resolve<Mock<IPlayerManager>>()
+                .Setup(i => i.TryGetPlayer(playerId, out It.Ref<Player>.IsAny))
+                .Throws(new InvalidOperationException("boom"));
+
+            // Act — a throw used to escape into the network poller, so the joiner got no reply at
+            // all and sat on the validation screen until its 30s deadline expired.
+            var payload = new MessagePayload<NetworkClientValidate>(
+                playerPeer, new NetworkClientValidate(playerId));
+            currentState.Handle_ClientValidate(payload);
+
+            // Assert — the connection is dropped rather than answered: NetworkClientValidated
+            // carries no reason, and answering "no hero" would push the player into creating a
+            // second character.
+            var messages = serverComponent.TestNetwork.SentNetworkMessages
+                .GetValueOrDefault(playerPeer.Id) ?? Enumerable.Empty<IMessage>();
+            Assert.Empty(messages.OfType<NetworkClientValidated>());
+
+            Assert.IsType<ResolveCharacterState>(connectionLogic.State);
         }
 
         [Fact]

--- a/source/Coop.Tests/Server/Services/Save/SaveGameHandlerTests.cs
+++ b/source/Coop.Tests/Server/Services/Save/SaveGameHandlerTests.cs
@@ -1,15 +1,29 @@
-﻿using Common.Network;
+using Common.Network;
 using Common.Tests.Utils;
+using Coop.Core.Server.Services.Save;
 using Coop.Core.Server.Services.Save.Handlers;
 using Coop.Core.Server.Services.Save.Messages;
+using GameInterface.CoopSessionData;
+using GameInterface.CoopSessionData.Save.Data;
+using GameInterface.Registry.Messages;
+using GameInterface.Services.Heroes.Messages;
+using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Players;
+using GameInterface.Services.Players.Data;
 using GameInterface.Services.Save.Messages;
 using Moq;
+using TaleWorlds.CampaignSystem;
 using Xunit;
 
 namespace Coop.Tests.Server.Services.Save;
 
 public class SaveGameHandlerTests
 {
+    private const string SaveName = "TestSave";
+    private const string ControllerId = "PlayerOne";
+    private const string LiveHeroId = "Hero_Live";
+    private const string MissingHeroId = "Hero_Missing";
+
     [Fact]
     public void GameSaveStateChanged_BroadcastsFirstStartAndLastEnd()
     {
@@ -20,7 +34,8 @@ public class SaveGameHandlerTests
             null!,
             null!,
             null!,
-            network.Object);
+            network.Object,
+            null!);
 
         var firstSave = new object();
         var secondSave = new object();
@@ -39,5 +54,123 @@ public class SaveGameHandlerTests
                 message => !message.IsSaving)),
             Times.Once);
         network.VerifyNoOtherCalls();
+    }
+
+    [Theory]
+    // A save written before controller ids were unique can hold the duplicates in either order,
+    // and the dead one comes first as often as not.
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AllGameObjectsRegistered_DuplicateController_RestoresTheRegistrationWhoseHeroExists(
+        bool missingFirst)
+    {
+        var missing = new Player(ControllerId, MissingHeroId, "Party_Missing", "Clan_One", "Character_Missing");
+        var live = new Player(ControllerId, LiveHeroId, "Party_Live", "Clan_One", "Character_Live");
+        var saved = missingFirst ? new[] { missing, live } : new[] { live, missing };
+
+        var playerRegistry = new Mock<IPlayerManager>();
+        playerRegistry.Setup(registry => registry.AddPlayer(It.IsAny<Player>())).Returns(true);
+
+        using var handler = CreateHandler(playerRegistry, saved);
+
+        // Restoring the registration that comes first would keep the dead one half the time,
+        // leaving the live hero unregistered and sending its owner to build another character.
+        playerRegistry.Verify(registry => registry.AddPlayer(live), Times.Once);
+        playerRegistry.Verify(registry => registry.AddPlayer(missing), Times.Never);
+    }
+
+    [Fact]
+    public void AllGameObjectsRegistered_DuplicateControllerWithNoLiveHero_RestoresExactlyOne()
+    {
+        var first = new Player(ControllerId, MissingHeroId, "Party_A", "Clan_One", "Character_A");
+        var second = new Player(ControllerId, "Hero_AlsoMissing", "Party_B", "Clan_One", "Character_B");
+
+        var playerRegistry = new Mock<IPlayerManager>();
+        playerRegistry.Setup(registry => registry.AddPlayer(It.IsAny<Player>())).Returns(true);
+
+        using var handler = CreateHandler(playerRegistry, new[] { first, second });
+
+        // Neither hero resolves, so there is nothing to prefer — but the controller must still end
+        // up with one registration, which its owner heals by joining.
+        playerRegistry.Verify(registry => registry.AddPlayer(It.IsAny<Player>()), Times.Once);
+        playerRegistry.Verify(registry => registry.AddPlayer(first), Times.Once);
+    }
+
+    [Fact]
+    public void AllGameObjectsRegistered_DistinctControllers_RestoresEvery()
+    {
+        var first = new Player("PlayerOne", LiveHeroId, "Party_A", "Clan_One", "Character_A");
+        var second = new Player("PlayerTwo", MissingHeroId, "Party_B", "Clan_Two", "Character_B");
+
+        var playerRegistry = new Mock<IPlayerManager>();
+        playerRegistry.Setup(registry => registry.AddPlayer(It.IsAny<Player>())).Returns(true);
+
+        using var handler = CreateHandler(playerRegistry, new[] { first, second });
+
+        // A missing hero is only a tie-breaker between duplicates; on its own it must not cost a
+        // controller its registration, or that player is sent to character creation for nothing.
+        playerRegistry.Verify(registry => registry.AddPlayer(first), Times.Once);
+        playerRegistry.Verify(registry => registry.AddPlayer(second), Times.Once);
+    }
+
+    /// <summary>
+    /// Builds a handler over a loaded session holding <paramref name="savedPlayers"/> and drives it
+    /// through the load sequence (GameLoaded, then AllGameObjectsRegistered). Only
+    /// <see cref="LiveHeroId"/> resolves in the object manager.
+    /// </summary>
+    private static SaveGameHandler CreateHandler(Mock<IPlayerManager> playerRegistry, Player[] savedPlayers)
+    {
+        var messageBroker = new TestMessageBroker();
+
+        var objectManager = new Mock<IObjectManager>();
+        Hero liveHero = null!;
+        objectManager.Setup(manager => manager.TryGetObject(LiveHeroId, out liveHero)).Returns(true);
+
+        var handler = new SaveGameHandler(
+            messageBroker,
+            new StubSaveManager(SessionWith(savedPlayers)),
+            new Mock<ICoopSessionProvider>().Object,
+            playerRegistry.Object,
+            new Mock<INetwork>().Object,
+            objectManager.Object);
+
+        messageBroker.Publish(new object(), new GameLoaded(SaveName));
+        messageBroker.Publish(new object(), new AllGameObjectsRegistered());
+
+        return handler;
+    }
+
+    /// <summary>
+    /// Serves one loaded session. A hand-written stub rather than a mock because ICoopSaveManager
+    /// is internal to Coop.Core, which is not marked visible to Moq's proxy generator.
+    /// </summary>
+    private sealed class StubSaveManager : ICoopSaveManager
+    {
+        private readonly ICoopSession session;
+
+        public StubSaveManager(ICoopSession session) => this.session = session;
+
+        public string DefaultPath => string.Empty;
+        public string FileType => ".json";
+
+        public ICoopSession LoadCoopSession(string saveName) => session;
+
+        public void SaveCoopSession(string saveName, ICoopSession session) { }
+    }
+
+    private static CoopSession SessionWith(Player[] players)
+    {
+        var empty = CoopSession.Empty;
+
+        return new CoopSession(
+            SaveName,
+            players,
+            empty.CraftingPlayerData,
+            empty.WorkshopPlayerData,
+            empty.CaravansPlayerData,
+            empty.AlleyPlayerData,
+            empty.InteractionsPlayerData,
+            empty.TradePlayerData,
+            empty.InventoryPlayerData);
     }
 }

--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -1275,16 +1275,15 @@ public class PlayerKingdomCreationFlowTests : IDisposable
             Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(targetKingdomId, out var targetKingdom));
             Assert.True(Server.ObjectManager.TryGetObject<Clan>(player1.ClanId, out var proposerClan));
             var playerManager = Server.Resolve<IPlayerManager>();
-            var players = (HashSet<Player>)AccessTools.Field(playerManager.GetType(), "_players").GetValue(playerManager);
-            var oldPlayer = players.Single(player => player.ControllerId == SecondControllerId);
+            var players = (Dictionary<string, Player>)AccessTools.Field(playerManager.GetType(), "_players").GetValue(playerManager);
+            Assert.True(players.ContainsKey(SecondControllerId));
 
-            Assert.True(players.Remove(oldPlayer));
-            Assert.True(players.Add(new Player(
+            players[SecondControllerId] = new Player(
                 SecondControllerId,
                 "missingHero",
                 player2.PartyId,
                 player2.ClanId,
-                player2.CharacterId)));
+                player2.CharacterId);
 
             kingdom.AddDecision(new DeclareWarDecision(proposerClan, targetKingdom));
         });

--- a/source/GameInterface.Tests/Services/Players/PlayerManagerTests.cs
+++ b/source/GameInterface.Tests/Services/Players/PlayerManagerTests.cs
@@ -142,6 +142,87 @@ public class PlayerManagerTests
         Assert.Same(secondPeer, resolvedPeer);
     }
 
+    [Fact]
+    public void AddPlayer_SecondRegistrationForSameController_IsRefused()
+    {
+        var playerManager = CreatePlayerManager(out _);
+        var registered = new Player(ControllerId, "FirstHero", string.Empty, string.Empty, string.Empty);
+        var replacement = new Player(ControllerId, "SecondHero", string.Empty, string.Empty, string.Empty);
+
+        Assert.True(playerManager.AddPlayer(registered));
+
+        // A registration whose hero was gone used to send its owner through character creation,
+        // and the character created there registered this same controller a second time. Player
+        // has no value equality, so a set of instances accepted it and every later lookup for the
+        // controller threw — inside a message handler, killing the join with no reply.
+        Assert.False(playerManager.AddPlayer(replacement));
+
+        Assert.True(playerManager.TryGetPlayer(ControllerId, out var resolved));
+        Assert.Same(registered, resolved);
+        Assert.Same(registered, Assert.Single(playerManager.Players));
+    }
+
+    [Fact]
+    public void AddPlayer_SameInstanceTwice_IsRefused()
+    {
+        var playerManager = CreatePlayerManager(out _);
+        var player = new Player(ControllerId, string.Empty, string.Empty, string.Empty, string.Empty);
+
+        Assert.True(playerManager.AddPlayer(player));
+        Assert.False(playerManager.AddPlayer(player));
+
+        Assert.Same(player, Assert.Single(playerManager.Players));
+    }
+
+    [Fact]
+    public void AddPlayer_NoControllerId_IsRefused()
+    {
+        var playerManager = CreatePlayerManager(out _);
+
+        Assert.False(playerManager.AddPlayer(
+            new Player(string.Empty, "SomeHero", string.Empty, string.Empty, string.Empty)));
+
+        Assert.Empty(playerManager.Players);
+        Assert.False(playerManager.TryGetPlayer(string.Empty, out _));
+    }
+
+    [Fact]
+    public void RemovePlayer_ThenRegisterReplacement_SucceedsForSameController()
+    {
+        var playerManager = CreatePlayerManager(out _);
+        var stale = new Player(ControllerId, "MissingHero", string.Empty, string.Empty, string.Empty);
+        var replacement = new Player(ControllerId, "CreatedHero", string.Empty, string.Empty, string.Empty);
+
+        Assert.True(playerManager.AddPlayer(stale));
+
+        // The join flow deregisters a registration naming a hero that no longer exists before
+        // routing its owner to character creation, so the created character can take the id.
+        Assert.True(playerManager.RemovePlayer(stale));
+        Assert.True(playerManager.AddPlayer(replacement));
+
+        Assert.True(playerManager.TryGetPlayer(ControllerId, out var resolved));
+        Assert.Same(replacement, resolved);
+        Assert.Same(replacement, Assert.Single(playerManager.Players));
+    }
+
+    [Fact]
+    public void RemovePlayer_SupersededInstance_LeavesCurrentRegistrationIntact()
+    {
+        var playerManager = CreatePlayerManager(out _);
+        var stale = new Player(ControllerId, "MissingHero", string.Empty, string.Empty, string.Empty);
+        var current = new Player(ControllerId, "CreatedHero", string.Empty, string.Empty, string.Empty);
+
+        Assert.True(playerManager.AddPlayer(stale));
+        Assert.True(playerManager.RemovePlayer(stale));
+        Assert.True(playerManager.AddPlayer(current));
+
+        // A caller still holding the superseded Player must not deregister its successor.
+        Assert.False(playerManager.RemovePlayer(stale));
+
+        Assert.True(playerManager.TryGetPlayer(ControllerId, out var resolved));
+        Assert.Same(current, resolved);
+    }
+
     private static ConditionalWeakTable<object, ControlledObjectInfo> GetPlayerObjects() =>
         (ConditionalWeakTable<object, ControlledObjectInfo>)AccessTools
             .Field(typeof(PlayerManager), "PlayerObjects")

--- a/source/GameInterface/Services/Players/PlayerManager.cs
+++ b/source/GameInterface/Services/Players/PlayerManager.cs
@@ -21,7 +21,9 @@ public interface IPlayerManager
     IReadOnlyCollection<Player> Players { get; }
 
     /// <summary>
-    /// Adds a player to the registry
+    /// Adds a player to the registry. A controller id maps to exactly one player, so a
+    /// registration for a controller that already has one is refused; deregister the old one
+    /// first (<see cref="RemovePlayer"/>) when replacing it.
     /// </summary>
     /// <param name="player">The player to be added to the registry</param>
     /// <returns>if the player was added to the registry</returns>
@@ -105,11 +107,18 @@ public class PlayerManager : IPlayerManager
         {
             lock (registrySync)
             {
-                return _players.ToArray();
+                return _players.Values.ToArray();
             }
         }
     }
-    private readonly HashSet<Player> _players = new HashSet<Player>();
+
+    // Keyed by controller id so a controller can only ever resolve to one player. Player has no
+    // value equality, so a set of instances happily accepted a second registration for a
+    // controller that already had one: a registration whose hero no longer existed sent its owner
+    // back through character creation, the created character registered the same controller
+    // again, and every later lookup for it threw inside a message handler — killing the join with
+    // no reply and leaving that client on the validation screen until its deadline expired.
+    private readonly Dictionary<string, Player> _players = new Dictionary<string, Player>();
 
     public PlayerManager(ILogger logger, IObjectManager objectManager, IControllerIdProvider controllerIdProvider)
     {
@@ -121,9 +130,32 @@ public class PlayerManager : IPlayerManager
     /// <inheritdoc cref="IPlayerManager.AddPlayer(Player)"/>
     public bool AddPlayer(Player player)
     {
+        if (player == null) return false;
+
+        if (string.IsNullOrEmpty(player.ControllerId))
+        {
+            logger.Error("Refusing to register a player with no controller id (hero {HeroId})", player.HeroId);
+            return false;
+        }
+
         lock (registrySync)
         {
-            if (!_players.Add(player)) return false;
+            if (_players.TryGetValue(player.ControllerId, out var registered))
+            {
+                // Keep the existing registration rather than replacing it silently: the caller
+                // owns that decision, and the join flow already deregisters a dead registration
+                // before creating a replacement. Reaching this means an unexpected double-add, or
+                // a save written before this fix that carries two entries for one controller.
+                if (!ReferenceEquals(registered, player))
+                    logger.Error(
+                        "Controller {ControllerId} is already registered to hero {RegisteredHeroId}; " +
+                        "refusing to also register hero {HeroId}",
+                        player.ControllerId, registered.HeroId, player.HeroId);
+
+                return false;
+            }
+
+            _players.Add(player.ControllerId, player);
         }
 
         // Add player objects for IsPlayer extension (i.e. MobilePartyExtensions)
@@ -168,12 +200,14 @@ public class PlayerManager : IPlayerManager
 
     public bool TryGetPlayer(string controllerId, out Player player)
     {
+        player = null;
+
+        if (string.IsNullOrEmpty(controllerId)) return false;
+
         lock (registrySync)
         {
-            player = _players.SingleOrDefault(player => player.ControllerId == controllerId);
+            return _players.TryGetValue(controllerId, out player);
         }
-
-        return player != null;
     }
 
     /// <inheritdoc cref="IPlayerManager.Contains(object)"/>
@@ -224,12 +258,17 @@ public class PlayerManager : IPlayerManager
     /// <inheritdoc cref="IPlayerManager.RemovePlayer(Player)"/>
     public bool RemovePlayer(Player player)
     {
-        if (player == null) return false;
+        if (player == null || string.IsNullOrEmpty(player.ControllerId)) return false;
 
         lock (registrySync)
         {
-            if (!_players.Remove(player)) return false;
+            // Match the instance, not just the controller id: a caller holding a superseded
+            // Player must not deregister whoever currently holds that controller.
+            if (!_players.TryGetValue(player.ControllerId, out var registered) ||
+                !ReferenceEquals(registered, player))
+                return false;
 
+            _players.Remove(player.ControllerId);
             controllerToPeer.Remove(player.ControllerId);
 
             // A rejoin adds a fresh peer link without clearing the old one, so sweep every peer


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

If a player's registration names a hero that no longer exists in the campaign, that player can never join again — and the failure is invisible to them.

`ResolveCharacterState.Handle_ClientValidate` finds the registration, fails to resolve its hero, and routes the player to character creation. The character created there calls `AddPlayer` with the **same controller id**. `Player` has no value equality and the registry was a `HashSet<Player>`, so the second registration was accepted. From that point `TryGetPlayer(controllerId, ...)` ran `SingleOrDefault` over two matches and threw:

```
System.InvalidOperationException: Sequence contains more than one matching element
  at PlayerManager.TryGetPlayer(String controllerId, Player& player)
  at PlayerManager.SetPeer(String controllerId, NetPeer peer)
  at CreateCharacterState.Handle_NetworkTransferNewHero(MessagePayload`1 obj)
```

That throw is inside a `MessageBroker` handler, so it dies in the poller: the rest of the handler never runs, no reply is sent, and the client sits on the validation screen until `ValidateModuleState`'s 30-second deadline expires. Every later reconnect from that controller hits the same throw, now from `Handle_ClientValidate`.

Seen live on a dedicated server: one poisoned controller, then 13 failed rejoins over the next hour while other players joined normally. The corresponding client log shows only `Timed out after 30s waiting for the server to validate the connection`, repeated — the module check itself passed every time.

## What is the new behavior?

**One registration per controller.** The registry is keyed by controller id, so a lookup can never be ambiguous and `TryGetPlayer` cannot throw. `AddPlayer` refuses a second registration for a controller that already has one and logs which heroes collided. `RemovePlayer` matches on the instance, so a caller holding a superseded `Player` cannot deregister its successor.

**The dead registration is dropped, not duplicated.** `ResolveCharacterState` deregisters a registration whose hero is missing before routing its owner to character creation, so the replacement takes the controller id cleanly. This is the root fix — the duplicate is never created.

**Joins fail loudly.** `Handle_ClientValidate` no longer lets an unexpected throw escape into the poller; it drops the connection so the client surfaces a disconnect immediately instead of hanging, matching the existing treatment of the module-validation step. It disconnects rather than answering "no hero" because that answer would push the player into creating a second character.

**Existing poisoned saves heal.** A session file that already carries two entries for one controller loads the first and logs the skip instead of silently registering both; the owner heals the leftover by joining, which drops the entry naming the missing hero.

## Bot Changelog Entry

- Fixed a player being permanently unable to rejoin a server — stuck on the "Validating modules" screen — after their character went missing from the save.

## Other information

Tests: `PlayerManagerTests` covers the refused duplicate, the deregister-then-replace path, and the superseded-instance guard. `ResolveCharacterStateTests` covers the stale registration being dropped on the way to character creation, and a throw during resolution not answering or advancing the connection.

Full unit suites green locally: 1484 passed, 14 skipped, 0 failed.
