### PR TITLE
Fix residual E2E flake: serialize patch churn, restore the game-thread mark, reset leaked battle statics

### DIFF
--- a/.github/scripts/run-e2e-shard.sh
+++ b/.github/scripts/run-e2e-shard.sh
@@ -105,12 +105,14 @@ esac
 assigned_case_count=$(printf '%s\n' "$assignment" | cut -f2)
 shard_filter=$(printf '%s\n' "$assignment" | cut -f3-)
 echo "running E2E shard $shard_index/$shard_count with $assigned_case_count discovered test cases"
+# Per-test result lines (not ErrorsOnly): flake triage needs to reconstruct which tests ran,
+# in what order, before a failure — an errors-only log makes that unrecoverable afterwards.
 "$dotnet_cmd" test "$test_project" \
     -c Release \
     --no-build \
     --no-restore \
     --filter "$shard_filter" \
-    --consoleLoggerParameters:ErrorsOnly
+    --logger "console;verbosity=normal"
 
 elapsed_seconds=$(( $(date +%s) - start_seconds ))
 echo "E2E shard $shard_index completed in ${elapsed_seconds}s"

--- a/source/Common.Tests/Utils/MessageCollection.cs
+++ b/source/Common.Tests/Utils/MessageCollection.cs
@@ -10,7 +10,20 @@ public class MessageCollection : IEnumerable<IMessage>
 {
     public readonly List<IMessage> Messages = new List<IMessage>();
 
-    public int Count => Messages.Count;
+    // Test-spawned background threads can send (append) while the test thread enumerates for an
+    // assertion; an unguarded List race loses entries or tears the enumeration with no exception.
+    private readonly object gate = new object();
+
+    public int Count
+    {
+        get
+        {
+            lock (gate)
+            {
+                return Messages.Count;
+            }
+        }
+    }
 
     /// <summary>
     /// Gets an iterator for all messages with type <typeparamref name="TMessage"/>
@@ -19,7 +32,7 @@ public class MessageCollection : IEnumerable<IMessage>
     /// <returns>Iterator for all messages with type <typeparamref name="TMessage"/></returns>
     public IEnumerable<TMessage> GetMessages<TMessage>() where TMessage : IMessage
     {
-        return Messages
+        return Snapshot()
             .Where(msg => typeof(TMessage).IsAssignableFrom(msg.GetType()))
             .Select(msg => (TMessage)msg);
     }
@@ -38,11 +51,31 @@ public class MessageCollection : IEnumerable<IMessage>
     /// Adds a message to the collection
     /// </summary>
     /// <param name="message">Message to add to the collection</param>
-    public void Add(IMessage message) => Messages.Add(message);
+    public void Add(IMessage message)
+    {
+        lock (gate)
+        {
+            Messages.Add(message);
+        }
+    }
 
-    public IEnumerator<IMessage> GetEnumerator() => Messages.GetEnumerator();
+    public IEnumerator<IMessage> GetEnumerator() => Snapshot().GetEnumerator();
 
-    IEnumerator IEnumerable.GetEnumerator() => Messages.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-    public void Clear() => Messages.Clear();
+    public void Clear()
+    {
+        lock (gate)
+        {
+            Messages.Clear();
+        }
+    }
+
+    private List<IMessage> Snapshot()
+    {
+        lock (gate)
+        {
+            return new List<IMessage>(Messages);
+        }
+    }
 }

--- a/source/Common.Tests/Utils/TestMessageBroker.cs
+++ b/source/Common.Tests/Utils/TestMessageBroker.cs
@@ -1,4 +1,6 @@
-﻿using Common.Messaging;
+﻿using Common.Logging;
+using Common.Messaging;
+using Serilog;
 
 namespace Common.Tests.Utils;
 
