### PR TITLE
List the game binaries and their versions in crash reports

### DIFF
--- a/source/Coop.CrashReporter.Tests/Coop.CrashReporter.Tests.csproj
+++ b/source/Coop.CrashReporter.Tests/Coop.CrashReporter.Tests.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <Compile Include="..\Coop.CrashReporter\CrashReportCollector.cs" Link="CrashReporter\CrashReportCollector.cs" />
     <Compile Include="..\Coop.CrashReporter\CrashReporterOptions.cs" Link="CrashReporter\CrashReporterOptions.cs" />
+    <Compile Include="..\Coop.CrashReporter\GameBinariesManifest.cs" Link="CrashReporter\GameBinariesManifest.cs" />
     <Compile Include="..\Coop.CrashReporter\MinidumpProcessIdReader.cs" Link="CrashReporter\MinidumpProcessIdReader.cs" />
   </ItemGroup>
 </Project>

--- a/source/Coop.CrashReporter.Tests/GameBinariesManifestTests.cs
+++ b/source/Coop.CrashReporter.Tests/GameBinariesManifestTests.cs
@@ -23,10 +23,9 @@ namespace Coop.CrashReporter.Tests
 
             bool written;
             string manifestPath = Path.Combine(tempRoot, GameBinariesManifest.FileName);
-            string summary = GameBinariesManifest.Write(
-                manifestPath,
-                binariesDirectory,
-                out written);
+            string summary = GameBinariesManifest
+                .Capture(binariesDirectory)
+                .Write(manifestPath, out written);
 
             Assert.True(written);
             Assert.Equal("2 files listed in " + GameBinariesManifest.FileName, summary);
@@ -36,6 +35,29 @@ namespace Coop.CrashReporter.Tests
             Assert.Contains("\"path\": \"engine_config.txt\", \"bytes\": 3", manifest);
             Assert.Contains("\"path\": \"Sample.dll\"", manifest);
             Assert.Contains("\"fileVersion\": \"" + expectedVersion.Trim() + "\"", manifest);
+        }
+
+        [Fact]
+        public void Capture_SnapshotsTheDirectoryBeforeTheManifestIsWritten()
+        {
+            string binariesDirectory = CreateBinariesDirectory();
+            string replacedPath = Path.Combine(binariesDirectory, "TaleWorlds.Core.dll");
+            File.WriteAllText(replacedPath, "original");
+
+            GameBinariesManifest manifest = GameBinariesManifest.Capture(binariesDirectory);
+
+            // Stands in for a launcher update between the crash and the finished report.
+            File.WriteAllText(replacedPath, "replaced by a launcher update");
+            File.WriteAllText(Path.Combine(binariesDirectory, "Added.dll"), "added later");
+
+            bool written;
+            string manifestPath = Path.Combine(tempRoot, GameBinariesManifest.FileName);
+            manifest.Write(manifestPath, out written);
+
+            Assert.True(written);
+            string json = File.ReadAllText(manifestPath);
+            Assert.Contains("\"path\": \"TaleWorlds.Core.dll\", \"bytes\": 8", json);
+            Assert.DoesNotContain("Added.dll", json);
         }
 
         [Fact]
@@ -49,7 +71,7 @@ namespace Coop.CrashReporter.Tests
 
             bool written;
             string manifestPath = Path.Combine(tempRoot, GameBinariesManifest.FileName);
-            GameBinariesManifest.Write(manifestPath, binariesDirectory, out written);
+            GameBinariesManifest.Capture(binariesDirectory).Write(manifestPath, out written);
 
             Assert.True(written);
             Assert.Contains("\"path\": \"Watchdog/Watchdog.txt\"", File.ReadAllText(manifestPath));
@@ -69,10 +91,9 @@ namespace Coop.CrashReporter.Tests
 
             bool written;
             string manifestPath = Path.Combine(tempRoot, GameBinariesManifest.FileName);
-            string summary = GameBinariesManifest.Write(
-                manifestPath,
-                binariesDirectory,
-                out written);
+            string summary = GameBinariesManifest
+                .Capture(binariesDirectory)
+                .Write(manifestPath, out written);
 
             string manifest = File.ReadAllText(manifestPath);
             Assert.True(written);
@@ -90,7 +111,7 @@ namespace Coop.CrashReporter.Tests
 
             bool written;
             string manifestPath = Path.Combine(tempRoot, GameBinariesManifest.FileName);
