### PR TITLE
Replicate kingdom membership changes to clients

### DIFF
--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -8,6 +8,7 @@ using Coop.Core.Server.Services.Stances.Messages;
 using E2E.Tests.Environment;
 using E2E.Tests.Environment.Instance;
 using E2E.Tests.Util;
+using GameInterface.Services.GameDebug.Commands;
 using GameInterface.Services.Clans.Messages;
 using GameInterface.Services.Entity;
 using GameInterface.Services.GameDebug.Messages;
@@ -322,6 +323,119 @@ public class PlayerKingdomCreationFlowTests : IDisposable
             message => message.ClanId == player.ClanId);
         Assert.Equal(kingdomId, factionChanged.OldKingdomId);
         Assert.Null(factionChanged.NewKingdomId);
+    }
+
+    // Every kingdom-membership path funnels through ChangeKingdomAction.ApplyInternal, which
+    // ClanKingdomMembershipReplicationPatch now postfixes on the server. Before that, only the call
+    // sites that remembered to call MoveClanToKingdom replicated; expel/leave/rebellion did not, so
+    // clients kept listing a departed clan in the kingdom roster until reload. This drives the
+    // vanilla action directly - NOT a debug command that republishes on its own - so it fails if the
+    // systemic patch is removed even while the command-level fixes stay in place.
+    [Fact]
+    public void LeavingAKingdom_ReplicatesRosterRemovalToClients()
+    {
+        var player = CreateSyncedPlayerContext();
+        var kingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+
+        // Seed through the vanilla action rather than raw field writes: writes made under
+        // AllowedThread deliberately bypass the sync publish, so a hand-seeded roster never reaches
+        // the clients and the "before" state would be empty. Joining this way also exercises the
+        // patch in the other direction.
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(kingdomId, out var kingdom));
+            Assert.True(Server.ObjectManager.TryGetObject<Clan>(player.ClanId, out var clan));
+            ChangeKingdomAction.ApplyByJoinToKingdom(clan, kingdom, showNotification: false);
+        });
+
+        foreach (var client in Clients)
+        {
+            client.Call(() =>
+            {
+                Assert.True(client.ObjectManager.TryGetObject<Kingdom>(kingdomId, out var kingdom));
+                Assert.True(client.ObjectManager.TryGetObject<Clan>(player.ClanId, out var clan));
+                Assert.Same(kingdom, clan.Kingdom);
+                Assert.Contains(clan, kingdom.Clans);
+            });
+        }
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Clan>(player.ClanId, out var clan));
+            ChangeKingdomAction.ApplyByLeaveKingdom(clan, showNotification: false);
+        });
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(kingdomId, out var kingdom));
+            Assert.True(Server.ObjectManager.TryGetObject<Clan>(player.ClanId, out var clan));
+            Assert.Null(clan.Kingdom);
+            Assert.DoesNotContain(clan, kingdom.Clans);
+        });
+
+        foreach (var client in Clients)
+        {
+            client.Call(() =>
+            {
+                Assert.True(client.ObjectManager.TryGetObject<Kingdom>(kingdomId, out var kingdom));
+                Assert.True(client.ObjectManager.TryGetObject<Clan>(player.ClanId, out var clan));
+                Assert.Null(clan.Kingdom);
+                Assert.DoesNotContain(clan, kingdom.Clans);
+            });
+        }
+    }
+
+    // coop.debug.clan.join_kingdom is the in-game lever used to verify lord recruitment, and it used
+    // to call ChangeKingdomAction.ApplyByJoinToKingdom on its own. Clan._kingdom is AutoSynced, so a
+    // client would agree the clan had switched sides while the destination kingdom's own roster
+    // still omitted it - the kingdom screen and every Kingdom.Clans consumer stayed stale.
+    [Fact]
+    public void JoinKingdomCommand_ReplicatesKingdomRosterToClients()
+    {
+        var player = CreateSyncedPlayerContext();
+        var previousKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var newKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(previousKingdomId, out var previousKingdom));
+            Assert.True(Server.ObjectManager.TryGetObject<Clan>(player.ClanId, out var clan));
+
+            using (new AllowedThread())
+            {
+                clan._kingdom = previousKingdom;
+                previousKingdom._clans ??= new MBList<Clan>();
+                previousKingdom._clans.Add(clan);
+            }
+        });
+
+        Server.Call(() =>
+        {
+            var result = ClanDebugCommands.JoinKingdom(new List<string> { player.ClanId, newKingdomId });
+            Assert.Contains("joined", result);
+
+            Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(previousKingdomId, out var previousKingdom));
+            Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(newKingdomId, out var newKingdom));
+            Assert.True(Server.ObjectManager.TryGetObject<Clan>(player.ClanId, out var clan));
+
+            Assert.Same(newKingdom, clan.Kingdom);
+            Assert.Contains(clan, newKingdom.Clans);
+            Assert.DoesNotContain(clan, previousKingdom.Clans);
+        });
+
+        foreach (var client in Clients)
+        {
+            client.Call(() =>
+            {
+                Assert.True(client.ObjectManager.TryGetObject<Kingdom>(previousKingdomId, out var previousKingdom));
+                Assert.True(client.ObjectManager.TryGetObject<Kingdom>(newKingdomId, out var newKingdom));
+                Assert.True(client.ObjectManager.TryGetObject<Clan>(player.ClanId, out var clan));
+
+                Assert.Same(newKingdom, clan.Kingdom);
+                Assert.Contains(clan, newKingdom.Clans);
+                Assert.DoesNotContain(clan, previousKingdom.Clans);
+            });
+        }
     }
 
     [Fact]

