### PR TITLE
[2649] Partition agent action polling in large battles

### DIFF
--- a/source/E2E.Tests/Services/Missions/AgentActionPollSchedulerTests.cs
+++ b/source/E2E.Tests/Services/Missions/AgentActionPollSchedulerTests.cs
@@ -1,0 +1,204 @@
+﻿using Missions.Agents.Handlers;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace E2E.Tests.Services.Missions;
+
+public class AgentActionPollSchedulerTests
+{
+    [Fact]
+    public void FallbackPartitions_VisitEveryAgentWithinOneSweep()
+    {
+        var scheduler = new AgentActionPollScheduler();
+        var agentIds = new List<Guid>();
+        for (int partition = 0;
+             partition < AgentActionPollScheduler.FallbackPartitionCount;
+             partition++)
+        {
+            agentIds.Add(CreateAgentId(partition, 0));
+            agentIds.Add(CreateAgentId(partition, 1));
+        }
+
+        var visits = new Dictionary<Guid, int>();
+        for (int poll = 0;
+             poll < AgentActionPollScheduler.FallbackPartitionCount;
+             poll++)
+        {
+            scheduler.BeginPoll(
+                registryVersion: 1,
+                refreshedAgentIds: poll == 0 ? agentIds : null);
+            foreach (Guid agentId in
+                     scheduler.CurrentFallbackAgentIds)
+            {
+                visits.TryGetValue(agentId, out int count);
+                visits[agentId] = count + 1;
+            }
+        }
+
+        Assert.Equal(agentIds.Count, visits.Count);
+        Assert.All(visits.Values, count => Assert.Equal(1, count));
+    }
+
+    [Fact]
+    public void ChangedRegistry_RefreshesAtTheBoundaryAndPrioritizesNewAgents()
+    {
+        var scheduler = new AgentActionPollScheduler();
+        Guid existingAgentId = CreateAgentId(partition: 0, index: 0);
+        Guid newAgentId = CreateAgentId(partition: 3, index: 0);
+        var initialAgentIds = new[] { existingAgentId };
+
+        scheduler.BeginPoll(
+            registryVersion: 1,
+            refreshedAgentIds: initialAgentIds);
+        Assert.Empty(scheduler.NewPriorityAgentIds);
+
+        for (int poll = 0; poll < 3; poll++)
+        {
+            Assert.False(scheduler.RequiresAgentRefresh(
+                registryVersion: 2));
+            scheduler.BeginPoll(
+                registryVersion: 2,
+                refreshedAgentIds: null);
+            Assert.Empty(scheduler.NewPriorityAgentIds);
+        }
+
+        Assert.True(scheduler.RequiresAgentRefresh(
+            registryVersion: 2));
+        scheduler.BeginPoll(
+            registryVersion: 2,
+            refreshedAgentIds: new[]
+            {
+                existingAgentId,
+                newAgentId,
+            });
+
+        Assert.Equal(
+            newAgentId,
+            Assert.Single(scheduler.NewPriorityAgentIds));
+    }
+
+    [Fact]
+    public void DirtyAgent_RemainsPriorityForTwoCleanPolls()
+    {
+        var scheduler = new AgentActionPollScheduler();
+        Guid agentId = CreateAgentId(partition: 3, index: 0);
+        Assert.True(scheduler.MarkDirty(agentId));
+
+        for (int poll = 0;
+             poll < AgentActionPollScheduler.CleanPriorityPolls;
+             poll++)
+        {
+            scheduler.BeginPoll(
+                registryVersion: 1,
+                refreshedAgentIds: poll == 0
+                    ? new[] { agentId }
+                    : null);
+            Assert.Contains(agentId, scheduler.GetDirtyAgentIds());
+            scheduler.CompletePoll(agentId, actionChanged: false);
+        }
+
+        Assert.Equal(0, scheduler.DirtyAgentCount);
+        Assert.Empty(scheduler.GetDirtyAgentIds());
+    }
+
+    [Fact]
+    public void ActionChange_RefreshesTheCleanPollWindow()
+    {
+        var scheduler = new AgentActionPollScheduler();
+        Guid agentId = CreateAgentId(partition: 3, index: 0);
+        scheduler.MarkDirty(agentId);
+
+        scheduler.BeginPoll(
+            registryVersion: 1,
+            refreshedAgentIds: new[] { agentId });
+        scheduler.CompletePoll(agentId, actionChanged: false);
+
+        scheduler.BeginPoll(
+            registryVersion: 1,
+            refreshedAgentIds: null);
+        scheduler.CompletePoll(agentId, actionChanged: true);
+
+        Assert.Equal(1, scheduler.DirtyAgentCount);
+        for (int poll = 0;
+             poll < AgentActionPollScheduler.CleanPriorityPolls;
+             poll++)
+        {
+            scheduler.BeginPoll(
+                registryVersion: 1,
+                refreshedAgentIds: null);
+            Assert.Contains(agentId, scheduler.GetDirtyAgentIds());
+            scheduler.CompletePoll(agentId, actionChanged: false);
+        }
+        Assert.Equal(0, scheduler.DirtyAgentCount);
+    }
+
+    [Fact]
+    public void RemovedDirtyAgent_IsNoLongerPriority()
+    {
+        var scheduler = new AgentActionPollScheduler();
+        Guid agentId = Guid.NewGuid();
+        scheduler.MarkDirty(agentId);
+
+        Assert.True(scheduler.RemoveDirty(agentId));
+
+        Assert.Empty(scheduler.GetDirtyAgentIds());
+    }
+
+    [Fact]
+    public void TryBeginAgent_SuppressesDuplicatePriorityAndFallbackVisits()
+    {
+        var scheduler = new AgentActionPollScheduler();
+        Guid agentId = CreateAgentId(partition: 0, index: 0);
+        scheduler.BeginPoll(
+            registryVersion: 1,
+            refreshedAgentIds: new[] { agentId });
+
+        Assert.True(scheduler.TryBeginAgent(agentId));
+        Assert.False(scheduler.TryBeginAgent(agentId));
+    }
+
+    [Fact]
+    public void Clear_RestartsAtTheFirstPartition()
+    {
+        var scheduler = new AgentActionPollScheduler();
+        scheduler.MarkDirty(Guid.NewGuid());
+        scheduler.BeginPoll(
+            registryVersion: 1,
+            refreshedAgentIds: Array.Empty<Guid>());
+
+        scheduler.Clear();
+        scheduler.BeginPoll(
+            registryVersion: 1,
+            refreshedAgentIds: Array.Empty<Guid>());
+
+        Assert.Equal(0, scheduler.CurrentPartition);
+        Assert.Equal(0, scheduler.DirtyAgentCount);
+    }
+
+    private static Guid CreateAgentId(int partition, int index)
+    {
+        for (int value = 1; ; value++)
+        {
+            byte[] bytes = new byte[16];
+            Buffer.BlockCopy(
+                BitConverter.GetBytes(value),
+                0,
+                bytes,
+                0,
+                sizeof(int));
+            Buffer.BlockCopy(
+                BitConverter.GetBytes(index),
+                0,
+                bytes,
+                sizeof(int),
+                sizeof(int));
+            var agentId = new Guid(bytes);
+            if (AgentActionPollScheduler.GetPartition(agentId)
+                == partition)
+            {
+                return agentId;
+            }
+        }
+    }
+}