-            GameBinariesManifest.Write(manifestPath, binariesDirectory, out written);
+            GameBinariesManifest.Capture(binariesDirectory).Write(manifestPath, out written);
 
             Assert.Contains(
                 "\"directory\": \"" + binariesDirectory.Replace("\\", "\\\\") + "\"",
@@ -105,10 +126,9 @@ namespace Coop.CrashReporter.Tests
 
             bool written;
             string manifestPath = Path.Combine(tempRoot, GameBinariesManifest.FileName);
-            string summary = GameBinariesManifest.Write(
-                manifestPath,
-                missingDirectory,
-                out written);
+            string summary = GameBinariesManifest
+                .Capture(missingDirectory)
+                .Write(manifestPath, out written);
 
             Assert.False(written);
             Assert.False(File.Exists(manifestPath));
@@ -123,7 +143,7 @@ namespace Coop.CrashReporter.Tests
 
             bool written;
             string manifestPath = Path.Combine(tempRoot, GameBinariesManifest.FileName);
-            string summary = GameBinariesManifest.Write(manifestPath, null, out written);
+            string summary = GameBinariesManifest.Capture(null).Write(manifestPath, out written);
 
             Assert.False(written);
             Assert.False(File.Exists(manifestPath));

--- a/source/Coop.CrashReporter.Tests/GameBinariesManifestTests.cs
+++ b/source/Coop.CrashReporter.Tests/GameBinariesManifestTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace Coop.CrashReporter.Tests
+{
+    public sealed class GameBinariesManifestTests : IDisposable
+    {
+        private readonly string tempRoot = Path.Combine(
+            Path.GetTempPath(),
+            "CoopBinariesManifestTests_" + Guid.NewGuid().ToString("N"));
+
+        [Fact]
+        public void Write_ListsFilesWithSizesAndVersions()
+        {
+            string binariesDirectory = CreateBinariesDirectory();
+            File.WriteAllText(Path.Combine(binariesDirectory, "engine_config.txt"), "abc");
+            string assemblyPath = Path.Combine(binariesDirectory, "Sample.dll");
+            File.Copy(typeof(GameBinariesManifest).Assembly.Location, assemblyPath);
+            string expectedVersion = FileVersionInfo.GetVersionInfo(assemblyPath).FileVersion;
+            Assert.False(string.IsNullOrWhiteSpace(expectedVersion));
+
+            bool written;
+            string manifestPath = Path.Combine(tempRoot, GameBinariesManifest.FileName);
+            string summary = GameBinariesManifest.Write(
+                manifestPath,
+                binariesDirectory,
+                out written);
+
+            Assert.True(written);
+            Assert.Equal("2 files listed in " + GameBinariesManifest.FileName, summary);
+            string manifest = File.ReadAllText(manifestPath);
+            Assert.Contains("\"fileCount\": 2", manifest);
+            Assert.Contains("\"truncated\": false", manifest);
+            Assert.Contains("\"path\": \"engine_config.txt\", \"bytes\": 3", manifest);
+            Assert.Contains("\"path\": \"Sample.dll\"", manifest);
+            Assert.Contains("\"fileVersion\": \"" + expectedVersion.Trim() + "\"", manifest);
+        }
+
+        [Fact]
+        public void Write_ListsNestedFilesRelativeToTheBinariesDirectory()
+        {
+            string binariesDirectory = CreateBinariesDirectory();
+            Directory.CreateDirectory(Path.Combine(binariesDirectory, "Watchdog"));
+            File.WriteAllText(
+                Path.Combine(binariesDirectory, "Watchdog", "Watchdog.txt"),
+                "watchdog");
+
+            bool written;
+            string manifestPath = Path.Combine(tempRoot, GameBinariesManifest.FileName);
+            GameBinariesManifest.Write(manifestPath, binariesDirectory, out written);
+
+            Assert.True(written);
+            Assert.Contains("\"path\": \"Watchdog/Watchdog.txt\"", File.ReadAllText(manifestPath));
+        }
+
+        [Fact]
+        public void Write_SkipsAndCountsDirectoriesBeyondTheDepthLimit()
+        {
+            string binariesDirectory = CreateBinariesDirectory();
+            string deepDirectory = binariesDirectory;
+            for (var depth = 1; depth <= GameBinariesManifest.MaximumDirectoryDepth + 1; depth++)
+            {
+                deepDirectory = Path.Combine(deepDirectory, "level" + depth);
+                Directory.CreateDirectory(deepDirectory);
+                File.WriteAllText(Path.Combine(deepDirectory, "level" + depth + ".txt"), "x");
+            }
+
+            bool written;
+            string manifestPath = Path.Combine(tempRoot, GameBinariesManifest.FileName);
+            string summary = GameBinariesManifest.Write(
+                manifestPath,
+                binariesDirectory,
+                out written);
+
+            string manifest = File.ReadAllText(manifestPath);
+            Assert.True(written);
+            Assert.Contains("\"skippedDirectories\": 1", manifest);
+            Assert.Contains("\"path\": \"level1/level1.txt\"", manifest);
+            Assert.Contains("\"path\": \"level1/level2/level2.txt\"", manifest);
+            Assert.DoesNotContain("level3.txt", manifest);
+            Assert.Contains("1 deeper directories not listed", summary);
+        }
+
+        [Fact]
+        public void Write_EscapesTheBinariesDirectoryPath()
+        {
+            string binariesDirectory = CreateBinariesDirectory();
+
+            bool written;
+            string manifestPath = Path.Combine(tempRoot, GameBinariesManifest.FileName);
+            GameBinariesManifest.Write(manifestPath, binariesDirectory, out written);
+
+            Assert.Contains(
+                "\"directory\": \"" + binariesDirectory.Replace("\\", "\\\\") + "\"",
+                File.ReadAllText(manifestPath));
+        }
+
+        [Fact]
+        public void Write_ReportsMissingDirectoryWithoutWritingAManifest()
+        {
+            Directory.CreateDirectory(tempRoot);
+            string missingDirectory = Path.Combine(tempRoot, "absent");
+
+            bool written;
+            string manifestPath = Path.Combine(tempRoot, GameBinariesManifest.FileName);
+            string summary = GameBinariesManifest.Write(
+                manifestPath,
+                missingDirectory,
+                out written);
+
+            Assert.False(written);
+            Assert.False(File.Exists(manifestPath));
+            Assert.Contains("not captured", summary);
+            Assert.Contains(missingDirectory, summary);
+        }
+
+        [Fact]
+        public void Write_ReportsUnresolvedDirectoryWithoutWritingAManifest()
+        {
+            Directory.CreateDirectory(tempRoot);
+
+            bool written;
+            string manifestPath = Path.Combine(tempRoot, GameBinariesManifest.FileName);
+            string summary = GameBinariesManifest.Write(manifestPath, null, out written);
+
+            Assert.False(written);
+            Assert.False(File.Exists(manifestPath));
+            Assert.Equal("not captured (directory was not resolved)", summary);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(tempRoot, true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+
+        private string CreateBinariesDirectory()
+        {
+            string binariesDirectory = Path.Combine(tempRoot, "Win64_Shipping_Client");
+            Directory.CreateDirectory(binariesDirectory);
+            return binariesDirectory;
+        }
+    }
+}

--- a/source/Coop.CrashReporter/Coop.CrashReporter.csproj
+++ b/source/Coop.CrashReporter/Coop.CrashReporter.csproj
@@ -45,6 +45,7 @@
   <ItemGroup>
     <Compile Include="CrashReportCollector.cs" />
     <Compile Include="CrashReporterOptions.cs" />
+    <Compile Include="GameBinariesManifest.cs" />
     <Compile Include="MinidumpProcessIdReader.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/source/Coop.CrashReporter/CrashReportCollector.cs
+++ b/source/Coop.CrashReporter/CrashReportCollector.cs
@@ -58,6 +58,15 @@ namespace Coop.CrashReporter
         {
             process.WaitForExit();
             int exitCode = process.ExitCode;
+
+            // Walked before anything waits on a dump: the zero exit-code path spends up to
+            // 30 seconds looking for one, and a launcher update inside that window would rewrite
+            // the very files being listed. A clean exit pays for a walk whose result is then
+            // thrown away, but the game's own binaries are still in the file cache it just used
+            // them from, so that is a fraction of a second in a process about to exit anyway.
+            GameBinariesManifest binaries = GameBinariesManifest.Capture(
+                options.GameBinariesDirectory);
+
             string dumpPath = exitCode == 0
                 ? WaitForMatchingDump(CrashDumpDiscoveryTimeout)
                 : null;
@@ -69,14 +78,9 @@ namespace Coop.CrashReporter
             Directory.CreateDirectory(logsDirectory);
             List<string> copiedLogs = CopyLogs(logsDirectory);
 
-            // Written before the dump wait so the listed versions are the ones that were on
-            // disk at the crash, not whatever a launcher update replaced them with meanwhile.
             string manifestPath = Path.Combine(reportDirectory, GameBinariesManifest.FileName);
             bool manifestWritten;
-            string binariesSummary = GameBinariesManifest.Write(
-                manifestPath,
-                options.GameBinariesDirectory,
-                out manifestWritten);
+            string binariesSummary = binaries.Write(manifestPath, out manifestWritten);
 
             if (dumpPath == null)
                 dumpPath = WaitForMatchingDump(CrashDumpDiscoveryTimeout);

--- a/source/Coop.CrashReporter/CrashReportCollector.cs
+++ b/source/Coop.CrashReporter/CrashReportCollector.cs
@@ -69,6 +69,15 @@ namespace Coop.CrashReporter
             Directory.CreateDirectory(logsDirectory);
             List<string> copiedLogs = CopyLogs(logsDirectory);
 
+            // Written before the dump wait so the listed versions are the ones that were on
+            // disk at the crash, not whatever a launcher update replaced them with meanwhile.
+            string manifestPath = Path.Combine(reportDirectory, GameBinariesManifest.FileName);
+            bool manifestWritten;
+            string binariesSummary = GameBinariesManifest.Write(
+                manifestPath,
+                options.GameBinariesDirectory,
+                out manifestWritten);
+
             if (dumpPath == null)
                 dumpPath = WaitForMatchingDump(CrashDumpDiscoveryTimeout);
 
@@ -85,13 +94,15 @@ namespace Coop.CrashReporter
                 exitCode,
                 dumpCopied,
                 dumpCaptureDetails,
+                binariesSummary,
                 copiedLogs);
-            WriteReadme(readmePath, dumpCopied);
+            WriteReadme(readmePath, dumpCopied, manifestWritten);
             CreateShareableZip(
                 Path.Combine(reportDirectory, "shareable.zip"),
                 readmePath,
                 reportPath,
                 dumpCopied ? copiedDumpPath : null,
+                manifestWritten ? manifestPath : null,
                 copiedLogs);
             return 0;
         }
@@ -331,6 +342,7 @@ namespace Coop.CrashReporter
             int exitCode,
             bool dumpCopied,
             string dumpCaptureDetails,
+            string binariesSummary,
             IEnumerable<string> copiedLogs)
         {
             var lines = new[]
@@ -343,12 +355,17 @@ namespace Coop.CrashReporter
                 "Exit code: " + exitCode.ToString(CultureInfo.InvariantCulture),
                 "Dump captured: " + (dumpCopied ? "yes" : "no"),
                 "Dump capture details: " + dumpCaptureDetails,
+                "Game binaries directory: " + (options.GameBinariesDirectory ?? "unknown"),
+                "Game binaries: " + binariesSummary,
                 "Logs captured: " + copiedLogs.Count().ToString(CultureInfo.InvariantCulture),
             };
             File.WriteAllLines(reportPath, lines, new UTF8Encoding(false));
         }
 
