### PR TITLE
[2641] Add large-battle CPU profiling support

### DIFF
--- a/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
@@ -18,6 +18,9 @@ using GameInterface.Services.MapEvents.Messages.Start;
 using GameInterface.Services.MapEvents.PlayerPartyInteractions;
 using GameInterface.Services.Missions;
 using GameInterface.Services.ObjectManager;
+#if DEBUG
+using GameInterface.Services.Party.Commands;
+#endif
 using GameInterface.Services.Players;
 using GameInterface.Services.Villages.Interfaces;
 using GameInterface.Utils.Commands;
@@ -511,7 +514,7 @@ public class MapEventDebugCommands
                $"{nearest.MemberRoster.TotalManCount} troops, {nearest.Position.ToVec2().Distance(mainPos):0.0} away.";
     }
 
-    // coop.debug.mapevent.start_nearest_bandit_attack PlayerOne [excludedPartyId]
+    // coop.debug.mapevent.start_nearest_bandit_attack testclient 900
     /// <summary>
     /// Starts a server-authoritative bandit attack encounter against a connected player.
     /// </summary>
@@ -523,9 +526,18 @@ public class MapEventDebugCommands
             return "Run this command on the server.";
         }
 
-        if (args.Count < 1 || args.Count > 2)
+#if DEBUG
+        const int maximumArgumentCount = 3;
+        const string usage = "Usage: coop.debug.mapevent.start_nearest_bandit_attack " +
+                             "<controllerId> [targetTroopsPerParty] [excludedPartyId]";
+#else
+        const int maximumArgumentCount = 2;
+        const string usage = "Usage: coop.debug.mapevent.start_nearest_bandit_attack " +
+                             "<controllerId> [excludedPartyId]";
+#endif
+        if (args.Count < 1 || args.Count > maximumArgumentCount)
         {
-            return "Usage: coop.debug.mapevent.start_nearest_bandit_attack <controllerId> [excludedPartyId]";
+            return usage;
         }
 
         if (!TryGetPlayerParty(args[0], requireReady: true, out var objectManager, out var playerParty, out var error))
@@ -533,36 +545,50 @@ public class MapEventDebugCommands
             return error;
         }
 
-        const int maximumFixtureTroops = 8;
-        var remainingFixtureTroops = maximumFixtureTroops;
-        var removedTroops = 0;
-        for (var index = playerParty.MemberRoster.Count - 1; index >= 0; index--)
+#if DEBUG
+        int? targetTroopsPerParty = null;
+#endif
+        string excludedPartyId = null;
+#if DEBUG
+        if (args.Count >= 2)
         {
-            var element = playerParty.MemberRoster.GetElementCopyAtIndex(index);
-            if (element.Character.IsHero)
-                continue;
-
-            var kept = Math.Min(element.Number, remainingFixtureTroops);
-            var removed = element.Number - kept;
-            if (removed > 0)
+            if (int.TryParse(args[1], out int parsedTarget))
             {
-                playerParty.MemberRoster.AddToCountsAtIndex(
-                    index,
-                    -removed,
-                    -Math.Min(element.WoundedNumber, removed),
-                    removeDepleted: false);
-                removedTroops += removed;
+                if (parsedTarget < 1
+                    || parsedTarget > LargeBattleRosterFixtureCommands.MaximumTargetTroopsPerParty)
+                {
+                    return $"Target troops per party must be from 1 to " +
+                           $"{LargeBattleRosterFixtureCommands.MaximumTargetTroopsPerParty}.";
+                }
+                targetTroopsPerParty = parsedTarget;
+                if (args.Count == 3)
+                    excludedPartyId = args[2];
             }
-            remainingFixtureTroops -= kept;
+            else
+            {
+                if (args.Count == 3)
+                {
+                    return usage;
+                }
+                excludedPartyId = args[1];
+            }
         }