--- a/source/GameInterface.Tests/Services/Kingdoms/KingdomHandlerTests.cs
+++ b/source/GameInterface.Tests/Services/Kingdoms/KingdomHandlerTests.cs
@@ -1,4 +1,5 @@
 ﻿using Common.Messaging;
+using Common.Network;
 using Common.Util;
 using GameInterface.Services.Kingdoms;
 using GameInterface.Services.Kingdoms.Handlers;
@@ -54,7 +55,8 @@ public class KingdomHandlerTests
             new Mock<IKingdomDecisionVoteManager>().Object,
             new Mock<IKingdomMembershipState>().Object,
             new Mock<IKingdomInterface>().Object,
-            new Mock<IKingdomCreator>().Object);
+            new Mock<IKingdomCreator>().Object,
+            new Mock<INetwork>().Object);
     }
 
     private static bool TryGetCulture(KingdomHandler handler, string cultureId, out CultureObject culture)

--- a/source/GameInterface/Services/Barters/Handlers/LordBarterHandler.cs
+++ b/source/GameInterface/Services/Barters/Handlers/LordBarterHandler.cs
@@ -1,4 +1,4 @@
-using Common;
+﻿using Common;
 using Common.Logging;
 using Common.Messaging;
 using Common.Network;
@@ -37,7 +37,6 @@ internal sealed partial class LordBarterHandler : IHandler
     private readonly IObjectManager objectManager;
     private readonly INetwork network;
     private readonly IPlayerManager playerManager;
-    private readonly IKingdomMembershipState kingdomMembershipState;
     private readonly ConversationPartyTracker conversationPartyTracker;
     private readonly LocationConversationTracker locationConversationTracker;
     private readonly IBarterClientPresentation presentation;
@@ -54,7 +53,6 @@ internal sealed partial class LordBarterHandler : IHandler
         IObjectManager objectManager,
         INetwork network,
         IPlayerManager playerManager,
-        IKingdomMembershipState kingdomMembershipState,
         ConversationPartyTracker conversationPartyTracker,
         LocationConversationTracker locationConversationTracker,
         IBarterClientPresentation presentation,
@@ -66,7 +64,6 @@ internal sealed partial class LordBarterHandler : IHandler
         this.objectManager = objectManager;
         this.network = network;
         this.playerManager = playerManager;
-        this.kingdomMembershipState = kingdomMembershipState;
         this.conversationPartyTracker = conversationPartyTracker;
         this.locationConversationTracker = locationConversationTracker;
         this.presentation = presentation;
@@ -190,9 +187,6 @@ internal sealed partial class LordBarterHandler : IHandler
 
             var kind = (LordBarterKind)request.Kind;
             var isSafePassage = kind == LordBarterKind.SafePassage;
-            var previousTargetKingdom = kind == LordBarterKind.JoinKingdomAsClan
-                ? targetHero.Clan.Kingdom
-                : null;
             IReadOnlyList<MobileParty> safePassageOpponents = Array.Empty<MobileParty>();
             float offerValue;
             if (isSafePassage)
@@ -231,15 +225,9 @@ internal sealed partial class LordBarterHandler : IHandler
                 }
             }
 
