### PR TITLE
[2651] Remove per-party pending map event resolution

### DIFF
--- a/source/E2E.Tests/Services/MapEvents/MapEventCollectionTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/MapEventCollectionTests.cs
@@ -88,11 +88,14 @@ public class MapEventCollectionTests : MapEventTestBase
     {
         Server.NetworkSentMessages.Clear();
         var staged = CreateServerMapEvent(commit: false);
+        PartyBase defender = null;
 
         Server.Call(() =>
         {
             var mapEvent = Get<MapEvent>(Server, staged.MapEventId);
+            defender = Get<MobileParty>(Server, staged.DefenderPartyId).Party;
             Server.Resolve<IMapEventInitializationBarrier>().AbortServer(mapEvent);
+            Assert.True(PendingMapEventPartyMovementPatch.CanAdvancePosition(defender));
         }, MapEventDisabledMethods);
 
         Assert.True(Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkMapEventInitialized>()).IsTerminal);
@@ -101,6 +104,51 @@ public class MapEventCollectionTests : MapEventTestBase
             Assert.False(instance.ObjectManager.Contains(staged.MapEventId));
             Assert.Null(Get<MobileParty>(instance, staged.AttackerPartyId).MapEvent);
             Assert.Null(Get<MobileParty>(instance, staged.DefenderPartyId).MapEvent);
+        });
+    }
+
+    [Fact]
+    public void PendingMovementBinding_IsIsolatedPerLifetimeScope()
+    {
+        var staged = CreateServerMapEvent(commit: false);
+        PartyBase serverDefender = null;
+
+        Server.Call(() =>
+        {
+            serverDefender = Get<MobileParty>(Server, staged.DefenderPartyId).Party;
+            Assert.False(PendingMapEventPartyMovementPatch.CanAdvancePosition(serverDefender));
+        });
+
+        foreach (var client in Clients)
+        {
+            client.Call(() =>
+                Assert.True(PendingMapEventPartyMovementPatch.CanAdvancePosition(serverDefender)));
+        }
+    }
+
+    [Fact]
+    public void Client_PendingPartyCancellationUnblocksMovement()
+    {
+        var staged = CreateServerMapEvent(commit: false);
+        var client = Clients.First();
+        string defenderPartyBaseId = null;
+
+        client.Call(() =>
+        {
+            var defender = Get<MobileParty>(client, staged.DefenderPartyId).Party;
+            Assert.True(client.ObjectManager.TryGetId(defender, out defenderPartyBaseId));
+        });
+
+        client.SimulateMessage(Server.NetPeer, new NetworkMapEventPartyPending(
+            staged.MapEventId,
+            defenderPartyBaseId,
+            isCancellation: true));
+
+        client.Call(() =>
+        {
+            var defender = Get<MobileParty>(client, staged.DefenderPartyId).Party;
+            Assert.False(client.Resolve<IMapEventInitializationBarrier>().IsPartyPending(defender));
+            Assert.True(PendingMapEventPartyMovementPatch.CanAdvancePosition(defender));
         });
     }
 