-        playerParty.MemberRoster.RemoveZeroCounts();
+#else
+        if (args.Count == 2)
+            excludedPartyId = args[1];
+#endif
 
         if (playerParty.CurrentSettlement != null)
         {
+#if DEBUG
+            if (targetTroopsPerParty.HasValue)
+            {
+                return $"Player {args[0]} must be on the campaign map before an exact-roster battle starts.";
+            }
+#endif
             LeaveSettlementAction.ApplyForParty(playerParty);
         }
 
-        var excludedPartyId = args.Count == 2 ? args[1] : null;
         var playerPosition = playerParty.Position.ToVec2();
         var banditParty = MobileParty.All
             .Where(p => p.IsActive && p.IsBandit && p != playerParty
@@ -576,18 +602,104 @@ public class MapEventDebugCommands
             return "No active bandit/looter party found on the map.";
         }
 
-        StartBattleAction.Apply(banditParty.Party, playerParty.Party);
+        int removedTroops = 0;
+#if DEBUG
+        if (targetTroopsPerParty.HasValue)
+        {
+            if (!LargeBattleRosterFixtureCommands.TryBegin(
+                    playerParty,
+                    banditParty,
+                    targetTroopsPerParty.Value,
+                    out string fixtureResult))
+            {
+                return $"Unable to prepare exact battle rosters: {fixtureResult}";
+            }
+        }
+        else
+#endif
+        {
+            const int maximumFixtureTroops = 8;
+            int remainingFixtureTroops = maximumFixtureTroops;
+            for (int index = playerParty.MemberRoster.Count - 1; index >= 0; index--)
+            {
+                TroopRosterElement element = playerParty.MemberRoster.GetElementCopyAtIndex(index);
+                if (element.Character.IsHero)
+                    continue;
 
-        var partyId = objectManager.TryGetId(banditParty, out string registryId)
-            ? registryId
-            : banditParty.StringId;
-        var partyBaseId = objectManager.TryGetId(banditParty.Party, out string partyBaseRegistryId)
-            ? partyBaseRegistryId
+                int kept = Math.Min(element.Number, remainingFixtureTroops);
+                int removed = element.Number - kept;
+                if (removed > 0)
+                {
+                    playerParty.MemberRoster.AddToCountsAtIndex(
+                        index,
+                        -removed,
+                        -Math.Min(element.WoundedNumber, removed),
+                        removeDepleted: false);
+                    removedTroops += removed;
+                }
+                remainingFixtureTroops -= kept;
+            }
+            playerParty.MemberRoster.RemoveZeroCounts();
+        }
+
+        try
+        {
+            StartBattleAction.Apply(banditParty.Party, playerParty.Party);
+        }
+        catch (Exception exception)
+        {
+            string cleanup = "Legacy roster changes remain applied.";
+#if DEBUG
+            if (targetTroopsPerParty.HasValue)
+                cleanup = LargeBattleRosterFixtureCommands.AbortActiveFixture();
+#endif
+            return $"Bandit attack setup failed: {exception.Message}\n{cleanup}";
+        }
+
+        MapEvent mapEvent = playerParty.MapEvent;
+        if (mapEvent == null || banditParty.MapEvent != mapEvent)
+        {
+            string cleanup = "Legacy roster changes remain applied.";
+#if DEBUG
+            if (targetTroopsPerParty.HasValue)
+                cleanup = LargeBattleRosterFixtureCommands.AbortActiveFixture();
+#endif
+            return "Bandit attack setup did not create a shared map event.\n" + cleanup;
+        }
+        if (!objectManager.TryGetId(mapEvent, out string mapEventId))
+        {
+            string cleanup = "Legacy roster changes remain applied.";
+#if DEBUG
+            if (targetTroopsPerParty.HasValue)
+                cleanup = LargeBattleRosterFixtureCommands.AbortActiveFixture();
+#endif
+            return "Bandit attack map event was not registered.\n" + cleanup;
+        }
+
+        string playerMobilePartyId = objectManager.TryGetId(playerParty, out string resolvedPlayerMobilePartyId)
+            ? resolvedPlayerMobilePartyId
+            : playerParty.StringId;
+        string playerPartyId = objectManager.TryGetId(playerParty.Party, out string resolvedPlayerPartyId)
+            ? resolvedPlayerPartyId
             : "<unregistered>";