@@ -7,6 +9,8 @@ namespace Common.Tests.Utils;
 /// </summary>
 public class TestMessageBroker : MessageBroker
 {
+    private static readonly ILogger Logger = LogManager.GetLogger<TestMessageBroker>();
+
     public readonly MessageCollection Messages = new MessageCollection();
 
     private readonly Dictionary<Type, List<WeakDelegate>> _subscribers = new Dictionary<Type, List<WeakDelegate>>();
@@ -34,7 +38,10 @@ public class TestMessageBroker : MessageBroker
             var weakDelegate = delegates[i];
             if (weakDelegate == null || weakDelegate.IsAlive == false)
             {
-                // Remove dead delegates
+                // A collected subscription target means this message is silently unhandled on the
+                // receiving instance — name it so a lost state-apply is diagnosable from test output.
+                Logger.Warning("Dropping dead subscriber {Method} for {MessageType}: its target was garbage collected",
+                    weakDelegate?.Method?.Name ?? "<unknown>", messageType.Name);
                 delegates.RemoveAt(i--);
                 continue;
             }

--- a/source/Common/GameThread.cs
+++ b/source/Common/GameThread.cs
@@ -232,6 +232,10 @@ public class GameThread : IUpdateable
                 throw new OperationCanceledException(
                     $"The game-thread session ended before the blocking {nameof(Run)} action was queued.");
             }
+            // This return is one of the few places marshalled work can vanish without a trace;
+            // name the dropped action so a lost state-apply is diagnosable from the log.
+            Logger.Warning("Dropping game-thread action {Label}: the session was cancelled before it was queued",
+                label ?? BuildLabel(callerFile, callerMember));
             return;
         }
 
@@ -414,6 +418,15 @@ public class GameThread : IUpdateable
         {
             discarded = new List<(Action, EventWaitHandle, string, CancellationToken)>(m_Queue);
             m_Queue.Clear();
+        }
+
+        if (discarded.Count > 0)
+        {
+            // A non-empty queue here means marshalled work was enqueued but never pumped — for a
+            // test harness that is a silently lost state-apply, so name every dropped action.
+            Logger.Warning("Discarding {Count} queued game-thread action(s) that no pump ever ran: {Labels}",
+                discarded.Count,
+                string.Join(", ", discarded.Select(task => task.Label ?? "(unlabeled)")));
         }
 
         foreach (var task in discarded)

--- a/source/Common/GameThread.cs
+++ b/source/Common/GameThread.cs
@@ -387,6 +387,42 @@ public class GameThread : IUpdateable
     }
 
     /// <summary>
+    /// The currently registered game-loop thread id (0 when unmarked). Pair with
+    /// <see cref="RestoreGameThread"/> so a scope that re-marks the game thread (e.g. a test harness
+    /// running a call on a worker thread) can put the previous registration back instead of leaving
+    /// the mark on a thread that may never pump the queue again.
+    /// </summary>
+    public int GameThreadId => m_GameLoopThreadId;
+
+    /// <summary>
+    /// Restores a registration previously read from <see cref="GameThreadId"/>.
+    /// </summary>
+    public void RestoreGameThread(int threadId)
+    {
+        m_GameLoopThreadId = threadId;
+    }
+
+    /// <summary>
+    /// Discards every queued action without running it, releasing any blocked callers waiting on
+    /// them. For test harnesses at environment boundaries: an action queued by a previous test
+    /// would otherwise execute inside a later environment's pump against a torn-down container.
+    /// </summary>
+    public void DiscardQueuedActions()
+    {
+        List<(Action Act, EventWaitHandle Wait, string Label, CancellationToken Cancellation)> discarded;
+        lock (m_QueueLock)
+        {
+            discarded = new List<(Action, EventWaitHandle, string, CancellationToken)>(m_Queue);
+            m_Queue.Clear();
+        }
+
+        foreach (var task in discarded)
+        {
+            task.Wait?.Set();
+        }
+    }
+
+    /// <summary>
     /// Clears the game-loop thread registration. A thread that was marked via
     /// <see cref="MarkGameThread"/> must call this before it exits: .NET recycles managed thread
     /// ids, so a registration left behind by a dead thread can silently promote an unrelated

--- a/source/Common/Logging/OutputSinkManager.cs
+++ b/source/Common/Logging/OutputSinkManager.cs
@@ -1,4 +1,4 @@
-﻿using Serilog.Core;
+using Serilog.Core;
 using Serilog.Events;
 using System;
 using System.Collections.Generic;