--- a/source/E2E.Tests/Services/Missions/BattleBlockingSyncTests.cs
+++ b/source/E2E.Tests/Services/Missions/BattleBlockingSyncTests.cs
@@ -181,7 +181,7 @@ public class BattleBlockingSyncTests : MissionTestEnvironment
                 AgentControllerType.AI,
                 out MirrorAgent aiMirror);
 
-            context.Component.AgentActionHandler.PollActionsAfterNativeTick();
+            PollAiFallbackSweep(context.Component);
             Assert.Empty(
                 context.Network.NetworkSentPackets
                     .GetPackets<AgentActionPacket>());
@@ -189,7 +189,7 @@ public class BattleBlockingSyncTests : MissionTestEnvironment
             aiMirror.Action0Index = 1001;
             aiMirror.Action0CodeType = actionType;
 
-            context.Component.AgentActionHandler.PollActionsAfterNativeTick();
+            PollAiFallbackSweep(context.Component);
 
             AgentActionPacket packet = Assert.Single(
                 context.Network.NetworkSentPackets
@@ -199,7 +199,7 @@ public class BattleBlockingSyncTests : MissionTestEnvironment
             Assert.Equal(1L, Assert.Single(packet.Sequences));
 
             context.Network.NetworkSentPackets.Packets.Clear();
-            context.Component.AgentActionHandler.PollActionsAfterNativeTick();
+            PollAiFallbackSweep(context.Component);
             Assert.Empty(
                 context.Network.NetworkSentPackets
                     .GetPackets<AgentActionPacket>());
@@ -225,7 +225,7 @@ public class BattleBlockingSyncTests : MissionTestEnvironment
                 AgentControllerType.AI,
                 out MirrorAgent aiMirror);
 
-            context.Component.AgentActionHandler.PollActionsAfterNativeTick();
+            PollAiFallbackSweep(context.Component);
             Assert.Empty(
                 context.Network.NetworkSentPackets
                     .GetPackets<AgentActionPacket>());
@@ -238,7 +238,7 @@ public class BattleBlockingSyncTests : MissionTestEnvironment
             aiMirror.Action1CodeType = Agent.ActionCodeType.Guard;
             aiMirror.Action1Direction = Agent.UsageDirection.DefendLeft;
 
