### PR TITLE
Addition of the feature to warn other clients for unsupported modules

### DIFF
--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -10,6 +10,8 @@ using Coop.LiveTesting;
 #endif
 using Coop.UI.LoadGameUI;
 using GameInterface;
+using GameInterface.Services.Modules;
+using GameInterface.Services.Modules.Handlers;
 using GameInterface.Services.MapEvents.PlayerPartyInteractions;
 using GameInterface.Services.Tournaments.UI;
 using GameInterface.Services.UI;
@@ -52,6 +54,8 @@ namespace Coop
         private string activeLogFilePath;
         private string informationalVersion = "unknown";
         private CrashReportingConsentCoordinator crashReportingConsent;
+        private UnsupportedModuleWarningHandler unsupportedModuleWarning;
+        private bool startupModuleWarningReady;
         private bool automaticCrashReportsRequested;
         private DateTime nextWatchdogRetryUtc;
 
@@ -108,6 +112,13 @@ namespace Coop
 
             SetupLogging();
             InitializeCrashReporting();
+
+            // Creates the handler during launch
+            if (!isServer)
+            {
+                unsupportedModuleWarning = new UnsupportedModuleWarningHandler(
+                    new TaleWorldsModuleInfoProvider());
+            }
 
             if (ManagedServerConfig.IsManagedServer)
             {
@@ -484,6 +495,7 @@ namespace Coop
         {
             base.OnBeforeInitialModuleScreenSetAsRoot();
             CrashDiagnostics.SetPhase("main-menu");
+            startupModuleWarningReady = true;
             InformationManager.DisplayMessage(new InformationMessage(ClientServerModeMessage));
         }
 
@@ -526,6 +538,7 @@ namespace Coop
 
             var isAtMainMenu = GameStateManager.Current?.ActiveState is InitialState;
             TryApplyAutomaticCrashReports();
+            TryShowUnsupportedModuleWarning(isAtMainMenu);
             TryShowCrashReportingConsent(isAtMainMenu);
 
             // Boot Steam services once the main menu is up, so a +connect_lobby launch resolves while joining is possible.
@@ -557,6 +570,19 @@ namespace Coop
             }
 
             crashReportingConsent.TryShowPrompt(
+                isAtMainMenu && !InformationManager.IsAnyInquiryActive(),
+                inquiry => InformationManager.ShowInquiry(inquiry));
+        }
+        
+        // Show the one-time unsupported module warning when the client startup UI is available.
+        private void TryShowUnsupportedModuleWarning(bool isAtMainMenu)
+        {
+            if (unsupportedModuleWarning == null || !startupModuleWarningReady || isServer || isAutoConnect)
+            {
+                return;
+            }
+            
+            unsupportedModuleWarning.TryShowPrompt(
                 isAtMainMenu && !InformationManager.IsAnyInquiryActive(),
                 inquiry => InformationManager.ShowInquiry(inquiry));
         }

--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -117,7 +117,11 @@ namespace Coop
             if (!isServer)
             {
                 unsupportedModuleWarning = new UnsupportedModuleWarningHandler(
-                    new TaleWorldsModuleInfoProvider());
+                    new TaleWorldsModuleInfoProvider(),
+                    new CoopOptionsStore(),
+                    exception => Logger.Warning(
+                        exception,
+                        "Unsupported module wwarning preference could not be saved"));
             }
 
             if (ManagedServerConfig.IsManagedServer)

--- a/source/GameInterface.Tests/Services/Modules/Handlers/UnsupportedModuleWarningHandlerTests.cs
+++ b/source/GameInterface.Tests/Services/Modules/Handlers/UnsupportedModuleWarningHandlerTests.cs
@@ -1,6 +1,7 @@
 ﻿using GameInterface.Services.Modules;
 using System.Collections.Generic;
 using GameInterface.Services.Modules.Handlers;
+using GameInterface.Services.UI.CoopOptions;
 using TaleWorlds.Library;
 using Xunit;
 
@@ -19,7 +20,7 @@ public class UnsupportedModuleWarningHandlerTests
             Module("StoryMode", isOfficial: true),
             Module("Coop", isOfficial: false));
 
-        var coordinator = new UnsupportedModuleWarningHandler(provider);
+        var coordinator = new UnsupportedModuleWarningHandler(provider, new TestOptionsStore(), _ => {});
         var shown = 0;
 
         coordinator.TryShowPrompt(true, _ => shown++);