@@ -10,14 +10,28 @@ public class OutputSinkManager : ILogEventSink
 {
     private static List<Action<string>> Callbacks { get; } = new List<Action<string>>();
 
+    // Emit runs on whatever thread logged (timers, pollers, thread-pool continuations) while
+    // callbacks are added/removed on the main thread; an unguarded List enumeration racing a
+    // mutation throws out of the sink into the logging caller.
+    private static readonly object gate = new object();
+
     internal OutputSinkManager() { }
 
     public static void AddLogCallback(Action<string> callback)
     {
-        Callbacks.Add(callback);
+        lock (gate)
+        {
+            Callbacks.Add(callback);
+        }
     }
 
-    public static bool RemoveLogCallback(Action<string> callback) => Callbacks.Remove(callback);
+    public static bool RemoveLogCallback(Action<string> callback)
+    {
+        lock (gate)
+        {
+            return Callbacks.Remove(callback);
+        }
+    }
 
     public void Emit(LogEvent logEvent)
     {
@@ -33,9 +47,24 @@ public class OutputSinkManager : ILogEventSink
             textWriter.Write(logEvent.Exception);
         }
 
-        foreach (var callback in Callbacks)
+        Action<string>[] callbacks;
+        lock (gate)
         {
-            callback(textWriter.ToString());
+            callbacks = Callbacks.ToArray();
+        }
+
+        foreach (var callback in callbacks)
+        {
+            try
+            {
+                callback(textWriter.ToString());
+            }
+            catch
+            {
+                // A dead sink (e.g. an xUnit output helper whose test already finished when a
+                // background thread logs) must not take down the logging caller or starve the
+                // remaining sinks.
+            }
         }
     }
 }

--- a/source/Common/Messaging/MessageBroker.cs
+++ b/source/Common/Messaging/MessageBroker.cs
@@ -51,7 +51,11 @@ public class MessageBroker : IMessageBroker
             var weakDelegate = delegates[i];
             if (weakDelegate.IsAlive == false)
             {
-                // Remove dead delegates
+                // Subscriptions are weak by design, but a collected target means this message is
+                // silently not handled — name it, because a lost handler is otherwise invisible
+                // (the classic trap: a closure/lambda subscription nothing kept alive).
+                Logger.Warning("Dropping dead subscriber {Method} for {MessageType}: its target was garbage collected",
+                    weakDelegate.Method?.Name ?? "<unknown>", typeof(T).Name);
                 delegates.RemoveAt(i--);
                 continue;
             }

--- a/source/E2E.Tests/Environment/E2ETestEnvironment.cs
+++ b/source/E2E.Tests/Environment/E2ETestEnvironment.cs
@@ -9,6 +9,7 @@ using E2E.Tests.Environment.Instance;
 using E2E.Tests.Util;
 using GameInterface;
 using GameInterface.AutoSync;
+using GameInterface.Services.MapEvents;
 using GameInterface.Services.MapEvents.PlayerPartyInteractions;
 using GameInterface.Services.Players;
 using GameInterface.Tests.Bootstrap;
@@ -52,11 +53,16 @@ public class E2ETestEnvironment : IDisposable
 
         GameThread.Instance.MarkGameThread();
 
+        // An action a previous environment queued but never pumped would otherwise execute inside
+        // this environment's first pump, against a torn-down container and the wrong game statics.
+        GameThread.Instance.DiscardQueuedActions();
+
         GameBootStrap.Initialize();
 
         // Process-wide interaction state must not leak between E2E test environments.
         PlayerPartyInteractionDialogState.Clear();
         PlayerPartyTradeContext.End();
+        ResetBattleModeState();
 
         IntegrationEnvironment = new TestEnvironment(output, numClients, registerGameInterface: true);
 
@@ -84,6 +90,21 @@ public class E2ETestEnvironment : IDisposable
     /// </summary>
     private void StopCampaignTimeHeartbeat()
         => Server.Resolve<CampaignTimeSyncHandler>().Dispose();
+
+    /// <summary>
+    /// Battle-mode gating lives in process-wide statics keyed by object-manager ids, and every
+    /// fresh environment re-mints the same ids (MapEvent_Created_1, ...). A claim leaked by a test
+    /// that never finalized its battle would silently gate joins, updates, and surrender for an
+    /// unrelated later test class that happens to reuse the id.
+    /// </summary>
+    private static void ResetBattleModeState()
+    {
+        ServerBattleModeArbiter.Reset();
+        BattleModeRegistry.End();
+        BattleConclusionGate.IsInCoopBattleMission = false;
+        BattleSpawnGate.EndBattle();
+        BattleSimulationReplay.Reset();
+    }
 
     /// <summary>
     /// Associates an already registered player with a connected E2E client peer.