-            context.Component.AgentActionHandler.PollActionsAfterNativeTick();
+            PollAiFallbackSweep(context.Component);
 
             AgentActionPacket packet = Assert.Single(
                 context.Network.NetworkSentPackets
@@ -253,10 +253,160 @@ public class BattleBlockingSyncTests : MissionTestEnvironment
             Assert.Equal(1L, Assert.Single(packet.Sequences));
 
             context.Network.NetworkSentPackets.Packets.Clear();
-            context.Component.AgentActionHandler.PollActionsAfterNativeTick();
+            PollAiFallbackSweep(context.Component);
             Assert.Empty(
                 context.Network.NetworkSentPackets
                     .GetPackets<AgentActionPacket>());
+        });
+    }
+
+    [Fact]
+    public void PollActionsAfterNativeTick_BlockedLocalAi_IsPolledImmediately()
+    {
+        RunScenario("owner", context =>
+        {
+            Agent player = SpawnRegisteredAgent(
+                context,
+                "owner",
+                Guid.NewGuid(),
+                AgentControllerType.Player,
+                out _);
+            Guid aiId = CreateAgentIdForPartition(partition: 3);
+            Agent aiAgent = SpawnRegisteredAgent(
+                context,
+                "owner",
+                aiId,
+                AgentControllerType.AI,
+                out MirrorAgent aiMirror);
+
+            PollAiFallbackSweep(context.Component);
+            aiMirror.Action0Index = 1001;
+            aiMirror.Action0CodeType =
+                Agent.ActionCodeType.ReleaseMelee;
+            MarkAgentDirtyThroughBlockedHit(
+                context.Component,
+                aiAgent,
+                player);
+
+            context.Component.AgentActionHandler
+                .PollActionsAfterNativeTick();
+
+            AgentActionPacket packet = Assert.Single(
+                context.Network.NetworkSentPackets
+                    .GetPackets<AgentActionPacket>());
+            Assert.Equal(aiId, Assert.Single(packet.AgentIds));
+        });
+    }
+
+    [Fact]
+    public void PollActionsAfterNativeTick_RemovedDirtyAgent_IsPruned()
+    {
+        RunScenario("owner", context =>
+        {
+            Agent player = SpawnRegisteredAgent(
+                context,
+                "owner",
+                Guid.NewGuid(),
+                AgentControllerType.Player,
+                out _);
+            Guid aiId = CreateAgentIdForPartition(partition: 3);
+            Agent oldAiAgent = SpawnRegisteredAgent(
+                context,
+                "owner",
+                aiId,
+                AgentControllerType.AI,
+                out _);
+
+            PollAiFallbackSweep(context.Component);
+            MarkAgentDirtyThroughBlockedHit(
+                context.Component,
+                oldAiAgent,
+                player);
+            Assert.True(context.Registry.RemoveAgent(aiId));
+            context.Component.AgentActionHandler
+                .PollActionsAfterNativeTick();
+
+            SpawnRegisteredAgent(
+                context,
+                "owner",
+                aiId,
+                AgentControllerType.AI,
+                out MirrorAgent newAiMirror);
+            newAiMirror.Action0Index = 1001;
+            newAiMirror.Action0CodeType =
+                Agent.ActionCodeType.ReleaseMelee;
+
+            context.Component.AgentActionHandler
+                .PollActionsAfterNativeTick();
+            Assert.Empty(
+                context.Network.NetworkSentPackets
+                    .GetPackets<AgentActionPacket>());
+
+            context.Component.AgentActionHandler
+                .PollActionsAfterNativeTick();
+            context.Component.AgentActionHandler
+                .PollActionsAfterNativeTick();
+            context.Component.AgentActionHandler
+                .PollActionsAfterNativeTick();
+            AgentActionPacket packet = Assert.Single(
+                context.Network.NetworkSentPackets
+                    .GetPackets<AgentActionPacket>());
+            Assert.Equal(aiId, Assert.Single(packet.AgentIds));
+        });
+    }
+
+    [Fact]
+    public void PollActionsAfterNativeTick_TransferredDirtyAgent_IsPruned()
+    {
+        RunScenario("owner", context =>
+        {
+            Agent player = SpawnRegisteredAgent(
+                context,
+                "owner",
+                Guid.NewGuid(),
+                AgentControllerType.Player,
+                out _);
+            Guid aiId = CreateAgentIdForPartition(partition: 3);
+            Agent aiAgent = SpawnRegisteredAgent(
+                context,
+                "owner",
+                aiId,
+                AgentControllerType.AI,
+                out MirrorAgent aiMirror);
+
+            PollAiFallbackSweep(context.Component);
+            MarkAgentDirtyThroughBlockedHit(
+                context.Component,
+                aiAgent,
+                player);
+            Assert.True(context.Registry.TryTransferAuthority(
+                "remote",
+                aiId));
+            context.Component.AgentActionHandler
+                .PollActionsAfterNativeTick();
+            Assert.True(context.Registry.TryTransferAuthority(
+                "owner",
+                aiId));
+            aiMirror.Action0Index = 1001;
+            aiMirror.Action0CodeType =
+                Agent.ActionCodeType.ReleaseMelee;
+
+            context.Component.AgentActionHandler
+                .PollActionsAfterNativeTick();
+            Assert.Empty(
+                context.Network.NetworkSentPackets
+                    .GetPackets<AgentActionPacket>());
+
+            context.Component.AgentActionHandler
+                .PollActionsAfterNativeTick();
+            context.Component.AgentActionHandler
+                .PollActionsAfterNativeTick();
+            context.Component.AgentActionHandler
+                .PollActionsAfterNativeTick();
+            AgentActionPacket packet = Assert.Single(
+                context.Network.NetworkSentPackets
+                    .GetPackets<AgentActionPacket>());
+            Assert.Equal(aiId, Assert.Single(packet.AgentIds));
         });
     }
 