@@ -37,7 +38,7 @@ public class UnsupportedModuleWarningHandlerTests
             Module("ExampleMod", isOfficial: false),
             Module("AnotherMod", isOfficial: false));
 
-        var coordinator = new UnsupportedModuleWarningHandler(provider);
+        var coordinator = new UnsupportedModuleWarningHandler(provider, new TestOptionsStore(), _ => {});
         InquiryData inquiry = null;
 
         coordinator.TryShowPrompt(true, value => inquiry = value);
@@ -63,7 +64,7 @@ public class UnsupportedModuleWarningHandlerTests
             Module("Coop", isOfficial: false),
             Module("NavalDLC", isOfficial: true, isDlc: true));
 
-        var coordinator = new UnsupportedModuleWarningHandler(provider);
+        var coordinator = new UnsupportedModuleWarningHandler(provider, new TestOptionsStore(), _ => {});
         InquiryData inquiry = null;
 
         coordinator.TryShowPrompt(true, value => inquiry = value);
@@ -81,7 +82,7 @@ public class UnsupportedModuleWarningHandlerTests
             Module("DedicatedServer.Linux", isOfficial: false),
             Module("DedicatedServer.Windows", isOfficial: false));
 
-        var coordinator = new UnsupportedModuleWarningHandler(provider);
+        var coordinator = new UnsupportedModuleWarningHandler(provider, new TestOptionsStore(), _ => {});
         var shown = 0;
 
         coordinator.TryShowPrompt(true, _ => shown++);
@@ -95,7 +96,7 @@ public class UnsupportedModuleWarningHandlerTests
         var provider = new TestModuleInfoProvider(
             Module("ExampleMod", isOfficial: false));
 
-        var coordinator = new UnsupportedModuleWarningHandler(provider);
+        var coordinator = new UnsupportedModuleWarningHandler(provider, new TestOptionsStore(), _ => {});
         var shown = 0;
 
         coordinator.TryShowPrompt(false, _ => shown++);
@@ -113,12 +114,83 @@ public class UnsupportedModuleWarningHandlerTests
             Module("Native", isOfficial: true),
             Module("Coop", isOfficial: false));
 
-        var coordinator = new UnsupportedModuleWarningHandler(provider);
+        var coordinator = new UnsupportedModuleWarningHandler(provider, new TestOptionsStore(), _ => {});
 
         coordinator.TryShowPrompt(true, _ => { });
         coordinator.TryShowPrompt(true, _ => { });
 
         Assert.Equal(1, provider.RequestCount);
+    }
+
+    [Fact]
+    public void Continue_DoesNotSuppressWarningOnNextLaunch()
+    {
+        var store = new TestOptionsStore();
+        var provider = new TestModuleInfoProvider(
+            Module("ExampleMod", isOfficial: false));
+        InquiryData inquiry = null;
+
+        var firstLaunchHandler = new UnsupportedModuleWarningHandler(
+            provider,
+            store,
+            _ => { });
+        firstLaunchHandler.TryShowPrompt(
+            true,
+            value => inquiry = value);
+        
+        Assert.NotNull(inquiry);
+
+        // Continue does not save a suppression preference.
+        inquiry.AffirmativeAction?.Invoke();
+
+        var secondLaunchHandler = new UnsupportedModuleWarningHandler(
+            provider,
+            store, _ => { });
+        var shownOnNextLaunch = 0;
+
+        secondLaunchHandler.TryShowPrompt(
+            true,
+            _ => shownOnNextLaunch++);
+        Assert.Equal(1, shownOnNextLaunch);
+    }
+    
+    [Fact]
+    public void DontShowAgain_SuppressesWarningOnNextLaunch()
+    {
+        var store = new TestOptionsStore();
+        var provider = new TestModuleInfoProvider(
+            Module("ExampleMod", isOfficial: false));
+        InquiryData inquiry = null;
+
+        var firstLaunchHandler = new UnsupportedModuleWarningHandler(
+            provider,
+            store,
+            _ => { });
+        firstLaunchHandler.TryShowPrompt(
+            true,
+            value => inquiry = value);
+
+        Assert.NotNull(inquiry);
+        Assert.NotNull(inquiry.NegativeAction);
+
+        inquiry.NegativeAction();
+
+        Assert.True(store.Options.TryGetSection(
+            UnsupportedModuleWarningHandler.TabId,
+            UnsupportedModuleWarningHandler.SectionId,
+            out UnsupportedModuleWarningOptions savedOptions));
+        Assert.True(savedOptions.DontShowAgain);
+        
+        var secondLaunchHandler = new UnsupportedModuleWarningHandler(
+            provider,
+            store,
+            _ => { });
+        var shownOnNextLaunch = 0;
+        secondLaunchHandler.TryShowPrompt(
+            true,
+            _ => shownOnNextLaunch++);
+        
+        Assert.Equal(0, shownOnNextLaunch);
     }
 
     private static ModuleInfo Module(
@@ -134,6 +206,9 @@ public class UnsupportedModuleWarningHandlerTests
         };
     }
 
