### PR TITLE
[2320] Show a connecting screen with a cancel for every join attempt

### DIFF
--- a/UIMovies/CoopJoinCancelOverlay.xml
+++ b/UIMovies/CoopJoinCancelOverlay.xml
@@ -1,0 +1,13 @@
+<Prefab>
+  <Window>
+    <Widget WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent" DoNotAcceptEvents="true">
+      <Children>
+        <Standard.Button Id="JoinCancelButton" WidthSizePolicy="Fixed" SuggestedWidth="220"
+                         HeightSizePolicy="Fixed" SuggestedHeight="64"
+                         HorizontalAlignment="Right" VerticalAlignment="Bottom"
+                         MarginRight="60" MarginBottom="60"
+                         Command.Click="ActionCancel" Parameter.Text="@CancelButtonText"/>
+      </Children>
+    </Widget>
+  </Window>
+</Prefab>

--- a/source/Coop.Core/Client/ClientLogic.cs
+++ b/source/Coop.Core/Client/ClientLogic.cs
@@ -75,7 +75,7 @@ public class ClientLogic : IClientLogic
     private IReadOnlyDictionary<Type, Func<IClientState>> CreateStateFactories() =>
         new Dictionary<Type, Func<IClientState>>
         {
-            [typeof(MainMenuState)] = () => new MainMenuState(this, context.MessageBroker, context.Network, context.GameInterface, context.GameStateInterface, context.LoadingInterface),
+            [typeof(MainMenuState)] = () => new MainMenuState(this, context.MessageBroker, context.Network, context.GameInterface, context.GameStateInterface, context.LoadingInterface, context.JoinAttemptOverlay, context.JoinAttempt, context.CoopFinalizer),
             [typeof(ValidateModuleState)] = () => new ValidateModuleState(this, context.MessageBroker, context.Network, context.ControllerIdProvider, context.CoopFinalizer, context.GameStateInterface, context.ModuleInfoProvider),
             [typeof(CharacterCreationState)] = () => new CharacterCreationState(this, context.MessageBroker, context.Network, context.HeroInterface, context.RegistryManager, context.ControllerIdProvider, context.LoadingInterface, context.PlayerManager, context.GameStateInterface, context.CoopFinalizer),
             [typeof(ReceivingSavedDataState)] = () => new ReceivingSavedDataState(this, context.MessageBroker, context.LoadingInterface, context.GameStateInterface),

--- a/source/Coop.Core/Client/ClientModule.cs
+++ b/source/Coop.Core/Client/ClientModule.cs
@@ -50,6 +50,13 @@ public class ClientModule : CommonModule
         builder.RegisterType<ConfiguredSessionJoinInfoSource>().As<ISessionJoinInfoSource>().InstancePerLifetimeScope();
         builder.RegisterType<SessionAdvertisementConfig>().AsSelf().InstancePerLifetimeScope();
 
+        // Keeps the module resolvable on its own; a session container registers the real intent.
+        builder.Register(c =>
+        {
+            var config = c.Resolve<INetworkConfig>();
+            return JoinAttemptPresentation.For(JoinIntent.PlayerDirect, config.Address, config.Port);
+        }).AsSelf().InstancePerLifetimeScope();
+
         RegisterAllTypesWithInterface<ClientModule, IHandler>(builder, autoInstantiate: true);
         RegisterAllTypesWithInterface<ClientModule, IPacketHandler>(builder, autoInstantiate: true);
     }

--- a/source/Coop.Core/Client/States/ClientContext.cs
+++ b/source/Coop.Core/Client/States/ClientContext.cs
@@ -1,6 +1,7 @@
 ﻿using Common.Messaging;
 using Common.Network;
 using Coop.Core.Common;
+using Coop.Core.Common.Session;
 using GameInterface;
 using GameInterface.Registry;
 using GameInterface.Services.Entity;
@@ -10,6 +11,7 @@ using GameInterface.Services.Modules;
 using GameInterface.Services.Players;
 using GameInterface.Services.Time.Interfaces;
 using GameInterface.Services.UI.Interfaces;
+using GameInterface.Services.UI.JoinCancel;
 
 namespace Coop.Core.Client.States;
 
@@ -32,7 +34,9 @@ public class ClientContext
         IHeroInterface heroInterface,
         IRegistryManager registryManager,
         IPlayerManager playerManager,
-        IMapTimeTrackerInterface mapTimeTrackerInterface)
+        IMapTimeTrackerInterface mapTimeTrackerInterface,
+        IJoinAttemptOverlay joinAttemptOverlay,
+        JoinAttemptPresentation joinAttempt)
     {
         MessageBroker = messageBroker;
         Network = network;
@@ -46,6 +50,8 @@ public class ClientContext
         RegistryManager = registryManager;
         PlayerManager = playerManager;
         MapTimeTrackerInterface = mapTimeTrackerInterface;
+        JoinAttemptOverlay = joinAttemptOverlay;
+        JoinAttempt = joinAttempt;
     }
 
     public IMessageBroker MessageBroker { get; }
@@ -60,4 +66,6 @@ public class ClientContext
     public IRegistryManager RegistryManager { get; }
     public IPlayerManager PlayerManager { get; }
     public IMapTimeTrackerInterface MapTimeTrackerInterface { get; }
+    public IJoinAttemptOverlay JoinAttemptOverlay { get; }
+    public JoinAttemptPresentation JoinAttempt { get; }
 }

--- a/source/Coop.Core/Client/States/MainMenuState.cs
+++ b/source/Coop.Core/Client/States/MainMenuState.cs
@@ -1,22 +1,42 @@
+﻿using Common;
+using Common.Logging;
 using Common.Messaging;
 using Common.Network;
+using Common.Network.Session.Messages;
 using Coop.Core.Client.Messages;
+using Coop.Core.Common;
+using Coop.Core.Common.Session;
 using GameInterface;
 using GameInterface.Services.GameState.Interfaces;
 using GameInterface.Services.UI.Interfaces;
+using GameInterface.Services.UI.JoinCancel;
+using GameInterface.Services.UI.Messages;
+using Serilog;
+using System.Threading;
+using TaleWorlds.Library;
 
 namespace Coop.Core.Client.States;
 
 /// <summary>