--- a/source/GameInterface.Tests/Services/MapEvents/MapEventInitializationBarrierTests.cs
+++ b/source/GameInterface.Tests/Services/MapEvents/MapEventInitializationBarrierTests.cs
@@ -1,0 +1,143 @@
+﻿using Autofac;
+using Common.Messaging;
+using Common.Network;
+using Common.Util;
+using GameInterface.Services.MapEvents.Initialization;
+using GameInterface.Services.ObjectManager;
+using Moq;
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using TaleWorlds.CampaignSystem.MapEvents;
+using TaleWorlds.CampaignSystem.Party;
+using Xunit;
+
+namespace GameInterface.Tests.Services.MapEvents;
+
+public class MapEventInitializationBarrierTests
+{
+    [Fact]
+    public void Binding_IsIsolatedByScopeAndRemovedOnDisposal()
+    {
+        var firstBarrier = new Mock<IMapEventInitializationBarrier>().Object;
+        var secondBarrier = new Mock<IMapEventInitializationBarrier>().Object;
+        var firstScope = BuildBindingScope(firstBarrier);
+        using var secondScope = BuildBindingScope(secondBarrier);
+
+        try
+        {
+            Assert.True(MapEventInitializationBarrierBinding.TryGet(firstScope, out var first));
+            Assert.Same(firstBarrier, first);
+            Assert.True(MapEventInitializationBarrierBinding.TryGet(secondScope, out var second));
+            Assert.Same(secondBarrier, second);
+
+            firstScope.Dispose();
+
+            Assert.False(MapEventInitializationBarrierBinding.TryGet(firstScope, out _));
+            Assert.True(MapEventInitializationBarrierBinding.TryGet(secondScope, out second));
+            Assert.Same(secondBarrier, second);
+        }
+        finally
+        {
+            firstScope.Dispose();
+        }
+    }
+
+    [Fact]
+    public void PendingPartyView_TracksCancellationAbortAndDisposal()
+    {
+        var mapEvent = ObjectHelper.SkipConstructor<MapEvent>();
+        var party = ObjectHelper.SkipConstructor<PartyBase>();
+        var barrier = CreateBarrier(mapEvent, party);
+
+        barrier.Register(mapEvent);
+        barrier.SetServerPartyPending(mapEvent, party, pending: true);
+        Assert.True(barrier.IsPartyPending(party));
+
+        barrier.SetServerPartyPending(mapEvent, party, pending: false);
+        Assert.False(barrier.IsPartyPending(party));
+
+        barrier.SetServerPartyPending(mapEvent, party, pending: true);
+        barrier.AbortServer(mapEvent);
+        Assert.False(barrier.IsPartyPending(party));
+
+        barrier.Register(mapEvent);
+        barrier.SetServerPartyPending(mapEvent, party, pending: true);
+        barrier.Dispose();
+        Assert.False(barrier.IsPartyPending(party));
+    }
+
+    [Fact]
+    public async Task PendingPartyView_SupportsConcurrentReadersWhilePublishing()
+    {
+        var mapEvent = ObjectHelper.SkipConstructor<MapEvent>();
+        var party = ObjectHelper.SkipConstructor<PartyBase>();
+        var unrelatedParty = ObjectHelper.SkipConstructor<PartyBase>();
+        using var barrier = CreateBarrier(mapEvent, party);
+        barrier.Register(mapEvent);
+
+        using var cancellation = new CancellationTokenSource();
+        using var readersReady = new CountdownEvent(4);
+        using var startReaders = new ManualResetEventSlim();
+        var failures = new ConcurrentQueue<Exception>();
+        long readCount = 0;
+        var readers = Enumerable.Range(0, 4).Select(_ => Task.Run(() =>
+        {
+            readersReady.Signal();
+            startReaders.Wait();
+            while (!cancellation.IsCancellationRequested)
+            {
+                try
+                {
+                    barrier.IsPartyPending(party);
+                    if (barrier.IsPartyPending(unrelatedParty))
+                        throw new InvalidOperationException("An unrelated party appeared in the pending snapshot");
+                    Interlocked.Increment(ref readCount);
+                }
+                catch (Exception ex)
+                {
+                    failures.Enqueue(ex);
+                    return;
+                }
+            }
+        })).ToArray();
+
+        readersReady.Wait();
+        startReaders.Set();
+        for (int i = 0; i < 1000; i++)
+        {
+            barrier.SetServerPartyPending(mapEvent, party, pending: true);
+            barrier.SetServerPartyPending(mapEvent, party, pending: false);
+        }
+        cancellation.Cancel();
+        await Task.WhenAll(readers);
+
+        Assert.True(Interlocked.Read(ref readCount) > 0);
+        Assert.Empty(failures);
+        Assert.False(barrier.IsPartyPending(party));
+    }
+
+    private static IContainer BuildBindingScope(IMapEventInitializationBarrier barrier)
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterInstance(barrier).As<IMapEventInitializationBarrier>();
+        builder.RegisterType<MapEventInitializationBarrierBinding>().InstancePerLifetimeScope().AutoActivate();
+        return builder.Build();
+    }
+
+    private static MapEventInitializationBarrier CreateBarrier(MapEvent mapEvent, PartyBase party)
+    {
+        var objectManager = new Mock<IObjectManager>();
+        string mapEventId = "map-event";
+        string partyId = "party";
+        objectManager.Setup(manager => manager.TryGetIdWithLogging(mapEvent, out mapEventId)).Returns(true);
+        objectManager.Setup(manager => manager.TryGetIdWithLogging(party, out partyId)).Returns(true);
+
+        return new MapEventInitializationBarrier(
+            new Mock<IMessageBroker>().Object,
+            new Mock<INetwork>().Object,
+            objectManager.Object);
+    }
+}