-            if (kind == LordBarterKind.JoinKingdomAsClan)
-            {
-                kingdomMembershipState.MoveClanToKingdom(
-                    previousTargetKingdom,
-                    targetKingdom,
-                    targetHero.Clan,
-                    publishCollectionChanges: true,
-                    republishExistingCollections: true);
-            }
+            // JoinKingdomAsClanBarterable.Apply ends in a ChangeKingdomAction on every path it can
+            // take, so ClanKingdomMembershipReplicationPatch has already republished the kingdom's
+            // collections and broadcast the membership by the time the loop above returns.
 
             if (isSafePassage)
                 ApplySafePassage(

--- a/source/GameInterface/Services/Clans/Commands/ClanDebugCommands.cs
+++ b/source/GameInterface/Services/Clans/Commands/ClanDebugCommands.cs
@@ -152,7 +152,20 @@ namespace GameInterface.Services.GameDebug.Commands
                 return $"Argument2: Kingdom not found by ID: {kingdomId}";
             }
 
+            if (!ContainerProvider.TryResolve<IKingdomMembershipState>(out var kingdomMembershipState))
+                return $"Unable to get {nameof(IKingdomMembershipState)}";
+
+            Kingdom previousKingdom = clan.Kingdom;
             ChangeKingdomAction.ApplyByJoinToKingdom(clan, newKingdom);
+
+            // Same reason as join_kingdom/leave_kingdom: the vanilla action alone does not
+            // replicate the kingdom's own clan/fief collections to clients.
+            kingdomMembershipState.MoveClanToKingdom(
+                previousKingdom,
+                newKingdom,
+                clan,
+                publishCollectionChanges: true,
+                republishExistingCollections: true);
 
             return clan.Name.ToString() + " has join the kingdom : " + newKingdom.Name.ToString();
         }
@@ -366,7 +379,20 @@ namespace GameInterface.Services.GameDebug.Commands
             if (objectManager.TryGetObject<Kingdom>(args[1], out var kingdom) == false)
                 return $"Unable to get Kingdom with {args[1]}";
 
+            if (ContainerProvider.TryResolve<IKingdomMembershipState>(out var kingdomMembershipState) == false)
+                return $"Unable to get {nameof(IKingdomMembershipState)}";
+
+            Kingdom previousKingdom = clan.Kingdom;
             ChangeKingdomAction.ApplyByJoinToKingdom(clan, kingdom);
+
+            // Mirrors leave_kingdom: the vanilla action alone leaves clients with a clan that
+            // claims the kingdom while the kingdom's own roster still omits it.
+            kingdomMembershipState.MoveClanToKingdom(
+                previousKingdom,
+                kingdom,
+                clan,
+                publishCollectionChanges: true,
+                republishExistingCollections: true);
 
             return $"{clan.Name} joined {kingdom.Name}";
         }

--- a/source/GameInterface/Services/Clans/Commands/ClanDebugCommands.cs
+++ b/source/GameInterface/Services/Clans/Commands/ClanDebugCommands.cs
@@ -152,20 +152,9 @@ namespace GameInterface.Services.GameDebug.Commands
                 return $"Argument2: Kingdom not found by ID: {kingdomId}";
             }
 
-            if (!ContainerProvider.TryResolve<IKingdomMembershipState>(out var kingdomMembershipState))
-                return $"Unable to get {nameof(IKingdomMembershipState)}";
-
-            Kingdom previousKingdom = clan.Kingdom;
+            // The collections replicate through ClanKingdomMembershipReplicationPatch, which postfixes
+            // ChangeKingdomAction.ApplyInternal - every entry point funnels through it.
             ChangeKingdomAction.ApplyByJoinToKingdom(clan, newKingdom);
-
-            // Same reason as join_kingdom/leave_kingdom: the vanilla action alone does not
-            // replicate the kingdom's own clan/fief collections to clients.
-            kingdomMembershipState.MoveClanToKingdom(
-                previousKingdom,
-                newKingdom,
-                clan,
-                publishCollectionChanges: true,
-                republishExistingCollections: true);
 
             return clan.Name.ToString() + " has join the kingdom : " + newKingdom.Name.ToString();
         }
@@ -379,20 +368,8 @@ namespace GameInterface.Services.GameDebug.Commands
             if (objectManager.TryGetObject<Kingdom>(args[1], out var kingdom) == false)
                 return $"Unable to get Kingdom with {args[1]}";
 
-            if (ContainerProvider.TryResolve<IKingdomMembershipState>(out var kingdomMembershipState) == false)
-                return $"Unable to get {nameof(IKingdomMembershipState)}";
-
-            Kingdom previousKingdom = clan.Kingdom;
+            // Replication is handled by ClanKingdomMembershipReplicationPatch on ApplyInternal.
             ChangeKingdomAction.ApplyByJoinToKingdom(clan, kingdom);