-/// State Logic Controller for the Main Menu Client State
+/// State Logic Controller for the Main Menu Client State. Owns the connecting screen for as long as
+/// the attempt is dialing: the engine's loading window for art and status, a coop layer for cancel.
 /// </summary>
 public class MainMenuState : ClientStateBase
 {
+    private static readonly ILogger Logger = LogManager.GetLogger<MainMenuState>();
+
     private readonly IMessageBroker messageBroker;
     private readonly INetwork network;
     private readonly IGameInterface gameInterface;
     private readonly IGameStateInterface gameStateInterface;
     private readonly ILoadingInterface loadingInterface;
+    private readonly IJoinAttemptOverlay joinAttemptOverlay;
+    private readonly JoinAttemptPresentation joinAttempt;
+    private readonly ICoopFinalizer coopFinalizer;
+
+    private volatile bool shown;
+    private volatile bool connected;
+    private volatile bool cancelling;
 
     public MainMenuState(
         IClientLogic logic,
@@ -24,37 +44,126 @@ public class MainMenuState : ClientStateBase
         INetwork network,
         IGameInterface gameInterface,
         IGameStateInterface gameStateInterface,
-        ILoadingInterface loadingInterface) : base(logic)
+        ILoadingInterface loadingInterface,
+        IJoinAttemptOverlay joinAttemptOverlay,
+        JoinAttemptPresentation joinAttempt,
+        ICoopFinalizer coopFinalizer) : base(logic)
     {
         this.messageBroker = messageBroker;
         this.network = network;
         this.gameInterface = gameInterface;
         this.gameStateInterface = gameStateInterface;
         this.loadingInterface = loadingInterface;
+        this.joinAttemptOverlay = joinAttemptOverlay;
+        this.joinAttempt = joinAttempt;
+        this.coopFinalizer = coopFinalizer;
         loadingInterface.HideLoadingScreen();
         messageBroker.Subscribe<NetworkConnected>(Handle_NetworkConnected);
+        messageBroker.Subscribe<CancelJoinAttempt>(Handle_CancelJoinAttempt);
     }
 
-    public override void Dispose() 
+    public override void Dispose()
     {
         messageBroker.Unsubscribe<NetworkConnected>(Handle_NetworkConnected);
+        messageBroker.Unsubscribe<CancelJoinAttempt>(Handle_CancelJoinAttempt);
+
+        if (connected) return;
+
+        HideJoinAttempt();
     }
 
     public override void Connect()
     {
+        ShowJoinAttempt();
         network.Start();
     }
 
     internal void Handle_NetworkConnected(MessagePayload<NetworkConnected> obj)
     {
+        connected = true;
+
+        using (GameThread.ActivateCancellation(CancellationToken.None))
+        {
+            GameThread.RunSafe(joinAttemptOverlay.Hide, context: "HideJoinAttemptOverlay");
+        }
+
         loadingInterface.ShowLoadingScreen(
-            "Connecting to Coop Server",
+            JoinAttemptPresentation.JoiningTitle,
             "Applying patches...");
         gameInterface.PatchAll();
         loadingInterface.SetLoadingMessage(
-            "Connecting to Coop Server",
+            JoinAttemptPresentation.JoiningTitle,
             "Validating modules...");
         Logic.ValidateModules();
+    }
+
+    internal void Handle_CancelJoinAttempt(MessagePayload<CancelJoinAttempt> obj)
+    {
+        if (!shown || connected || cancelling) return;
+
+        cancelling = true;
+
+        using (GameThread.ActivateCancellation(CancellationToken.None))
+        {
+            GameThread.EnqueueSafe(FinishCancel, context: nameof(CancelJoinAttempt));
+        }
+    }
+
+    private void FinishCancel()
+    {
+        try
+        {
+            if (connected) return;
+
+            Logger.Information("Player cancelled a {Intent} join attempt", joinAttempt.Intent);
+
+            // Held lobby membership would keep a host slot and make a retried join no-op.
+            if (joinAttempt.Intent == JoinIntent.PlayerSteam)
+            {
+                messageBroker.Publish(this, new SessionJoinAbandoned());
+            }
+
+            // Before the screen comes down, so a throw above leaves the button up to press again.
+            coopFinalizer.Finalize(closeText: null);
+
+            HideJoinAttempt();
+            InformationManager.DisplayMessage(new InformationMessage(joinAttempt.CancelledNotice));
+        }
+        catch
+        {
+            cancelling = false;
+            throw;
+        }
+    }
+
+    private void ShowJoinAttempt()
+    {
+        shown = true;
+
+        GameThread.RunSafe(() =>
+        {
+            loadingInterface.ShowLoadingScreen(joinAttempt.Title, joinAttempt.Description);
+            try
+            {
+                joinAttemptOverlay.Show(joinAttempt.CancelLabel);
+            }
+            catch
+            {
+                loadingInterface.HideLoadingScreen();
+                throw;
+            }
+        }, context: "ShowJoinAttempt");
+    }
+
+    private void HideJoinAttempt()
+    {
+        if (!shown) return;
+
+        using (GameThread.ActivateCancellation(CancellationToken.None))
+        {
+            GameThread.RunSafe(joinAttemptOverlay.Hide, context: "HideJoinAttemptOverlay");
+            GameThread.RunSafe(loadingInterface.HideLoadingScreen, context: "HideJoinAttemptWindow");
+        }
     }
 
     public override void Disconnect()

--- a/source/Coop.Core/Client/States/MainMenuState.cs
+++ b/source/Coop.Core/Client/States/MainMenuState.cs
@@ -81,6 +81,7 @@ public class MainMenuState : ClientStateBase
     internal void Handle_NetworkConnected(MessagePayload<NetworkConnected> obj)
     {
         connected = true;
+        shown = false;
 
         using (GameThread.ActivateCancellation(CancellationToken.None))
         {
@@ -88,11 +89,11 @@ public class MainMenuState : ClientStateBase
         }
 
         loadingInterface.ShowLoadingScreen(
-            JoinAttemptPresentation.JoiningTitle,
+            joinAttempt.Title,
             "Applying patches...");
         gameInterface.PatchAll();
         loadingInterface.SetLoadingMessage(
-            JoinAttemptPresentation.JoiningTitle,
+            joinAttempt.Title,
             "Validating modules...");
         Logic.ValidateModules();
     }
@@ -123,7 +124,6 @@ public class MainMenuState : ClientStateBase
                 messageBroker.Publish(this, new SessionJoinAbandoned());
             }
 
-            // Before the screen comes down, so a throw above leaves the button up to press again.
             coopFinalizer.Finalize(closeText: null);
 
             HideJoinAttempt();