@@ -114,6 +135,11 @@ public class E2ETestEnvironment : IDisposable
         {
             if (disposed) return;
             disposed = true;
+
+            // Teardown disposes handlers whose Dispose bodies marshal via GameThread.RunSafe; make
+            // this thread the game thread so that work runs inline here instead of queueing onto a
+            // queue that would only be pumped inside a later test's environment.
+            GameThread.Instance.MarkGameThread();
 
             try
             {
@@ -146,6 +172,8 @@ public class E2ETestEnvironment : IDisposable
                 }
                 finally
                 {
+                    // Nothing queued by this environment may survive into the next one.
+                    GameThread.Instance.DiscardQueuedActions();
                     // Async tests can re-mark their continuation thread; keep it marked through fixture teardown.
                     GameThread.Instance.UnmarkGameThread();
                 }

--- a/source/E2E.Tests/Environment/Instance/EnvironmentInstance.cs
+++ b/source/E2E.Tests/Environment/Instance/EnvironmentInstance.cs
@@ -43,8 +43,6 @@ public abstract class EnvironmentInstance : IDisposable
     private readonly MockNetworkBase mockNetwork;
     private readonly ILifetimeScope container;
 
-    private readonly static object _lock = new object();
-
     public EnvironmentInstance(
         TestMessageBroker messageBroker,
         MockNetworkBase mockNetwork,
@@ -95,11 +93,14 @@ public abstract class EnvironmentInstance : IDisposable
             disabledMethods = Array.Empty<MethodBase>();
         }
 
-        lock (_lock)
+        // The same lock StaticScope takes, so PatchScope's patch/unpatch cannot interleave with
+        // another thread executing patched game code inside a SimulateMessage/SimulatePacket —
+        // those only enter GameInstance.@lock (via StaticScope), and the previous separate _lock
+        // left the Harmony rewrites unguarded against them. Monitor is reentrant per thread, which
+        // routed sends rely on: a Call's handler chain synchronously delivers into another
+        // instance's Simulate*, nesting scopes on the same thread.
+        lock (GameInstance.@lock)
         {
-            // xUnit can move a test from its constructor thread before the next instance call.
-            GameThread.Instance.MarkGameThread();
-
             using (new PatchScope(disabledMethods))
             {
                 using (new StaticScope(this))
@@ -156,6 +157,8 @@ public abstract class EnvironmentInstance : IDisposable
         private readonly TaleWorlds.MountAndBlade.Module previousModule;
         private readonly TestMessageBroker previousMessageBroker;
         private readonly bool wasServer;
+        private readonly bool markedGameThread;
+        private readonly int previousGameThreadId;
 
         public StaticScope(EnvironmentInstance instance, bool markGameThread = true)
         {
@@ -170,6 +173,12 @@ public abstract class EnvironmentInstance : IDisposable
                 if (markGameThread)
                 {
                     // xUnit can move a test from its fixture-constructor thread before the next scoped call.
+                    // Save-and-restore rather than bare-mark: a scope entered on a worker thread (e.g.
+                    // Task.Run(() => Server.Call(...))) must not leave the game-thread mark on that thread —
+                    // every later GameThread.RunSafe from the real test thread would silently enqueue onto
+                    // a queue nobody pumps instead of running inline.
+                    markedGameThread = true;
+                    previousGameThreadId = GameThread.Instance.GameThreadId;
                     GameThread.Instance.MarkGameThread();
                 }
 
@@ -203,6 +212,12 @@ public abstract class EnvironmentInstance : IDisposable
                     {
                         RestorePreviousStatics();
                     }
+                    else if (markedGameThread)
+                    {
+                        // The mark is set before the statics are saved, so a throw in between must
+                        // still put it back (RestorePreviousStatics is not reachable yet here).
+                        GameThread.Instance.RestoreGameThread(previousGameThreadId);
+                    }
                 }
                 finally
                 {
@@ -233,6 +248,10 @@ public abstract class EnvironmentInstance : IDisposable
             ModInformation.IsServer = wasServer;
             GameInterface.ContainerProvider.SetContainer(previousContainer);
             previousMessageBroker.SetStaticInstance();
+            if (markedGameThread)
+            {
+                GameThread.Instance.RestoreGameThread(previousGameThreadId);
+            }
         }
     }
 

--- a/source/E2E.Tests/Environment/MeshNetworkRouter.cs
+++ b/source/E2E.Tests/Environment/MeshNetworkRouter.cs
@@ -1,4 +1,5 @@
 using Common.Messaging;
+using Common.Util;
 using E2E.Tests.Environment.Instance;
 using E2E.Tests.Environment.Mock;
 using GameInterface.Services.Entity;
@@ -24,7 +25,7 @@ public class MeshNetworkRouter
 
         foreach (var (instance, mesh) in clients)
             if (mesh != sender)
-                instance.SimulateMessage(sender.NetPeer, message);
+                Deliver(() => instance.SimulateMessage(sender.NetPeer, message));
     }
 
     public void Send(MockBattleNetwork sender, string controllerId, IMessage message)
@@ -33,7 +34,7 @@ public class MeshNetworkRouter
 
         foreach (var (instance, mesh) in clients)
             if (mesh != sender && ControllerIdOf(instance) == controllerId)
-                instance.SimulateMessage(sender.NetPeer, message);
+                Deliver(() => instance.SimulateMessage(sender.NetPeer, message));
     }
 
     public void SendAllBut(MockBattleNetwork sender, string excludedControllerId, IMessage message)