--- a/source/GameInterface/GameInterfaceModule.cs
+++ b/source/GameInterface/GameInterfaceModule.cs
@@ -17,6 +17,7 @@ using GameInterface.Services.Kingdoms;
 using GameInterface.Services.LiveTesting;
 using GameInterface.Services.MapEventParties;
 using GameInterface.Services.MapEvents;
+using GameInterface.Services.MapEvents.Initialization;
 using GameInterface.Services.MapEvents.Logging;
 using GameInterface.Services.MobileParties;
 using GameInterface.Services.MobileParties.Data;
@@ -84,6 +85,7 @@ public class GameInterfaceModule : Module
         builder.RegisterType<KingdomMembershipState>().AsSelf().As<IKingdomMembershipState>().InstancePerLifetimeScope();
         builder.RegisterType<MainPartyBattleRewardsCache>().As<IMainPartyBattleRewardsCache>().InstancePerLifetimeScope();
         builder.RegisterType<PacketManager>().As<IPacketManager>().InstancePerLifetimeScope();
+        builder.RegisterType<MapEventInitializationBarrierBinding>().InstancePerLifetimeScope().AutoActivate();
 
         builder.RegisterModule<ServiceModule>();
         builder.RegisterModule<ObjectManagerModule>();

--- a/source/GameInterface/Services/MapEvents/Initialization/MapEventInitializationBarrier.cs
+++ b/source/GameInterface/Services/MapEvents/Initialization/MapEventInitializationBarrier.cs
@@ -14,6 +14,7 @@ using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Encounters;
 using TaleWorlds.CampaignSystem.GameMenus;
@@ -49,6 +50,7 @@ internal sealed class MapEventInitializationBarrier : IMapEventInitializationBar
     private readonly INetwork network;
     private readonly IObjectManager objectManager;
     private readonly Dictionary<MapEvent, State> states = new Dictionary<MapEvent, State>();
+    private HashSet<PartyBase> pendingParties = new HashSet<PartyBase>();
     private bool disposed;
 
     public MapEventInitializationBarrier(IMessageBroker messageBroker, INetwork network, IObjectManager objectManager)
@@ -69,37 +71,48 @@ internal sealed class MapEventInitializationBarrier : IMapEventInitializationBar
         messageBroker.Unsubscribe<NetworkMapEventInitialized>(HandleCommit);
         messageBroker.Unsubscribe<CampaignTick>(Handle_CampaignTick);
         states.Clear();
+        PublishPendingParties();
     }
 
     public bool IsPending(MapEvent mapEvent) =>
         mapEvent != null && states.TryGetValue(mapEvent, out var state) && !state.Committed;
 
     public bool IsPartyPending(PartyBase party) =>
