### PR TITLE
Potential fix to hide the debug servers from public discovery

### DIFF
--- a/source/Coop.Core/Server/ServerModule.cs
+++ b/source/Coop.Core/Server/ServerModule.cs
@@ -98,9 +98,20 @@ public class ServerModule : CommonModule
             .As<ISteamLobbyApi>()
             .As<ISteamPublicLobbyApi>()
             .InstancePerLifetimeScope();
-        builder.Register(context => new SteamPublicLobbyAdvertiser(
-                context.Resolve<ISteamPublicLobbyApi>(),
-                context.Resolve<SessionAdvertisementConfig>().Visibility))
+        // Debug servers remain joinable through steam but are excluded from the public discovery
+        // Release builds continue to use the configured visibility.
+        builder.Register(context =>
+            {
+                var visibility = context.Resolve<SessionAdvertisementConfig>().Visibility;
+
+#if DEBUG
+                visibility = ServerVisibility.None;
+#endif
+
+                return new SteamPublicLobbyAdvertiser(
+                    context.Resolve<ISteamPublicLobbyApi>(),
+                    visibility);
+            })
             .As<ISessionAdvertiser>()
             .As<ISteamLobbyOwner>()
             .InstancePerLifetimeScope();


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

No new classes were added. The existing Steam lobby advertiser and browser tests cover the hidden-lobby behavior. No new tests were added because this change only selects the already-tested `ServerVisibility.None` behavior for Debug builds.

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?
Debug standalone-server builds use the configured Steam lobby visibility. When configured as public, development servers appear in the public Steam lobby list.

## What is the new behavior?
Resolves #2274

Debug standalone-server builds now force `ServerVisibility.None`, which excludes them from public Steam lobby discovery. The underlying Steam lobby is still created, so Steam tunneling and explicit joins remain available.

Release builds continue to use the configured server visibility.

## Bot Changelog Entry
- Debug servers no longer appear in the public Steam lobby list.

## Other information
The focused Steam lobby advertiser and browser tests passed in Debug:

- 39 passed
- 0 failed
- 0 skipped

Live Steam lobby-list validation was not possible with the local Debug configuration because it automatically connects the client to the local server.