### PR TITLE
Fix to the crash from the clear command in the console - 2635

### DIFF
--- a/source/GameInterface/Services/UI/Patches/MBDebugPatch.cs
+++ b/source/GameInterface/Services/UI/Patches/MBDebugPatch.cs
@@ -1,0 +1,38 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using TaleWorlds.Engine;
+
+namespace GameInterface.Services.UI.Patches;
+
+///<summary>
+/// Prevents the TaleWorlds debug console clear command from crashing game sessions that do not
+/// have an attached Windows system console by replacing the engine implementation with a safe
+/// Harmony prefix.
+/// </summary>
+[HarmonyPatch(typeof(MBDebug))]
+internal static class MBDebugPatch
+{
+    [HarmonyPatch(nameof(MBDebug.ClearConsole))]
+    [HarmonyPrefix]
+    private static bool ClearConsolePrefix(List<string> strings, ref string __result)
+    {
+        // Bannerlord may run without an attached Windows console, which makes Console.Clear unsafe.
+        try
+        {
+            Console.Clear();
+            __result = "Debug console cleared.";
+        }
+        catch (IOException)
+        {
+            __result = "Clearing the system console is not supported in this environment.";
+        }
+        catch (InvalidOperationException)
+        {
+            __result = "Clearing the system console is not supported in this environment.";
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
Running the `console.clear` command can crash the game in sessions without an attached Windows system console.

The underlying TaleWorlds engine implementation calls `System.Console.Clear()`, which throws `System.IO.IOException: The handle is invalid` in this environment.

## What is the new behavior?
Resolves #2635 

The `MBDebug.ClearConsole` command is now patched with a Harmony prefix that safely handles environments without an attached system console.

When `Console.Clear()` is unsupported, the command now returns a message instead of crashing the game.

## Bot Changelog Entry
- Fixed a crash when using the `console.clear` debug command in game sessions without a system console.

## Other information
This fix patches the external TaleWorlds `MBDebug.ClearConsole` method at runtime instead of modifying engine source directly.