-        party != null && states.Values.Any(state => state.Parties.Contains(party) || state.Announced.Contains(party));
+        party != null && Volatile.Read(ref pendingParties).Contains(party);
 
     public void Register(MapEvent mapEvent, bool committed = false)
     {
         if (disposed || mapEvent == null) return;
         if (!states.TryGetValue(mapEvent, out var state)) states.Add(mapEvent, state = new State(mapEvent));
-        if (!committed) return;
-        Capture(state, mapEvent);
-        state.Committed = true;
-        state.Parties.Clear();
+        if (committed)
+        {
+            Capture(state, mapEvent);
+            state.Committed = true;
+            state.Parties.Clear();
+        }
+        PublishPendingParties();
     }
 
     public void SetServerPartyPending(MapEvent mapEvent, PartyBase party, bool pending)
     {
         if (mapEvent == null || party == null || !states.TryGetValue(mapEvent, out var state)) return;
-        if (!state.Committed && !(pending ? state.Announced.Add(party) : state.Announced.Remove(party))) return;
+        bool stateChanged = false;
+        if (!state.Committed)
+        {
+            stateChanged = pending ? state.Announced.Add(party) : state.Announced.Remove(party);
+            if (!stateChanged) return;
+        }
         if (objectManager.TryGetIdWithLogging(mapEvent, out var mapEventId) &&
             objectManager.TryGetIdWithLogging(party, out var partyId))
         {
+            if (stateChanged) PublishPendingParties();
             network.SendAll(new NetworkMapEventPartyPending(mapEventId, partyId, !pending));
             return;
         }
-        if (!state.Committed)
+        if (stateChanged)
         {
             if (pending) state.Announced.Remove(party); else state.Announced.Add(party);
+            PublishPendingParties();
         }
     }
 
@@ -126,6 +139,7 @@ internal sealed class MapEventInitializationBarrier : IMapEventInitializationBar
         network.SendAll(new NetworkMapEventInitialized(mapEventId, false, trackerId, componentId, visualId));
         state.Committed = true;
         state.Announced.Clear();
+        PublishPendingParties();
     }
 
     public void AbortServer(MapEvent mapEvent)
@@ -151,6 +165,7 @@ internal sealed class MapEventInitializationBarrier : IMapEventInitializationBar
             Register(mapEvent);
             if (message.IsCancellation) states[mapEvent].Parties.Remove(party);
             else states[mapEvent].Parties.Add(party);
+            PublishPendingParties();
         }, context: nameof(NetworkMapEventPartyPending));
     }
 
@@ -215,6 +230,7 @@ internal sealed class MapEventInitializationBarrier : IMapEventInitializationBar
             if (state.Visual != null) PublishVisual(state.Visual, state.Position);
             state.Committed = true;
             state.Parties.Clear();
+            PublishPendingParties();
         }
         catch (Exception ex)
         {
@@ -241,12 +257,13 @@ internal sealed class MapEventInitializationBarrier : IMapEventInitializationBar
 
         if (state == null || state.Committed)
         {
-            state?.Parties.Remove(party.Party);
+            if (state?.Parties.Remove(party.Party) == true) PublishPendingParties();
             afterCommit?.Invoke();
             return;
         }
 
         state.Parties.Add(party.Party);
+        PublishPendingParties();
         state.Callback += afterCommit;
     }
 
@@ -309,6 +326,7 @@ internal sealed class MapEventInitializationBarrier : IMapEventInitializationBar
 
         foreach (var visual in state.Owned.OfType<GauntletMapEventVisual>().ToArray()) EndVisual(visual);
         states.Remove(mapEvent);
+        PublishPendingParties();
         foreach (var instance in state.Owned) objectManager.Remove(instance);
     }
 
@@ -453,6 +471,17 @@ internal sealed class MapEventInitializationBarrier : IMapEventInitializationBar
         (mapEvent.MapEventVisual is not GauntletMapEventVisual visual || ReferenceEquals(state.Visual, visual));
 
     internal static TroopUpgradeTracker GetTracker(MapEvent mapEvent) => mapEvent == null ? null : TrackerField(mapEvent);
