### PR TITLE
[2650] Reuse learned movement batch sizes

### DIFF
--- a/source/E2E.Tests/Services/Missions/MovementTrafficBudgetTests.cs
+++ b/source/E2E.Tests/Services/Missions/MovementTrafficBudgetTests.cs
@@ -120,6 +120,236 @@ public sealed class MovementTrafficBudgetTests
         Assert.Equal(new[] { firstId, secondId }, sentIds);
     }
 
+    [Fact]
+    public void Sender_ReusesLearnedTargetUntilGrowthCadenceExpires()
+    {
+        var network = new Mock<IBattleNetwork>();
+        var sentCounts = new List<int>();
+        network.Setup(x => x.SendAll(It.IsAny<IPacket>(), It.IsAny<byte[]>()))
+            .Callback<IPacket, byte[]>((packet, _) =>
+                sentCounts.Add(((SizedPacket)packet).Count));
+        var compressor = new SizedPacketCompressor();
+        var sender = new MovementBatchSender(
+            network.Object,
+            compressor,
+            new ControllableTrafficBudget(10000));
+        Guid[] ids = CreateIds(12);
+
+        sender.Send(
+            new[] { CreateBatch(ids, valueOffset: 0) },
+            legacyBatch: null,
+            maxPayloadBytes: 50,
+            CreatePacket,
+            onSent: null);
+
+        compressor.BytesPerSnapshot = 5;
+        compressor.Reset();
+        sentCounts.Clear();
+        sender.BeginFrame(0.5f);
+        sender.Send(
+            new[] { CreateBatch(ids, valueOffset: 100) },
+            legacyBatch: null,
+            maxPayloadBytes: 50,
+            CreatePacket,
+            onSent: null);
+
+        Assert.Equal(new[] { 5, 5, 2 }, sentCounts);
+        Assert.Equal(sentCounts.Count, compressor.SerializeCalls);
+
+        compressor.Reset();
+        sentCounts.Clear();
+        sender.BeginFrame(0.5f);
+        sender.Send(
+            new[] { CreateBatch(ids, valueOffset: 200) },
+            legacyBatch: null,
+            maxPayloadBytes: 50,
+            CreatePacket,
+            onSent: null);
+
+        Assert.Equal(new[] { 10, 2 }, sentCounts);
+        Assert.True(compressor.SerializeCalls > sentCounts.Count);
+    }
+
+    [Fact]
+    public void Sender_ShrinksLearnedTargetImmediatelyWhenItNoLongerFits()
+    {
+        var network = new Mock<IBattleNetwork>();
+        var sentCounts = new List<int>();
+        network.Setup(x => x.SendAll(It.IsAny<IPacket>(), It.IsAny<byte[]>()))
+            .Callback<IPacket, byte[]>((packet, _) =>
+                sentCounts.Add(((SizedPacket)packet).Count));
+        var compressor = new SizedPacketCompressor();
+        var sender = new MovementBatchSender(
+            network.Object,
+            compressor,
+            new ControllableTrafficBudget(10000));
+        Guid[] ids = CreateIds(12);
+
+        sender.Send(
+            new[] { CreateBatch(ids, valueOffset: 0) },
+            legacyBatch: null,
+            maxPayloadBytes: 50,
+            CreatePacket,
+            onSent: null);
+
+        compressor.BytesPerSnapshot = 20;
+        compressor.Reset();
+        sentCounts.Clear();
+        sender.Send(
+            new[] { CreateBatch(ids, valueOffset: 100) },
+            legacyBatch: null,
+            maxPayloadBytes: 50,
+            CreatePacket,
+            onSent: null);
+
+        Assert.Equal(new[] { 2, 2, 2, 2, 2, 2 }, sentCounts);
+        Assert.True(compressor.SerializeCalls > sentCounts.Count);
+    }
+
+    [Fact]
+    public void Sender_ConstrainedBudgetDoesNotPostponeDueGrowthProbe()
+    {
+        var network = new Mock<IBattleNetwork>();
+        var sentCounts = new List<int>();
+        network.Setup(x => x.SendAll(It.IsAny<IPacket>(), It.IsAny<byte[]>()))
+            .Callback<IPacket, byte[]>((packet, _) =>
+                sentCounts.Add(((SizedPacket)packet).Count));
+        var compressor = new SizedPacketCompressor();
+        var budget = new ControllableTrafficBudget(50);
+        var sender = new MovementBatchSender(network.Object, compressor, budget);
+        Guid[] ids = CreateIds(12);
+
+        sender.Send(
+            new[] { CreateBatch(ids, valueOffset: 0) },
+            legacyBatch: null,
+            maxPayloadBytes: 50,
+            CreatePacket,
+            onSent: null);
+
+        compressor.BytesPerSnapshot = 5;
+        budget.AvailableBytes = 30;
+        sentCounts.Clear();
+        sender.BeginFrame(1f);
+        sender.Send(
+            new[] { CreateBatch(ids, valueOffset: 100) },
+            legacyBatch: null,
+            maxPayloadBytes: 50,
+            CreatePacket,
+            onSent: null);
+        Assert.Equal(new[] { 5, 1 }, sentCounts);
+
+        budget.AvailableBytes = 50;
+        sentCounts.Clear();
+        sender.BeginFrame(0.1f);
+        sender.Send(
+            new[] { CreateBatch(ids, valueOffset: 200) },
+            legacyBatch: null,
+            maxPayloadBytes: 50,
+            CreatePacket,
+            onSent: null);
+
+        Assert.Equal(new[] { 10 }, sentCounts);
+    }
+
+    [Fact]
+    public void Sender_GrowthCadenceIsIsolatedByScopeAndIdFormat()
+    {
+        var network = new Mock<IBattleNetwork>();
+        var sentCounts = new List<int>();
+        network.Setup(x => x.SendAll(It.IsAny<IPacket>(), It.IsAny<byte[]>()))
+            .Callback<IPacket, byte[]>((packet, _) =>
+                sentCounts.Add(((SizedPacket)packet).Count));
+        var compressor = new SizedPacketCompressor();
+        var sender = new MovementBatchSender(
+            network.Object,
+            compressor,
+            new ControllableTrafficBudget(10000));
+        Guid[] ids = CreateIds(12);
+
+        sender.Send(
+            new[] { CreateBatch(ids, valueOffset: 0) },
+            legacyBatch: null,
+            maxPayloadBytes: 50,
+            CreatePacket,
+            onSent: null);
+        sender.Send(
+            new[] { CreateCompactBatch("scope", ids, valueOffset: 0) },
+            legacyBatch: null,
+            maxPayloadBytes: 50,
+            CreatePacket,
+            onSent: null);
+
+        compressor.BytesPerSnapshot = 5;
+        sender.BeginFrame(1f);
+        sentCounts.Clear();
+        sender.Send(
+            new[] { CreateBatch(ids, valueOffset: 100) },
+            legacyBatch: null,
+            maxPayloadBytes: 50,
+            CreatePacket,
+            onSent: null);
+        Assert.Equal(10, sentCounts[0]);
+
+        sentCounts.Clear();
+        sender.Send(
+            new[] { CreateCompactBatch("scope", ids, valueOffset: 100) },
+            legacyBatch: null,
+            maxPayloadBytes: 50,
+            CreatePacket,
+            onSent: null);
+
+        Assert.Equal(10, sentCounts[0]);
+    }
+
+    [Fact]
+    public void Sender_PriorityBatchDoesNotConsumeNormalGrowthCadence()
+    {
+        var network = new Mock<IBattleNetwork>();
+        var sentCounts = new List<int>();
+        network.Setup(x => x.SendAll(It.IsAny<IPacket>(), It.IsAny<byte[]>()))
+            .Callback<IPacket, byte[]>((packet, _) =>
+                sentCounts.Add(((SizedPacket)packet).Count));
+        var compressor = new SizedPacketCompressor();
+        var sender = new MovementBatchSender(
+            network.Object,
+            compressor,
+            new ControllableTrafficBudget(10000));
+        Guid[] ids = CreateIds(12);
+
+        sender.Send(
+            new[] { CreateCompactBatch("scope", ids[0..1], valueOffset: 0, isPriority: true) },
+            legacyBatch: null,
+            maxPayloadBytes: 50,
+            CreatePacket,
+            onSent: null);
+        sentCounts.Clear();
+        sender.Send(
+            new[] { CreateCompactBatch("scope", ids, valueOffset: 0) },
+            legacyBatch: null,
+            maxPayloadBytes: 50,
+            CreatePacket,
+            onSent: null);
+        Assert.Equal(5, sentCounts[0]);
+
+        compressor.BytesPerSnapshot = 5;
+        sender.BeginFrame(1f);
+        sender.Send(
+            new[] { CreateCompactBatch("scope", ids[0..1], valueOffset: 100, isPriority: true) },
+            legacyBatch: null,
+            maxPayloadBytes: 50,
+            CreatePacket,
+            onSent: null);
+        sentCounts.Clear();
+        sender.Send(
+            new[] { CreateCompactBatch("scope", ids, valueOffset: 100) },
+            legacyBatch: null,
+            maxPayloadBytes: 50,
+            CreatePacket,
+            onSent: null);
+
+        Assert.Equal(10, sentCounts[0]);
+    }
+
     private static Guid[] CreateIds(int count)
     {
         var ids = new Guid[count];
@@ -150,6 +380,22 @@ public sealed class MovementTrafficBudgetTests
         return batch;
     }
 