+        string banditMobilePartyId = objectManager.TryGetId(banditParty, out string resolvedBanditMobilePartyId)
+            ? resolvedBanditMobilePartyId
+            : banditParty.StringId;
+        string banditPartyId = objectManager.TryGetId(banditParty.Party, out string resolvedBanditPartyId)
+            ? resolvedBanditPartyId
+            : "<unregistered>";
+        string target = "legacy";
+#if DEBUG
+        if (targetTroopsPerParty.HasValue)
+            target = targetTroopsPerParty.Value.ToString();
+#endif
 
-        return $"Started attack by {banditParty.Name} (StringId {banditParty.StringId}, " +
-               $"registry id {partyId}, PartyBase id {partyBaseId}) " +
-               $"against player {args[0]} after removing {removedTroops} excess fixture troops.";
+        return $"BANDIT_ATTACK_STARTED controller={args[0]} mapEvent={mapEventId} " +
+               $"playerMobileParty={playerMobilePartyId} playerParty={playerPartyId} " +
+               $"banditMobileParty={banditMobilePartyId} banditParty={banditPartyId} " +
+               $"playerTroops={playerParty.MemberRoster.TotalManCount} " +
+               $"banditTroops={banditParty.MemberRoster.TotalManCount} " +
+               $"targetPerParty={target} removedLegacyTroops={removedTroops}";
     }
 
     [CommandLineArgumentFunction("finish_non_battle_encounter", "coop.debug.mapevent")]

--- a/source/GameInterface/Services/Party/Commands/LargeBattleRosterFixtureCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/LargeBattleRosterFixtureCommands.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.MapEvents;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Roster;
 using static TaleWorlds.Library.CommandLineFunctionality;
@@ -17,6 +18,7 @@ namespace GameInterface.Services.Party.Commands;
 
 internal static class LargeBattleRosterFixtureCommands
 {
+    internal const int MaximumTargetTroopsPerParty = 2000;
     private const string FixtureTroopId = "imperial_recruit";
     private static LargeBattleRosterFixture fixture;
 
@@ -41,15 +43,13 @@ internal static class LargeBattleRosterFixtureCommands
         if (!ModInformation.IsServer)
             return "Run this command on the server.";
         if (args.Count != 3
-            || !int.TryParse(args[2], out int addedPerParty)
-            || addedPerParty < 1
-            || addedPerParty > 500)
+            || !int.TryParse(args[2], out int targetTroopsPerParty)
+            || targetTroopsPerParty < 1
+            || targetTroopsPerParty > MaximumTargetTroopsPerParty)
         {
             return "Usage: coop.debug.mobileparty.large_battle_roster_begin " +
-                   "<firstPartyId> <secondPartyId> <troopsPerParty:1-500>";
+                   $"<firstPartyId> <secondPartyId> <targetTroopsPerParty:1-{MaximumTargetTroopsPerParty}>";
         }