@@ -142,6 +142,9 @@ public class MainMenuState : ClientStateBase
 
         GameThread.RunSafe(() =>
         {
+            // A hide that ran while this was queued cannot take down a layer that is not up yet.
+            if (!shown) return;
+
             loadingInterface.ShowLoadingScreen(joinAttempt.Title, joinAttempt.Description);
             try
             {
@@ -158,6 +161,8 @@ public class MainMenuState : ClientStateBase
     private void HideJoinAttempt()
     {
         if (!shown) return;
+
+        shown = false;
 
         using (GameThread.ActivateCancellation(CancellationToken.None))
         {

--- a/source/Coop.Core/Common/Session/JoinAttemptPresentation.cs
+++ b/source/Coop.Core/Common/Session/JoinAttemptPresentation.cs
@@ -1,0 +1,50 @@
+﻿using System;
+
+namespace Coop.Core.Common.Session;
+
+/// <summary>
+/// The wording a join attempt shows while it is in flight: loading-screen title and description,
+/// the cancel button's label, and what the player is told once they cancel.
+/// </summary>
+public sealed class JoinAttemptPresentation
+{
+    // Matches the title the post-connect states keep using, so a successful attempt advances the
+    // description without the heading changing under the player.
+    internal const string JoiningTitle = "Connecting to Coop Server";
+    private const string HostingTitle = "Hosting Coop Server";
+    private const string PlayerCancelLabel = "Cancel";
+    private const string PlayerCancelledNotice = "Connection attempt cancelled";
+
+    private JoinAttemptPresentation(
+        JoinIntent intent, string title, string description, string cancelLabel, string cancelledNotice)
+    {
+        Intent = intent;
+        Title = title;
+        Description = description;
+        CancelLabel = cancelLabel;
+        CancelledNotice = cancelledNotice;
+    }
+
+    public JoinIntent Intent { get; }
+    public string Title { get; }
+    public string Description { get; }
+    public string CancelLabel { get; }
+    public string CancelledNotice { get; }
+
+    public static JoinAttemptPresentation For(JoinIntent intent, string address, int port) => intent switch
+    {
+        JoinIntent.PlayerDirect => new JoinAttemptPresentation(intent, JoiningTitle,
+            $"Contacting {address}:{port}...", PlayerCancelLabel, PlayerCancelledNotice),
+
+        // A tunnelled Steam join dials a local pump, so the host is named by route not by address.
+        JoinIntent.PlayerSteam => new JoinAttemptPresentation(intent, JoiningTitle,
+            "Contacting the host through Steam...", PlayerCancelLabel, PlayerCancelledNotice),
+
+        // Cancelling abandons the wait, not the server, which this instance never owns.
+        JoinIntent.HostLoopback => new JoinAttemptPresentation(intent, HostingTitle,
+            "Waiting for the server to load the campaign save...", "Stop Waiting",
+            "Stopped waiting for the co-op server. Its window stays open until you close it."),
+
+        _ => throw new ArgumentOutOfRangeException(nameof(intent), intent, "Unknown join intent"),
+    };
+}

--- a/source/Coop.Core/Common/Session/JoinAttemptPresentation.cs
+++ b/source/Coop.Core/Common/Session/JoinAttemptPresentation.cs
@@ -8,9 +8,7 @@ namespace Coop.Core.Common.Session;
 /// </summary>
 public sealed class JoinAttemptPresentation
 {
-    // Matches the title the post-connect states keep using, so a successful attempt advances the
-    // description without the heading changing under the player.
-    internal const string JoiningTitle = "Connecting to Coop Server";
+    private const string JoiningTitle = "Connecting to Coop Server";
     private const string HostingTitle = "Hosting Coop Server";
     private const string PlayerCancelLabel = "Cancel";
     private const string PlayerCancelledNotice = "Connection attempt cancelled";

--- a/source/Coop.Core/Common/Session/JoinIntent.cs
+++ b/source/Coop.Core/Common/Session/JoinIntent.cs
@@ -1,0 +1,17 @@
+﻿namespace Coop.Core.Common.Session;
+
+/// <summary>
+/// Why a client session is being started. Every join path funnels through the same client start,
+/// so the caller's intent is the only thing that tells them apart.
+/// </summary>
+public enum JoinIntent
+{
+    /// <summary>The player entered an address on the co-op join screen.</summary>
+    PlayerDirect,
+
+    /// <summary>The player picked a Steam lobby, or accepted an invite.</summary>
+    PlayerSteam,
+
+    /// <summary>This instance hosted, and is connecting to its own standalone server process.</summary>
+    HostLoopback,
+}

--- a/source/Coop.Core/CoopartiveMultiplayerExperience.cs
+++ b/source/Coop.Core/CoopartiveMultiplayerExperience.cs
@@ -52,7 +52,7 @@ namespace Coop.Core
         // A spawned server has to load the whole campaign save before it binds its port.
         public static readonly TimeSpan HostedServerStartTimeout = TimeSpan.FromMinutes(5);
 
-        private const string StartRefusedNotice =
+        public const string StartRefusedNotice =
             "Another co-op session is still starting; try joining again shortly";
         private const string HostClientStartFailedNotice =
             "Could not start the co-op client; the standalone server remains open until you close it";
@@ -342,10 +342,9 @@ namespace Coop.Core
 
             try
             {
+                // A refusal leaves the process-wide tunnel and lobby to the start still in flight.
                 if (!StartAsClient(configuration, intent: JoinIntent.PlayerSteam))
                 {
-                    joinEndpointPreparer.TearDownActiveTunnel();
-                    messageBroker.Publish(this, new SessionJoinAbandoned());
                     InformationManager.DisplayMessage(new InformationMessage(StartRefusedNotice));
                     return;
                 }

--- a/source/Coop.Core/CoopartiveMultiplayerExperience.cs
+++ b/source/Coop.Core/CoopartiveMultiplayerExperience.cs
@@ -52,6 +52,11 @@ namespace Coop.Core
         // A spawned server has to load the whole campaign save before it binds its port.
         public static readonly TimeSpan HostedServerStartTimeout = TimeSpan.FromMinutes(5);
 
+        private const string StartRefusedNotice =
+            "Another co-op session is still starting; try joining again shortly";
+        private const string HostClientStartFailedNotice =
+            "Could not start the co-op client; the standalone server remains open until you close it";
+
         public CoopartiveMultiplayerExperience(
             bool standaloneServerProcess = false,
             Action<string> setCrashPhase = null)
@@ -103,7 +108,10 @@ namespace Coop.Core
                 EnableSteamInvites = connectMessage.EnableSteamInvites,
             };
 
-            StartAsClient(configuration, advertisementConfig);
+            if (!StartAsClient(configuration, advertisementConfig, JoinIntent.PlayerDirect))
+            {
+                InformationManager.DisplayMessage(new InformationMessage(StartRefusedNotice));
+            }
         }
 
         private void Handle(MessagePayload<AttemptHost> obj)
@@ -198,7 +206,12 @@ namespace Coop.Core
 
             try
             {
-                StartAsClient(configuration, advertisementConfig);
+                if (!StartAsClient(configuration, advertisementConfig, JoinIntent.HostLoopback))
+                {
+                    hostedSession = false;
+                    InformationManager.DisplayMessage(new InformationMessage(HostClientStartFailedNotice));
+                    return;
+                }
 
                 container.Resolve<SteamJoinWatchdog>().Arm(configuration.Address, configuration.Port,
                     timeout: HostedServerStartTimeout,
@@ -212,8 +225,7 @@ namespace Coop.Core
                 Logger.Error(ex, "Hosted co-op session failed to start");
                 hostedSession = false;
                 DestroyContainer();
-                InformationManager.DisplayMessage(new InformationMessage(
-                    "Could not start the co-op client; the standalone server remains open until you close it"));
+                InformationManager.DisplayMessage(new InformationMessage(HostClientStartFailedNotice));
             }
         }
 
@@ -330,7 +342,13 @@ namespace Coop.Core
 
             try
             {
-                StartAsClient(configuration);
+                if (!StartAsClient(configuration, intent: JoinIntent.PlayerSteam))
+                {
+                    joinEndpointPreparer.TearDownActiveTunnel();
+                    messageBroker.Publish(this, new SessionJoinAbandoned());
+                    InformationManager.DisplayMessage(new InformationMessage(StartRefusedNotice));
+                    return;
+                }
 
                 container.Resolve<SteamJoinWatchdog>().Arm(prepared.Address, prepared.Port, prepared.Tunneled);
             }
@@ -560,20 +578,28 @@ namespace Coop.Core
             }
         }
 
-        public void StartAsClient(INetworkConfig configuration = null, SessionAdvertisementConfig advertisementConfig = null)
+        /// <returns>
+        /// <see langword="false"/> when the start was refused because another one is still in flight,
+        /// so callers do not act on a container that belongs to that other attempt.
+        /// </returns>
+        public bool StartAsClient(
+            INetworkConfig configuration = null,
+            SessionAdvertisementConfig advertisementConfig = null,
+            JoinIntent intent = JoinIntent.PlayerDirect)
         {
             lock (containerGate)
             {
-                StartAsClientCore(configuration, advertisementConfig);
+                return StartAsClientCore(configuration, advertisementConfig, intent);
             }
         }
 
-        private void StartAsClientCore(
+        private bool StartAsClientCore(
             INetworkConfig configuration,
-            SessionAdvertisementConfig advertisementConfig)
+            SessionAdvertisementConfig advertisementConfig,
+            JoinIntent intent)
         {
             // A second Host or Join click while patches are still applying would tear down the in-flight start
-            if (coopStarting) return;
+            if (coopStarting) return false;
 
             DestroyContainer();
             setCrashPhase("starting-client");
@@ -594,6 +620,11 @@ namespace Coop.Core
                 builder.RegisterInstance(advertisementConfig).AsSelf().SingleInstance();
             }
 
+            // Null config is the debug auto-connect entry point.
+            var joinConfig = configuration ?? this.configuration;
+            var presentation = JoinAttemptPresentation.For(intent, joinConfig.Address, joinConfig.Port);
+            builder.RegisterInstance(presentation).AsSelf().SingleInstance();
+
             container = builder.Build();
 
             GameInterface.ContainerProvider.SetContainer(container);
@@ -609,14 +640,17 @@ namespace Coop.Core
 
             if (loadingInterface.IsLoadingScreenAvailable)
             {
-                loadingInterface.ShowLoadingScreen("Connecting to Coop Server", "Applying patches...");
+                // Marshalled: Steam callbacks arrive off the game thread.
+                GameThread.RunSafe(
+                    () => loadingInterface.ShowLoadingScreen(presentation.Title, "Applying patches..."),
+                    context: "PrimeJoinAttemptLoadingScreen");
 
                 PatchAllOffGameThread(gameInterface, loadingInterface, () =>
                 {
                     setCrashPhase("connecting");
                     container.Resolve<ILogic>().Start();
                 });
-                return;
+                return true;
             }
 
             setCrashPhase("applying-patches");
@@ -626,6 +660,8 @@ namespace Coop.Core
             var logic = container.Resolve<ILogic>();
             setCrashPhase("connecting");
             logic.Start();
+
+            return true;
         }
 
         private void DestroyContainer()

--- a/source/Coop.Tests/Client/States/MainMenuStateTests.cs
+++ b/source/Coop.Tests/Client/States/MainMenuStateTests.cs
@@ -1,10 +1,15 @@
 ﻿using Autofac;
+using Common;
 using Common.Messaging;
 using Coop.Core.Client;
 using Coop.Core.Client.Messages;
 using Coop.Core.Client.States;
+using Coop.Core.Common.Services.Connection.Messages;
+using Coop.Core.Common.Session;
 using GameInterface.Services.GameState.Interfaces;
 using GameInterface.Services.UI.Interfaces;
+using GameInterface.Services.UI.JoinCancel;
+using GameInterface.Services.UI.Messages;
 using Moq;
 using Xunit;
 using Xunit.Abstractions;
@@ -16,6 +21,8 @@ namespace Coop.Tests.Client.States
         private readonly IClientLogic clientLogic;
         private readonly ClientTestComponent clientComponent;
         private readonly Mock<ILoadingInterface> loadingInterfaceMock;
+        private readonly Mock<IJoinAttemptOverlay> overlayMock;
+        private readonly JoinAttemptPresentation joinAttempt;
 
         public MainMenuStateTests(ITestOutputHelper output)
         {
@@ -24,6 +31,131 @@ namespace Coop.Tests.Client.States
 
             clientLogic = container.Resolve<IClientLogic>()!;
             loadingInterfaceMock = container.Resolve<Mock<ILoadingInterface>>();
+            overlayMock = container.Resolve<Mock<IJoinAttemptOverlay>>();
+            joinAttempt = container.Resolve<JoinAttemptPresentation>();
+        }
+
+        private static void DrainGameThread() => GameThread.Run(() => { }, blocking: true);
+
+        private MainMenuState StartDialing()
+        {
+            var state = clientLogic.SetState<MainMenuState>();
+            clientLogic.Connect();
+            DrainGameThread();
+            loadingInterfaceMock.Invocations.Clear();
+            overlayMock.Invocations.Clear();
+            clientComponent.TestMessageBroker.Messages.Clear();
+            return state;
+        }
+
+        private static MessagePayload<T> Payload<T>(T message) where T : IMessage =>
+            new MessagePayload<T>(null, message);
+
+        [Fact]
+        public void Connecting_RaisesTheConnectingScreenWithACancel()
+        {
+            clientLogic.SetState<MainMenuState>();
+            clientLogic.Connect();
+            DrainGameThread();
+
+            loadingInterfaceMock.Verify(x => x.ShowLoadingScreen(
+                joinAttempt.Title, joinAttempt.Description), Times.Once);
+            overlayMock.Verify(x => x.Show(joinAttempt.CancelLabel), Times.Once);
+        }
+
+        [Fact]
+        public void ReEnteringOnSessionEnd_ShowsNoConnectingScreen()
+        {
+            // MissionState, CharacterCreationState and ReceivingSavedDataState all re-enter this
+            // state when a session ends, with no join in flight to show a screen for.
+            clientLogic.SetState<MainMenuState>();
+            DrainGameThread();
+
+            loadingInterfaceMock.Verify(x => x.ShowLoadingScreen(
+                It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            overlayMock.Verify(x => x.Show(It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public void ReEnteringOnSessionEnd_IgnoresCancel()
+        {
+            var state = clientLogic.SetState<MainMenuState>();
+            DrainGameThread();
+            clientComponent.TestMessageBroker.Messages.Clear();
+
+            state.Handle_CancelJoinAttempt(Payload(new CancelJoinAttempt()));
+            DrainGameThread();
+
+            Assert.Empty(clientComponent.TestMessageBroker.GetMessagesFromType<EndCoopMode>());
+        }
+
+        [Fact]
+        public void NetworkConnected_TakesCancelDownAndLeavesTheWindowToTheNextState()
+        {
+            var state = StartDialing();
+
+            state.Handle_NetworkConnected(Payload(new NetworkConnected()));
+            DrainGameThread();
+
+            overlayMock.Verify(x => x.Hide(), Times.Once);
+            loadingInterfaceMock.Verify(x => x.HideLoadingScreen(), Times.Never);
+        }
+
+        [Fact]
+        public void CancelJoinAttempt_TakesTheScreenDownAndEndsTheSession()
+        {
+            var state = StartDialing();
+
+            state.Handle_CancelJoinAttempt(Payload(new CancelJoinAttempt()));
+            DrainGameThread();
+
+            overlayMock.Verify(x => x.Hide(), Times.AtLeastOnce);
+            loadingInterfaceMock.Verify(x => x.HideLoadingScreen(), Times.AtLeastOnce);
+            Assert.Single(clientComponent.TestMessageBroker.GetMessagesFromType<EndCoopMode>());
+        }
+
+        [Fact]
+        public void CancelJoinAttempt_AfterTheHandshakeLands_LeavesTheSessionAlone()
+        {
+            var state = StartDialing();
+            state.Handle_NetworkConnected(Payload(new NetworkConnected()));
+            DrainGameThread();
+            clientComponent.TestMessageBroker.Messages.Clear();
+
+            state.Handle_CancelJoinAttempt(Payload(new CancelJoinAttempt()));
+            DrainGameThread();
+
+            Assert.Empty(clientComponent.TestMessageBroker.GetMessagesFromType<EndCoopMode>());
+        }
+
+        [Fact]
+        public void Dispose_WhileDialing_TakesTheWholeScreenDown()
+        {
+            // Container teardown after a rejected or failed start disposes this state with no
+            // transition; missing it strands the player behind the loading screen.
+            var state = StartDialing();
+
+            state.Dispose();
+            DrainGameThread();
+
+            overlayMock.Verify(x => x.Hide(), Times.AtLeastOnce);
+            loadingInterfaceMock.Verify(x => x.HideLoadingScreen(), Times.AtLeastOnce);
+        }
+
+        [Fact]
+        public void Dispose_AfterTheHandshakeLands_LeavesTheWindowToTheNextState()
+        {
+            var state = StartDialing();
+            state.Handle_NetworkConnected(Payload(new NetworkConnected()));
+            DrainGameThread();
+            loadingInterfaceMock.Invocations.Clear();
+            overlayMock.Invocations.Clear();
+
+            state.Dispose();
+            DrainGameThread();
+
+            loadingInterfaceMock.Verify(x => x.HideLoadingScreen(), Times.Never);
+            overlayMock.Verify(x => x.Hide(), Times.Never);
         }
 
         [Fact]

--- a/source/Coop.Tests/Client/States/MainMenuStateTests.cs
+++ b/source/Coop.Tests/Client/States/MainMenuStateTests.cs
@@ -1,6 +1,7 @@
 ﻿using Autofac;
 using Common;
 using Common.Messaging;
+using Common.Network.Session.Messages;
 using Coop.Core.Client;
 using Coop.Core.Client.Messages;
 using Coop.Core.Client.States;
@@ -23,9 +24,11 @@ namespace Coop.Tests.Client.States
         private readonly Mock<ILoadingInterface> loadingInterfaceMock;
         private readonly Mock<IJoinAttemptOverlay> overlayMock;
         private readonly JoinAttemptPresentation joinAttempt;
+        private readonly ITestOutputHelper output;
 
         public MainMenuStateTests(ITestOutputHelper output)
         {
+            this.output = output;
             clientComponent = new ClientTestComponent(output);
             var container = clientComponent.Container;
 
@@ -112,6 +115,33 @@ namespace Coop.Tests.Client.States
             overlayMock.Verify(x => x.Hide(), Times.AtLeastOnce);
             loadingInterfaceMock.Verify(x => x.HideLoadingScreen(), Times.AtLeastOnce);
             Assert.Single(clientComponent.TestMessageBroker.GetMessagesFromType<EndCoopMode>());
+        }
+
+        [Fact]
+        public void CancelJoinAttempt_OnASteamJoin_AbandonsTheLobby()
+        {
+            var steamComponent = new ClientTestComponent(output, JoinIntent.PlayerSteam);
+            var steamLogic = steamComponent.Container.Resolve<IClientLogic>()!;
+            var state = steamLogic.SetState<MainMenuState>();
+            steamLogic.Connect();
+            DrainGameThread();
+            steamComponent.TestMessageBroker.Messages.Clear();
+
+            state.Handle_CancelJoinAttempt(Payload(new CancelJoinAttempt()));
+            DrainGameThread();
+
+            Assert.Single(steamComponent.TestMessageBroker.GetMessagesFromType<SessionJoinAbandoned>());
+        }
+
+        [Fact]
+        public void CancelJoinAttempt_OnADirectJoin_LeavesTheLobbyAlone()
+        {
+            var state = StartDialing();
+
+            state.Handle_CancelJoinAttempt(Payload(new CancelJoinAttempt()));
+            DrainGameThread();
+
+            Assert.Empty(clientComponent.TestMessageBroker.GetMessagesFromType<SessionJoinAbandoned>());
         }
 
         [Fact]

--- a/source/Coop.Tests/ClientTestComponent.cs
+++ b/source/Coop.Tests/ClientTestComponent.cs
@@ -1,5 +1,7 @@
 ﻿using Autofac;
+using Common.Network;
 using Coop.Core.Client;
+using Coop.Core.Common.Session;
 using GameInterface.Registry;
 using Xunit.Abstractions;
 
@@ -7,11 +9,19 @@ namespace Coop.Tests;
 
 internal class ClientTestComponent : TestComponentBase
 {
-    public ClientTestComponent(ITestOutputHelper output) : base(output)
+    public ClientTestComponent(ITestOutputHelper output, JoinIntent intent = JoinIntent.PlayerDirect)
+        : base(output)
     {
         var builder = new ContainerBuilder();
         builder.RegisterModule<ClientModule>();
         builder.RegisterModule<RegistryModule>();
+
+        // Overrides ClientModule's registration, which is pinned to one intent.
+        builder.Register(c =>
+        {
+            var config = c.Resolve<INetworkConfig>();
+            return JoinAttemptPresentation.For(intent, config.Address, config.Port);
+        }).AsSelf().InstancePerLifetimeScope();
 
         Container = BuildContainer(builder);
     }

--- a/source/Coop.Tests/Session/JoinAttemptPresentationTests.cs
+++ b/source/Coop.Tests/Session/JoinAttemptPresentationTests.cs
@@ -1,0 +1,60 @@
+﻿using Coop.Core.Common.Session;
+using System;
+using Xunit;
+
+namespace Coop.Tests.Session;
+
+public class JoinAttemptPresentationTests
+{
+    [Fact]
+    public void For_DirectJoin_NamesTheEndpointBeingDialled()
+    {
+        var presentation = JoinAttemptPresentation.For(JoinIntent.PlayerDirect, "203.0.113.7", 4200);
+
+        Assert.Equal("Contacting 203.0.113.7:4200...", presentation.Description);
+        Assert.Equal("Cancel", presentation.CancelLabel);
+    }
+
+    [Fact]
+    public void For_SteamJoin_KeepsTheTunnelEndpointOutOfTheDescription()
+    {
+        var presentation = JoinAttemptPresentation.For(JoinIntent.PlayerSteam, "127.0.0.1", 27015);
+
+        Assert.DoesNotContain("127.0.0.1", presentation.Description);
+        Assert.DoesNotContain("27015", presentation.Description);
+    }
+
+    [Fact]
+    public void For_HostLoopback_SaysTheServerOutlivesTheCancelledWait()
+    {
+        var presentation = JoinAttemptPresentation.For(JoinIntent.HostLoopback, "127.0.0.1", 4200);
+
+        Assert.Contains("stays open", presentation.CancelledNotice);
+        Assert.NotEqual("Cancel", presentation.CancelLabel);
+    }
+
+    [Fact]
+    public void For_PlayerJoins_KeepTheTitleThePostConnectStatesUse()
+    {
+        // MainMenuState shows this title once connected; matching it means the heading does not
+        // change under the player when the handshake lands.
+        Assert.Equal("Connecting to Coop Server",
+            JoinAttemptPresentation.For(JoinIntent.PlayerDirect, "localhost", 4200).Title);
+        Assert.Equal("Connecting to Coop Server",
+            JoinAttemptPresentation.For(JoinIntent.PlayerSteam, "localhost", 4200).Title);
+    }
+
+    [Fact]
+    public void For_EveryDefinedIntent_ProvidesCompleteCopy()
+    {
+        foreach (JoinIntent intent in Enum.GetValues(typeof(JoinIntent)))
+        {
+            var presentation = JoinAttemptPresentation.For(intent, "localhost", 4200);
+
+            Assert.False(string.IsNullOrWhiteSpace(presentation.Title), $"{intent} title");
+            Assert.False(string.IsNullOrWhiteSpace(presentation.Description), $"{intent} description");
+            Assert.False(string.IsNullOrWhiteSpace(presentation.CancelLabel), $"{intent} cancel label");
+            Assert.False(string.IsNullOrWhiteSpace(presentation.CancelledNotice), $"{intent} notice");
+        }
+    }
+}

--- a/source/Coop.Tests/TestComponentBase.cs
+++ b/source/Coop.Tests/TestComponentBase.cs
@@ -31,6 +31,7 @@ using Coop.Core.Server.Services.MobileParties;
 using GameInterface.Services.TroopRosters.Interfaces;
 using GameInterface.Services.UI;
 using GameInterface.Services.UI.Interfaces;
+using GameInterface.Services.UI.JoinCancel;
 using GameInterface.Services.Villages.Interfaces;
 using Moq;
 using Serilog;
@@ -104,6 +105,7 @@ internal abstract class TestComponentBase
         RegisterMock<IMapTimeTrackerInterface>(builder);
         RegisterMock<IJoinCampaignBaselineSender>(builder);
         RegisterMock<ILoadingInterface>(builder);
+        RegisterMock<IJoinAttemptOverlay>(builder);
         RegisterMock<ICoopSessionProvider>(builder);
         RegisterMock<ITroopRosterInterface>(builder);
         RegisterMock<IMobilePartyInterface>(builder);

--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -454,9 +454,10 @@ namespace Coop
                         {
                             Coop.StartAsServer(null, ManagedServerConfig.Password, ManagedServerConfig.Visibility);
                         }
-                        else
+                        else if (!Coop.StartAsClient())
                         {
-                            Coop.StartAsClient();
+                            InformationManager.DisplayMessage(new InformationMessage(
+                                CoopartiveMultiplayerExperience.StartRefusedNotice));
                         }
                     },
                     () => { return (false, new TextObject("")); }

--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -653,8 +653,8 @@ namespace Coop
                     else
                     {
                         Logger.Information("[AutoConnect] InitialState active — auto-starting as client...");
-                        Coop.StartAsClient();
-                        Logger.Information("[AutoConnect] StartAsClient() completed");
+                        bool started = Coop.StartAsClient();
+                        Logger.Information("[AutoConnect] StartAsClient() returned {Started}", started);
                     }
                 }
                 catch (Exception ex)

--- a/source/GameInterface.Tests/Services/UI/CoopJoinCancelOverlayMovieTests.cs
+++ b/source/GameInterface.Tests/Services/UI/CoopJoinCancelOverlayMovieTests.cs
@@ -1,0 +1,23 @@
+﻿using System.Linq;
+using System.Xml.Linq;
+using Xunit;
+
+namespace GameInterface.Tests.Services.UI;
+
+/// <summary>
+/// Overlay-specific layout checks for the join-cancel movie; its view-model bindings are covered
+/// by the <see cref="PopupUIMovieBindingTests"/> theory table.
+/// </summary>
+public class CoopJoinCancelOverlayMovieTests
+{
+    [Fact]
+    public void RootContainer_FillsTheScreenWithoutAcceptingEvents()
+    {
+        var document = XDocument.Load(PopupUIMovieBindingTests.FindMoviePath("CoopJoinCancelOverlay.xml"));
+        var container = document.Descendants("Widget").First();
+
+        Assert.Equal("true", container.Attribute("DoNotAcceptEvents")?.Value);
+        Assert.Equal("StretchToParent", container.Attribute("WidthSizePolicy")?.Value);
+        Assert.Equal("StretchToParent", container.Attribute("HeightSizePolicy")?.Value);
+    }
+}

--- a/source/GameInterface.Tests/Services/UI/JoinCancelVMTests.cs
+++ b/source/GameInterface.Tests/Services/UI/JoinCancelVMTests.cs
@@ -1,0 +1,70 @@
+﻿using Common.Messaging;
+using GameInterface.Services.UI.JoinCancel;
+using GameInterface.Services.UI.Messages;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace GameInterface.Tests.Services.UI;
+
+public class JoinCancelVMTests
+{
+    [Fact]
+    public void ActionCancel_PublishesTheCancelRequest()
+    {
+        using var messageBroker = new MessageBroker();
+        var requests = Subscribe(messageBroker, out var subscription);
+        var viewModel = new JoinCancelVM("Cancel", messageBroker);
+
+        viewModel.ActionCancel();
+
+        Assert.Single(requests);
+        GC.KeepAlive(subscription);
+    }
+
+    [Fact]
+    public void ActionCancel_StaysUsableAfterARequestThatWasDropped()
+    {
+        using var messageBroker = new MessageBroker();
+        var handled = 0;
+        // The broker swallows a handler's exception, so a press whose teardown blew up is
+        // indistinguishable from one that worked. Either way the player must be able to press again.
+        Action<MessagePayload<CancelJoinAttempt>> subscription = _ =>
+        {
+            handled++;
+            if (handled == 1) throw new InvalidOperationException("the session was already gone");
+        };
+        messageBroker.Subscribe(subscription);
+        var viewModel = new JoinCancelVM("Cancel", messageBroker);
+
+        viewModel.ActionCancel();
+        viewModel.ActionCancel();
+
+        Assert.Equal(2, handled);
+        GC.KeepAlive(subscription);
+    }
+
+    [Fact]
+    public void CancelButtonText_TakesTheLabelItWasGiven()
+    {
+        using var messageBroker = new MessageBroker();
+        var viewModel = new JoinCancelVM("Stop waiting", messageBroker);
+
+        Assert.Equal("Stop waiting", viewModel.CancelButtonText);
+
+        viewModel.CancelButtonText = "Cancel";
+
+        Assert.Equal("Cancel", viewModel.CancelButtonText);
+    }
+
+    // The broker holds subscriptions weakly, so the handler has to be kept alive by the test.
+    private static List<CancelJoinAttempt> Subscribe(
+        IMessageBroker messageBroker,
+        out Action<MessagePayload<CancelJoinAttempt>> subscription)
+    {
+        var requests = new List<CancelJoinAttempt>();
+        subscription = payload => requests.Add(payload.What);
+        messageBroker.Subscribe(subscription);
+        return requests;
+    }
+}

--- a/source/GameInterface.Tests/Services/UI/PopupUIMovieBindingTests.cs
+++ b/source/GameInterface.Tests/Services/UI/PopupUIMovieBindingTests.cs
@@ -1,5 +1,6 @@
 using GameInterface.Services.UI.Credits;
 using GameInterface.Services.UI.Donate;
+using GameInterface.Services.UI.JoinCancel;
 using System;
 using System.IO;
 using System.Linq;
@@ -21,6 +22,7 @@ public class PopupUIMovieBindingTests
     {
         { "DonatePopupUIMovie.xml", typeof(DonatePopupVM) },
         { "CreditsPopupUIMovie.xml", typeof(CreditsPopupVM) },
+        { "CoopJoinCancelOverlay.xml", typeof(JoinCancelVM) },
     };
 
     [Theory]
@@ -79,7 +81,7 @@ public class PopupUIMovieBindingTests
         }
     }
 
-    private static string FindMoviePath(string movieFile, [CallerFilePath] string sourceFile = "")
+    internal static string FindMoviePath(string movieFile, [CallerFilePath] string sourceFile = "")
     {
         var sourceDirectory = Path.GetDirectoryName(sourceFile);
         return Path.GetFullPath(Path.Combine(sourceDirectory!,

--- a/source/GameInterface/Services/UI/JoinCancel/JoinAttemptOverlay.cs
+++ b/source/GameInterface/Services/UI/JoinCancel/JoinAttemptOverlay.cs
@@ -5,10 +5,8 @@ using TaleWorlds.ScreenSystem;
 namespace GameInterface.Services.UI.JoinCancel;
 
 /// <summary>
-/// The cancel affordance a coop join attempt shows while it is in flight. The art and status text
-/// behind it are the engine's own loading window, driven through
-/// <see cref="Interfaces.ILoadingInterface"/>. Both methods touch Gauntlet state and must be
-/// called on the game thread.
+/// The cancel affordance a coop join attempt shows while it is in flight, over the engine's own
+/// loading window. Both methods touch Gauntlet state and must be called on the game thread.
 /// </summary>
 public interface IJoinAttemptOverlay : IGameAbstraction
 {

--- a/source/GameInterface/Services/UI/JoinCancel/JoinAttemptOverlay.cs
+++ b/source/GameInterface/Services/UI/JoinCancel/JoinAttemptOverlay.cs
@@ -1,0 +1,79 @@
+﻿using TaleWorlds.Engine.GauntletUI;
+using TaleWorlds.GauntletUI.Data;
+using TaleWorlds.ScreenSystem;
+
+namespace GameInterface.Services.UI.JoinCancel;
+
+/// <summary>
+/// The cancel affordance a coop join attempt shows while it is in flight. The art and status text
+/// behind it are the engine's own loading window, driven through
+/// <see cref="Interfaces.ILoadingInterface"/>. Both methods touch Gauntlet state and must be
+/// called on the game thread.
+/// </summary>
+public interface IJoinAttemptOverlay : IGameAbstraction
+{
+    void Show(string cancelLabel);
+
+    /// <summary>Safe to call when nothing is shown.</summary>
+    void Hide();
+}
+
+/// <inheritdoc cref="IJoinAttemptOverlay"/>
+public sealed class JoinAttemptOverlay : GlobalLayer, IJoinAttemptOverlay
+{
+    // Outranks the engine's loading-window global layer, so the button draws over it.
+    private const int CancelLayerOrder = 115005;
+
+    private const string CancelMovieName = "CoopJoinCancelOverlay";
+
+    private GauntletLayer gauntletLayer;
+    private GauntletMovieIdentifier movie;
+    private JoinCancelVM dataSource;
+    private bool isShown;
+
+    public void Show(string cancelLabel)
+    {
+        if (isShown) return;
+
+        // Marked before the layer goes up so a partial Show can still be taken down.
+        isShown = true;
+
+        dataSource = new JoinCancelVM(cancelLabel);
+        gauntletLayer = new GauntletLayer(CancelMovieName, CancelLayerOrder)
+        {
+            IsFocusLayer = true,
+        };
+        movie = gauntletLayer.LoadMovie(CancelMovieName, dataSource);
+        Layer = gauntletLayer;
+
+        // The layers below hide the cursor; without this the button cannot be clicked.
+        gauntletLayer.InputRestrictions.SetInputRestrictions();
+        ScreenManager.AddGlobalLayer(this, false);
+        ScreenManager.TrySetFocus(gauntletLayer);
+    }
+
+    public void Hide()
+    {
+        if (!isShown) return;
+
+        isShown = false;
+        if (gauntletLayer == null) return;
+
+        try
+        {
+            gauntletLayer.IsFocusLayer = false;
+            ScreenManager.TryLoseFocus(gauntletLayer);
+            gauntletLayer.InputRestrictions.ResetInputRestrictions();
+            gauntletLayer.ReleaseMovie(movie);
+        }
+        finally
+        {
+            // Even a failed teardown must unregister the layer and drop the handles.
+            ScreenManager.RemoveGlobalLayer(this);
+            dataSource.OnFinalize();
+            dataSource = null;
+            movie = null;
+            gauntletLayer = null;
+        }
+    }
+}

--- a/source/GameInterface/Services/UI/JoinCancel/JoinCancelVM.cs
+++ b/source/GameInterface/Services/UI/JoinCancel/JoinCancelVM.cs
@@ -1,0 +1,45 @@
+﻿using Common.Messaging;
+using GameInterface.Services.UI.Messages;
+using System;
+using TaleWorlds.Library;
+
+namespace GameInterface.Services.UI.JoinCancel;
+
+/// <summary>
+/// View model behind the join-cancel button. Every press publishes <see cref="CancelJoinAttempt"/>;
+/// the handler knows whether a teardown is already under way and drops the repeats.
+/// </summary>
+internal sealed class JoinCancelVM : ViewModel
+{
+    private readonly IMessageBroker messageBroker;
+
+    private string cancelButtonText;
+
+    public JoinCancelVM(string cancelButtonText)
+        : this(cancelButtonText, MessageBroker.Instance)
+    {
+    }
+
+    public JoinCancelVM(string cancelButtonText, IMessageBroker messageBroker)
+    {
+        if (messageBroker == null) throw new ArgumentNullException(nameof(messageBroker));
+
+        this.messageBroker = messageBroker;
+        this.cancelButtonText = cancelButtonText;
+    }
+
+    [DataSourceProperty]
+    public string CancelButtonText
+    {
+        get => cancelButtonText;
+        set
+        {
+            if (cancelButtonText == value) return;
+
+            cancelButtonText = value;
+            OnPropertyChanged(nameof(CancelButtonText));
+        }
+    }
+
+    public void ActionCancel() => messageBroker.Publish(this, new CancelJoinAttempt());
+}

--- a/source/GameInterface/Services/UI/Messages/CancelJoinAttempt.cs
+++ b/source/GameInterface/Services/UI/Messages/CancelJoinAttempt.cs
@@ -1,0 +1,11 @@
+﻿using Common.Messaging;
+
+namespace GameInterface.Services.UI.Messages;
+
+/// <summary>
+/// Player request to abandon a join attempt that has not connected yet, ending the connect
+/// retry loop that would otherwise redial forever.
+/// </summary>
+public record CancelJoinAttempt : ICommand
+{
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] New feature (non-breaking change that adds functionality)

## What is the current behavior?

A join attempt gives the player nothing to look at and no way out. The Join screen stays up while the client dials, and on failure it silently redials every 3 seconds. Cancelling only closes the screen — the retry loop keeps running behind the menu, so if the target server comes up minutes later the player is pulled into a session they thought they had walked away from.

## What is the new behavior?

Resolves #2320

Every join attempt — direct IP, Steam, and hosting's own loopback join — raises Bannerlord's loading screen naming what it is contacting, with a Cancel button. Cancel ends the session, which disposes the network and stops the retry loop, and returns to the Join screen with the address intact; the confirmation is a line in the corner message log rather than a pop-up. Unsolicited endings (server exited, join timeout, refused password) keep their pop-ups.

The screen lives on the engine's loading window through the existing `ILoadingInterface` — an earlier revision drew it on a screen of its own, on a claim about the loading window that re-testing disproved; @ShoT-UPfps was right to push back. The one custom piece is a small layer above the window carrying the Cancel button, which the window's text-only view model cannot.

It is owned by `MainMenuState`, the client's initial state, which already hides that window on the way in and re-shows it on `NetworkConnected` — so ownership follows the state's lifetime rather than a flag in the session orchestrator. A `JoinIntent` picks the wording, so a Steam join never names an endpoint the player did not type, and cancelling a host's own loopback wait says the standalone server stays open.

## Validation

- Units 1721 passed / 0 failed / 14 skipped, Release, at 68029ee9. E2E runs in CI on this branch; the earlier hand-run figure was measured against a superseded commit and is not repeated here.
- Direct join, in game on 1.4.7: the screen holds `Contacting localhost:4200...` across 14 redials; Cancel logs `Player cancelled a "PlayerDirect" join attempt`, the log then stops growing (the redial loop is dead, not just hidden), the screen comes down and `Connection attempt cancelled` appears.
- Hosting's loopback join, on a Release build: the spawned standalone server kept logging for 95 seconds after Cancel and exited only when its own window was closed.
- Hosting's loopback join, Release build 68029ee9, in game on 1.4.7: the heading stays `Hosting Coop Server` across the handshake while the description advances from `Waiting for the server to load the campaign save...` to `Applying patches...`, and the `Stop Waiting` button is withdrawn on connect. Frames 4s apart, below.
- The Steam-initiated join is unit-covered but was not playtested — it needs a lobby and a second machine.

CodeFactor reports `Handle(AttemptHost)` as a Complex Method. That is its advisory annotation; the added branch is the refused-start guard that stops callers acting on a container belonging to another attempt.

<img width="1600" height="900" alt="1-connecting-screen" src="https://github.com/user-attachments/assets/2c032601-0ca7-41ee-bed0-a9ab9003819b" />

<img width="1600" height="900" alt="2-after-cancel" src="https://github.com/user-attachments/assets/0237c006-2f62-412d-a874-10adf8e1a4bd" />

<img width="1616" height="1970" alt="3-hosted-heading-holds" src="https://github.com/user-attachments/assets/cc270e3b-aab0-44e9-b091-bbb95cf5dd72" />

## Bot Changelog Entry

- Joining a co-op server now shows the standard Bannerlord loading screen naming the server being contacted, with a Cancel button.
- Cancelling a join attempt now actually stops it instead of leaving it retrying in the background, and returns you to the join screen with the address you typed still filled in.