+    /// <summary>
+    /// Supplies module information for unsupported module warning tests
+    /// </summary>
     private sealed class TestModuleInfoProvider : IModuleInfoProvider
     {
         private readonly IEnumerable<ModuleInfo> modules;
@@ -151,4 +226,35 @@ public class UnsupportedModuleWarningHandlerTests
             return modules;
         }
     }
+    
+    /// <summary>
+    /// Stores Coop options in memory for unsupported module warning tests
+    /// </summary>
+    private sealed class TestOptionsStore : ICoopOptionsStore
+    {
+        public TestOptionsStore(CoopOptionsData options = null)
+        {
+            Options = options ?? new CoopOptionsData();
+        }
+        public string FilePath => string.Empty;
+
+        public CoopOptionsData Options { get; private set; }
+
+        public bool TryLoad(out CoopOptionsData options)
+        {
+            options = Options;
+            return true;
+        }
+
+        public CoopOptionsData LoadOrDefault()
+        {
+            return Options;
+        }
+
+        public void Save(CoopOptionsData options)
+        {
+            Options = options;
+        }
+    }
 }
+

--- a/source/GameInterface.Tests/Services/Modules/Handlers/UnsupportedModuleWarningHandlerTests.cs
+++ b/source/GameInterface.Tests/Services/Modules/Handlers/UnsupportedModuleWarningHandlerTests.cs
@@ -1,0 +1,154 @@
+﻿using GameInterface.Services.Modules;
+using System.Collections.Generic;
+using GameInterface.Services.Modules.Handlers;
+using TaleWorlds.Library;
+using Xunit;
+
+namespace GameInterface.Tests.Services.Modules.Handlers;
+/// <summary>
+/// Addition of multiple tests to check the logic behind the warning
+/// </summary>
+public class UnsupportedModuleWarningHandlerTests
+{
+    [Fact]
+    public void OfficialModulesAndCoop_DoNotShowWarning()
+    {
+        var provider = new TestModuleInfoProvider(
+            Module("Native", isOfficial: true),
+            Module("SandBox", isOfficial: true),
+            Module("StoryMode", isOfficial: true),
+            Module("Coop", isOfficial: false));
+
+        var coordinator = new UnsupportedModuleWarningHandler(provider);
+        var shown = 0;
+
+        coordinator.TryShowPrompt(true, _ => shown++);
+
+        Assert.Equal(0, shown);
+        Assert.Equal(1, provider.RequestCount);
+    }
+
+    [Fact]
+    public void CommunityModules_AreListedInWarning()
+    {
+        var provider = new TestModuleInfoProvider(
+            Module("Native", isOfficial: true),
+            Module("Coop", isOfficial: false),
+            Module("ExampleMod", isOfficial: false),
+            Module("AnotherMod", isOfficial: false));
+
+        var coordinator = new UnsupportedModuleWarningHandler(provider);
+        InquiryData inquiry = null;
+
+        coordinator.TryShowPrompt(true, value => inquiry = value);
+
+        Assert.NotNull(inquiry);
+        Assert.Equal(
+            UnsupportedModuleWarningHandler.PromptTitle,
+            inquiry.TitleText);
+        Assert.Equal(
+            "Bannerlord Coop may be unstable when used with additional modules. " +
+            "The following active modules are not supported:\n\n" +
+            "- AnotherMod\n" +
+            "- ExampleMod\n\n" +
+            "Continue at your own risk.",
+            inquiry.Text);
+    }
+
+    [Fact]
+    public void OfficialOptionalModule_ShowsWarning()
+    {
+        var provider = new TestModuleInfoProvider(
+            Module("Native", isOfficial: true),
+            Module("Coop", isOfficial: false),
+            Module("NavalDLC", isOfficial: true, isDlc: true));
+
+        var coordinator = new UnsupportedModuleWarningHandler(provider);
+        InquiryData inquiry = null;
+
+        coordinator.TryShowPrompt(true, value => inquiry = value);
+
+        Assert.NotNull(inquiry);
+        Assert.Contains("- NavalDLC", inquiry.Text);
+    }
+
+    [Fact]
+    public void DedicatedServerModules_DoNotShowWarning()
+    {
+        var provider = new TestModuleInfoProvider(
+            Module("Native", isOfficial: true),
+            Module("Coop", isOfficial: false),
+            Module("DedicatedServer.Linux", isOfficial: false),
+            Module("DedicatedServer.Windows", isOfficial: false));
+
+        var coordinator = new UnsupportedModuleWarningHandler(provider);
+        var shown = 0;
+
+        coordinator.TryShowPrompt(true, _ => shown++);
+
+        Assert.Equal(0, shown);
+    }
+
+    [Fact]
+    public void Prompt_IsNotShownUntilAllowedAndIsShownOnlyOnce()
+    {
+        var provider = new TestModuleInfoProvider(
+            Module("ExampleMod", isOfficial: false));
+
+        var coordinator = new UnsupportedModuleWarningHandler(provider);
+        var shown = 0;
+
+        coordinator.TryShowPrompt(false, _ => shown++);
+        coordinator.TryShowPrompt(true, _ => shown++);
+        coordinator.TryShowPrompt(true, _ => shown++);
+
+        Assert.Equal(1, shown);
+        Assert.Equal(1, provider.RequestCount);
+    }
+
+    [Fact]
+    public void NoUnsupportedModules_AreEvaluatedOnlyOnce()
+    {
+        var provider = new TestModuleInfoProvider(
+            Module("Native", isOfficial: true),
+            Module("Coop", isOfficial: false));
+
+        var coordinator = new UnsupportedModuleWarningHandler(provider);
+
+        coordinator.TryShowPrompt(true, _ => { });
+        coordinator.TryShowPrompt(true, _ => { });
+
+        Assert.Equal(1, provider.RequestCount);
+    }
+
+    private static ModuleInfo Module(
+        string id,
+        bool isOfficial,
+        bool isDlc = false)
+    {
+        return new ModuleInfo
+        {
+            Id = id,
+            IsOfficial = isOfficial,
+            IsDlc = isDlc,
+        };
+    }
+
+    private sealed class TestModuleInfoProvider : IModuleInfoProvider
+    {
+        private readonly IEnumerable<ModuleInfo> modules;
+
+        public TestModuleInfoProvider(params ModuleInfo[] modules)
+        {
+            this.modules = modules;
+        }
+
+        public int RequestCount { get; private set; }
+
+        public IEnumerable<ModuleInfo> GetModuleInfos()
+        {
+            RequestCount++;
+            return modules;
+        }
+    }
+}

