### PR TITLE
Add sponsors section to credits and reorder sections

### DIFF
--- a/UIMovies/CreditsPopupUIMovie.xml
+++ b/UIMovies/CreditsPopupUIMovie.xml
@@ -44,6 +44,26 @@
                                 <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
                                             MarginBottom="8" Brush="Clan.TabControl.Text" Brush.FontSize="32"
                                             Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
+                                            Text="@SponsorsHeaderText"/>
+                                <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
+                                            MarginBottom="24" Brush="Clan.TabControl.Text" Brush.FontSize="23"
+                                            Brush.FontColor="#B8B8B8FF"
+                                            Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
+                                            Text="@SponsorsText"/>
+
+                                <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
+                                            MarginBottom="8" Brush="Clan.TabControl.Text" Brush.FontSize="32"
+                                            Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
+                                            Text="@SupportersHeaderText"/>
+                                <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
+                                            MarginBottom="24" Brush="Clan.TabControl.Text" Brush.FontSize="23"
+                                            Brush.FontColor="#B8B8B8FF"
+                                            Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
+                                            Text="@SupportersText"/>
+
+                                <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
+                                            MarginBottom="8" Brush="Clan.TabControl.Text" Brush.FontSize="32"
+                                            Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
                                             Text="@ContributorsHeaderText"/>
                                 <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
                                             MarginBottom="24" Brush="Clan.TabControl.Text" Brush.FontSize="23"
@@ -56,20 +76,10 @@
                                             Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
                                             Text="@CommunityHeaderText"/>
                                 <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
-                                            MarginBottom="24" Brush="Clan.TabControl.Text" Brush.FontSize="23"
-                                            Brush.FontColor="#B8B8B8FF"
-                                            Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
-                                            Text="@CommunityText"/>
-
-                                <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
-                                            MarginBottom="8" Brush="Clan.TabControl.Text" Brush.FontSize="32"
-                                            Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
-                                            Text="@SupportersHeaderText"/>
-                                <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
                                             MarginBottom="8" Brush="Clan.TabControl.Text" Brush.FontSize="23"
                                             Brush.FontColor="#B8B8B8FF"
                                             Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
-                                            Text="@SupportersText"/>
+                                            Text="@CommunityText"/>
                               </Children>
                             </ListPanel>
                           </Children>

--- a/source/GameInterface.Tests/Services/UI/CreditsPopupVMTests.cs
+++ b/source/GameInterface.Tests/Services/UI/CreditsPopupVMTests.cs
@@ -30,9 +30,10 @@ public class CreditsPopupVMTests
     {
         var viewModel = new CreditsPopupVM(() => { });
 
+        Assert.Equal(ExpectedSectionText(CreditsRoster.Sponsors), viewModel.SponsorsText);
+        Assert.Equal(ExpectedSectionText(CreditsRoster.Supporters), viewModel.SupportersText);
         Assert.Equal(ExpectedSectionText(CreditsRoster.Contributors), viewModel.ContributorsText);
         Assert.Equal(ExpectedSectionText(CreditsRoster.Community), viewModel.CommunityText);
-        Assert.Equal(ExpectedSectionText(CreditsRoster.Supporters), viewModel.SupportersText);
     }
 
     [Fact]

--- a/source/GameInterface/Services/UI/Credits/CreditsPopupVM.cs
+++ b/source/GameInterface/Services/UI/Credits/CreditsPopupVM.cs
@@ -5,8 +5,8 @@ using TaleWorlds.Library;
 namespace GameInterface.Services.UI.Credits;
 
 /// <summary>
-/// Backs the credits popup: a title above named sections (contributors, community, supporters)
-/// and a close button. Section names come from <see cref="CreditsRoster"/>.
+/// Backs the credits popup: a title above named sections (sponsors, supporters, contributors,
+/// community) and a close button. Section names come from <see cref="CreditsRoster"/>.
 /// </summary>
 public class CreditsPopupVM : ViewModel
 {
@@ -20,12 +20,14 @@ public class CreditsPopupVM : ViewModel
     }
 
     public string TitleText => "Credits";
+    public string SponsorsHeaderText => "Sponsors";
+    public string SupportersHeaderText => "Supporters";
     public string ContributorsHeaderText => "Contributors";
     public string CommunityHeaderText => "Community";
-    public string SupportersHeaderText => "Supporters";
+    public string SponsorsText => FormatNames(CreditsRoster.Sponsors);
+    public string SupportersText => FormatNames(CreditsRoster.Supporters);
     public string ContributorsText => FormatNames(CreditsRoster.Contributors);
     public string CommunityText => FormatNames(CreditsRoster.Community);
-    public string SupportersText => FormatNames(CreditsRoster.Supporters);
     public string CloseButtonText => "Close";
 
     public void ActionClose()

--- a/source/GameInterface/Services/UI/Credits/CreditsRoster.cs
+++ b/source/GameInterface/Services/UI/Credits/CreditsRoster.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace GameInterface.Services.UI.Credits;
 
@@ -8,6 +8,19 @@ namespace GameInterface.Services.UI.Credits;
 /// </summary>
 internal static class CreditsRoster
 {
+    /// <summary>Organizations and communities sponsoring the project.</summary>
+    public static readonly IReadOnlyList<string> Sponsors = new[]
+    {
+        "骑砍中文站 (www.mountblade.com.cn)",
+    };
+
+    /// <summary>People who supported the project financially (donations, Patreon).</summary>
+    public static readonly IReadOnlyList<string> Supporters = new[]
+    {
+        "Koung",
+        "Lord Zippykins",
+    };
+
     /// <summary>
     /// GitHub contributors ordered by contribution count
     /// (github.com/Bannerlord-Coop-Team/BannerlordCoop/graphs/contributors).
@@ -64,10 +77,4 @@ internal static class CreditsRoster
 
     /// <summary>Community members: moderators, translators, testers, and other helpers.</summary>
     public static readonly IReadOnlyList<string> Community = new string[0];
-
-    /// <summary>People who supported the project financially (donations, Patreon).</summary>
-    public static readonly IReadOnlyList<string> Supporters = new[]
-    {
-        "Koung",
-    };
 }


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [x] Other... Please describe: Credits roster content update.


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The credits popup has no Sponsors section, and renders sections in the order Contributors, Community, Supporters.


## What is the new behavior?
<!-- Insert issue id after hashtag. -->
<!-- Describe functionality added. Add images or videos to show how it works if applies -->

- Adds a **Sponsors** section with 骑砍中文站 (www.mountblade.com.cn).
- Adds **Lord Zippykins** to Supporters.
- Reorders the popup to Sponsors → Supporters → Contributors. Community (still empty, renders "Coming soon") stays last since the reorder didn't cover it.

`CreditsPopupVMTests` now covers the Sponsors section, and `PopupUIMovieBindingTests` already guards the new `@SponsorsHeaderText` / `@SponsorsText` bindings against the VM. Credits + popup-binding tests pass (10/10).


## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->

None — do not include this PR in the changelog.


## Other information

The sponsor name is CJK; `CreditsRoster.cs` is saved UTF-8 with BOM so the literal survives any toolchain that would otherwise decode it as ANSI. Verified the string compiles intact into `GameInterface.dll`. Worth a quick in-game look to confirm the credits font renders the glyphs rather than boxes.