-
-            // Mirrors leave_kingdom: the vanilla action alone leaves clients with a clan that
-            // claims the kingdom while the kingdom's own roster still omits it.
-            kingdomMembershipState.MoveClanToKingdom(
-                previousKingdom,
-                kingdom,
-                clan,
-                publishCollectionChanges: true,
-                republishExistingCollections: true);
 
             return $"{clan.Name} joined {kingdom.Name}";
         }
@@ -416,22 +393,14 @@ namespace GameInterface.Services.GameDebug.Commands
             if (clan.Kingdom == null)
                 return $"{clan.Name} does not belong to a kingdom";
 
-            if (!ContainerProvider.TryResolve<IKingdomMembershipState>(out var kingdomMembershipState))
-                return $"Unable to get {nameof(IKingdomMembershipState)}";
+            string kingdomName = clan.Kingdom.Name.ToString();
 
-            Kingdom previousKingdom = clan.Kingdom;
-            string kingdomName = previousKingdom.Name.ToString();
+            // Replication is handled by ClanKingdomMembershipReplicationPatch on ApplyInternal, which
+            // also sends the explicit "no kingdom" message AutoSync cannot express.
             if (clan.IsUnderMercenaryService)
                 ChangeKingdomAction.ApplyByLeaveKingdomAsMercenary(clan);
             else
                 ChangeKingdomAction.ApplyByLeaveKingdom(clan);
-
-            kingdomMembershipState.MoveClanToKingdom(
-                previousKingdom,
-                kingdom: null,
-                clan: clan,
-                publishCollectionChanges: true,
-                republishExistingCollections: true);
 
             return $"{clan.Name} left {kingdomName}";
         }

--- a/source/GameInterface/Services/Clans/Handlers/VassalServiceHandler.cs
+++ b/source/GameInterface/Services/Clans/Handlers/VassalServiceHandler.cs
@@ -23,20 +23,17 @@ internal class VassalServiceHandler : IHandler
     private static readonly ILogger Logger = LogManager.GetLogger<VassalServiceHandler>();
 
     private readonly IMessageBroker messageBroker;
-    private readonly IKingdomMembershipState kingdomMembershipState;
     private readonly IObjectManager objectManager;
     private readonly INetwork network;
     private readonly IPlayerManager playerManager;
 
     public VassalServiceHandler(
         IMessageBroker messageBroker,
-        IKingdomMembershipState kingdomMembershipState,
         IObjectManager objectManager,
         INetwork network,
         IPlayerManager playerManager)
     {
         this.messageBroker = messageBroker;
-        this.kingdomMembershipState = kingdomMembershipState;
         this.objectManager = objectManager;
         this.network = network;
         this.playerManager = playerManager;
@@ -105,10 +102,10 @@ internal class VassalServiceHandler : IHandler
             return false;
         }
 
-        Kingdom previousKingdom = clan.Kingdom;
-
         if (clan.Kingdom == kingdom)
         {
+            // Promoting a mercenary already in this kingdom only clears IsUnderMercenaryService; the
+            // kingdom's rosters do not change, so there is nothing to republish here.
             if (!clan.IsUnderMercenaryService)
             {
                 Logger.Warning("Rejected vassal service request because clan {ClanId} already belongs to kingdom {KingdomId}", clanId, kingdomId);
@@ -130,6 +127,8 @@ internal class VassalServiceHandler : IHandler
                 EndMercenaryServiceAction.EndByLeavingKingdom(clan);
             }
 
+            // ClanKingdomMembershipReplicationPatch postfixes ApplyInternal, so the kingdom's clan and
+            // fief collections are republished from there.
             ChangeKingdomAction.ApplyByJoinToKingdom(clan, kingdom);
         }
 
@@ -139,12 +138,6 @@ internal class VassalServiceHandler : IHandler
             return false;
         }
 
