### PR TITLE
Potential fix to the player captivity reconnection -  2598

### DIFF
--- a/source/Coop.Core/Server/Services/Players/Handlers/PlayerPartyVisibilityHandler.cs
+++ b/source/Coop.Core/Server/Services/Players/Handlers/PlayerPartyVisibilityHandler.cs
@@ -20,6 +20,7 @@ using SandBox.View.Map.Managers;
 using Serilog;
 using System.Collections.Generic;
 using System.Linq;
+using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.MapEvents;
 using TaleWorlds.CampaignSystem.Party;
 
@@ -138,6 +139,18 @@ internal class PlayerPartyVisibilityHandler : IHandler
             if (party.IsActive)
             {
                 return; // fresh join, never parked, nothing to restore
+            }
+
+            // Retrieves the player and outs it to the Hero Object
+            // Checks if the player is prisoner or if they belong there
+            // If they do, the Debug message appears.
+            if (objectManager.TryGetObject(player.HeroId, out Hero hero) &&
+                (hero.IsPrisoner || hero.PartyBelongedToAsPrisoner != null))
+            {
+                Logger.Debug("Keeping captive party {PartyId} parked for peer {Peer}",
+                    party.StringId,
+                    peer.Id);
+                return;
             }
 
             party.IsActive = true;


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When a player reconnects or re-enters the campaign, `PlayerPartyVisibilityHandler` restores their inactive party and recreates its map visual.

That is correct for normal disconnected players, but captive player parties are also intentionally parked with `IsActive = false`. Because the reconnect path only checked `party.IsActive`, a player who was still captive could have their parked party reactivated and its map visual recreated before the captivity release flow ran.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #2598

Campaign re-entry now checks the mapped player hero's captivity state before restoring an inactive party.

If the hero is still a prisoner, the reconnect handler leaves the parked party inactive and does not recreate its map visual. Normal non-captive reconnects still restore the party as before, and the existing captivity release flow still reactivates the party after ransom/release.

Manual verification performed with the client:

1. Started the server and the client.
2. Used `coop.debug.player_captivity.random_capture_player Player` on the server to force player captivity.
3. Confirmed with `coop.debug.player_captivity.observe_player Player`:
   - `IsPrisoner: True`
   - `PartyActive: False`
4. Reconnected the captive client.
5. Confirmed the player remained captive and parked:
   - `IsPrisoner: True`
   - `PartyActive: False`
6. Used `coop.debug.player_captivity.ransom_player_at_settlement Player` on the server.
7. Confirmed the player was ransomed properly:
   - `IsPrisoner: False`
   - `PartyActive:  True`
9. Reconnected again and confirmed release restored the party:
   - `IsPrisoner: False`
   - `PartyActive: True`

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->

- Fixed captive player parties reappearing on the map after reconnecting.

## Other information

This change does not alter how captivity starts or ends. It only prevents the disconnected-party restore path from overriding an already-active captivity state.