@@ -42,11 +43,20 @@ public class MeshNetworkRouter
 
         foreach (var (instance, mesh) in clients)
             if (mesh != sender && ControllerIdOf(instance) != excludedControllerId)
-                instance.SimulateMessage(sender.NetPeer, message);
+                Deliver(() => instance.SimulateMessage(sender.NetPeer, message));
     }
 
     private ClientInstance SenderInstance(MockBattleNetwork sender)
         => clients.First(c => c.mesh == sender).instance;
+
+    private static void Deliver(Action delivery)
+    {
+        // Each E2E instance represents a separate process, so the receiver must not inherit the sender's allowance.
+        using (AllowedThread.Suspend())
+        {
+            delivery();
+        }
+    }
 
     private static string ControllerIdOf(ClientInstance instance)
         => instance.Resolve<IControllerIdProvider>().ControllerId;

--- a/source/E2E.Tests/Environment/PacketCollection.cs
+++ b/source/E2E.Tests/Environment/PacketCollection.cs
@@ -9,11 +9,29 @@ public class PacketCollection
 {
     public readonly List<IPacket> Packets = new List<IPacket>();
 
-    public int Count => Packets.Count;
+    // Same hazard as MessageCollection: background-thread sends racing test-thread assertions.
+    private readonly object gate = new object();
+
+    public int Count
+    {
+        get
+        {
+            lock (gate)
+            {
+                return Packets.Count;
+            }
+        }
+    }
 
     public IEnumerable<TPacket> GetPackets<TPacket>() where TPacket : IPacket
     {
-        return Packets
+        List<IPacket> snapshot;
+        lock (gate)
+        {
+            snapshot = new List<IPacket>(Packets);
+        }
+
+        return snapshot
             .Where(msg => typeof(TPacket).IsAssignableFrom(msg.GetType()))
             .Select(msg => (TPacket)msg);
     }
@@ -23,5 +41,11 @@ public class PacketCollection
         return GetPackets<TPacket>().Count();
     }
 
-    public void Add(IPacket message) => Packets.Add(message);
+    public void Add(IPacket message)
+    {
+        lock (gate)
+        {
+            Packets.Add(message);
+        }
+    }
 }

--- a/source/GameInterface/Services/MapEvents/BattleSimulationReplay.cs
+++ b/source/GameInterface/Services/MapEvents/BattleSimulationReplay.cs
@@ -84,6 +84,20 @@ internal static class BattleSimulationReplay
         isSpectator = spectator;
     }
 
+    /// <summary>
+    /// Drops any in-flight playback. For session/test-environment boundaries: a playback left
+    /// active under a stale map-event id would swallow ticks for an unrelated future battle that
+    /// reuses the id.
+    /// </summary>
+    public static void Reset()
+    {
+        arrivedRounds.Clear();
+        mapEventId = null;
+        finishRequested = false;
+        skipRequested = false;
+        isSpectator = false;
+    }
+
     /// <summary>Queue a round streamed from the server (applied on the next tick).</summary>
     public static void EnqueueRound(ResolvedChange[] round)
     {

--- a/source/GameInterface/Services/MapEvents/Initialization/MapEventInitializationBarrier.cs
+++ b/source/GameInterface/Services/MapEvents/Initialization/MapEventInitializationBarrier.cs
@@ -115,10 +115,21 @@ internal sealed class MapEventInitializationBarrier : IMapEventInitializationBar
                     tracker.AddParty(party);
         }
         Capture(state, mapEvent);