+
+    private void PublishPendingParties()
+    {
+        var snapshot = new HashSet<PartyBase>();
+        foreach (var state in states.Values)
+        {
+            snapshot.UnionWith(state.Parties);
+            snapshot.UnionWith(state.Announced);
+        }
+        Volatile.Write(ref pendingParties, snapshot);
+    }
 
     private static void Capture(State state, MapEvent mapEvent)
     {

--- a/source/GameInterface/Services/MapEvents/Initialization/MapEventInitializationBarrierBinding.cs
+++ b/source/GameInterface/Services/MapEvents/Initialization/MapEventInitializationBarrierBinding.cs
@@ -1,0 +1,42 @@
+﻿using Autofac;
+using Autofac.Core;
+using System;
+using System.Collections.Concurrent;
+
+namespace GameInterface.Services.MapEvents.Initialization;
+
+internal sealed class MapEventInitializationBarrierBinding : IDisposable
+{
+    private static readonly ConcurrentDictionary<IComponentRegistry, IMapEventInitializationBarrier> Bindings =
+        new ConcurrentDictionary<IComponentRegistry, IMapEventInitializationBarrier>();
+
+    private readonly IComponentRegistry componentRegistry;
+    private readonly IMapEventInitializationBarrier barrier;
+    private bool disposed;
+
+    public MapEventInitializationBarrierBinding(
+        ILifetimeScope lifetimeScope,
+        IMapEventInitializationBarrier barrier)
+    {
+        componentRegistry = lifetimeScope.ComponentRegistry;
+        this.barrier = barrier;
+
+        if (!Bindings.TryAdd(componentRegistry, barrier))
+            throw new InvalidOperationException("A map-event initialization barrier is already bound to this scope");
+    }
+
+    public void Dispose()
+    {
+        if (disposed) return;
+        disposed = true;
+        Bindings.TryRemove(componentRegistry, out _);
+    }
+
+    internal static bool TryGet(
+        ILifetimeScope lifetimeScope,
+        out IMapEventInitializationBarrier barrier)
+    {
+        barrier = null;
+        return lifetimeScope != null && Bindings.TryGetValue(lifetimeScope.ComponentRegistry, out barrier);
+    }
+}

--- a/source/GameInterface/Services/MapEvents/Patches/PendingMapEventPartyMovementPatch.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/PendingMapEventPartyMovementPatch.cs
@@ -15,6 +15,7 @@ internal static class PendingMapEventPartyMovementPatch
 
     internal static bool IsPending(PartyBase party) =>
         party != null &&
-        ContainerProvider.TryResolve<IMapEventInitializationBarrier>(out var barrier) &&
+        ContainerProvider.TryGetContainer(out var lifetimeScope) &&
+        MapEventInitializationBarrierBinding.TryGet(lifetimeScope, out var barrier) &&
         barrier.IsPartyPending(party);
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Large battles repeatedly perform the same pending map-event lookup and scan for every moving party, adding client CPU work even when almost no parties are waiting for initialization.

## What is the new behavior?

Resolves #2651

The client reuses one session lookup and checks pending parties directly, preserving movement blocking while map events initialize and releasing parties when initialization completes, is cancelled, or aborts.

| 900-vs-900 client metric | Current | New |
| --- | --- | --- |
| Pending transition | 2.026 µs/lookup, 3.158 s total | 0.180 µs/lookup, 0.327 s total (91% less per lookup) |
| Deployment (20 s) | 2.169 µs/lookup, 3.257 s total | 0.091 µs/lookup, 0.157 s total (96% less per lookup) |
| Active combat (25 s) | 2.274 µs/lookup, 4.149 s total | 0.091 µs/lookup, 0.173 s total (96% less per lookup) |
| Pending-path resolutions | 1.50–1.82 million per window | 0 per window, with 1 scope binding |

## Bot Changelog Entry

- Reduced CPU usage during battles