+    private static MovementBatch<int> CreateCompactBatch(
+        string scopeId,
+        Guid[] ids,
+        int valueOffset,
+        bool isPriority = false)
+    {
+        var batch = new MovementBatch<int>(scopeId, isPriority);
+        for (int i = 0; i < ids.Length; i++)
+        {
+            batch.CanonicalIds.Add(ids[i]);
+            batch.CompactIds.Add((ushort)(i + 1));
+            batch.Data.Add(valueOffset + i);
+        }
+        return batch;
+    }
+
     private static IPacket CreatePacket(
         string identityScopeId,
         ushort[] compactIds,
@@ -158,13 +404,61 @@ public sealed class MovementTrafficBudgetTests
 
     private sealed class SizedPacketCompressor : IMovementPacketCompressor
     {
+        public int BytesPerSnapshot { get; set; } = 10;
+        public int SerializeCalls { get; private set; }
+
         public byte[] Serialize(IPacket packet) =>
-            new byte[((SizedPacket)packet).Count * 10];
+            new byte[RecordSerialization((SizedPacket)packet)];
 
         public bool TryRestore(IPacket packet, out IPacket restored)
         {
             restored = packet;
             return true;
+        }
+
+        public void Reset()
+        {
+            SerializeCalls = 0;
+        }
+
+        private int RecordSerialization(SizedPacket packet)
+        {
+            SerializeCalls++;
+            return packet.Count * BytesPerSnapshot;
+        }
+    }
+
+    private sealed class ControllableTrafficBudget : IMovementTrafficBudget
+    {
+        private readonly int initialBytes;
+
+        public int AvailableBytes { get; set; }
+
+        public ControllableTrafficBudget(int availableBytes)
+        {
+            initialBytes = availableBytes;
+            AvailableBytes = availableBytes;
+        }
+
+        public void Advance(float elapsedSeconds)
+        {
+        }
+
+        public bool TrySpend(int bytes)
+        {
+            if (bytes <= 0 || bytes > AvailableBytes) return false;
+
+            AvailableBytes -= bytes;
+            return true;
+        }
+
+        public void ReportFrame(int deferredSnapshots, float maximumDeferredAgeSeconds)
+        {
+        }
+
+        public void Clear()
+        {
+            AvailableBytes = initialBytes;
         }
     }
 

--- a/source/E2E.Tests/Services/Missions/MovementTrafficTests.cs
+++ b/source/E2E.Tests/Services/Missions/MovementTrafficTests.cs
@@ -296,7 +296,7 @@ public class MovementTrafficTests : MissionTestEnvironment
     }
 
     [Fact]