-        kingdomMembershipState.MoveClanToKingdom(
-            previousKingdom,
-            kingdom,
-            clan,
-            publishCollectionChanges: true,
-            republishExistingCollections: true);
         if (!kingdom.Clans.Contains(clan))
         {
             Logger.Error("Vassal service did not add clan {ClanId} to kingdom {KingdomId} collections", clanId, kingdomId);

--- a/source/GameInterface/Services/Clans/Patches/ClanKingdomMembershipReplicationPatch.cs
+++ b/source/GameInterface/Services/Clans/Patches/ClanKingdomMembershipReplicationPatch.cs
@@ -1,0 +1,69 @@
+using Common;
+using Common.Logging;
+using Common.Messaging;
+using GameInterface.Services.Kingdoms;
+using GameInterface.Services.Kingdoms.Messages;
+using HarmonyLib;
+using Serilog;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Actions;
+
+namespace GameInterface.Services.Clans.Patches;
+
+/// <summary>
+/// Republishes kingdom membership collections after any server-side kingdom change.
+/// </summary>
+/// <remarks>
+/// <see cref="Clan"/>._kingdom is AutoSynced, but the kingdom's own <c>_clans</c>, <c>_fiefsCache</c>,
+/// <c>_townsCache</c> and <c>_settlementsCache</c> are not reliably intercepted. Without this, clients
+/// agree the clan changed sides while the kingdom's roster still lists it in the old kingdom - the
+/// kingdom screen and every Kingdom.Clans consumer stay stale until a reload.
+///
+/// Individual call sites used to fix this one at a time, so each new membership path (expel, leave,
+/// rebellion, clan destruction, a host-initiated defection that never reaches LordBarterHandler) had
+/// to remember to do it, and most did not. Every one of them funnels through ApplyInternal, so the
+/// republish belongs here rather than in each caller.
+///
+/// MoveClanToKingdom and KingdomCollectionSync.AddClan are idempotent, so call sites that already
+/// republish explicitly stay correct.
+/// </remarks>
+[HarmonyPatch(typeof(ChangeKingdomAction), "ApplyInternal")]
+internal class ClanKingdomMembershipReplicationPatch
+{
+    private static readonly ILogger Logger = LogManager.GetLogger<ClanKingdomMembershipReplicationPatch>();
+
+    [HarmonyPrefix]
+    private static void Prefix(Clan clan, out Kingdom __state)
+    {
+        // Captured before the action mutates it; the postfix needs the kingdom being left.
+        __state = clan?.Kingdom;
+    }
+
+    [HarmonyPostfix]
+    private static void Postfix(Clan clan, Kingdom __state)
+    {
+        if (!ModInformation.IsServer || clan == null) return;
+
+        var newKingdom = clan.Kingdom;
+        if (ReferenceEquals(newKingdom, __state)) return;
+
+        if (!ContainerProvider.TryResolve<IKingdomMembershipState>(out var kingdomMembershipState))
+        {
+            Logger.Error("Kingdom membership changed for clan {Clan} before the membership state was available",
+                clan.StringId);
+            return;
+        }
+
+        kingdomMembershipState.MoveClanToKingdom(
+            __state,
+            newKingdom,
+            clan,
+            publishCollectionChanges: true,
+            republishExistingCollections: true);
+
+        // The kingdom's collections are handled above, but Clan._kingdom itself is an AutoSynced
+        // reference field and AutoSync cannot send a null one (it keys on the object id), so a clan
+        // that left, was expelled or rebelled stayed a member on every client. Send it explicitly.
+        MessageBroker.Instance.Publish(clan, new ClanKingdomMembershipChanged(clan, newKingdom));
+    }
+}

--- a/source/GameInterface/Services/Clans/Patches/ClanKingdomMembershipReplicationPatch.cs
+++ b/source/GameInterface/Services/Clans/Patches/ClanKingdomMembershipReplicationPatch.cs
@@ -21,11 +21,14 @@ namespace GameInterface.Services.Clans.Patches;
 ///
 /// Individual call sites used to fix this one at a time, so each new membership path (expel, leave,
 /// rebellion, clan destruction, a host-initiated defection that never reaches LordBarterHandler) had
-/// to remember to do it, and most did not. Every one of them funnels through ApplyInternal, so the
-/// republish belongs here rather than in each caller.
+/// to remember to do it, and most did not. Every ChangeKingdomAction entry point funnels through
+/// ApplyInternal, so the republish belongs here rather than in each caller, and the callers that
+/// used to do it themselves have had that removed - two republishes of the same collections is
+/// idempotent but sends every snapshot twice.
 ///
-/// MoveClanToKingdom and KingdomCollectionSync.AddClan are idempotent, so call sites that already
-/// republish explicitly stay correct.
+/// Call sites that change membership WITHOUT a ChangeKingdomAction - KingdomDebugCommand and
+/// PlayerPartyInteractionOutcomeHandler drive IKingdomMembershipState directly, which is what moves
+/// the clan - are unaffected by this patch and still publish for themselves.
 /// </remarks>
 [HarmonyPatch(typeof(ChangeKingdomAction), "ApplyInternal")]
 internal class ClanKingdomMembershipReplicationPatch

--- a/source/GameInterface/Services/Kingdoms/Handlers/KingdomHandler.cs
+++ b/source/GameInterface/Services/Kingdoms/Handlers/KingdomHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Common.Logging;
 using Common.Messaging;
+using Common.Network;
 using Common;
 using Common.Extensions;
 using Common.Util;
@@ -32,6 +33,7 @@ public class KingdomHandler : IHandler
     private readonly IKingdomMembershipState kingdomMembershipState;
     private readonly IKingdomInterface kingdomInterface;
     private readonly IKingdomCreator kingdomCreator;
+    private readonly INetwork network;
 
     public KingdomHandler(
         IMessageBroker messageBroker,
@@ -40,7 +42,8 @@ public class KingdomHandler : IHandler
         IKingdomDecisionVoteManager decisionVoteManager,
         IKingdomMembershipState kingdomMembershipState,
         IKingdomInterface kingdomInterface,
-        IKingdomCreator kingdomCreator)
+        IKingdomCreator kingdomCreator,
+        INetwork network)
     {
         this.messageBroker = messageBroker;
         this.objectManager = objectManager;
@@ -49,6 +52,7 @@ public class KingdomHandler : IHandler
         this.kingdomMembershipState = kingdomMembershipState;
         this.kingdomInterface = kingdomInterface;
         this.kingdomCreator = kingdomCreator;
+        this.network = network;
         messageBroker.Subscribe<AddDecision>(HandleAddDecision);
         messageBroker.Subscribe<RemoveDecision>(HandleRemoveDecision);
         messageBroker.Subscribe<ChangeKingdomPolicy>(HandleChangeKingdomPolicy);
@@ -57,6 +61,78 @@ public class KingdomHandler : IHandler
         messageBroker.Subscribe<ApplyKingdomDecisionResolved>(HandleApplyKingdomDecisionResolved);
         messageBroker.Subscribe<CreateKingdom>(HandleCreateKingdom);
         messageBroker.Subscribe<PlayerKingdomCreated>(HandlePlayerKingdomCreated);
+        messageBroker.Subscribe<ClanKingdomMembershipChanged>(HandleClanKingdomMembershipChanged);
+        messageBroker.Subscribe<NetworkClanKingdomMembershipChanged>(HandleNetworkClanKingdomMembershipChanged);
+    }
+
+    /// <summary>Server: broadcast the clan's authoritative kingdom, including "none".</summary>
+    private void HandleClanKingdomMembershipChanged(MessagePayload<ClanKingdomMembershipChanged> payload)
+    {
+        if (!ModInformation.IsServer) return;
+        if (!objectManager.TryGetIdWithLogging(payload.What.Clan, out var clanId)) return;
+
+        // A null kingdom is the whole point of this message; only resolve an id when there is one.
+        string kingdomId = null;
+        if (payload.What.Kingdom != null &&
+            !objectManager.TryGetIdWithLogging(payload.What.Kingdom, out kingdomId)) return;
+
+        network.SendAll(new NetworkClanKingdomMembershipChanged(clanId, kingdomId));
+    }
+
+    /// <summary>Client: apply the authoritative kingdom the server sent.</summary>
+    private void HandleNetworkClanKingdomMembershipChanged(MessagePayload<NetworkClanKingdomMembershipChanged> payload)
+    {
+        if (!ModInformation.IsClient) return;
+
+        var data = payload.What;
+        GameThread.RunSafe(() =>
+        {
+            if (!objectManager.TryGetObjectWithLogging<Clan>(data.ClanId, out var clan)) return;
+
+            Kingdom kingdom = null;
+            if (data.KingdomId != null &&
+                !objectManager.TryGetObjectWithLogging<Kingdom>(data.KingdomId, out kingdom)) return;
+
+            if (ReferenceEquals(clan.Kingdom, kingdom)) return;
+
+            using (new AllowedThread())
+            {
+                clan._kingdom = kingdom;
+            }
+
+            // The kingdom's own rosters arrive as their own collection messages; keeping the local
+            // caches consistent here avoids a window where the clan points at a kingdom that does
+            // not list it (or vice versa).
+            kingdomMembershipState.MoveClanToKingdom(
+                previousKingdom: null,
+                kingdom,
+                clan,
+                publishCollectionChanges: false);
+
+            RefreshSettlementVisuals(clan);
+        },
+            context: nameof(NetworkClanKingdomMembershipChanged));
+    }
+
+    /// <summary>
+    /// Redraws the map banners of every settlement the clan holds after its kingdom changed.
+    /// </summary>
+    /// <remarks>
+    /// A settlement's map colour comes from its owner clan's kingdom, so a defection silently changes
+    /// how every one of that clan's fiefs should look - but nothing invalidates the visual, so the
+    /// client keeps drawing the old realm's banner until something else happens to dirty it. The
+    /// ownership path already does this (SettlementOwnershipHandler); the kingdom-change path did not.
+    /// </remarks>
+    private static void RefreshSettlementVisuals(Clan clan)
+    {
+        var settlements = clan?.Settlements;
+        if (settlements == null) return;
+
+        foreach (var settlement in settlements)
+        {
+            // Villages included: they carry the owning clan's colours too.
+            settlement?.Party?.SetVisualAsDirty();
+        }
     }
 
     private void HandleCreateKingdom(MessagePayload<CreateKingdom> obj)