--- a/source/GameInterface/Services/Modules/Handlers/AdditionalModuleWarningHandler.cs
+++ b/source/GameInterface/Services/Modules/Handlers/AdditionalModuleWarningHandler.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Linq;
+using TaleWorlds.Library;
+
+namespace GameInterface.Services.Modules.Handlers;
+
+
+/// <summary>
+/// Detects active modules that are unsupported by COOP and prepare
+/// a one-time informational warning for the client.
+/// </summary>
+public class AdditionalModuleWarningHandler
+{
+    public const string PromptTitle = "Additional Modules Detected";
+
+    private const string CoopModuleId = "Coop";
+    private const string DedicatedServerModulePrefix = "DedicatedServer";
+    
+    private readonly IModuleInfoProvider moduleInfoProvider;
+
+    private bool modulesEvaluated;
+    private bool promptShown;
+    private string[] unsupportedModuleIds = Array.Empty<string>();
+    
+    public AdditionalModuleWarningHandler(
+        IModuleInfoProvider moduleInfoProvider)
+    {
+        this.moduleInfoProvider = moduleInfoProvider ?? throw new ArgumentNullException(nameof(moduleInfoProvider));
+    }
+
+    public void TryShowPrompt(bool canShow, Action<InquiryData> showInquiry)
+    {
+        if (!canShow || promptShown)
+        {
+            return;
+        }
+
+        EvaluateModules();
+        if (unsupportedModuleIds.Length == 0)
+        {
+            return;
+        }
+
+        if (showInquiry == null)
+        {
+            throw new ArgumentNullException(nameof(showInquiry));
+        }
+        
+        promptShown = true;
+        showInquiry(new InquiryData(
+            PromptTitle,
+            BuildPromptText(unsupportedModuleIds),
+            true,
+            false,
+            "Continue",
+            string.Empty,
+            null,
+            null));
+    }
+
+    private void EvaluateModules()
+    {
+        if (modulesEvaluated)
+        {
+            return;
+        }
+
+        modulesEvaluated = true;
+        unsupportedModuleIds = moduleInfoProvider.GetModuleInfos()
+            .Where(IsUnsupported)
+            .Select(module => module.Id)
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static bool IsUnsupported(ModuleInfo module)
+    {
+        if (string.Equals(module.Id, CoopModuleId, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (module.Id?.StartsWith(
+                DedicatedServerModulePrefix,
+                StringComparison.OrdinalIgnoreCase) == true)
+        {
+            return false;
+        }
+
+        return !module.IsOfficial || module.IsDlc;
+    }
+
+    private static string BuildPromptText(string[] moduleIds)
+    {
+        return "Bannerlord Coop may be unstable when used with additional modules." +
+               "The following active modules aree not supported:\n\n" +
+               string.Join("\n", moduleIds.Select(id => "- " + id)) +
+               "\n\nContinue at your own risk";
+    }
+}

--- a/source/GameInterface/Services/Modules/Handlers/UnsupportedModuleWarningHandler.cs
+++ b/source/GameInterface/Services/Modules/Handlers/UnsupportedModuleWarningHandler.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Linq;
+using System.Text.Json.Serialization;
+using System.Xml.Linq;
 using TaleWorlds.Library;
+using GameInterface.Services.UI.CoopOptions;
 
 namespace GameInterface.Services.Modules.Handlers;
 
@@ -12,25 +15,41 @@ namespace GameInterface.Services.Modules.Handlers;
 public class UnsupportedModuleWarningHandler
 {
     public const string PromptTitle = "Additional Modules Detected";
+    public const string TabId = "Warnings";
+    public const string SectionId = "UnsupportedModules";
 
     private const string CoopModuleId = "Coop";
     private const string DedicatedServerModulePrefix = "DedicatedServer.";
     
     private readonly IModuleInfoProvider moduleInfoProvider;
-
+    private readonly ICoopOptionsStore optionsStore;
+    private readonly Action<Exception> reportError;
+    
+    private bool optionsLoaded;
+    private bool warningsSuppressed; 
     private bool modulesEvaluated;
     private bool promptShown;
     private string[] unsupportedModuleIds = Array.Empty<string>();
     
     public UnsupportedModuleWarningHandler(
-        IModuleInfoProvider moduleInfoProvider)
+        IModuleInfoProvider moduleInfoProvider,
+        ICoopOptionsStore optionsStore,
+        Action<Exception> reportError)
     {
         this.moduleInfoProvider = moduleInfoProvider ?? throw new ArgumentNullException(nameof(moduleInfoProvider));
+        this.optionsStore = optionsStore ?? throw new ArgumentNullException(nameof(optionsStore));
+        this.reportError = reportError;
     }
 
     public void TryShowPrompt(bool canShow, Action<InquiryData> showInquiry)
     {
         if (!canShow || promptShown)
+        {
+            return;
+        }
+
+        LoadOptions();
+        if (warningsSuppressed)
         {
             return;
         }
@@ -51,11 +70,52 @@ public class UnsupportedModuleWarningHandler
             PromptTitle,
             BuildPromptText(unsupportedModuleIds),
             true,
-            false,
+            true,
             "Continue",
-            string.Empty,
+            "Don't Show Again",
             null,
-            null));
+            SupressWarning));
+    }
+    
+    private void LoadOptions()
+    {
+        if (optionsLoaded)
+        {
+            return;
+        }
+        
+        optionsLoaded = true;
+
+        CoopOptionsData options = optionsStore.LoadOrDefault();
+        if (options.TryGetSection(
+                TabId,
+                SectionId,
+                out UnsupportedModuleWarningOptions saved))
+        {
+            warningsSuppressed = saved.DontShowAgain;
+        }
+    }
+
+    private void SupressWarning()
+    {
+        warningsSuppressed = true;
+
+        try
+        {
+            CoopOptionsData options = optionsStore.LoadOrDefault();
+            options.SetSection(
+                TabId,
+                SectionId,
+                new UnsupportedModuleWarningOptions
+                {
+                    DontShowAgain = true,
+                });
+            optionsStore.Save(options);
+        }
+        catch (Exception exception)
+        {
+            reportError?.Invoke(exception);
+        }
     }
 
     private void EvaluateModules()