@@ -2435,6 +2585,56 @@ public class BattleBlockingSyncTests : MissionTestEnvironment
     private static void DrainGameThread()
     {
         GameThread.Run(() => { }, blocking: true);
+    }
+
+    private static void PollAiFallbackSweep(
+        ICoopMissionComponent component)
+    {
+        for (int poll = 0;
+             poll < AgentActionPollScheduler.FallbackPartitionCount;
+             poll++)
+        {
+            component.AgentActionHandler.PollActionsAfterNativeTick();
+        }
+    }
+
+    private static void MarkAgentDirtyThroughBlockedHit(
+        ICoopMissionComponent component,
+        Agent affectedAgent,
+        Agent affectorAgent)
+    {
+        var blow = new Blow(affectorAgent.Index);
+        var collisionData = new AttackCollisionData
+        {
+            _collisionResult =
+                (int)CombatCollisionResult.Blocked
+        };
+        component.AgentActionHandler.ObserveBlockedHit(
+            affectedAgent,
+            affectorAgent,
+            isBlocked: true,
+            in blow,
+            in collisionData);
+    }
+
+    private static Guid CreateAgentIdForPartition(int partition)
+    {
+        for (int value = 1; ; value++)
+        {
+            byte[] bytes = new byte[16];
+            Buffer.BlockCopy(
+                BitConverter.GetBytes(value),
+                0,
+                bytes,
+                0,
+                sizeof(int));
+            var agentId = new Guid(bytes);
+            if (AgentActionPollScheduler.GetPartition(agentId)
+                == partition)
+            {
+                return agentId;
+            }
+        }
     }
 
     private static Agent SpawnAgent(

--- a/source/E2E.Tests/Services/Missions/NetworkAgentRegistryTests.cs
+++ b/source/E2E.Tests/Services/Missions/NetworkAgentRegistryTests.cs
@@ -89,6 +89,36 @@ public class NetworkAgentRegistryTests
     }
 
     [Fact]
+    public void Version_ChangesOnlyWhenRegistryStateChanges()
+    {
+        var registry = NewRegistry(localControllerId: "me");
+        var agent = ObjectHelper.SkipConstructor<Agent>();
+        Guid agentId = Guid.NewGuid();
+        long initialVersion = registry.Version;
+
+        Assert.True(registry.TryRegisterAgent(
+            "host",
+            agentId,
+            agent));
+        long registeredVersion = registry.Version;
+        Assert.True(registeredVersion > initialVersion);
+
+        Assert.True(registry.TryTransferAuthority("host", agentId));
+        Assert.Equal(registeredVersion, registry.Version);
+
+        Assert.True(registry.TryTransferAuthority("me", agentId));
+        long transferredVersion = registry.Version;
+        Assert.True(transferredVersion > registeredVersion);
+
+        Assert.True(registry.RemoveAgent(agentId));
+        long removedVersion = registry.Version;
+        Assert.True(removedVersion > transferredVersion);
+
+        Assert.False(registry.RemoveAgent(agentId));
+        Assert.Equal(removedVersion, registry.Version);
+    }
+
+    [Fact]
     public void TransferAuthority_ClearsEquipmentStateFromPreviousController()
     {
         var (registry, _, id) = RegisterAgent(ownerControllerId: "host", localControllerId: "me");

--- a/source/Missions/Agents/Handlers/AgentActionHandler.cs
+++ b/source/Missions/Agents/Handlers/AgentActionHandler.cs
@@ -69,10 +69,17 @@ public class AgentActionHandler : IAgentActionHandler
     private readonly IControllerIdProvider controllerIdProvider;
     private readonly IRemoteAgentActionProcessor remoteActionProcessor;
     private readonly IGuardReactionHandler guardReactionHandler;
+    private readonly IAgentActionPollScheduler actionPollScheduler;
 
     // Outbound observation and sequence share one record because both belong to the local agent's action stream.
     private readonly Dictionary<Guid, LocalAgentActionState> _localAgentStates =
         new Dictionary<Guid, LocalAgentActionState>();
+    private readonly HashSet<Guid> _inputPriorityAgentIds =
+        new HashSet<Guid>();
+    private readonly List<Guid> _inputPriorityAgentSnapshot =
+        new List<Guid>();
+    private readonly List<Guid> _refreshedAgentIds =
+        new List<Guid>();
 
     private bool _disposed;
 
@@ -107,7 +114,8 @@ public class AgentActionHandler : IAgentActionHandler
         INetworkAgentRegistry agentRegistry,
         IControllerIdProvider controllerIdProvider,
         IRemoteAgentActionProcessor remoteActionProcessor,
-        IGuardReactionHandler guardReactionHandler)
+        IGuardReactionHandler guardReactionHandler,
+        IAgentActionPollScheduler actionPollScheduler)
     {
         this.client = client;
         this.packetManager = packetManager;
@@ -116,6 +124,7 @@ public class AgentActionHandler : IAgentActionHandler
         this.controllerIdProvider = controllerIdProvider;
         this.remoteActionProcessor = remoteActionProcessor;
         this.guardReactionHandler = guardReactionHandler;
+        this.actionPollScheduler = actionPollScheduler;
 
         this.packetManager.RegisterPacketHandler(this);
         this.messageBroker.Subscribe<NetworkBattleHostAssigned>(Handle_BattleHostAssigned);
@@ -148,16 +157,11 @@ public class AgentActionHandler : IAgentActionHandler
 
         if (afterNativeTick)
         {
-            foreach (CoopAgentInfo info in agentRegistry.GetAgents(
-                controllerIdProvider.ControllerId))
-            {
-                PollAgentAction(
-                    info,
-                    afterNativeTick: true,
-                    ref ids,
-                    ref actions,
-                    ref sequences);
-            }
+            PollPostNativeActions(
+                mission,
+                ref ids,
+                ref actions,
+                ref sequences);
         }
         else
         {
@@ -191,7 +195,127 @@ public class AgentActionHandler : IAgentActionHandler
             packet => client.SendAll(packet));
     }
 