@@ -398,5 +474,7 @@ public class KingdomHandler : IHandler
         messageBroker.Unsubscribe<ApplyKingdomDecisionResolved>(HandleApplyKingdomDecisionResolved);
         messageBroker.Unsubscribe<CreateKingdom>(HandleCreateKingdom);
         messageBroker.Unsubscribe<PlayerKingdomCreated>(HandlePlayerKingdomCreated);
+        messageBroker.Unsubscribe<ClanKingdomMembershipChanged>(HandleClanKingdomMembershipChanged);
+        messageBroker.Unsubscribe<NetworkClanKingdomMembershipChanged>(HandleNetworkClanKingdomMembershipChanged);
     }
 }

--- a/source/GameInterface/Services/Kingdoms/Handlers/KingdomHandler.cs
+++ b/source/GameInterface/Services/Kingdoms/Handlers/KingdomHandler.cs
@@ -93,21 +93,26 @@ public class KingdomHandler : IHandler
             if (data.KingdomId != null &&
                 !objectManager.TryGetObjectWithLogging<Kingdom>(data.KingdomId, out kingdom)) return;
 
-            if (ReferenceEquals(clan.Kingdom, kingdom)) return;
-
-            using (new AllowedThread())
+            // Only MOVE the clan when the value actually changed - but always refresh the visuals below.
+            // The _kingdom AutoSync packet usually lands before this explicit message, so by the time it
+            // arrives the value already matches and returning early here left every fief the clan holds
+            // still flying its old kingdom's colours until something else happened to redraw them.
+            if (!ReferenceEquals(clan.Kingdom, kingdom))
             {
-                clan._kingdom = kingdom;
-            }
+                using (new AllowedThread())
+                {
+                    clan._kingdom = kingdom;
+                }
 