-    public void PollMovement_ProbesForBatchGrowthOnlyOncePerScopeAndTick()
+    public void PollMovement_ReusesLearnedBatchSizeBeforeGrowthCadence()
     {
         using var fixture = new MissionEngineFixture();
         var peer = Clients.First();
@@ -357,10 +357,7 @@ public class MovementTrafficTests : MissionTestEnvironment
                 .GetPackets<MovementPacket>()
                 .ToArray();
             Assert.True(packets.Length > 1);
-            Assert.InRange(
-                compressor.SerializeCalls,
-                packets.Length,
-                packets.Length + 1);
+            Assert.Equal(packets.Length, compressor.SerializeCalls);
             AssertSerializedBatchesFitRelay(serializer, network);
         });
     }

--- a/source/Missions/Agents/Handlers/MovementBatchSender.cs
+++ b/source/Missions/Agents/Handlers/MovementBatchSender.cs
@@ -69,19 +69,40 @@ public sealed class MovementBatchSender : IMovementBatchSender
 {
     private static readonly ILogger Logger = LogManager.GetLogger<MovementBatchSender>();
     private const int InitialBatchSize = 3;
+    private const double GrowthProbeIntervalSeconds = 1d;
 
     private readonly IBattleNetwork client;
     private readonly IMovementPacketCompressor packetCompressor;
     private readonly IMovementTrafficBudget trafficBudget;
-    private readonly Dictionary<(Type SnapshotType, string IdentityScopeId, MovementIdFormat IdFormat), int>
+    private readonly Dictionary<(
+        Type SnapshotType,
+        string IdentityScopeId,
+        MovementIdFormat IdFormat,
+        bool IsPriority), int>
         preferredBatchSizes =
-            new Dictionary<(Type SnapshotType, string IdentityScopeId, MovementIdFormat IdFormat), int>();
+            new Dictionary<(
+                Type SnapshotType,
+                string IdentityScopeId,
+                MovementIdFormat IdFormat,
+                bool IsPriority), int>();
+    private readonly Dictionary<(
+        Type SnapshotType,
+        string IdentityScopeId,
+        MovementIdFormat IdFormat,
+        bool IsPriority), double>
+        nextGrowthProbeTimes =
+            new Dictionary<(
+                Type SnapshotType,
+                string IdentityScopeId,
+                MovementIdFormat IdFormat,
+                bool IsPriority), double>();
     private readonly HashSet<(Type SnapshotType, string IdentityScopeId)> canonicalIdFallbacks =
         new HashSet<(Type SnapshotType, string IdentityScopeId)>();
     private readonly Dictionary<(Type SnapshotType, string IdentityScopeId, bool IsPriority), int> sendOffsets =
         new Dictionary<(Type SnapshotType, string IdentityScopeId, bool IsPriority), int>();
     private readonly Dictionary<(Type SnapshotType, bool IsPriority), int> batchOffsets =
         new Dictionary<(Type SnapshotType, bool IsPriority), int>();
+    private double growthProbeClockSeconds;
 
     public MovementBatchSender(
         IBattleNetwork client,
@@ -93,7 +114,12 @@ public sealed class MovementBatchSender : IMovementBatchSender
         this.trafficBudget = trafficBudget ?? new MovementTrafficBudget();
     }
 
-    public void BeginFrame(float elapsedSeconds) => trafficBudget.Advance(elapsedSeconds);
+    public void BeginFrame(float elapsedSeconds)
+    {
+        if (elapsedSeconds > 0f)
+            growthProbeClockSeconds += elapsedSeconds;
+        trafficBudget.Advance(elapsedSeconds);
+    }
 
     public MovementSendResult Send<T>(
         IEnumerable<MovementBatch<T>> scopedBatches,
@@ -134,9 +160,11 @@ public sealed class MovementBatchSender : IMovementBatchSender
     public void Clear()
     {
         preferredBatchSizes.Clear();
+        nextGrowthProbeTimes.Clear();
         canonicalIdFallbacks.Clear();
         sendOffsets.Clear();
         batchOffsets.Clear();
+        growthProbeClockSeconds = 0d;
         trafficBudget.Clear();
     }
 
@@ -165,7 +193,7 @@ public sealed class MovementBatchSender : IMovementBatchSender
             batch.IdentityScopeId == null || canonicalIdFallbacks.Contains(fallbackKey)
                 ? MovementIdFormat.Canonical
                 : MovementIdFormat.Compact;
-        bool probeForGrowth = true;
+        bool allowGrowthProbe = true;
         int sentCount = 0;
 
         for (int start = 0; start < orderedBatch.Data.Count;)
@@ -174,11 +202,19 @@ public sealed class MovementBatchSender : IMovementBatchSender
             if (availablePayloadBytes <= 0) break;
 
             int remaining = orderedBatch.Data.Count - start;
-            var preferenceKey = (typeof(T), batch.IdentityScopeId, idFormat);
+            var preferenceKey = (
+                typeof(T),
+                batch.IdentityScopeId,
+                idFormat,
+                batch.IsPriority);
             int preferredCount = preferredBatchSizes.TryGetValue(
                 preferenceKey, out int previousSafeCount)
                 ? previousSafeCount
                 : InitialBatchSize;
+            bool probeForGrowth = allowGrowthProbe && ShouldProbeForGrowth(
+                preferenceKey,
+                availablePayloadBytes,
+                maxPayloadBytes);
 
             SerializedMovementBatch candidate = FindLargestFittingBatch(
                 orderedBatch,
@@ -198,11 +234,20 @@ public sealed class MovementBatchSender : IMovementBatchSender
 
             if (!candidate.Fits(availablePayloadBytes) && idFormat == MovementIdFormat.Compact)
             {
+                var canonicalPreferenceKey = (
+                    typeof(T),
+                    batch.IdentityScopeId,
+                    MovementIdFormat.Canonical,
+                    batch.IsPriority);
+                bool probeCanonicalForGrowth = allowGrowthProbe && ShouldProbeForGrowth(
+                    canonicalPreferenceKey,
+                    availablePayloadBytes,
+                    maxPayloadBytes);
                 SerializedMovementBatch canonicalCandidate = FindLargestFittingBatch(
                     orderedBatch,
                     start,
                     preferredCount,
-                    probeForGrowth,
+                    probeCanonicalForGrowth,
                     availablePayloadBytes,
                     MovementIdFormat.Canonical,
                     createPacket);
@@ -216,7 +261,8 @@ public sealed class MovementBatchSender : IMovementBatchSender
                 {
                     idFormat = MovementIdFormat.Canonical;
                     canonicalIdFallbacks.Add(fallbackKey);
-                    preferenceKey = (typeof(T), batch.IdentityScopeId, idFormat);
+                    preferenceKey = canonicalPreferenceKey;
+                    probeForGrowth = probeCanonicalForGrowth;
                     candidate = canonicalCandidate;
                 }
                 else
@@ -249,10 +295,21 @@ public sealed class MovementBatchSender : IMovementBatchSender
                     orderedBatch.Data[start + i]);
 
             if (availablePayloadBytes == maxPayloadBytes)
-                RememberPreferredBatchSize(preferenceKey, candidate.Count, remaining);
+            {
+                bool preferenceChanged = RememberPreferredBatchSize(
+                    preferenceKey,
+                    candidate.Count,
+                    remaining);
+                if (probeForGrowth || preferenceChanged ||
+                    !nextGrowthProbeTimes.ContainsKey(preferenceKey))
+                {
+                    nextGrowthProbeTimes[preferenceKey] =
+                        growthProbeClockSeconds + GrowthProbeIntervalSeconds;
+                }
+            }
             sentCount += candidate.Count;
             start += candidate.Count;
-            probeForGrowth = false;
+            allowGrowthProbe = false;
         }
 
         if (batch.Data.Count > 0)
@@ -319,17 +376,33 @@ public sealed class MovementBatchSender : IMovementBatchSender
             maxPayloadBytes);
     }
 