-        if (fixture != null)
-            return "A large-battle roster fixture is already pending restoration.";
         if (!TryGetObjectManager(out IObjectManager objectManager))
             return "Unable to resolve ObjectManager.";
         if (!TryResolveParty(
@@ -68,13 +68,69 @@ internal static class LargeBattleRosterFixtureCommands
         {
             return secondError;
         }
+
+        TryBegin(
+            firstParty,
+            secondParty,
+            targetTroopsPerParty,
+            out string result);
+        return result;
+    }
+
+    internal static bool TryBegin(
+        MobileParty firstParty,
+        MobileParty secondParty,
+        int targetTroopsPerParty,
+        out string result)
+    {
+        if (!ModInformation.IsServer)
+        {
+            result = "Run this command on the server.";
+            return false;
+        }
+        if (targetTroopsPerParty < 1
+            || targetTroopsPerParty > MaximumTargetTroopsPerParty)
+        {
+            result =
+                $"Target troops per party must be from 1 to {MaximumTargetTroopsPerParty}.";
+            return false;
+        }
+        if (fixture != null)
+        {
+            result = "A large-battle roster fixture is already pending restoration.";
+            return false;
+        }
+        if (firstParty == null || secondParty == null)
+        {
+            result = "The fixture requires two available parties.";
+            return false;
+        }
         if (firstParty == secondParty)
-            return "The fixture requires two distinct parties.";
+        {
+            result = "The fixture requires two distinct parties.";
+            return false;
+        }
+        int firstTotal = firstParty.MemberRoster.TotalManCount;
+        int secondTotal = secondParty.MemberRoster.TotalManCount;
+        if (firstTotal > targetTroopsPerParty
+            || secondTotal > targetTroopsPerParty)
+        {
+            result =
+                $"Both parties must have at most {targetTroopsPerParty} troops before the fixture starts. " +
+                $"Actual totals: {firstParty.StringId}={firstTotal}, {secondParty.StringId}={secondTotal}.";
+            return false;
+        }
+        if (!TryGetObjectManager(out IObjectManager objectManager))
+        {
+            result = "Unable to resolve ObjectManager.";
+            return false;
+        }
         if (!objectManager.TryGetObject(
                 FixtureTroopId,
                 out CharacterObject fixtureTroop))
         {
-            return $"Unable to resolve fixture troop {FixtureTroopId}.";
+            result = $"Unable to resolve fixture troop {FixtureTroopId}.";
+            return false;
         }
 
         var activeFixture = new LargeBattleRosterFixture
@@ -85,16 +141,38 @@ internal static class LargeBattleRosterFixtureCommands
         };
         fixture = activeFixture;
 
-        firstParty.MemberRoster.AddToCounts(
-            fixtureTroop,
-            addedPerParty);
-        secondParty.MemberRoster.AddToCounts(
-            fixtureTroop,
-            addedPerParty);
+        try
+        {
+            int firstAdded = targetTroopsPerParty - firstTotal;
+            int secondAdded = targetTroopsPerParty - secondTotal;
+            if (firstAdded > 0)
+                firstParty.MemberRoster.AddToCounts(fixtureTroop, firstAdded);
+            if (secondAdded > 0)
+                secondParty.MemberRoster.AddToCounts(fixtureTroop, secondAdded);
+        }
+        catch (Exception exception)
+        {
+            try
+            {
+                Restore(activeFixture.FirstParty);
+                Restore(activeFixture.SecondParty);
+                fixture = null;
+                result = $"Large-battle roster fixture setup failed and was restored: {exception.Message}";
+            }
+            catch (Exception restoreException)
+            {
+                result =
+                    $"Large-battle roster fixture setup failed: {exception.Message}. " +
+                    $"Automatic restoration also failed: {restoreException.Message}. Run the abort command.";
+            }
+            return false;
+        }
 
-        return
-            $"LARGE_BATTLE_ROSTER_FIXTURE_STARTED troop={FixtureTroopId} addedPerParty={addedPerParty}\n" +
+        result =
+            $"LARGE_BATTLE_ROSTER_FIXTURE_STARTED troop={FixtureTroopId} " +
+            $"targetPerParty={targetTroopsPerParty}\n" +
             FormatState("active", firstParty, secondParty);
+        return true;
     }
 
     [CommandLineArgumentFunction("large_battle_roster_status", "coop.debug.mobileparty")]
@@ -139,6 +217,47 @@ internal static class LargeBattleRosterFixtureCommands
             return "Run this command on the server.";
         if (args.Count != 0)
             return "Usage: coop.debug.mobileparty.large_battle_roster_restore";