-    private void PollAgentAction(
+    private void PollPostNativeActions(
+        Mission mission,
+        ref List<Guid> ids,
+        ref List<AgentActionData> actions,
+        ref List<long> sequences)
+    {
+        IReadOnlyCollection<Guid> refreshedAgentIds = null;
+        long registryVersion = agentRegistry.Version;
+        if (actionPollScheduler.RequiresAgentRefresh(registryVersion))
+        {
+            _refreshedAgentIds.Clear();
+            foreach (CoopAgentInfo info in agentRegistry.GetAgents(
+                controllerIdProvider.ControllerId))
+            {
+                _refreshedAgentIds.Add(info.AgentId);
+            }
+            refreshedAgentIds = _refreshedAgentIds;
+        }
+        actionPollScheduler.BeginPoll(
+            registryVersion,
+            refreshedAgentIds);
+
+        Agent mainAgent = mission.MainAgent;
+        if (mainAgent != null
+            && agentRegistry.TryGetAgentInfo(
+                mainAgent,
+                out CoopAgentInfo mainAgentInfo))
+        {
+            PollPostNativeAgent(
+                mainAgentInfo.AgentId,
+                mission,
+                ref ids,
+                ref actions,
+                ref sequences);
+        }
+
+        _inputPriorityAgentSnapshot.Clear();
+        foreach (Guid agentId in _inputPriorityAgentIds)
+            _inputPriorityAgentSnapshot.Add(agentId);
+        foreach (Guid agentId in _inputPriorityAgentSnapshot)
+        {
+            PollPostNativeAgent(
+                agentId,
+                mission,
+                ref ids,
+                ref actions,
+                ref sequences);
+        }
+
+        foreach (Guid agentId in
+                 actionPollScheduler.NewPriorityAgentIds)
+        {
+            PollPostNativeAgent(
+                agentId,
+                mission,
+                ref ids,
+                ref actions,
+                ref sequences);
+        }
+
+        foreach (Guid agentId in actionPollScheduler.GetDirtyAgentIds())
+        {
+            PollPostNativeAgent(
+                agentId,
+                mission,
+                ref ids,
+                ref actions,
+                ref sequences);
+        }
+
+        foreach (Guid agentId in
+                 actionPollScheduler.CurrentFallbackAgentIds)
+        {
+            PollPostNativeAgent(
+                agentId,
+                mission,
+                ref ids,
+                ref actions,
+                ref sequences);
+        }
+    }
+
+    private void PollPostNativeAgent(
+        Guid agentId,
+        Mission mission,
+        ref List<Guid> ids,
+        ref List<AgentActionData> actions,
+        ref List<long> sequences)
+    {
+        if (!actionPollScheduler.TryBeginAgent(agentId))
+            return;
+
+        if (!agentRegistry.TryGetAgentInfo(
+                agentId,
+                out CoopAgentInfo info)
+            || !agentRegistry.IsLocallyControlled(agentId))
+        {
+            actionPollScheduler.RemoveDirty(agentId);
+            _inputPriorityAgentIds.Remove(agentId);
+            return;
+        }
+
+        bool isMainAgent =
+            ReferenceEquals(info.Agent, mission.MainAgent);
+        bool consumesInputPriority =
+            !isMainAgent
+            && _inputPriorityAgentIds.Contains(agentId);
+        bool actionChanged = PollAgentAction(
+            info,
+            afterNativeTick: true,
+            ref ids,
+            ref actions,
+            ref sequences);
+        if (consumesInputPriority)
+            _inputPriorityAgentIds.Remove(agentId);
+        actionPollScheduler.CompletePoll(
+            agentId,
+            actionChanged && !isMainAgent);
+    }
+
+    private bool PollAgentAction(
         CoopAgentInfo info,
         bool afterNativeTick,
         ref List<Guid> ids,
@@ -212,7 +336,7 @@ public class AgentActionHandler : IAgentActionHandler
             agent,
             actionSyncedAgent);
 #endif
-        if (!actionSyncedAgent) return;
+        if (!actionSyncedAgent) return false;
 
         int action0 = agent.GetCurrentAction(0).Index;
         int action1 = agent.GetCurrentAction(1).Index;
@@ -259,6 +383,7 @@ public class AgentActionHandler : IAgentActionHandler
         if (!afterNativeTick && isPlayerControlled)
         {
             state.HasInputBoundaryObservation = true;
+            _inputPriorityAgentIds.Add(info.AgentId);
             state.InputBoundaryDefendFlags = defendFlags;
             state.InputBoundaryGuardMode = guardMode;
         }
@@ -266,6 +391,7 @@ public class AgentActionHandler : IAgentActionHandler
             || agent != Mission.Current.MainAgent)
         {
             state.HasInputBoundaryObservation = false;
+            _inputPriorityAgentIds.Remove(info.AgentId);
             state.InputBoundaryDefendFlags =
                 Agent.MovementControlFlag.None;
             state.InputBoundaryGuardMode = Agent.GuardMode.None;
@@ -324,7 +450,7 @@ public class AgentActionHandler : IAgentActionHandler
                 state.ActionGuardMode = actionGuardMode;
                 _localAgentStates[info.AgentId] = state;
             }