-        if (!TryGetId(mapEvent, out var mapEventId) ||
-            !TryGetId(tracker, out var trackerId) || !TryGetId(mapEvent.Component, out var componentId) ||
-            !TryGetId(mapEvent.MapEventVisual as GauntletMapEventVisual, out var visualId))
+        bool hasEventId = TryGetId(mapEvent, out var mapEventId);
+        bool hasTrackerId = TryGetId(tracker, out var trackerId);
+        bool hasComponentId = TryGetId(mapEvent.Component, out var componentId);
+        bool hasVisualId = TryGetId(mapEvent.MapEventVisual as GauntletMapEventVisual, out var visualId);
+        if (!hasEventId || !hasTrackerId || !hasComponentId || !hasVisualId)
         {
+            // The abort destroys the whole battle graph on the server AND every client; without a
+            // named reason its only trace is a generic ObjectManager id-miss line, which has made
+            // this exit the least diagnosable step of battle replication.
+            Logger.Error(
+                "Aborting MapEvent commit: unresolvable id (event={HasEventId}, tracker={HasTrackerId}, " +
+                "component={HasComponentId} [{ComponentType}], visual={HasVisualId} [{VisualType}])",
+                hasEventId, hasTrackerId,
+                hasComponentId, mapEvent.Component?.GetType().Name ?? "null",
+                hasVisualId, mapEvent.MapEventVisual?.GetType().Name ?? "null");
             AbortServer(mapEvent);
             return;
         }
@@ -131,7 +142,10 @@ internal sealed class MapEventInitializationBarrier : IMapEventInitializationBar
     public void AbortServer(MapEvent mapEvent)
     {
         if (mapEvent == null || !states.TryGetValue(mapEvent, out var state) || state.Committed) return;
-        if (TryGetId(mapEvent, out var id)) network.SendAll(new NetworkMapEventInitialized(id, true));
+        bool notified = TryGetId(mapEvent, out var id);
+        Logger.Error("Aborting MapEvent {MapEventId}: destroying its graph on the server and every notified client",
+            notified ? id : "<unregistered>");
+        if (notified) network.SendAll(new NetworkMapEventInitialized(id, true));
         DestroyGraph(mapEvent);
     }
 