+        return RestoreActiveFixture();
+    }
+
+    [CommandLineArgumentFunction("large_battle_roster_abort", "coop.debug.mobileparty")]
+    public static string Abort(List<string> args)
+    {
+        if (!ModInformation.IsServer)
+            return "Run this command on the server.";
+        if (args.Count != 0)
+            return "Usage: coop.debug.mobileparty.large_battle_roster_abort";
+        return AbortActiveFixture();
+    }
+
+    internal static string AbortActiveFixture()
+    {
+        if (fixture == null)
+            return "No large-battle roster fixture is pending restoration.";
+
+        MobileParty firstParty = fixture.FirstParty.Party;
+        MobileParty secondParty = fixture.SecondParty.Party;
+        MapEvent mapEvent = firstParty?.MapEvent;
+        bool finalizedMapEvent = mapEvent != null
+            && mapEvent == secondParty?.MapEvent
+            && !mapEvent.IsFinalized;
+        string restoration;
+        try
+        {
+            if (finalizedMapEvent)
+                mapEvent.FinalizeEvent();
+        }
+        finally
+        {
+            restoration = RestoreActiveFixture();
+        }
+
+        return $"LARGE_BATTLE_ROSTER_FIXTURE_ABORTED finalizedMapEvent={finalizedMapEvent}\n" +
+               restoration;
+    }
+
+    internal static string RestoreActiveFixture()
+    {
         if (fixture == null)
             return "No large-battle roster fixture is pending restoration.";
 
@@ -155,7 +274,6 @@ internal static class LargeBattleRosterFixtureCommands
                 activeFixture.FirstParty,
                 out string firstError))
         {
-            fixture = null;
             return firstError;
         }
         if (!TryResolveSnapshotParty(
@@ -163,7 +281,6 @@ internal static class LargeBattleRosterFixtureCommands
                 activeFixture.SecondParty,
                 out string secondError))
         {
-            fixture = null;
             return secondError;
         }
 

--- a/source/Missions/Battles/BattleDebugCommands.cs
+++ b/source/Missions/Battles/BattleDebugCommands.cs
@@ -4,6 +4,7 @@ using GameInterface.Services.MapEvents;
 using Missions.Agents.Packets;
 #if DEBUG
 using Missions.Diagnostics;
+using System.Diagnostics;
 #endif
 using System;
 using System.Collections.Generic;
@@ -99,6 +100,82 @@ internal static class BattleDebugCommands
     private static Guid wieldTestAgentId;
     private static EquipmentIndex wieldTestOriginalMainHand;
     private static bool wieldTestActive;