-            // The kingdom's own rosters arrive as their own collection messages; keeping the local
-            // caches consistent here avoids a window where the clan points at a kingdom that does
-            // not list it (or vice versa).
-            kingdomMembershipState.MoveClanToKingdom(
-                previousKingdom: null,
-                kingdom,
-                clan,
-                publishCollectionChanges: false);
+                // The kingdom's own rosters arrive as their own collection messages; keeping the local
+                // caches consistent here avoids a window where the clan points at a kingdom that does
+                // not list it (or vice versa).
+                kingdomMembershipState.MoveClanToKingdom(
+                    previousKingdom: null,
+                    kingdom,
+                    clan,
+                    publishCollectionChanges: false);
+            }
 
             RefreshSettlementVisuals(clan);
         },

--- a/source/GameInterface/Services/Kingdoms/Messages/ClanKingdomMembershipChanged.cs
+++ b/source/GameInterface/Services/Kingdoms/Messages/ClanKingdomMembershipChanged.cs
@@ -1,0 +1,51 @@
+using Common.Messaging;
+using ProtoBuf;
+using TaleWorlds.CampaignSystem;
+
+namespace GameInterface.Services.Kingdoms.Messages;
+
+/// <summary>
+/// Raised on the server whenever a clan's kingdom changes, so the new value can be replicated
+/// explicitly rather than relying on the AutoSync reference field.
+/// </summary>
+internal readonly struct ClanKingdomMembershipChanged : IEvent
+{
+    public readonly Clan Clan;
+    public readonly Kingdom Kingdom;
+
+    public ClanKingdomMembershipChanged(Clan clan, Kingdom kingdom)
+    {
+        Clan = clan;
+        Kingdom = kingdom;
+    }
+}
+
+/// <summary>
+/// The authoritative kingdom a clan now belongs to. A null <see cref="KingdomId"/> means "no kingdom".
+/// </summary>
+/// <remarks>
+/// AutoSync cannot express this. Its reference-field templates key on the object id
+/// (<c>if (!objectManager.TryGetId(data.Value, out string id)) return;</c>), and a null reference has
+/// no id - so the set is never sent, and on the receiving side <c>TryGetObject</c> fails so it is
+/// never applied. Assigning a synced reference field to null is therefore silently dropped.
+///
+/// For kingdom membership that meant a clan which left, was expelled, or rebelled stayed a member on
+/// every client until the next reload. The join direction always worked, which is why it went
+/// unnoticed. This message carries the value either way, so it is correct rather than merely
+/// covering the null case.
+/// </remarks>
+[ProtoContract(SkipConstructor = true)]
+public readonly struct NetworkClanKingdomMembershipChanged : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string ClanId;
+
+    [ProtoMember(2)]
+    public readonly string KingdomId;
+
+    public NetworkClanKingdomMembershipChanged(string clanId, string kingdomId)
+    {
+        ClanId = clanId;
+        KingdomId = kingdomId;
+    }
+}