@@ -160,11 +174,28 @@ internal sealed class MapEventInitializationBarrier : IMapEventInitializationBar
         GameThread.RunSafe(() =>
         {
             if (!objectManager.TryGetObjectWithLogging<MapEvent>(message.MapEventId, out var mapEvent)) return;
-            if (message.IsTerminal || string.IsNullOrEmpty(message.TroopUpgradeTrackerId) ||
-                !objectManager.TryGetObjectWithLogging<TroopUpgradeTracker>(message.TroopUpgradeTrackerId, out var tracker) ||
-                !Matches(message.ComponentId, mapEvent.Component) ||
-                !Matches(message.VisualId, mapEvent.MapEventVisual as GauntletMapEventVisual))
+            if (message.IsTerminal)
             {
+                FinishClient(mapEvent, abort: true);
+                return;
+            }
+
+            TroopUpgradeTracker tracker = null;
+            bool hasTracker = !string.IsNullOrEmpty(message.TroopUpgradeTrackerId) &&
+                objectManager.TryGetObjectWithLogging<TroopUpgradeTracker>(message.TroopUpgradeTrackerId, out tracker);
+            bool componentMatches = Matches(message.ComponentId, mapEvent.Component);
+            bool visualMatches = Matches(message.VisualId, mapEvent.MapEventVisual as GauntletMapEventVisual);
+            if (!hasTracker || !componentMatches || !visualMatches)
+            {
+                // Destroying the replica graph over a mismatch must say WHICH member mismatched —
+                // the local-vs-message visual identity in particular separates "the server's null
+                // overwrite never replicated here" from "the commit raced the reference sync".
+                Logger.Error(
+                    "Client destroying MapEvent {MapEventId} graph at commit: tracker={HasTracker}, " +
+                    "componentMatch={ComponentMatches}, visualMatch={VisualMatches} " +
+                    "(message visual id {VisualId}, local visual {LocalVisualType})",
+                    message.MapEventId, hasTracker, componentMatches, visualMatches,
+                    message.VisualId ?? "null", mapEvent.MapEventVisual?.GetType().Name ?? "null");
                 FinishClient(mapEvent, abort: true);
                 return;
             }

--- a/source/GameInterface/Services/MapEvents/Initialization/MapEventInitializationBarrier.cs
+++ b/source/GameInterface/Services/MapEvents/Initialization/MapEventInitializationBarrier.cs
@@ -115,21 +115,9 @@ internal sealed class MapEventInitializationBarrier : IMapEventInitializationBar
                     tracker.AddParty(party);
         }
         Capture(state, mapEvent);
-        bool hasEventId = TryGetId(mapEvent, out var mapEventId);
-        bool hasTrackerId = TryGetId(tracker, out var trackerId);
-        bool hasComponentId = TryGetId(mapEvent.Component, out var componentId);
-        bool hasVisualId = TryGetId(mapEvent.MapEventVisual as GauntletMapEventVisual, out var visualId);
-        if (!hasEventId || !hasTrackerId || !hasComponentId || !hasVisualId)
+        if (!TryResolveCommitIds(mapEvent, tracker,
+                out var mapEventId, out var trackerId, out var componentId, out var visualId))
         {
-            // The abort destroys the whole battle graph on the server AND every client; without a
-            // named reason its only trace is a generic ObjectManager id-miss line, which has made
-            // this exit the least diagnosable step of battle replication.
-            Logger.Error(
-                "Aborting MapEvent commit: unresolvable id (event={HasEventId}, tracker={HasTrackerId}, " +
-                "component={HasComponentId} [{ComponentType}], visual={HasVisualId} [{VisualType}])",
-                hasEventId, hasTrackerId,
-                hasComponentId, mapEvent.Component?.GetType().Name ?? "null",
-                hasVisualId, mapEvent.MapEventVisual?.GetType().Name ?? "null");
             AbortServer(mapEvent);
             return;
         }
@@ -137,6 +125,27 @@ internal sealed class MapEventInitializationBarrier : IMapEventInitializationBar
         network.SendAll(new NetworkMapEventInitialized(mapEventId, false, trackerId, componentId, visualId));
         state.Committed = true;
         state.Announced.Clear();
+    }
+
+    private bool TryResolveCommitIds(MapEvent mapEvent, TroopUpgradeTracker tracker,
+        out string mapEventId, out string trackerId, out string componentId, out string visualId)
+    {
+        bool hasEventId = TryGetId(mapEvent, out mapEventId);
+        bool hasTrackerId = TryGetId(tracker, out trackerId);
+        bool hasComponentId = TryGetId(mapEvent.Component, out componentId);
+        bool hasVisualId = TryGetId(mapEvent.MapEventVisual as GauntletMapEventVisual, out visualId);
+        if (hasEventId && hasTrackerId && hasComponentId && hasVisualId) return true;
+
+        // The resulting abort destroys the whole battle graph on the server AND every client;
+        // without a named reason its only trace is a generic ObjectManager id-miss line, which has
+        // made this exit the least diagnosable step of battle replication.
+        Logger.Error(
+            "Aborting MapEvent commit: unresolvable id (event={HasEventId}, tracker={HasTrackerId}, " +
+            "component={HasComponentId} [{ComponentType}], visual={HasVisualId} [{VisualType}])",
+            hasEventId, hasTrackerId,
+            hasComponentId, mapEvent.Component?.GetType().Name ?? "null",
+            hasVisualId, mapEvent.MapEventVisual?.GetType().Name ?? "null");
+        return false;
     }
 
     public void AbortServer(MapEvent mapEvent)

--- a/source/GameInterface/Services/MapEvents/ServerBattleModeArbiter.cs
+++ b/source/GameInterface/Services/MapEvents/ServerBattleModeArbiter.cs
@@ -128,4 +128,16 @@ internal static class ServerBattleModeArbiter
             modes.Remove(mapEventId);
         }
     }
+
+    /// <summary>
+    /// Drops every claim. For session/test-environment boundaries: object-manager ids restart
+    /// there, so a claim held under a stale id would gate an unrelated future battle that reuses it.
+    /// </summary>
+    public static void Reset()
+    {
+        lock (lockObj)
+        {
+            modes.Clear();
+        }
+    }
 }


### PR DESCRIPTION
## Problem