+
+    [CommandLineArgumentFunction("cpu_snapshot", "coop.debug.battle")]
+    public static string CpuSnapshot(List<string> args)
+    {
+        if (args.Count != 0)
+            return "Usage: coop.debug.battle.cpu_snapshot";
+
+        Mission mission = Mission.Current;
+        CoopBattleController controller = mission?.GetMissionBehavior<CoopBattleController>();
+        Agent[] activeAgents = mission == null
+            ? Array.Empty<Agent>()
+            : mission.Agents.Where(agent => agent.IsActive()).ToArray();
+        bool registryAvailable = ContainerProvider.TryResolve<INetworkAgentRegistry>(
+            out var registry);
+        CoopAgentInfo[] registeredAgents = registryAvailable
+            ? registry.GetControllerIds()
+                .SelectMany(registry.GetAgents)
+                .GroupBy(info => info.AgentId)
+                .Select(group => group.First())
+                .ToArray()
+            : Array.Empty<CoopAgentInfo>();
+        CoopAgentInfo[] registeredActiveAgents = registeredAgents
+            .Where(info => info.Agent != null
+                && info.Agent.Mission == mission
+                && info.Agent.IsActive())
+            .ToArray();
+        int registeredLocalActive = registeredActiveAgents.Count(
+            info => registryAvailable && registry.IsLocallyControlled(info.AgentId));
+        int registeredRemoteActive = registeredActiveAgents.Length - registeredLocalActive;
+        int registeredHumansActive = registeredActiveAgents.Count(info => info.Agent.IsHuman);
+        int registeredMountsActive = registeredActiveAgents.Count(info => info.Agent.IsMount);
+        bool deploymentReady = mission?
+            .GetMissionBehavior<DeploymentMissionController>()
+            ?.TeamSetupOver == true;
+        var result = mission?.MissionResult;
+
+        int processId;
+        double processCpuMilliseconds;
+        long workingSetMiB;
+        long privateMemoryMiB;
+        int threadCount;
+        using (Process process = Process.GetCurrentProcess())
+        {
+            processId = process.Id;
+            processCpuMilliseconds = process.TotalProcessorTime.TotalMilliseconds;
+            workingSetMiB = process.WorkingSet64 / (1024L * 1024L);
+            privateMemoryMiB = process.PrivateMemorySize64 / (1024L * 1024L);
+            threadCount = process.Threads.Count;
+        }
+
+        return $"CPU_SNAPSHOT pid={processId} " +
+               $"fps={Utilities.GetFps().ToString("0.00", CultureInfo.InvariantCulture)} " +
+               $"mainFps={Utilities.GetMainFps().ToString("0.00", CultureInfo.InvariantCulture)} " +
+               $"rendererFps={Utilities.GetRendererFps().ToString("0.00", CultureInfo.InvariantCulture)} " +
+               $"activeAgents={activeAgents.Length} " +
+               $"activeHumans={activeAgents.Count(agent => agent.IsHuman)} " +
+               $"activeMounts={activeAgents.Count(agent => agent.IsMount)} " +
+               $"registryAvailable={registryAvailable} " +
+               $"registeredAgents={registeredAgents.Length} " +
+               $"registeredActive={registeredActiveAgents.Length} " +
+               $"registeredHumansActive={registeredHumansActive} " +
+               $"registeredMountsActive={registeredMountsActive} " +
+               $"registeredLocalActive={registeredLocalActive} " +
+               $"registeredRemoteActive={registeredRemoteActive} " +
+               $"processCpuMs={processCpuMilliseconds.ToString("0", CultureInfo.InvariantCulture)} " +
+               $"workingSetMiB={workingSetMiB} privateMemoryMiB={privateMemoryMiB} threads={threadCount} " +
+               $"battleActive={controller != null} " +
+               $"instance={controller?.Session.InstanceId ?? "none"} " +
+               $"own={controller?.Session.OwnControllerId ?? "none"} " +
+               $"host={controller?.Session.IsLocalHost ?? false} " +
+               $"activated={controller?.Deployment.IsActivated ?? false} " +
+               $"committed={controller?.Deployment.IsCommitted ?? false} " +
+               $"deploymentReady={deploymentReady} " +
+               $"resultState={result?.BattleState.ToString() ?? "None"} " +
+               $"battleResolved={result?.BattleResolved ?? false}";
+    }
 
     [CommandLineArgumentFunction("action_performance", "coop.debug.battle")]
     public static string ActionPerformance(List<string> args)

--- a/source/Missions/Battles/BattleDebugCommands.cs
+++ b/source/Missions/Battles/BattleDebugCommands.cs
@@ -121,11 +121,13 @@ internal static class BattleDebugCommands
                 .Select(group => group.First())
                 .ToArray()
             : Array.Empty<CoopAgentInfo>();
-        CoopAgentInfo[] registeredActiveAgents = registeredAgents
-            .Where(info => info.Agent != null
-                && info.Agent.Mission == mission
-                && info.Agent.IsActive())
-            .ToArray();
+        CoopAgentInfo[] registeredActiveAgents = mission == null
+            ? Array.Empty<CoopAgentInfo>()
+            : registeredAgents
+                .Where(info => info.Agent != null
+                    && info.Agent.Mission == mission
+                    && info.Agent.IsActive())
+                .ToArray();
         int registeredLocalActive = registeredActiveAgents.Count(
             info => registryAvailable && registry.IsLocallyControlled(info.AgentId));
         int registeredRemoteActive = registeredActiveAgents.Length - registeredLocalActive;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [x] Other... Please describe:

## What is the current behavior?

Large field battles cannot be staged at exact 900-person rosters with automatic restoration, and the client does not expose enough runtime state to attribute CPU cost consistently.

## What is the new behavior?

Resolves #2641

Developers can stage an exact reversible 900-versus-900 player-versus-bandit field battle and capture client FPS, population, ownership, process, and battle-state measurements for CPU analysis.

## Bot Changelog Entry

Skip