### PR DESCRIPTION
### Issues

- **#2724** — "Canceling a kingdom leaves players marked as kingdom members". This is the null case above: the server clears `Clan._kingdom`, but AutoSync keys on an object id and cannot express a null reference, so clients kept the clan in the destroyed kingdom and refused to let it join another. The explicit `ClanKingdomMembershipChanged` message added here carries "no kingdom". Worth a retest by the reporter before closing — the report says a restart did not clear it, which this change would not explain on its own.
- **#2559** — "Joining a kingdom as a vassal does not change all colors", specifically *"settlements are not highlighted"*. That half is fixed here: settlement visuals are refreshed on every membership change, and the second commit covers the case where the refresh was skipped because the AutoSync packet had already made the values match. The banner and shield colours the reporter also mentions are **not** addressed by this PR.

### What was broken

`Clan._kingdom` is AutoSynced, but the kingdom's own `_clans` / `_fiefsCache` collections are not reliably intercepted, so clients kept listing a clan in its old realm until a reload. Worse, AutoSync cannot express a null reference at all — its templates key on the object id — so a clan that left, was expelled or rebelled never lost its kingdom on clients.

A clan's fiefs also kept flying the old kingdom's colours. The `_kingdom` AutoSync packet usually lands before the explicit membership message, so by the time that message arrived the value already matched, the equality check returned early, and `RefreshSettlementVisuals` was skipped.

### What it does now

- Postfixes `ChangeKingdomAction.ApplyInternal` on the server so every membership path — join, leave, expel, rebellion, clan destruction — republishes the collections and broadcasts the authoritative kingdom, including "no kingdom".
- Redraws settlement map banners on apply, since their colour comes from the owning clan's kingdom.
- Makes only the *move* conditional on the kingdom differing; the redraw always runs.
- `coop.debug.clan.join_kingdom` and `change_clan_kingdom` republish too. They previously called the vanilla action alone and so reported a result they had not actually replicated.

### Why this approach

Every other membership mutation in the repo republishes the collections explicitly (see `VassalServiceHandler.ApplyVassalage`); this follows the same pattern rather than adding a new sync mechanism for the null case.

---

### The stack

Split out of #2668 so each PR fixes a single problem. Review and merge bottom-up: every PR targets the branch below it, and the bottom targets `development`.

1. **#2747 — Replicate kingdom membership changes to clients** ← this PR
2. #2748 — Restore lord recruitment by persuasion
3. #2749 — Fix barters being refused, double-applied or misreported
4. #2750 — Let clients grant fiefs, and pay the relation for it
5. #2751 — Make retreating from a battle server-authoritative
6. #2752 — Fix breaking into a besieged settlement, and the capture aftermath menu
7. #2753 — Make besieged settlements sortie, and fix which side a relief force joins
8. #2754 — Add debug commands for driving siege and sortie scenarios
9. #2755 — Free a captor holding a captured player, and replicate army joins
10. #2756 — Pull nearby AI parties into a player's battle, and keep Surrender working
11. #2757 — Fix battle deployment wedging and sides spawning nothing
12. #2758 — Stop silently dropping party state, and a 4,200 line/sec log flood
13. #2759 — Split the methods the analyzer flagged as too complex