The campaign-time heartbeat fix (#2569, `1bba6186f`) reduced but did not end the repo-wide E2E flake: post-fix runs — including on `development` itself — still drop 8–15 `MapEvents`/`Villages`/`SiegeEvents` tests per shard, different subsets each run, all with one signature: **server-created `MapEvent`/`MapEventSide` state silently never materializes on the client replica** (`Assert.NotNull` on `MapEventSide` in the `SetMainPartyInBattle` helpers, `TryGetObject<MapEvent>` misses). Recent examples: runs 30935011666 (a credits-XML-only branch), 30934817042, 30953611637, 30952103612, and the 12 non-hideout failures in 30890911211.

Diagnosis was done by mining those runs' logs and auditing the harness. Three residual mechanisms cooperate, all harness-level:

### 1. Harmony patch churn was unguarded against concurrent packet simulation
`EnvironmentInstance.Call` serialized on its own static `_lock`, while `SimulateMessage`/`SimulatePacket` only took `GameInstance.@lock` (via `StaticScope`) — and `PatchScope` rewrote detours **outside** that lock. Any background thread delivering a packet could execute patched game code mid-patch/unpatch, silently dropping a detour. `Call` now takes `GameInstance.@lock` itself (the lock every `Simulate*` already honors). Monitor reentrancy is load-bearing and preserved: routed sends synchronously nest `Simulate*` inside a `Call` on the same thread.

### 2. The game-thread mark was stolen by worker threads and never restored
`StaticScope` called `MarkGameThread()` with no restore. A `Call` on a pool thread (`Task.Run(() => Server.Call(...))` in `PlayerPartyInteractionFlowTests`) permanently stole the mark, after which every `GameThread.RunSafe` client-apply — the map-event commit broadcast path (`MapEventInitializationBarrier` → `FinishClient`) — silently **enqueued onto a queue nobody pumps** instead of running inline. That is the desync. Stale queued actions then executed inside a *later* test's pump against a torn-down container — visible in the CI logs as the swallowed `VillagePatches.cs:44` NRE (`Failed to run action on the game thread: "(none)"`) and an Autofac `ObjectDisposedException`.

`StaticScope` now saves/restores the mark (new `GameThread.GameThreadId` / `RestoreGameThread`), and `E2ETestEnvironment` discards queued actions at construction and teardown (new `GameThread.DiscardQueuedActions`, which releases blocked waiters), with teardown re-marking its own thread so handler `Dispose` bodies run inline.

### 3. Battle-mode gating statics leaked across environments under reused ids
`ServerBattleModeArbiter.modes`, `BattleModeRegistry`, `BattleConclusionGate`, `BattleSpawnGate`, and `BattleSimulationReplay` are process-wide and keyed by object-manager ids — which restart at `MapEvent_Created_1` in every fresh environment. A claim leaked by a test that never finalized its battle silently gated joins, raid updates, and surrender for whichever unrelated class ran next — producing the order-dependent "different subsets each run" pattern (xUnit class order shifts between builds). The environment ctor now resets them next to the existing `PlayerPartyInteractionDialogState.Clear()` precedent.

### Supporting hardening
- `MeshNetworkRouter` deliveries now suspend the sender's `AllowedThread` allowance exactly like `TestNetworkRouter.Deliver` — receivers were inheriting the sender's allowance and silently skipping every receive-path patch.
- `MessageCollection`/`PacketCollection` guard their lists — background-thread sends were racing test-thread assertions with no exception on loss.
- `OutputSinkManager` snapshots its callback list under a lock and survives a dead xUnit `ITestOutputHelper` being logged to from a background thread after its test ended.

## Verification (local, Release)

- `CoopUnitTests.slnf`: **1,535 passed, 0 failed** (Common, CrashReporter, Coop, IntegrationTests, GameInterface)
- Full `E2E.Tests` suite in a single process: **1,171 passed, 0 failed, 4 skipped** (7m59s)
- The previously-failing suites also green when run as standalone chunks (MapEvents 187/187, Villages+Siege+Missions 646/646)

The flake does not reproduce locally (it is load-dependent, CI-only), so the real proof is CI stability over the next batch of PR runs — but each fixed mechanism is individually confirmed against the CI log breadcrumbs it produces.

Related but **not** part of this flake (deterministic branch-side failures found during log mining, owners notified separately): hideout-sync's `_isSpotted` intercept test mismatch, and more-barters' `AmbiguousMatchException` on the new `EndEngagement` overload.