@@ -99,4 +159,12 @@ public class UnsupportedModuleWarningHandler
                string.Join("\n", moduleIds.Select(id => "- " + id)) +
                "\n\nContinue at your own risk.";
     }
+}
+/// <summary>
+/// Stores the client's preference for the unsupported module startup warning.
+/// </summary>
+public class UnsupportedModuleWarningOptions
+{
+    [JsonPropertyName("dontShowAgain")]
+    public bool DontShowAgain {get; set;}
 }

--- a/source/GameInterface/Services/Modules/Handlers/UnsupportedModuleWarningHandler.cs
+++ b/source/GameInterface/Services/Modules/Handlers/UnsupportedModuleWarningHandler.cs
@@ -94,9 +94,9 @@ public class UnsupportedModuleWarningHandler
 
     private static string BuildPromptText(string[] moduleIds)
     {
-        return "Bannerlord Coop may be unstable when used with additional modules." +
-               "The following active modules aree not supported:\n\n" +
+        return "Bannerlord Coop may be unstable when used with additional modules. " +
+               "The following active modules are not supported:\n\n" +
                string.Join("\n", moduleIds.Select(id => "- " + id)) +
-               "\n\nContinue at your own risk";
+               "\n\nContinue at your own risk.";
     }
 }

--- a/source/GameInterface/Services/Modules/Handlers/UnsupportedModuleWarningHandler.cs
+++ b/source/GameInterface/Services/Modules/Handlers/UnsupportedModuleWarningHandler.cs
@@ -14,7 +14,7 @@ public class UnsupportedModuleWarningHandler
     public const string PromptTitle = "Additional Modules Detected";
 
     private const string CoopModuleId = "Coop";