-            return;
+            return false;
         }
 
         bool action0Discrete =
@@ -423,7 +549,7 @@ public class AgentActionHandler : IAgentActionHandler
         }
         _localAgentStates[info.AgentId] = state;
         if (!broadcast)
-            return;
+            return false;
 
 #if DEBUG
         MissionActionDiagnostics.RecordActionUpdate();
@@ -440,6 +566,7 @@ public class AgentActionHandler : IAgentActionHandler
         (ids ??= new List<Guid>()).Add(info.AgentId);
         (actions ??= new List<AgentActionData>()).Add(actionData);
         (sequences ??= new List<long>()).Add(sequence);
+        return true;
     }
 
     public void CatchUpJoiner(string controllerId)
@@ -560,6 +687,12 @@ public class AgentActionHandler : IAgentActionHandler
         in Blow blow,
         in AttackCollisionData collisionData)
     {
+        if (isBlocked)
+        {
+            MarkActionPollDirty(affectedAgent);
+            MarkActionPollDirty(affectorAgent);
+        }
+
         if (isBlocked
             && affectedAgent != null
             && affectorAgent != null
@@ -581,6 +714,21 @@ public class AgentActionHandler : IAgentActionHandler
             blow.IsMissile,
             collisionData.CollisionResult,
             remoteActionProcessor.GetOutgoingBattleHostEpoch());
+    }
+
+    private void MarkActionPollDirty(Agent agent)
+    {
+        if (agent == null
+            || ReferenceEquals(agent, Mission.Current?.MainAgent)
+            || !agentRegistry.TryGetAgentInfo(
+                agent,
+                out CoopAgentInfo info)
+            || !agentRegistry.IsLocallyControlled(info.AgentId))
+        {
+            return;
+        }
+
+        actionPollScheduler.MarkDirty(info.AgentId);
     }
 
     private void Handle_BattleHostAssigned(
@@ -819,6 +967,10 @@ public class AgentActionHandler : IAgentActionHandler
         packetManager.RemovePacketHandler(this);
         remoteActionProcessor.Dispose();
         guardReactionHandler.Dispose();
+        actionPollScheduler.Clear();
         _localAgentStates.Clear();
+        _inputPriorityAgentIds.Clear();
+        _inputPriorityAgentSnapshot.Clear();
+        _refreshedAgentIds.Clear();
     }
 }