-    private void RememberPreferredBatchSize(
-        (Type SnapshotType, string IdentityScopeId, MovementIdFormat IdFormat) preferenceKey,
+    private bool ShouldProbeForGrowth(
+        (Type SnapshotType, string IdentityScopeId, MovementIdFormat IdFormat, bool IsPriority)
+            preferenceKey,
+        int availablePayloadBytes,
+        int maxPayloadBytes)
+    {
+        if (!preferredBatchSizes.ContainsKey(preferenceKey)) return true;
+        if (availablePayloadBytes != maxPayloadBytes) return false;
+
+        return !nextGrowthProbeTimes.TryGetValue(preferenceKey, out double nextProbeTime) ||
+               growthProbeClockSeconds >= nextProbeTime;
+    }
+
+    private bool RememberPreferredBatchSize(
+        (Type SnapshotType, string IdentityScopeId, MovementIdFormat IdFormat, bool IsPriority)
+            preferenceKey,
         int safeCount,
         int remaining)
     {
-        if (safeCount < remaining ||
-            !preferredBatchSizes.TryGetValue(preferenceKey, out int previousSafeCount) ||
-            safeCount > previousSafeCount)
-        {
-            preferredBatchSizes[preferenceKey] = safeCount;
-        }
+        bool hadPrevious = preferredBatchSizes.TryGetValue(
+            preferenceKey,
+            out int previousSafeCount);
+        if (safeCount >= remaining && hadPrevious && safeCount <= previousSafeCount)
+            return false;
+
+        preferredBatchSizes[preferenceKey] = safeCount;
+        return !hadPrevious || safeCount != previousSafeCount;
     }
 
     private SerializedMovementBatch FindLargestFittingBatch<T>(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Large battles repeatedly serialize extra movement packet candidates after already finding a safe packet size, adding client CPU work while units are moving.

## What is the new behavior?

Resolves #2650

Movement traffic reuses its learned exact packet size between periodic growth checks, still shrinks immediately when a packet no longer fits, and keeps priority traffic and alternate ID formats independent.

Matched one-client 900-vs-900 profiling measured the targeted serialization path as follows:

| 900-vs-900 measurement | Current | New |
| --- | ---: | ---: |
| Extra candidates during deployment | 1,741 | 52 (-97.0%) |
| Deployment candidate-build time | 214.75 ms | 165.42 ms (-23.0%) |
| Extra candidates during active combat | 15,378 | 7,777 (-49.4%) |
| Active-combat growth candidates | 2,600 | 91 (-96.5%) |
| Active-combat candidates per packet | 1.514 | 1.194 (-21.1%) |
| Active-combat candidate-build time | 1,391.17 ms | 1,384.55 ms (-0.5%) |
| Whole-client active-combat CPU | 7.440 cores | 7.490 cores (+0.7%) |

The repeated probe work dropped, but this matched pair did not measure a whole-client CPU reduction. The new run emitted 42.0% more packets with effectively identical active-combat wire bytes, so packet sizing needs another matched measurement before changing the probe cadence.

## Bot Changelog Entry

- Reduced client CPU overhead from movement updates in large battles.