-    private const string DedicatedServerModulePrefix = "DedicatedServer";
+    private const string DedicatedServerModulePrefix = "DedicatedServer.";
     
     private readonly IModuleInfoProvider moduleInfoProvider;
 

--- a/source/GameInterface/Services/Modules/Handlers/UnsupportedModuleWarningHandler.cs
+++ b/source/GameInterface/Services/Modules/Handlers/UnsupportedModuleWarningHandler.cs
@@ -9,7 +9,7 @@ namespace GameInterface.Services.Modules.Handlers;
 /// Detects active modules that are unsupported by COOP and prepare
 /// a one-time informational warning for the client.
 /// </summary>
-public class AdditionalModuleWarningHandler
+public class UnsupportedModuleWarningHandler
 {
     public const string PromptTitle = "Additional Modules Detected";
 
@@ -22,7 +22,7 @@ public class AdditionalModuleWarningHandler
     private bool promptShown;
     private string[] unsupportedModuleIds = Array.Empty<string>();
     
-    public AdditionalModuleWarningHandler(
+    public UnsupportedModuleWarningHandler(
         IModuleInfoProvider moduleInfoProvider)
     {
         this.moduleInfoProvider = moduleInfoProvider ?? throw new ArgumentNullException(nameof(moduleInfoProvider));


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
Clients are not warned when Bannerlord Coop is launched with additional unsupported modules enabled. This can leave players unaware that other active modules may cause instability.

## What is the new behavior?
Resolves #2056

When a client launches Bannerlord Coop with unsupported modules enabled, a one-time startup inquiry warns that the game may be unstable and lists the unsupported module IDs.

The warning:

- excludes official non-DLC Bannerlord modules;
- excludes the Coop module;
- excludes `DedicatedServer.*` modules;
- includes community modules and official optional DLC;
- waits until the initial client UI is available and no other inquiry is active;
- is not shown for server or auto-connect launches;
- and is displayed only once per application launch.

Six unit tests cover supported modules, community modules, official optional modules, dedicated-server modules, deferred display, and one-time evaluation/display behavior.

## Bot Changelog Entry
- Added a startup warning when Bannerlord Coop is launched with unsupported modules enabled.

## Other information
Validation performed:

- All six `UnsupportedModuleWarningHandlerTests` pass.
- A normal client launch with only official modules and Coop does not display the warning.
- A normal client launch with an additional community module displays the warning and lists that module.
- Debug server and auto-connect launches are not interrupted by the warning.
<img width="1919" height="1079" alt="Screenshot 2026-08-05 023310" src="https://github.com/user-attachments/assets/d9ff396f-08fe-449d-ab41-02822c74004c" />