--- a/source/Missions/Agents/Handlers/AgentActionPollScheduler.cs
+++ b/source/Missions/Agents/Handlers/AgentActionPollScheduler.cs
@@ -1,0 +1,181 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Missions.Agents.Handlers;
+
+public interface IAgentActionPollScheduler
+{
+    int CurrentPartition { get; }
+    int DirtyAgentCount { get; }
+    IReadOnlyCollection<Guid> CurrentFallbackAgentIds { get; }
+    IReadOnlyCollection<Guid> NewPriorityAgentIds { get; }
+
+    bool RequiresAgentRefresh(long registryVersion);
+    void BeginPoll(
+        long registryVersion,
+        IReadOnlyCollection<Guid> refreshedAgentIds);
+    IReadOnlyCollection<Guid> GetDirtyAgentIds();
+    bool TryBeginAgent(Guid agentId);
+    void CompletePoll(Guid agentId, bool actionChanged);
+    bool MarkDirty(Guid agentId);
+    bool RemoveDirty(Guid agentId);
+    void Clear();
+}
+
+internal sealed class AgentActionPollScheduler : IAgentActionPollScheduler
+{
+    internal const int FallbackPartitionCount = 4;
+    internal const int CleanPriorityPolls = 2;
+
+    private readonly List<Guid>[] fallbackPartitions;
+    private readonly HashSet<Guid> knownAgentIds =
+        new HashSet<Guid>();
+    private readonly HashSet<Guid> refreshedAgentIdSet =
+        new HashSet<Guid>();
+    private readonly List<Guid> newPriorityAgentIds =
+        new List<Guid>();
+    private readonly Dictionary<Guid, DirtyAgentState> dirtyAgents =
+        new Dictionary<Guid, DirtyAgentState>();
+    private readonly List<Guid> dirtyAgentSnapshot = new List<Guid>();
+    private readonly HashSet<Guid> currentPollAgentIds =
+        new HashSet<Guid>();
+
+    private long snapshotVersion = -1;
+
+    public AgentActionPollScheduler()
+    {
+        fallbackPartitions = new List<Guid>[FallbackPartitionCount];
+        for (int partition = 0;
+             partition < FallbackPartitionCount;
+             partition++)
+        {
+            fallbackPartitions[partition] = new List<Guid>();
+        }
+    }
+
+    public int CurrentPartition { get; private set; } = -1;
+    public int DirtyAgentCount => dirtyAgents.Count;
+    public IReadOnlyCollection<Guid> CurrentFallbackAgentIds =>
+        CurrentPartition < 0
+            ? Array.Empty<Guid>()
+            : fallbackPartitions[CurrentPartition];
+    public IReadOnlyCollection<Guid> NewPriorityAgentIds =>
+        newPriorityAgentIds;
+
+    public bool RequiresAgentRefresh(long registryVersion) =>
+        snapshotVersion < 0
+        || (registryVersion != snapshotVersion
+            && CurrentPartition == FallbackPartitionCount - 1);
+
+    public void BeginPoll(
+        long registryVersion,
+        IReadOnlyCollection<Guid> refreshedAgentIds)
+    {
+        bool refreshAgents = RequiresAgentRefresh(registryVersion);
+        newPriorityAgentIds.Clear();
+        if (refreshAgents)
+        {
+            if (refreshedAgentIds == null)
+                throw new ArgumentNullException(nameof(refreshedAgentIds));
+
+            bool initialSnapshot = snapshotVersion < 0;
+            foreach (List<Guid> partition in fallbackPartitions)
+                partition.Clear();
+            refreshedAgentIdSet.Clear();
+            foreach (Guid agentId in refreshedAgentIds)
+            {
+                refreshedAgentIdSet.Add(agentId);
+                fallbackPartitions[GetPartition(agentId)].Add(agentId);
+                if (!initialSnapshot && !knownAgentIds.Contains(agentId))
+                    newPriorityAgentIds.Add(agentId);
+            }
+            knownAgentIds.Clear();
+            foreach (Guid agentId in refreshedAgentIdSet)
+                knownAgentIds.Add(agentId);
+            snapshotVersion = registryVersion;
+        }
+        else if (refreshedAgentIds != null)
+        {
+            throw new ArgumentException(
+                "Agent ids were supplied when no refresh was due.",
+                nameof(refreshedAgentIds));
+        }
+
+        currentPollAgentIds.Clear();
+        CurrentPartition =
+            (CurrentPartition + 1) % FallbackPartitionCount;
+    }
+
+    public IReadOnlyCollection<Guid> GetDirtyAgentIds()
+    {
+        dirtyAgentSnapshot.Clear();
+        foreach (Guid agentId in dirtyAgents.Keys)
+            dirtyAgentSnapshot.Add(agentId);
+        return dirtyAgentSnapshot;
+    }
+
+    public bool TryBeginAgent(Guid agentId) =>
+        currentPollAgentIds.Add(agentId);
+
+    public void CompletePoll(Guid agentId, bool actionChanged)
+    {
+        if (actionChanged)
+        {
+            MarkDirty(agentId);
+            return;
+        }
+
+        if (!dirtyAgents.TryGetValue(
+                agentId,
+                out DirtyAgentState state))
+        {
+            return;
+        }
+
+        state.CleanPollsRemaining--;
+        if (state.CleanPollsRemaining <= 0)
+        {
+            dirtyAgents.Remove(agentId);
+        }
+        else
+        {
+            dirtyAgents[agentId] = state;
+        }
+    }
+
+    public bool MarkDirty(Guid agentId)
+    {
+        bool added = !dirtyAgents.TryGetValue(
+            agentId,
+            out DirtyAgentState state);
+        state.CleanPollsRemaining = CleanPriorityPolls;
+        dirtyAgents[agentId] = state;
+        return added;
+    }
+
+    public bool RemoveDirty(Guid agentId) =>
+        dirtyAgents.Remove(agentId);
+
+    public void Clear()
+    {
+        foreach (List<Guid> partition in fallbackPartitions)
+            partition.Clear();
+        knownAgentIds.Clear();
+        refreshedAgentIdSet.Clear();
+        newPriorityAgentIds.Clear();
+        dirtyAgents.Clear();
+        dirtyAgentSnapshot.Clear();
+        currentPollAgentIds.Clear();
+        snapshotVersion = -1;
+        CurrentPartition = -1;
+    }
+
+    internal static int GetPartition(Guid agentId) =>
+        (agentId.GetHashCode() & int.MaxValue)
+        % FallbackPartitionCount;
+
+    private struct DirtyAgentState
+    {
+        public int CleanPollsRemaining;
+    }
+}