-        private static void WriteReadme(string readmePath, bool dumpCopied)
+        private static void WriteReadme(
+            string readmePath,
+            bool dumpCopied,
+            bool manifestWritten)
         {
             var lines = new List<string>
             {
@@ -366,6 +383,14 @@ namespace Coop.CrashReporter
                 lines.Add("The ZIP contains dump.dmp for advanced debugging.");
             }
 
+            if (manifestWritten)
+            {
+                lines.Add("");
+                lines.Add(
+                    GameBinariesManifest.FileName +
+                    " lists the file names, sizes and versions found in the game's binaries folder.");
+            }
+
             File.WriteAllLines(readmePath, lines, new UTF8Encoding(false));
         }
 
@@ -374,6 +399,7 @@ namespace Coop.CrashReporter
             string readmePath,
             string reportPath,
             string dumpPath,
+            string manifestPath,
             IEnumerable<string> copiedLogs)
         {
             using (var stream = new FileStream(
@@ -387,6 +413,8 @@ namespace Coop.CrashReporter
                 AddFile(archive, reportPath, "report.txt", false);
                 if (dumpPath != null)
                     AddFile(archive, dumpPath, "dump.dmp", false);
+                if (manifestPath != null)
+                    AddFile(archive, manifestPath, GameBinariesManifest.FileName, false);
 
                 foreach (string logPath in copiedLogs)
                 {

--- a/source/Coop.CrashReporter/CrashReporterOptions.cs
+++ b/source/Coop.CrashReporter/CrashReporterOptions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.IO;
+using System.Security;
 
 namespace Coop.CrashReporter
 {
@@ -15,7 +16,8 @@ namespace Coop.CrashReporter
             string role,
             string build,
             string programDataRoot,
-            string outputRoot)
+            string outputRoot,
+            string gameBinariesDirectory = null)
         {
             ProcessId = processId;
             ProcessStartUtcTicks = processStartUtcTicks;
@@ -26,6 +28,7 @@ namespace Coop.CrashReporter
                 Path.GetFullPath(programDataRoot),
                 BannerlordDirectoryName);
             OutputRoot = Path.GetFullPath(outputRoot);
+            GameBinariesDirectory = NormalizeOptionalPath(gameBinariesDirectory);
         }
 
         public int ProcessId { get; }
@@ -35,6 +38,32 @@ namespace Coop.CrashReporter
         public string Build { get; }
         public string BannerlordDataRoot { get; }
         public string OutputRoot { get; }
+
+        /// <summary>
+        /// The game's bin/Win64_Shipping_Client directory as resolved by the module, or null when
+        /// the module could not resolve it. Only used to list installed files, so a bad value must
+        /// never fail option parsing.
+        /// </summary>
+        public string GameBinariesDirectory { get; }
+
+        private static string NormalizeOptionalPath(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                return null;
+
+            try
+            {
+                return Path.GetFullPath(path);
+            }
+            catch (Exception exception) when (
+                exception is ArgumentException ||
+                exception is NotSupportedException ||
+                exception is PathTooLongException ||
+                exception is SecurityException)
+            {
+                return null;
+            }
+        }
 
         public static bool TryParse(string[] args, out CrashReporterOptions options)
         {
@@ -72,7 +101,8 @@ namespace Coop.CrashReporter
                     Environment.GetEnvironmentVariable("COOP_CRASH_ROLE") ?? "unknown",
                     Environment.GetEnvironmentVariable("COOP_CRASH_BUILD") ?? "unknown",
                     programDataRoot,
-                    outputRoot);
+                    outputRoot,
+                    Environment.GetEnvironmentVariable("COOP_CRASH_GAME_BINARIES"));
                 return true;
             }
             catch (Exception exception) when (

--- a/source/Coop.CrashReporter/GameBinariesManifest.cs
+++ b/source/Coop.CrashReporter/GameBinariesManifest.cs
@@ -8,12 +8,16 @@ using System.Text;
 namespace Coop.CrashReporter
 {
     /// <summary>
-    /// Writes a JSON manifest of every file in the game binaries directory
-    /// (bin/Win64_Shipping_Client) together with its version, size and last write time.
-    /// A dump does not say which build, which DLC or which mixture of hand-copied game files
-    /// was actually installed, so the manifest is what tells a broken install apart from a real bug.
+    /// A JSON manifest of every file in the game binaries directory (bin/Win64_Shipping_Client)
+    /// together with its version, size and last write time. A dump does not say which build, which
+    /// DLC or which mixture of hand-copied game files was actually installed, so the manifest is
+    /// what tells a broken install apart from a real bug.
+    /// <para>
+    /// Capturing and writing are separate: the walk has to happen the moment the game exits, while
+    /// the report directory it is written to only exists once a crash is confirmed.
+    /// </para>
     /// </summary>
-    internal static class GameBinariesManifest
+    internal sealed class GameBinariesManifest
     {
         internal const string FileName = "game-binaries.json";
 
@@ -24,23 +28,50 @@ namespace Coop.CrashReporter
         internal const int MaximumDirectoryDepth = 2;
 
         // Bounds the manifest if the directory ever contains something unexpected, e.g. an
-        // unpacked asset dump; a full game install lists well under a thousand files.
+        // unpacked asset dump; a full game install lists well under a thousand files and holds
+        // a handful of directories.
         private const int MaximumFileCount = 20000;
+        private const int MaximumDirectoryCount = 5000;
+
+        private readonly string directory;
+        private readonly string failure;
+        private readonly DateTime capturedUtc;
+        private readonly List<FileEntry> files;
+        private readonly int skippedDirectories;
+        private readonly bool truncated;
+
+        private GameBinariesManifest(string failure)
+        {
+            this.failure = failure;
+        }
+
+        private GameBinariesManifest(
+            string directory,
+            DateTime capturedUtc,
+            List<FileEntry> files,
+            int skippedDirectories,
+            bool truncated)
+        {
+            this.directory = directory;
+            this.capturedUtc = capturedUtc;
+            this.files = files;
+            this.skippedDirectories = skippedDirectories;
+            this.truncated = truncated;
+        }
 
         /// <summary>
-        /// Writes the manifest and returns a one-line summary for the report. <paramref name="written"/>
-        /// is true when the manifest file exists on disk afterwards.
+        /// Walks the binaries directory. Call this as soon as the game process exits: everything
+        /// after it - waiting for a dump, copying logs - is time the files can still change in.
         /// </summary>
-        internal static string Write(
-            string manifestPath,
-            string binariesDirectory,
-            out bool written)
+        internal static GameBinariesManifest Capture(string binariesDirectory)
         {
-            written = false;
             if (string.IsNullOrEmpty(binariesDirectory))
-                return "not captured (directory was not resolved)";
+                return new GameBinariesManifest("not captured (directory was not resolved)");
             if (!Directory.Exists(binariesDirectory))
-                return "not captured (directory does not exist: " + binariesDirectory + ")";
+            {
+                return new GameBinariesManifest(
+                    "not captured (directory does not exist: " + binariesDirectory + ")");
+            }
 
             string root = binariesDirectory.TrimEnd(
                 Path.DirectorySeparatorChar,
@@ -48,6 +79,23 @@ namespace Coop.CrashReporter
             int skippedDirectories;
             bool truncated;
             List<FileEntry> files = ReadFiles(root, out skippedDirectories, out truncated);
+            return new GameBinariesManifest(
+                root,
+                DateTime.UtcNow,
+                files,
+                skippedDirectories,
+                truncated);
+        }
+
+        /// <summary>
+        /// Writes the captured manifest and returns a one-line summary for the report.
+        /// <paramref name="written"/> is true when the manifest file exists on disk afterwards.
+        /// </summary>
+        internal string Write(string manifestPath, out bool written)
+        {
+            written = false;
+            if (failure != null)
+                return failure;
 
             try
             {
@@ -58,7 +106,7 @@ namespace Coop.CrashReporter
                     FileShare.Read))
                 using (var writer = new StreamWriter(stream, new UTF8Encoding(false)))
                 {
-                    WriteManifest(writer, root, files, skippedDirectories, truncated);
+                    WriteManifest(writer);
                 }
             }
             catch (IOException)
@@ -95,21 +143,29 @@ namespace Coop.CrashReporter
             var entries = new List<FileEntry>();
             var pending = new Stack<PendingDirectory>();
             pending.Push(new PendingDirectory(root, 0));
+            var queuedDirectories = 0;
             skippedDirectories = 0;
             truncated = false;
 
             while (pending.Count > 0 && !truncated)
             {
                 PendingDirectory current = pending.Pop();
-                foreach (string subdirectory in TryGetDirectories(current.Path))
+                foreach (string subdirectory in EnumerateDirectoriesSafely(current.Path))
                 {
-                    if (current.Depth < MaximumDirectoryDepth)
-                        pending.Push(new PendingDirectory(subdirectory, current.Depth + 1));
-                    else
+                    // Queueing is capped for the same reason the file count is: a directory with
+                    // a million children must not grow the queue until the reporter dies.
+                    if (current.Depth >= MaximumDirectoryDepth ||
+                        queuedDirectories >= MaximumDirectoryCount)
+                    {
                         skippedDirectories++;
+                        continue;
+                    }
+
+                    pending.Push(new PendingDirectory(subdirectory, current.Depth + 1));
+                    queuedDirectories++;
                 }
 
-                foreach (string file in TryGetFiles(current.Path))
+                foreach (string file in EnumerateFilesSafely(current.Path))
                 {
                     if (entries.Count >= MaximumFileCount)
                     {
@@ -130,36 +186,61 @@ namespace Coop.CrashReporter
             return entries;
         }
 
-        // An unreadable subdirectory must cost its own contents, not the whole manifest.
-        private static string[] TryGetDirectories(string directory)
+        private static IEnumerable<string> EnumerateDirectoriesSafely(string directory)
         {
-            try
-            {
-                return Directory.GetDirectories(directory);
-            }
-            catch (IOException)
-            {
-                return new string[0];
-            }
-            catch (UnauthorizedAccessException)
-            {
-                return new string[0];
-            }
+            return EnumerateSafely(directory, Directory.EnumerateDirectories);
         }
 
-        private static string[] TryGetFiles(string directory)
+        private static IEnumerable<string> EnumerateFilesSafely(string directory)
         {
+            return EnumerateSafely(directory, Directory.EnumerateFiles);
+        }
+
+        // Lazy on purpose: the materializing GetFiles/GetDirectories allocate every path in a
+        // directory up front, so MaximumFileCount could not stop an unpacked asset dump from
+        // exhausting the reporter before it ever wrote the report. Enumerating also means an
+        // unreadable directory costs its own contents, not the whole manifest.
+        private static IEnumerable<string> EnumerateSafely(
+            string directory,
+            Func<string, IEnumerable<string>> enumerate)
+        {
+            IEnumerator<string> enumerator;
             try
             {
-                return Directory.GetFiles(directory);
+                enumerator = enumerate(directory).GetEnumerator();
             }
             catch (IOException)
             {
-                return new string[0];
+                yield break;
             }
             catch (UnauthorizedAccessException)
             {
-                return new string[0];
+                yield break;
+            }
+
+            using (enumerator)
+            {
+                while (true)
+                {
+                    string current;
+                    try
+                    {
+                        if (!enumerator.MoveNext())
+                            yield break;
+
+                        current = enumerator.Current;
+                    }
+                    catch (IOException)
+                    {
+                        yield break;
+                    }
+                    catch (UnauthorizedAccessException)
+                    {
+                        yield break;
+                    }
+
+                    yield return current;
+                }
             }
         }
 
@@ -216,16 +297,11 @@ namespace Coop.CrashReporter
                 .Replace(Path.DirectorySeparatorChar, '/');
         }
 
-        private static void WriteManifest(
-            TextWriter writer,
-            string directory,
-            List<FileEntry> files,
-            int skippedDirectories,
-            bool truncated)
+        private void WriteManifest(TextWriter writer)
         {
             writer.WriteLine("{");
             writer.WriteLine("  \"capturedUtc\": " +
-                Quote(DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture)) + ",");
+                Quote(capturedUtc.ToString("O", CultureInfo.InvariantCulture)) + ",");
             writer.WriteLine("  \"directory\": " + Quote(directory) + ",");
             writer.WriteLine("  \"fileCount\": " +
                 files.Count.ToString(CultureInfo.InvariantCulture) + ",");

--- a/source/Coop.CrashReporter/GameBinariesManifest.cs
+++ b/source/Coop.CrashReporter/GameBinariesManifest.cs
@@ -1,0 +1,330 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+namespace Coop.CrashReporter
+{
+    /// <summary>
+    /// Writes a JSON manifest of every file in the game binaries directory
+    /// (bin/Win64_Shipping_Client) together with its version, size and last write time.
+    /// A dump does not say which build, which DLC or which mixture of hand-copied game files
+    /// was actually installed, so the manifest is what tells a broken install apart from a real bug.
+    /// </summary>
+    internal static class GameBinariesManifest
+    {
+        internal const string FileName = "game-binaries.json";
+
+        // The interesting files are the game's own binaries and the runtime folders next to them
+        // (bin/Win64_Shipping_Client/Microsoft.NETCore.App/<version>). Walking everything instead
+        // pulls in the bundled mono tree - 4700 files whose versions no one has ever needed, and a
+        // minute and a half of disk on a cold cache right after the game died.
+        internal const int MaximumDirectoryDepth = 2;
+
+        // Bounds the manifest if the directory ever contains something unexpected, e.g. an
+        // unpacked asset dump; a full game install lists well under a thousand files.
+        private const int MaximumFileCount = 20000;
+
+        /// <summary>
+        /// Writes the manifest and returns a one-line summary for the report. <paramref name="written"/>
+        /// is true when the manifest file exists on disk afterwards.
+        /// </summary>
+        internal static string Write(
+            string manifestPath,
+            string binariesDirectory,
+            out bool written)
+        {
+            written = false;
+            if (string.IsNullOrEmpty(binariesDirectory))
+                return "not captured (directory was not resolved)";
+            if (!Directory.Exists(binariesDirectory))
+                return "not captured (directory does not exist: " + binariesDirectory + ")";
+
+            string root = binariesDirectory.TrimEnd(
+                Path.DirectorySeparatorChar,
+                Path.AltDirectorySeparatorChar);
+            int skippedDirectories;
+            bool truncated;
+            List<FileEntry> files = ReadFiles(root, out skippedDirectories, out truncated);
+
+            try
+            {
+                using (var stream = new FileStream(
+                    manifestPath,
+                    FileMode.Create,
+                    FileAccess.Write,
+                    FileShare.Read))
+                using (var writer = new StreamWriter(stream, new UTF8Encoding(false)))
+                {
+                    WriteManifest(writer, root, files, skippedDirectories, truncated);
+                }
+            }
+            catch (IOException)
+            {
+                return "not captured (manifest could not be written)";
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return "not captured (manifest could not be written)";
+            }
+
+            written = true;
+            var summary = new StringBuilder();
+            summary.Append(files.Count.ToString(CultureInfo.InvariantCulture));
+            summary.Append(" files listed in ").Append(FileName);
+            if (skippedDirectories > 0)
+            {
+                summary.Append(", ")
+                    .Append(skippedDirectories.ToString(CultureInfo.InvariantCulture))
+                    .Append(" deeper directories not listed");
+            }
+
+            if (truncated)
+                summary.Append(" (truncated)");
+
+            return summary.ToString();
+        }
+
+        private static List<FileEntry> ReadFiles(
+            string root,
+            out int skippedDirectories,
+            out bool truncated)
+        {
+            var entries = new List<FileEntry>();
+            var pending = new Stack<PendingDirectory>();
+            pending.Push(new PendingDirectory(root, 0));
+            skippedDirectories = 0;
+            truncated = false;
+
+            while (pending.Count > 0 && !truncated)
+            {
+                PendingDirectory current = pending.Pop();
+                foreach (string subdirectory in TryGetDirectories(current.Path))
+                {
+                    if (current.Depth < MaximumDirectoryDepth)
+                        pending.Push(new PendingDirectory(subdirectory, current.Depth + 1));
+                    else
+                        skippedDirectories++;
+                }
+
+                foreach (string file in TryGetFiles(current.Path))
+                {
+                    if (entries.Count >= MaximumFileCount)
+                    {
+                        truncated = true;
+                        break;
+                    }
+
+                    FileEntry entry = TryReadEntry(root, file);
+                    if (entry != null)
+                        entries.Add(entry);
+                }
+            }
+
+            entries.Sort((left, right) => string.Compare(
+                left.RelativePath,
+                right.RelativePath,
+                StringComparison.OrdinalIgnoreCase));
+            return entries;
+        }
+
+        // An unreadable subdirectory must cost its own contents, not the whole manifest.
+        private static string[] TryGetDirectories(string directory)
+        {
+            try
+            {
+                return Directory.GetDirectories(directory);
+            }
+            catch (IOException)
+            {
+                return new string[0];
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return new string[0];
+            }
+        }
+
+        private static string[] TryGetFiles(string directory)
+        {
+            try
+            {
+                return Directory.GetFiles(directory);
+            }
+            catch (IOException)
+            {
+                return new string[0];
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return new string[0];
+            }
+        }
+
+        private static FileEntry TryReadEntry(string root, string path)
+        {
+            try
+            {
+                var info = new FileInfo(path);
+                var entry = new FileEntry
+                {
+                    RelativePath = GetRelativePath(root, path),
+                    Length = info.Length,
+                    LastWriteUtc = info.LastWriteTimeUtc,
+                };
+
+                if (HasVersionResource(path))
+                {
+                    FileVersionInfo version = FileVersionInfo.GetVersionInfo(path);
+                    entry.FileVersion = NullIfEmpty(version.FileVersion);
+                    entry.ProductVersion = NullIfEmpty(version.ProductVersion);
+                }
+
+                return entry;
+            }
+            catch (IOException)
+            {
+                return null;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return null;
+            }
+        }
+
+        private static bool HasVersionResource(string path)
+        {
+            string extension = Path.GetExtension(path);
+            return extension.Equals(".dll", StringComparison.OrdinalIgnoreCase) ||
+                   extension.Equals(".exe", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string NullIfEmpty(string value)
+        {
+            return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+        }
+
+        private static string GetRelativePath(string root, string path)
+        {
+            string relative = path.StartsWith(root, StringComparison.OrdinalIgnoreCase)
+                ? path.Substring(root.Length)
+                : path;
+            return relative
+                .TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                .Replace(Path.DirectorySeparatorChar, '/');
+        }
+
+        private static void WriteManifest(
+            TextWriter writer,
+            string directory,
+            List<FileEntry> files,
+            int skippedDirectories,
+            bool truncated)
+        {
+            writer.WriteLine("{");
+            writer.WriteLine("  \"capturedUtc\": " +
+                Quote(DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture)) + ",");
+            writer.WriteLine("  \"directory\": " + Quote(directory) + ",");
+            writer.WriteLine("  \"fileCount\": " +
+                files.Count.ToString(CultureInfo.InvariantCulture) + ",");
+            writer.WriteLine("  \"maximumDirectoryDepth\": " +
+                MaximumDirectoryDepth.ToString(CultureInfo.InvariantCulture) + ",");
+            writer.WriteLine("  \"skippedDirectories\": " +
+                skippedDirectories.ToString(CultureInfo.InvariantCulture) + ",");
+            writer.WriteLine("  \"truncated\": " + (truncated ? "true" : "false") + ",");
+            writer.WriteLine("  \"files\": [");
+
+            var line = new StringBuilder();
+            for (var index = 0; index < files.Count; index++)
+            {
+                FileEntry file = files[index];
+                line.Length = 0;
+                line.Append("    { \"path\": ").Append(Quote(file.RelativePath));
+                line.Append(", \"bytes\": ")
+                    .Append(file.Length.ToString(CultureInfo.InvariantCulture));
+                line.Append(", \"modifiedUtc\": ").Append(
+                    Quote(file.LastWriteUtc.ToString("O", CultureInfo.InvariantCulture)));
+                if (file.FileVersion != null)
+                    line.Append(", \"fileVersion\": ").Append(Quote(file.FileVersion));
+                if (file.ProductVersion != null)
+                    line.Append(", \"productVersion\": ").Append(Quote(file.ProductVersion));
+                line.Append(index == files.Count - 1 ? " }" : " },");
+                writer.WriteLine(line.ToString());
+            }
+
+            writer.WriteLine("  ]");
+            writer.WriteLine("}");
+        }
+
+        private static string Quote(string value)
+        {
+            var builder = new StringBuilder(value.Length + 2);
+            builder.Append('"');
+            foreach (char character in value)
+            {
+                switch (character)
+                {
+                    case '"':
+                        builder.Append("\\\"");
+                        break;
+                    case '\\':
+                        builder.Append("\\\\");
+                        break;
+                    case '\b':
+                        builder.Append("\\b");
+                        break;
+                    case '\f':
+                        builder.Append("\\f");
+                        break;
+                    case '\n':
+                        builder.Append("\\n");
+                        break;
+                    case '\r':
+                        builder.Append("\\r");
+                        break;
+                    case '\t':
+                        builder.Append("\\t");
+                        break;
+                    default:
+                        if (character < ' ')
+                        {
+                            builder.Append("\\u").Append(
+                                ((int)character).ToString("x4", CultureInfo.InvariantCulture));
+                        }
+                        else
+                        {
+                            builder.Append(character);
+                        }
+
+                        break;
+                }
+            }
+
+            builder.Append('"');
+            return builder.ToString();
+        }
+
+        private sealed class PendingDirectory
+        {
+            public PendingDirectory(string path, int depth)
+            {
+                Path = path;
+                Depth = depth;
+            }
+
+            public readonly string Path;
+            public readonly int Depth;
+        }
+
+        private sealed class FileEntry
+        {
+            public string RelativePath;
+            public long Length;
+            public DateTime LastWriteUtc;
+            public string FileVersion;
+            public string ProductVersion;
+        }
+    }
+}

--- a/source/Coop/Coop.csproj
+++ b/source/Coop/Coop.csproj
@@ -206,6 +206,7 @@
     <Compile Include="BootPatches.cs" />
     <Compile Include="CoopMod.cs" />
     <Compile Include="CrashReporting\CrashDiagnostics.cs" />
+    <Compile Include="CrashReporting\GameBinariesDirectory.cs" />
     <Compile Include="LiveTesting\LiveTestControlServer.cs" />
     <Compile Include="Lib\NoHarmony\NoHarmonyLoader.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -296,6 +296,17 @@ namespace Coop
                     startInfo.EnvironmentVariables["COOP_CRASH_BUILD"] = informationalVersion;
                     startInfo.EnvironmentVariables["COOP_CRASH_READY"] = readyEventName;
 
+                    string gameBinariesDirectory = GameBinariesDirectory.Resolve();
+                    if (gameBinariesDirectory == null)
+                    {
+                        Logger.Warning(
+                            "Game binaries directory could not be resolved; crash reports will not list installed game files");
+                    }
+                    else
+                    {
+                        startInfo.EnvironmentVariables["COOP_CRASH_GAME_BINARIES"] = gameBinariesDirectory;
+                    }
+
                     using (var ready = new EventWaitHandle(
                         false,
                         EventResetMode.AutoReset,

--- a/source/Coop/CrashReporting/GameBinariesDirectory.cs
+++ b/source/Coop/CrashReporting/GameBinariesDirectory.cs
@@ -1,0 +1,58 @@
+using System;
+using System.IO;
+using System.Security;
+using TaleWorlds.Library;
+
+namespace Coop.CrashReporting
+{
+    /// <summary>
+    /// Resolves the directory the running game's binaries live in (bin/Win64_Shipping_Client) so the
+    /// crash reporter can record which files and versions were installed. The resolution has to happen
+    /// in the module: the reporter is a plain process with no TaleWorlds assemblies of its own.
+    /// </summary>
+    internal static class GameBinariesDirectory
+    {
+        /// <summary>
+        /// The full path of the game's binaries directory, or null when it cannot be resolved.
+        /// </summary>
+        internal static string Resolve()
+        {
+            // BasePath.Name is the install root (a path relative to the bin directory on Windows) and
+            // Common.ConfigName is the platform's bin folder name, e.g. Win64_Shipping_Client. Fully
+            // qualified because the module's own Common assembly shadows TaleWorlds.Library.Common.
+            string resolved = TryGetFullPath(Path.Combine(
+                BasePath.Name,
+                "bin",
+                TaleWorlds.Library.Common.ConfigName));
+            if (resolved != null && Directory.Exists(resolved))
+                return resolved;
+
+            // Headless and test hosts do not always run out of the game's bin directory, in which case
+            // the executable's own directory is the honest answer.
+            string executableDirectory = TryGetFullPath(AppDomain.CurrentDomain.BaseDirectory);
+            return executableDirectory != null && Directory.Exists(executableDirectory)
+                ? executableDirectory
+                : null;
+        }
+
+        private static string TryGetFullPath(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                return null;
+
+            try
+            {
+                return Path.GetFullPath(path);
+            }
+            catch (Exception exception) when (
+                exception is ArgumentException ||
+                exception is NotSupportedException ||
+                exception is PathTooLongException ||
+                exception is IOException ||
+                exception is SecurityException)
+            {
+                return null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?

A coop crash report folder holds `report.txt`, the copied logs, `dump.dmp` and `shareable.zip`. It records the mod build, but nothing about the install it was running against, so a stale, partially updated or hand-patched `bin/Win64_Shipping_Client` is indistinguishable from a real bug when reading a dump.

## What is the new behavior?

Crash reports now include `game-binaries.json`, listing every file in the game's binaries directory with its size, last write time and, for DLLs and EXEs, its file and product version. It is written into the report folder and into `shareable.zip`, and `report.txt` gains a `Game binaries directory:` / `Game binaries:` summary line.

- The module resolves the directory through Bannerlord's own helpers — `BasePath.Name` + `Common.ConfigName` — and passes it to the reporter in `COOP_CRASH_GAME_BINARIES`. The reporter is a plain process with no TaleWorlds assemblies, so the resolution has to happen module-side. If the resolved path does not exist (headless hosts), it falls back to the executable's own directory; if nothing resolves, the report says so instead of guessing.
- Traversal stops two directories deep. A full walk pulls in the bundled `mono` tree — 5473 files, 1.1 MB of JSON and 99 s of cold disk right after the game died. Bounded, a real install is 736 files, 172 KB and 0.4 s, and still covers `Microsoft.NETCore.App/<version>` and `Watchdog`. Directories that were not descended into are counted in the manifest (`skippedDirectories`) and in the `report.txt` summary rather than silently dropped.
- Unreadable subdirectories and files are skipped individually, so one locked folder cannot cost the whole manifest, and a failure to resolve or write it never blocks the rest of the report.

Verified against the real install: 736 entries, valid JSON, TaleWorlds DLLs listed with size and timestamp. `Coop.CrashReporter.Tests` covers the listing, nested paths, the depth limit, path escaping, and both "not captured" paths (9 tests green); `Coop` and `Coop.CrashReporter` build clean.

## Bot Changelog Entry

- Crash reports now include a list of the game's installed files and their versions, making it easier to spot a broken or out-of-date game install.

## Other information

Sample entry:

```json
{ "path": "TaleWorlds.CampaignSystem.dll", "bytes": 5462464, "modifiedUtc": "2026-07-25T19:47:30.5117697Z", "fileVersion": "1.0.0.0", "productVersion": "1.0.0" }
```