--- a/source/Missions/MissionModule.cs
+++ b/source/Missions/MissionModule.cs
@@ -183,6 +183,9 @@ public class MissionModule : Module
         builder.RegisterType<GuardReactionHandler>()
             .As<IGuardReactionHandler>()
             .InstancePerDependency();
+        builder.RegisterType<AgentActionPollScheduler>()
+            .As<IAgentActionPollScheduler>()
+            .InstancePerDependency();
         builder.RegisterType<AgentActionHandler>().As<IAgentActionHandler>().InstancePerDependency();
         builder.RegisterType<VanillaOrderVoiceService>()
             .As<IVanillaOrderVoiceService>()

--- a/source/Missions/NetworkAgentRegistry.cs
+++ b/source/Missions/NetworkAgentRegistry.cs
@@ -5,6 +5,7 @@ using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using TaleWorlds.MountAndBlade;
 
 namespace Missions;
@@ -14,6 +15,8 @@ namespace Missions;
 /// </summary>
 public interface INetworkAgentRegistry : IDisposable
 {
+    long Version { get; }
+
     /// <summary>Clears all data.</summary>
     void Clear();
     bool TryRegisterAgent(string controllerId, Guid agentId, Agent agent);
@@ -58,6 +61,7 @@ public class NetworkAgentRegistry : INetworkAgentRegistry
     private readonly Dictionary<(string Scope, ushort MovementId), CoopAgentInfo> MovementIdToInfo = new();
     private readonly Dictionary<string, List<CoopAgentInfo>> ControllerAgentMap = new();
     private readonly IControllerIdProvider controllerIdProvider;
+    private long version;
 
     public NetworkAgentRegistry(IControllerIdProvider controllerIdProvider)
     {
@@ -65,6 +69,8 @@ public class NetworkAgentRegistry : INetworkAgentRegistry
     }
 
     public void Dispose() => Clear();
+
+    public long Version => Interlocked.Read(ref version);
 
     /// <inheritdoc/>
     public void Clear()
@@ -75,6 +81,7 @@ public class NetworkAgentRegistry : INetworkAgentRegistry
             IdToInfo.Clear();
             MovementIdToInfo.Clear();
             ControllerAgentMap.Clear();
+            Interlocked.Increment(ref version);
         }
     }
 
@@ -179,6 +186,7 @@ public class NetworkAgentRegistry : INetworkAgentRegistry
             }
 
             controlledAgents.Add(agentInfo);
+            Interlocked.Increment(ref version);
 
             return true;
         }
@@ -222,6 +230,8 @@ public class NetworkAgentRegistry : INetworkAgentRegistry
         succeeded &= AgentToInfo.Remove(agentInfo.Agent);
         if (agentInfo.MovementId != 0)
             succeeded &= MovementIdToInfo.Remove((agentInfo.MovementScopeId, agentInfo.MovementId));
+        if (succeeded)
+            Interlocked.Increment(ref version);
         return succeeded;
     }
 
@@ -304,7 +314,10 @@ public class NetworkAgentRegistry : INetworkAgentRegistry
                     MovementIdToInfo.Remove((agentInfo.MovementScopeId, agentInfo.MovementId));
             }
 
-            return ControllerAgentMap.Remove(controllerId);
+            bool removed = ControllerAgentMap.Remove(controllerId);
+            if (removed)
+                Interlocked.Increment(ref version);
+            return removed;
         }
     }
 
@@ -383,6 +396,7 @@ public class NetworkAgentRegistry : INetworkAgentRegistry
             }
 
             newAgents.Add(agentInfo);
+            Interlocked.Increment(ref version);
 
             return true;
         }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Large battles repeatedly scan every locally controlled agent after each native tick, spending CPU on hundreds of agents even when only a few actions or guard states change.

## What is the new behavior?

Resolves #2649

Large battles spread background AI action checks across four bounded frame groups while immediately checking the player and agents with recent action or guard activity. Action ordering and synchronization remain unchanged, with less polling work per frame.

Matched one-client 900-vs-900 profiling measured the targeted action-check path as follows:

| 900-vs-900 measurement | Current | New |
| --- | ---: | ---: |
| Action-poll CPU | 77.58 ms/s | 39.73 ms/s (-48.8%) |
| Per-agent action-check CPU | 31.77 ms/s | 4.31 ms/s (-86.4%) |
| Agents visited per polling call | 988.26 | 260.00 (-73.7%) |
| Action-check time per call | 933.02 us | 528.79 us (-43.3%) |

## Bot Changelog Entry

- Reduced CPU time spent checking AI actions during large battles.
