### PR TITLE
Fix barters being refused, double-applied or misreported

### DIFF
--- a/source/Coop.Tests/GameInterface/Services/MapEvents/ConversationPartyTrackerTests.cs
+++ b/source/Coop.Tests/GameInterface/Services/MapEvents/ConversationPartyTrackerTests.cs
@@ -94,18 +94,28 @@ public class ConversationPartyTrackerTests
         Assert.False(tracker.IsEmpty);
     }
 
+    // Replaces TryEndEngagement_SharedParty_ReleasesOnlyAfterLastPlayer, which asserted that two
+    // players could hold the same party at once. Sharing existed so simultaneous ATTACKERS converged
+    // on one MapEvent, but every server-side conversation outcome is authorised only as "this peer
+    // holds an engagement with this party", so a shared hold also let two players each apply the same
+    // one-shot result - two recruiters persuading one lord, both paying, the lord defecting twice.
+    // Attackers still converge: the holder starts the battle and the contender's retry joins that
+    // MapEvent through the attackerInMapEvent/defenderInMapEvent branch in ConversationRequestHandler.
     [Fact]
-    public void TryEndEngagement_SharedParty_ReleasesOnlyAfterLastPlayer()
+    public void TryBeginEngagement_PartyHeldByAnotherPlayer_IsRejectedUntilReleased()
     {
         tracker.TryBeginEngagement(firstPlayer, "player1", "lord1", wasAiDisabled: false);
-        Assert.True(tracker.TryBeginEngagement(secondPlayer, "player2", "lord1", wasAiDisabled: true));
-        Assert.True(tracker.IsEngagerParty("lord1", "player2"));
 
+        Assert.False(tracker.TryBeginEngagement(secondPlayer, "player2", "lord1", wasAiDisabled: true));
+        Assert.False(tracker.IsEngagerParty("lord1", "player2"));
+        Assert.True(tracker.IsEngagerParty("lord1", "player1"));
+
+        // The holder releasing frees the party outright - there is no second holder to wait for.
         tracker.TryEndEngagement(firstPlayer, out _, out _, out var releaseAfterFirst);
-        Assert.False(releaseAfterFirst);
-        Assert.True(tracker.TryGetEngagement("lord1", out var remaining));
-        Assert.False(remaining.WasAiDisabled);
+        Assert.True(releaseAfterFirst);
+        Assert.True(tracker.IsEmpty);
 
+        Assert.True(tracker.TryBeginEngagement(secondPlayer, "player2", "lord1", wasAiDisabled: true));
         tracker.TryEndEngagement(secondPlayer, out _, out _, out var releaseAfterSecond);
         Assert.True(releaseAfterSecond);
         Assert.True(tracker.IsEmpty);

--- a/source/E2E.Tests/Services/Heroes/LordBarterSyncTests.cs
+++ b/source/E2E.Tests/Services/Heroes/LordBarterSyncTests.cs
@@ -205,6 +205,223 @@ public class LordBarterSyncTests : MapEventTestBase
         });
     }
 
+    /// <summary>
+    /// A lord standing INSIDE a settlement still leads an active party, so the settlement must be
+    /// resolved before the map party. MobileParty.IsActive is only cleared by RemoveParty, player
+    /// captivity and load - entering a settlement leaves it true - so resolving the map party first
+    /// classifies every settlement-menu barter as MapParty. The server then requires a conversation
+    /// hold that a settlement menu never acquires, and refuses the barter after the player has
+    /// already played out the conversation.
+    /// </summary>
+    /// <remarks>
+    /// StationarySettlementConversation_ClientResolversUseSettlementContext above does NOT cover this:
+    /// it asserts the target has no party at all, so the map-party branch cannot match either way.
+    /// </remarks>
+    [Fact]
+    public void SettlementConversation_WithLordLeadingAnActiveParty_StillResolvesSettlementContext()
+    {
+        var client = Clients.First();
+        var player = CreatePartyWithRegisteredLeader();
+        var target = CreatePartyWithRegisteredLeader();
+        var settlementId = TestEnvironment.CreateRegisteredObject<Settlement>();
+
+        SetMainHero(player.HeroId);
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(player.MobilePartyId, out var playerParty));
+            Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(target.MobilePartyId, out var targetParty));
+            Assert.True(Server.ObjectManager.TryGetObject<Settlement>(settlementId, out var settlement));
+
+            playerParty.CurrentSettlement = settlement;
+            targetParty.CurrentSettlement = settlement;
+        });
+
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Hero>(player.HeroId, out var playerHero));
+            Assert.True(client.ObjectManager.TryGetObject<Hero>(target.HeroId, out var targetHero));
+            Assert.True(client.ObjectManager.TryGetObject<MobileParty>(player.MobilePartyId, out var playerParty));
+            Assert.True(client.ObjectManager.TryGetObject<MobileParty>(target.MobilePartyId, out var targetParty));
+
+            // The premise of the bug: the lord's party is inside the settlement AND still active.
+            Assert.True(targetParty.IsActive);
+            Assert.Same(playerParty.CurrentSettlement, targetParty.CurrentSettlement);
+
+            var barter = new BarterData(playerHero, targetHero, playerParty.Party, targetParty.Party, null);
+
+            Assert.True(LordBarterPatch.TryGetConversationContext(
+                barter, client.ObjectManager, out var lordContext, out var lordContextId));
+            Assert.Equal(PeaceConversationContext.Settlement, lordContext);
+            Assert.Equal(settlementId, lordContextId);
+
+            Assert.True(PeaceBarterPatch.TryGetConversationContext(
+                barter, client.ObjectManager, out var peaceContext, out var peaceContextId));
+            Assert.Equal(PeaceConversationContext.Settlement, peaceContext);
+            Assert.Equal(settlementId, peaceContextId);
+        });
+    }
+
+    /// <summary>
+    /// The reordering above must not steal an ordinary map conversation: on the map neither side has a
+    /// CurrentSettlement, so the settlement branch cannot match and the map party still wins.
+    /// </summary>
+    [Fact]
+    public void MapConversation_WithNeitherSideInASettlement_StillResolvesMapPartyContext()
+    {
+        var client = Clients.First();
+        var player = CreatePartyWithRegisteredLeader();
+        var target = CreatePartyWithRegisteredLeader();
+
+        SetMainHero(player.HeroId);
+
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Hero>(player.HeroId, out var playerHero));
+            Assert.True(client.ObjectManager.TryGetObject<Hero>(target.HeroId, out var targetHero));
+            Assert.True(client.ObjectManager.TryGetObject<MobileParty>(player.MobilePartyId, out var playerParty));
+            Assert.True(client.ObjectManager.TryGetObject<MobileParty>(target.MobilePartyId, out var targetParty));
+
+            Assert.Null(playerParty.CurrentSettlement);
+            Assert.Null(targetParty.CurrentSettlement);
+
+            var barter = new BarterData(playerHero, targetHero, playerParty.Party, targetParty.Party, null);
+
+            Assert.True(LordBarterPatch.TryGetConversationContext(
+                barter, client.ObjectManager, out var lordContext, out _));
+            Assert.Equal(PeaceConversationContext.MapParty, lordContext);
+
+            Assert.True(PeaceBarterPatch.TryGetConversationContext(
+                barter, client.ObjectManager, out var peaceContext, out _));
+            Assert.Equal(PeaceConversationContext.MapParty, peaceContext);
+        });
+    }
+
+    /// <summary>
+    /// A settlement-menu conversation acquires no engagement, so authority comes from co-location - and
+    /// co-location is NOT exclusive: every player standing in the settlement satisfies it. Without a
+    /// reservation, two kingdom leaders could each authorize, each pay, and each move the same clan in
+    /// turn, which is the very duplication the map-party hold exists to prevent.
+    /// </summary>
+    [Fact]
+    public void SettlementConversation_WhenAnotherPlayerHoldsTheLord_RefusesTheSecondAuthorization()
+    {
+        const int initialPlayerGold = 1_000_000;
+        const int offeredGold = 100_000;
+        var clientOne = Clients.First();
+        var clientTwo = Clients.Skip(1).First();
+        var playerOne = CreatePartyWithRegisteredLeader();
+        var playerTwo = CreatePartyWithRegisteredLeader();
+        var targetHeroId = TestEnvironment.CreateRegisteredObject<Hero>();
+        var settlementId = TestEnvironment.CreateRegisteredObject<Settlement>();
+        var requestOne = Guid.NewGuid().ToString("N");
+        var requestTwo = Guid.NewGuid().ToString("N");
+
+        RegisterPlayer(clientOne, playerOne.HeroId, playerOne.MobilePartyId, "PlayerOne");
+        RegisterPlayer(clientTwo, playerTwo.HeroId, playerTwo.MobilePartyId, "PlayerTwo");
+        Server.Call(() =>
+        {
+            new GoldBarterBehavior().RegisterEvents();
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(playerOne.HeroId, out var heroOne));
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(playerTwo.HeroId, out var heroTwo));
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(targetHeroId, out var targetHero));
+            Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(playerOne.MobilePartyId, out var partyOne));
+            Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(playerTwo.MobilePartyId, out var partyTwo));
+            Assert.True(Server.ObjectManager.TryGetObject<Settlement>(settlementId, out var settlement));
+
+            heroOne.Gold = initialPlayerGold;
+            heroTwo.Gold = initialPlayerGold;
+            // Both players are standing in the same settlement as the lord, so both satisfy co-location.
+            partyOne.CurrentSettlement = settlement;
+            partyTwo.CurrentSettlement = settlement;
+            targetHero.StayingInSettlement = settlement;
+        });
+        Server.NetworkSentMessages.Clear();
+
+        clientOne.Call(() => clientOne.Resolve<INetwork>().SendAll(new NetworkAuthorizeLordBarter(
+            requestOne, targetHeroId, PeaceConversationContext.Settlement, settlementId, LordBarterKind.Generic)));
+        clientTwo.Call(() => clientTwo.Resolve<INetwork>().SendAll(new NetworkAuthorizeLordBarter(
+            requestTwo, targetHeroId, PeaceConversationContext.Settlement, settlementId, LordBarterKind.Generic)));
+
+        // The second player never got an authorization, so their request must be refused outright.
+        clientTwo.Call(() => clientTwo.Resolve<INetwork>().SendAll(new NetworkRequestLordBarter(
+            targetHeroId, PeaceConversationContext.Settlement, settlementId, LordBarterKind.Generic,
+            new[] { new PeaceBarterTerm(PeaceBarterTermType.Gold, playerTwo.HeroId, null, null, true, offeredGold) },
+            requestTwo)));
+        TestEnvironment.FlushCoalescer();
+
+        var refused = Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkLordBarterResult>());
+        Assert.False(refused.Accepted);
+        Server.NetworkSentMessages.Clear();
+
+        // The holder is unaffected: their barter still goes through.
+        clientOne.Call(() => clientOne.Resolve<INetwork>().SendAll(new NetworkRequestLordBarter(
+            targetHeroId, PeaceConversationContext.Settlement, settlementId, LordBarterKind.Generic,
+            new[] { new PeaceBarterTerm(PeaceBarterTermType.Gold, playerOne.HeroId, null, null, true, offeredGold) },
+            requestOne)));
+        TestEnvironment.FlushCoalescer();
+
+        var accepted = Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkLordBarterResult>());
+        Assert.True(accepted.Accepted);
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(playerOne.HeroId, out var heroOne));
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(playerTwo.HeroId, out var heroTwo));
+            // Paid exactly once, by the holder.
+            Assert.Equal(initialPlayerGold - offeredGold, heroOne.Gold);
+            Assert.Equal(initialPlayerGold, heroTwo.Gold);
+        });
+    }
+
+    /// <summary>
+    /// The reservation must not lock a lord for the rest of the session. Cancelling releases it, which is
+    /// the path a player takes by backing out of the conversation; expiry uses the same released-if-not-live
+    /// check in IsTargetHeldByAnotherPeer.
+    /// </summary>
+    [Fact]
+    public void SettlementConversation_AfterTheHolderCancels_TheLordIsAvailableAgain()
+    {
+        var clientOne = Clients.First();
+        var clientTwo = Clients.Skip(1).First();
+        var playerOne = CreatePartyWithRegisteredLeader();
+        var playerTwo = CreatePartyWithRegisteredLeader();
+        var targetHeroId = TestEnvironment.CreateRegisteredObject<Hero>();
+        var settlementId = TestEnvironment.CreateRegisteredObject<Settlement>();
+        var requestOne = Guid.NewGuid().ToString("N");
+        var requestTwo = Guid.NewGuid().ToString("N");
+
+        RegisterPlayer(clientOne, playerOne.HeroId, playerOne.MobilePartyId, "PlayerOne");
+        RegisterPlayer(clientTwo, playerTwo.HeroId, playerTwo.MobilePartyId, "PlayerTwo");
+        Server.Call(() =>
+        {
+            new GoldBarterBehavior().RegisterEvents();
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(targetHeroId, out var targetHero));
+            Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(playerOne.MobilePartyId, out var partyOne));
+            Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(playerTwo.MobilePartyId, out var partyTwo));
+            Assert.True(Server.ObjectManager.TryGetObject<Settlement>(settlementId, out var settlement));
+            partyOne.CurrentSettlement = settlement;
+            partyTwo.CurrentSettlement = settlement;
+            targetHero.StayingInSettlement = settlement;
+        });
+
+        clientOne.Call(() => clientOne.Resolve<INetwork>().SendAll(new NetworkAuthorizeLordBarter(
+            requestOne, targetHeroId, PeaceConversationContext.Settlement, settlementId, LordBarterKind.Generic)));
+        clientOne.Call(() => clientOne.Resolve<INetwork>().SendAll(
+            new NetworkCancelLordBarterAuthorization(requestOne)));
+
+        clientTwo.Call(() => clientTwo.Resolve<INetwork>().SendAll(new NetworkAuthorizeLordBarter(
+            requestTwo, targetHeroId, PeaceConversationContext.Settlement, settlementId, LordBarterKind.Generic)));
+        Server.NetworkSentMessages.Clear();
+
+        clientTwo.Call(() => clientTwo.Resolve<INetwork>().SendAll(new NetworkRequestLordBarter(
+            targetHeroId, PeaceConversationContext.Settlement, settlementId, LordBarterKind.Generic,
+            Array.Empty<PeaceBarterTerm>(), requestTwo)));
+        TestEnvironment.FlushCoalescer();
+
+        var result = Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkLordBarterResult>());
+        Assert.True(result.Accepted);
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
@@ -953,8 +1170,10 @@ public class LordBarterSyncTests : MapEventTestBase
     }
 
     private void RegisterPlayer(EnvironmentInstance client, string heroId, string mobilePartyId)
+        => RegisterPlayer(client, heroId, mobilePartyId, "PlayerOne");
+
+    private void RegisterPlayer(EnvironmentInstance client, string heroId, string mobilePartyId, string controllerId)
     {
-        const string controllerId = "PlayerOne";
         client.Resolve<IControllerIdProvider>().SetControllerId(controllerId);
         RegisterAsPlayerParty(controllerId, heroId, mobilePartyId);
         Server.Resolve<IPlayerManager>().SetPeer(controllerId, client.NetPeer);

--- a/source/E2E.Tests/Services/Heroes/RomanceMarriageBarterSyncTests.cs
+++ b/source/E2E.Tests/Services/Heroes/RomanceMarriageBarterSyncTests.cs
@@ -1,4 +1,4 @@
-using Common.Util;
+﻿using Common.Util;
 using Common.Network;
 using E2E.Tests.Environment.Instance;
 using E2E.Tests.Services.MapEvents;
@@ -213,6 +213,105 @@ public class RomanceMarriageBarterSyncTests : MapEventTestBase
         if (id == "str_barter_agreed")
             throw new NullReferenceException("Server conversation presentation was invoked.");
     }
+
+    /// <summary>
+    /// Once the barterables have been applied the gold has already moved on the authoritative server, so a
+    /// later failure must NOT be reported as a rejection - the client would roll its UI back over a change
+    /// that really happened, and the two sides would disagree about the gold. The spouse links failing is
+    /// worth logging, but the answer to the client is still "accepted".
+    /// </summary>
+    [Fact]
+    public void PersonalMarriageBarter_WhenSpouseLinksDoNotTakeAfterApply_StillReportsSuccess()
+    {
+        const int initialPlayerGold = 1_000_000;
+        const int offeredGold = 250_000;
+
+        var client = Clients.First();
+        var player = CreatePartyWithRegisteredLeader();
+        var counterparty = CreatePartyWithRegisteredLeader();
+        var spouseId = TestEnvironment.CreateRegisteredObject<Hero>();
+        var settlementId = TestEnvironment.CreateRegisteredObject<Settlement>();
+        var requestId = Guid.NewGuid().ToString("N");
+        var harmony = new Harmony($"e2e.marriage-links-fail.{Guid.NewGuid():N}");
+
+        RegisterPlayer(client, player.HeroId, player.MobilePartyId);
+        SetMainHero(player.HeroId);
+
+        try
+        {
+            Server.Call(() =>
+            {
+                new GoldBarterBehavior().RegisterEvents();
+
+                // Suppress ONLY the marriage barterable, so every other barterable (the gold) still
+                // applies. That reproduces "the mutation landed but the spouse links did not".
+                harmony.Patch(
+                    AccessTools.Method(typeof(MarriageBarterable), nameof(MarriageBarterable.Apply)),
+                    prefix: new HarmonyMethod(
+                        typeof(RomanceMarriageBarterSyncTests),
+                        nameof(SuppressMarriageBarterableApply)));
+
+                Assert.True(Server.ObjectManager.TryGetObject<Hero>(player.HeroId, out var playerHero));
+                Assert.True(Server.ObjectManager.TryGetObject<Hero>(counterparty.HeroId, out var counterpartyHero));
+                Assert.True(Server.ObjectManager.TryGetObject<Hero>(spouseId, out var spouse));
+                Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(player.MobilePartyId, out var playerParty));
+                Assert.True(Server.ObjectManager.TryGetObject<Settlement>(settlementId, out var settlement));
+
+                playerHero.SetBirthDay(CampaignTime.YearsFromNow(-30f));
+                spouse.SetBirthDay(CampaignTime.YearsFromNow(-25f));
+                playerHero.Occupation = Occupation.Lord;
+                spouse.Occupation = Occupation.Lord;
+                spouse.IsFemale = !playerHero.IsFemale;
+                spouse.Clan = counterpartyHero.Clan;
+                playerHero.Gold = initialPlayerGold;
+
+                playerParty.CurrentSettlement = settlement;
+                counterpartyHero.PartyBelongedTo = null;
+                counterpartyHero.StayingInSettlement = settlement;
+
+                Romance.SetRomanticState(playerHero, spouse, Romance.RomanceLevelEnum.CoupleAgreedOnMarriage);
+            });
+            Server.NetworkSentMessages.Clear();
+
+            client.Call(() => client.Resolve<INetwork>().SendAll(new NetworkAuthorizeMarriageBarter(
+                requestId, counterparty.HeroId, MarriageConversationContext.Settlement, settlementId,
+                spouseId, player.HeroId)));
+
+            client.Call(() => client.Resolve<INetwork>().SendAll(new NetworkRequestMarriageBarter(
+                counterparty.HeroId, MarriageConversationContext.Settlement, settlementId,
+                spouseId, player.HeroId,
+                new[]
+                {
+                    new MarriageBarterTerm(
+                        MarriageBarterTermType.Gold, player.HeroId, objectId: null,
+                        itemModifierId: null, itemModifierNull: true, amount: offeredGold),
+                },
+                requestId)));
+            TestEnvironment.FlushCoalescer();
+
+            var result = Server.NetworkSentMessages.GetMessages<NetworkMarriageBarterResult>().Single();
+
+            Server.Call(() =>
+            {
+                Assert.True(Server.ObjectManager.TryGetObject<Hero>(spouseId, out var spouse));
+                Assert.True(Server.ObjectManager.TryGetObject<Hero>(player.HeroId, out var playerHero));
+
+                // Premise: the links really did not take...
+                Assert.NotEqual(playerHero, spouse.Spouse);
+                // ...and the gold really did move, which is why a rejection would be the desync.
+                Assert.Equal(initialPlayerGold - offeredGold, playerHero.Gold);
+            });
+
+            Assert.True(result.Accepted);
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmony.Id);
+        }
+
+    }
+
+    private static bool SuppressMarriageBarterableApply() => false;
 
     [Theory]
     [InlineData(false, false, false)]

--- a/source/E2E.Tests/Services/Heroes/RomanceMarriageBarterSyncTests.cs
+++ b/source/E2E.Tests/Services/Heroes/RomanceMarriageBarterSyncTests.cs
@@ -308,7 +308,6 @@ public class RomanceMarriageBarterSyncTests : MapEventTestBase
         {
             harmony.UnpatchAll(harmony.Id);
         }
-
     }
 
     private static bool SuppressMarriageBarterableApply() => false;

--- a/source/GameInterface.Tests/Services/MapEvents/ConversationPartyTrackerTests.cs
+++ b/source/GameInterface.Tests/Services/MapEvents/ConversationPartyTrackerTests.cs
@@ -61,4 +61,28 @@ public class ConversationPartyTrackerTests
             requireRequestIdMatch: true));
         tracker.Dispose();
     }
+
+    // A held party belongs to exactly one player. Server-side conversation outcomes are authorised
+    // only as "this peer holds an engagement with this party", so a shared hold let two players each
+    // apply the same one-shot result - two recruiters persuading one lord, both paying, the lord
+    // defecting twice.
+    [Fact]
+    public void TryBeginEngagement_WhenPartyEngagedByAnotherPlayer_Fails()
+    {
+        var tracker = new ConversationPartyTracker(new Mock<IObjectManager>().Object);
+        var firstPlayer = new object();
+        var secondPlayer = new object();
+
+        Assert.True(tracker.TryBeginEngagement(firstPlayer, "player1", "lord1", wasAiDisabled: false));
+        Assert.False(tracker.TryBeginEngagement(secondPlayer, "player2", "lord1", wasAiDisabled: true));
+        Assert.False(tracker.TryGetEngagement(secondPlayer, out _));
+
+        // The holder still owns it, and releasing frees the party for the next player.
+        Assert.True(tracker.TryEndEngagement(firstPlayer, out _, out _, out var shouldRelease));
+        Assert.True(shouldRelease);
+        Assert.True(tracker.TryBeginEngagement(secondPlayer, "player2", "lord1", wasAiDisabled: false));
+
+        Assert.True(tracker.TryEndEngagement(secondPlayer, out _, out _, out _));
+        tracker.Dispose();
+    }
 }

--- a/source/GameInterface/Services/Barters/Handlers/LordBarterHandler.cs
+++ b/source/GameInterface/Services/Barters/Handlers/LordBarterHandler.cs
@@ -458,8 +458,23 @@ internal sealed partial class LordBarterHandler : IHandler
         playerParty = mobileParty.Party;
         targetParty = targetHero.PartyBelongedTo?.Party;
 
-        var context = (PeaceConversationContext)request.Context;
-        if (context == PeaceConversationContext.MapParty)
+        var conversationContext = (PeaceConversationContext)request.Context;
+        if (conversationContext == PeaceConversationContext.Settlement)
+        {
+            // A settlement-menu conversation acquires no engagement - there is no agent and no
+            // location mission to lock - so authority comes from co-location instead: both the
+            // requesting party and the target must actually be inside the settlement named by the
+            // request. That is as strong as the hold for this case, because a player who is not in
+            // the settlement cannot be talking to someone who is.
+            if (!objectManager.TryGetObject(request.ContextId, out Settlement conversationSettlement) ||
+                mobileParty.CurrentSettlement != conversationSettlement ||
+                targetHero.CurrentSettlement != conversationSettlement)
+            {
+                reason = "The lord settlement conversation is no longer active.";
+                return false;
+            }
+        }
+        else if (conversationContext == PeaceConversationContext.MapParty)
         {
             if (!objectManager.TryGetObject(request.ContextId, out PartyBase requestedParty) ||
                 requestedParty != targetParty ||
@@ -475,7 +490,7 @@ internal sealed partial class LordBarterHandler : IHandler
                 return false;
             }
         }
-        else if (context == PeaceConversationContext.Location)
+        else if (conversationContext == PeaceConversationContext.Location)
         {
             if (targetHero.CharacterObject == null ||
                 !objectManager.TryGetId(targetHero.CharacterObject, out var characterId) ||
@@ -488,13 +503,10 @@ internal sealed partial class LordBarterHandler : IHandler
         }
         else
         {
-            if (!objectManager.TryGetObject(request.ContextId, out Settlement settlement) ||
-                mobileParty.CurrentSettlement != settlement ||
-                targetHero.CurrentSettlement != settlement)
-            {
-                reason = "The lord settlement conversation is no longer active.";
-                return false;
-            }
+            // Refused rather than validated as a settlement conversation - accepting a context we do
+            // not understand is how an unvalidated barter gets through.
+            reason = "The lord conversation context is not supported.";
+            return false;
         }
 
         if (targetHero.IsPrisoner || targetHero.Clan == null)

--- a/source/GameInterface/Services/Barters/Handlers/LordBarterHandler.cs
+++ b/source/GameInterface/Services/Barters/Handlers/LordBarterHandler.cs
@@ -89,14 +89,16 @@ internal sealed partial class LordBarterHandler : IHandler
         messageBroker.Unsubscribe<PlayerDisconnected>(HandlePlayerDisconnected);
 
         // Every other access to these dictionaries happens on the game thread (handlers are drained
-        // there), so clearing them from the disposing thread is a data race. Marshal, as
-        // ConversationPartyTracker.Dispose does.
+        // there), so clearing them from the disposing thread would be a data race - marshal instead.
+        // NOT blocking: Dispose runs during container teardown, when the game loop may already have
+        // stopped pumping, and a blocking wait there just times out after 30s and fails the teardown.
+        // If the queued clear never runs, the handler is being discarded anyway.
         GameThread.RunSafe(() =>
         {
             authorizations.Clear();
             completedResults.Clear();
         },
-            blocking: true,
+            blocking: false,
             context: nameof(LordBarterHandler));
 
         LordBarterPatch.ClearPendingRequest();

--- a/source/GameInterface/Services/Barters/Handlers/LordBarterHandler.cs
+++ b/source/GameInterface/Services/Barters/Handlers/LordBarterHandler.cs
@@ -372,6 +372,19 @@ internal sealed partial class LordBarterHandler : IHandler
             return;
         }
 
+        // A map-party conversation is already exclusive: ConversationPartyTracker holds the target for
+        // exactly one peer. A settlement-menu conversation acquires no such hold - authority there is
+        // co-location - and co-location is NOT exclusive: every player standing in the settlement
+        // satisfies it, so without this two kingdom leaders could each authorize, each pay, and each
+        // move the same clan in turn. Reserve the target hero for one peer at a time.
+        if (IsTargetHeldByAnotherPeer(peer, authorization.TargetHeroId))
+        {
+            Logger.Warning(
+                "Rejected lord barter authorization for {TargetHeroId}: another player is already negotiating with that lord",
+                authorization.TargetHeroId);
+            return;
+        }
+
         authorizations[peer] = new LordBarterAuthorization(
             authorization.RequestId,
             authorization.TargetHeroId,
@@ -381,6 +394,26 @@ internal sealed partial class LordBarterHandler : IHandler
             authorization.TargetKingdomId,
             DateTime.UtcNow.Add(AuthorizationLifetime));
         completedResults.Remove(peer);
+    }
+
+    /// <summary>
+    /// Whether a DIFFERENT peer already holds a live authorization against this lord. Expired entries
+    /// do not reserve anything, so a player who walked away cannot block the lord for the rest of the
+    /// session - the authorization lifetime is what releases it.
+    /// </summary>
+    private bool IsTargetHeldByAnotherPeer(NetPeer peer, string targetHeroId)
+    {
+        if (string.IsNullOrEmpty(targetHeroId)) return false;
+
+        var now = DateTime.UtcNow;
+        foreach (var entry in authorizations)
+        {
+            if (entry.Key == peer) continue;
+            if (entry.Value.ExpiresAtUtc <= now) continue;
+            if (entry.Value.TargetHeroId == targetHeroId) return true;
+        }
+
+        return false;
     }
 
     private bool TryGetAuthorization(
@@ -739,7 +772,7 @@ internal sealed partial class LordBarterHandler : IHandler
     private sealed class LordBarterAuthorization
     {
         public string RequestId { get; }
-        private string TargetHeroId { get; }
+        public string TargetHeroId { get; }
         private int Context { get; }
         private string ContextId { get; }
         private int Kind { get; }

--- a/source/GameInterface/Services/Barters/Handlers/LordBarterHandler.cs
+++ b/source/GameInterface/Services/Barters/Handlers/LordBarterHandler.cs
@@ -205,25 +205,9 @@ internal sealed partial class LordBarterHandler : IHandler
             var previousTargetKingdom = kind == LordBarterKind.JoinKingdomAsClan
                 ? targetHero.Clan.Kingdom
                 : null;
-            IReadOnlyList<MobileParty> safePassageOpponents = Array.Empty<MobileParty>();
-            float offerValue;
-            if (isSafePassage)
-            {
-                var safePassageOffer = EvaluateSafePassageOffer(
-                    barter,
-                    playerHero,
-                    playerParty.MobileParty,
-                targetHero,
-                targetParty.MobileParty);
-                safePassageOpponents = safePassageOffer.OpponentParties;
-                offerValue = safePassageOffer.OfferValue;
-            }
-            else
-            {
-                offerValue = BarterManager.Instance.GetOfferValueForFaction(
-                    barter,
-                    targetHero.Clan);
-            }
+
+            var (offerValue, safePassageOpponents) =
+                EvaluateOffer(barter, playerHero, playerParty, targetHero, targetParty, isSafePassage);
 
             if (offerValue < -0.01f)
             {
@@ -253,61 +237,20 @@ internal sealed partial class LordBarterHandler : IHandler
             authorizations.Remove(peer);
             mutationStarted = true;
 
-            // Captured before Apply(), which is what moves the clan out of targetHero's reach.
-            var joinTargetClan = (LordBarterKind)request.Kind == LordBarterKind.JoinKingdomAsClan
-                ? targetHero.Clan
-                : null;
-
-            var offered = barter.GetOfferedBarterables();
-            foreach (var barterable in offered)
-            {
-                if (!(barterable is SafePassageBarterable) &&
-                    !(barterable is NoAttackBarterable))
-                {
-                    barterable.Apply();
-                }
-            }
-
-            // Clan._kingdom is AutoSynced, but the Kingdom._clans / fief collections are not reliably
-            // intercepted, so clients would otherwise see the clan claim the kingdom while the
-            // kingdom's own roster still omitted it. The clan and its previous kingdom are captured
-            // BEFORE Apply() above, which is what moves the clan out of targetHero's reach.
-            if (joinTargetClan != null)
-            {
-                kingdomMembershipState.MoveClanToKingdom(
-                    previousTargetKingdom,
-                    targetKingdom,
-                    joinTargetClan,
-                    publishCollectionChanges: true,
-                    republishExistingCollections: true);
-
-                if (targetKingdom != null && !targetKingdom.Clans.Contains(joinTargetClan))
-                {
-                    Logger.Error(
-                        "Lord defection did not add clan {Clan} to kingdom {Kingdom} collections",
-                        joinTargetClan.StringId,
-                        targetKingdom.StringId);
-                }
-
-                ApplyDefectionPersuasionXp(playerHero, request.PersuasionOutcomes);
-            }
-
-            if (isSafePassage)
-                ApplySafePassage(
-                    targetParty?.MobileParty,
-                    playerParty?.MobileParty,
-                    safePassageOpponents);
-
-            CampaignEventDispatcher.Instance.OnBarterAccepted(playerHero, targetHero, offered);
-            ApplyOverpayRelationBonus(playerHero, targetHero, offerValue);
-
-            if (isSafePassage)
-                ConversationPartyHold.EndEngagement(conversationPartyTracker, peer);
-
-            FlushGold(playerHero);
-            FlushGold(targetHero);
-            FlushHeroDeveloper(playerHero);
-            SendAccepted(peer, request, playerHero.Gold);
+            ApplyAcceptedBarter(
+                peer,
+                request,
+                barter,
+                playerHero,
+                playerParty,
+                targetHero,
+                targetParty,
+                targetKingdom,
+                previousTargetKingdom,
+                kind,
+                isSafePassage,
+                offerValue,
+                safePassageOpponents);
         }
         catch (Exception exception)
         {
@@ -320,6 +263,119 @@ internal sealed partial class LordBarterHandler : IHandler
 
             Reject(peer, request, playerHero?.Gold ?? 0, "The server could not process the lord barter.");
         }
+    }
+
+    /// <summary>
+    /// What the target thinks the offer is worth. Safe passage is priced against the parties it
+    /// would call off; everything else against the target's clan.
+    /// </summary>
+    private (float OfferValue, IReadOnlyList<MobileParty> OpponentParties) EvaluateOffer(
+        BarterData barter,
+        Hero playerHero,
+        PartyBase playerParty,
+        Hero targetHero,
+        PartyBase targetParty,
+        bool isSafePassage)
+    {
+        if (isSafePassage)
+        {
+            return EvaluateSafePassageOffer(
+                barter, playerHero, playerParty.MobileParty, targetHero, targetParty.MobileParty);
+        }
+
+        return (BarterManager.Instance.GetOfferValueForFaction(barter, targetHero.Clan),
+                Array.Empty<MobileParty>());
+    }
+
+    /// <summary>
+    /// Commits an accepted barter.
+    /// </summary>
+    /// <remarks>
+    /// Everything here runs past the point of no return - the authorization has been spent and
+    /// mutationStarted is set - so a throw from this point on is reported as success rather than
+    /// telling the client to roll back a change the server really made.
+    /// </remarks>
+    private void ApplyAcceptedBarter(
+        NetPeer peer,
+        NetworkRequestLordBarter request,
+        BarterData barter,
+        Hero playerHero,
+        PartyBase playerParty,
+        Hero targetHero,
+        PartyBase targetParty,
+        Kingdom targetKingdom,
+        Kingdom previousTargetKingdom,
+        LordBarterKind kind,
+        bool isSafePassage,
+        float offerValue,
+        IReadOnlyList<MobileParty> safePassageOpponents)
+    {
+        // Captured before Apply(), which is what moves the clan out of targetHero's reach.
+        var joinTargetClan = kind == LordBarterKind.JoinKingdomAsClan ? targetHero.Clan : null;
+
+        var offered = barter.GetOfferedBarterables();
+        foreach (var barterable in offered)
+        {
+            if (!(barterable is SafePassageBarterable) &&
+                !(barterable is NoAttackBarterable))
+            {
+                barterable.Apply();
+            }
+        }
+
+        if (joinTargetClan != null)
+            CompleteDefection(playerHero, request, joinTargetClan, previousTargetKingdom, targetKingdom);
+
+        if (isSafePassage)
+            ApplySafePassage(
+                targetParty?.MobileParty,
+                playerParty?.MobileParty,
+                safePassageOpponents);
+
+        CampaignEventDispatcher.Instance.OnBarterAccepted(playerHero, targetHero, offered);
+        ApplyOverpayRelationBonus(playerHero, targetHero, offerValue);
+
+        if (isSafePassage)
+            ConversationPartyHold.EndEngagement(conversationPartyTracker, peer);
+
+        FlushGold(playerHero);
+        FlushGold(targetHero);
+        FlushHeroDeveloper(playerHero);
+        SendAccepted(peer, request, playerHero.Gold);
+    }
+
+    /// <summary>
+    /// Moves the defecting clan into its new kingdom and awards the persuasion XP.
+    /// </summary>
+    /// <remarks>
+    /// Clan._kingdom is AutoSynced, but the Kingdom._clans / fief collections are not reliably
+    /// intercepted, so clients would otherwise see the clan claim the kingdom while the kingdom's
+    /// own roster still omitted it. The clan and its previous kingdom are captured BEFORE the
+    /// barterables are applied, which is what moves the clan out of targetHero's reach.
+    /// </remarks>
+    private void CompleteDefection(
+        Hero playerHero,
+        NetworkRequestLordBarter request,
+        Clan joinTargetClan,
+        Kingdom previousTargetKingdom,
+        Kingdom targetKingdom)
+    {
+        kingdomMembershipState.MoveClanToKingdom(
+            previousTargetKingdom,
+            targetKingdom,
+            joinTargetClan,
+            publishCollectionChanges: true,
+            republishExistingCollections: true);
+
+        if (targetKingdom != null && !targetKingdom.Clans.Contains(joinTargetClan))
+        {
+            Logger.Error(
+                "Lord defection did not add clan {Clan} to kingdom {Kingdom} collections",
+                joinTargetClan.StringId,
+                targetKingdom.StringId);
+        }
+
+        ApplyDefectionPersuasionXp(playerHero, request.PersuasionOutcomes);
     }
 
     private void ProcessAuthorization(NetPeer peer, NetworkAuthorizeLordBarter authorization)
@@ -454,37 +510,19 @@ internal sealed partial class LordBarterHandler : IHandler
         targetParty = null;
         reason = null;
 
-        // Persuasion outcomes only belong on a defection, and the count is bounded so a tampered
-        // client cannot claim an arbitrary number of successful attempts. Rejected outright rather
-        // than truncated, so a malformed request fails loudly instead of earning partial credit.
-        if (string.IsNullOrEmpty(request.RequestId) ||
-            !Enum.IsDefined(typeof(PeaceConversationContext), request.Context) ||
-            !Enum.IsDefined(typeof(LordBarterKind), request.Kind) ||
-            (request.PersuasionOutcomes != null &&
-             (request.PersuasionOutcomes.Length > LordBarterPatch.MaxDefectionPersuasionOutcomes ||
-              ((LordBarterKind)request.Kind != LordBarterKind.JoinKingdomAsClan &&
-               request.PersuasionOutcomes.Length > 0))))
+        if (!IsRequestWellFormed(request))
         {
             reason = "The server received an invalid lord barter request format.";
             return false;
         }
 
-        if (!playerManager.TryGetPlayer(peer, out Player player) ||
-            !objectManager.TryGetObject(player.HeroId, out playerHero) ||
-            !objectManager.TryGetObject(player.MobilePartyId, out MobileParty mobileParty) ||
-            !objectManager.TryGetObject(request.TargetHeroId, out targetHero))
+        if (!TryResolveParticipants(peer, request, out playerHero, out var mobileParty, out targetHero))
         {
             reason = "The server could not identify the lord barter participants.";
             return false;
         }
 
-        // IsAlive matches MarriageBarterHandler's participant check: a hero can die between the
-        // authorization and the request, and every barterable dereferences both heroes.
-        if (targetHero.IsPlayerHero() ||
-            !targetHero.IsAlive ||
-            !playerHero.IsAlive ||
-            mobileParty.LeaderHero != playerHero ||
-            !mobileParty.IsActive)
+        if (!AreParticipantsAvailable(playerHero, targetHero, mobileParty))
         {
             reason = "The lord barter participants are no longer available.";
             return false;
@@ -493,56 +531,8 @@ internal sealed partial class LordBarterHandler : IHandler
         playerParty = mobileParty.Party;
         targetParty = targetHero.PartyBelongedTo?.Party;
 
-        var conversationContext = (PeaceConversationContext)request.Context;
-        if (conversationContext == PeaceConversationContext.Settlement)
-        {
-            // A settlement-menu conversation acquires no engagement - there is no agent and no
-            // location mission to lock - so authority comes from co-location instead: both the
-            // requesting party and the target must actually be inside the settlement named by the
-            // request. That is as strong as the hold for this case, because a player who is not in
-            // the settlement cannot be talking to someone who is.
-            if (!objectManager.TryGetObject(request.ContextId, out Settlement conversationSettlement) ||
-                mobileParty.CurrentSettlement != conversationSettlement ||
-                targetHero.CurrentSettlement != conversationSettlement)
-            {
-                reason = "The lord settlement conversation is no longer active.";
-                return false;
-            }
-        }
-        else if (conversationContext == PeaceConversationContext.MapParty)
-        {
-            if (!objectManager.TryGetObject(request.ContextId, out PartyBase requestedParty) ||
-                requestedParty != targetParty ||
-                requestedParty.MobileParty?.IsActive != true ||
-                requestedParty.MobileParty.MapEvent != null ||
-                mobileParty.MapEvent != null ||
-                !objectManager.TryGetId(playerParty, out var playerPartyId) ||
-                !conversationPartyTracker.TryGetEngagement(peer, out var engagement) ||
-                engagement.PartyId != request.ContextId ||
-                engagement.EngagerPartyId != playerPartyId)
-            {
-                reason = "The lord conversation is no longer active.";
-                return false;
-            }
-        }
-        else if (conversationContext == PeaceConversationContext.Location)
-        {
-            if (targetHero.CharacterObject == null ||
-                !objectManager.TryGetId(targetHero.CharacterObject, out var characterId) ||
-                !locationConversationTracker.TryGetEngagement(peer, out var npcKey) ||
-                npcKey != LocationConversationTracker.ComposeKey(request.ContextId, characterId))
-            {
-                reason = "The lord conversation is no longer active.";
-                return false;
-            }
-        }
-        else
-        {
-            // Refused rather than validated as a settlement conversation - accepting a context we do
-            // not understand is how an unvalidated barter gets through.
-            reason = "The lord conversation context is not supported.";
+        if (!TryValidateConversation(peer, request, mobileParty, playerParty, targetParty, targetHero, out reason))
             return false;
-        }
 
         if (targetHero.IsPrisoner || targetHero.Clan == null)
         {
@@ -550,6 +540,156 @@ internal sealed partial class LordBarterHandler : IHandler
             return false;
         }
 
+        return true;
+    }
+
+    /// <summary>
+    /// Whether the request is structurally valid, before anything is resolved from it.
+    /// </summary>
+    /// <remarks>
+    /// Persuasion outcomes only belong on a defection, and the count is bounded so a tampered
+    /// client cannot claim an arbitrary number of successful attempts. Rejected outright rather
+    /// than truncated, so a malformed request fails loudly instead of earning partial credit.
+    /// </remarks>
+    private static bool IsRequestWellFormed(NetworkRequestLordBarter request)
+    {
+        if (string.IsNullOrEmpty(request.RequestId)) return false;
+        if (!Enum.IsDefined(typeof(PeaceConversationContext), request.Context)) return false;
+        if (!Enum.IsDefined(typeof(LordBarterKind), request.Kind)) return false;
+
+        var outcomes = request.PersuasionOutcomes;
+        if (outcomes == null) return true;
+        if (outcomes.Length > LordBarterPatch.MaxDefectionPersuasionOutcomes) return false;
+
+        return (LordBarterKind)request.Kind == LordBarterKind.JoinKingdomAsClan || outcomes.Length == 0;
+    }
+
+    /// <summary>
+    /// Resolves the requesting player and the target. Outputs stay partially assigned on failure,
+    /// so a caller can still report the requester's gold when the target is what went missing.
+    /// </summary>
+    private bool TryResolveParticipants(
+        NetPeer peer,
+        NetworkRequestLordBarter request,
+        out Hero playerHero,
+        out MobileParty mobileParty,
+        out Hero targetHero)
+    {
+        playerHero = null;
+        mobileParty = null;
+        targetHero = null;
+
+        return playerManager.TryGetPlayer(peer, out Player player) &&
+               objectManager.TryGetObject(player.HeroId, out playerHero) &&
+               objectManager.TryGetObject(player.MobilePartyId, out mobileParty) &&
+               objectManager.TryGetObject(request.TargetHeroId, out targetHero);
+    }
+
+    /// <summary>
+    /// IsAlive matches MarriageBarterHandler's participant check: a hero can die between the
+    /// authorization and the request, and every barterable dereferences both heroes.
+    /// </summary>
+    private static bool AreParticipantsAvailable(Hero playerHero, Hero targetHero, MobileParty mobileParty)
+    {
+        return !targetHero.IsPlayerHero() &&
+               targetHero.IsAlive &&
+               playerHero.IsAlive &&
+               mobileParty.LeaderHero == playerHero &&
+               mobileParty.IsActive;
+    }
+
+    /// <summary>
+    /// Confirms the conversation the request claims is still live, by the rules of its context.
+    /// </summary>
+    private bool TryValidateConversation(
+        NetPeer peer,
+        NetworkRequestLordBarter request,
+        MobileParty mobileParty,
+        PartyBase playerParty,
+        PartyBase targetParty,
+        Hero targetHero,
+        out string reason)
+    {
+        switch ((PeaceConversationContext)request.Context)
+        {
+            case PeaceConversationContext.Settlement:
+                reason = "The lord settlement conversation is no longer active.";
+                return IsSettlementConversationLive(request, mobileParty, targetHero, ref reason);
+
+            case PeaceConversationContext.MapParty:
+                reason = "The lord conversation is no longer active.";
+                return IsMapPartyConversationLive(peer, request, mobileParty, playerParty, targetParty, ref reason);
+
+            case PeaceConversationContext.Location:
+                reason = "The lord conversation is no longer active.";
+                return IsLocationConversationLive(peer, request, targetHero, ref reason);
+
+            default:
+                // Refused rather than validated as a settlement conversation - accepting a context we
+                // do not understand is how an unvalidated barter gets through.
+                reason = "The lord conversation context is not supported.";
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// A settlement-menu conversation acquires no engagement - there is no agent and no location
+    /// mission to lock - so authority comes from co-location instead: both the requesting party and
+    /// the target must actually be inside the settlement named by the request. That is as strong as
+    /// the hold for this case, because a player who is not in the settlement cannot be talking to
+    /// someone who is.
+    /// </summary>
+    private bool IsSettlementConversationLive(
+        NetworkRequestLordBarter request, MobileParty mobileParty, Hero targetHero, ref string reason)
+    {
+        if (!objectManager.TryGetObject(request.ContextId, out Settlement conversationSettlement) ||
+            mobileParty.CurrentSettlement != conversationSettlement ||
+            targetHero.CurrentSettlement != conversationSettlement)
+        {
+            return false;
+        }
+
+        reason = null;
+        return true;
+    }
+
+    private bool IsMapPartyConversationLive(
+        NetPeer peer,
+        NetworkRequestLordBarter request,
+        MobileParty mobileParty,
+        PartyBase playerParty,
+        PartyBase targetParty,
+        ref string reason)
+    {
+        if (!objectManager.TryGetObject(request.ContextId, out PartyBase requestedParty) ||
+            requestedParty != targetParty ||
+            requestedParty.MobileParty?.IsActive != true ||
+            requestedParty.MobileParty.MapEvent != null ||
+            mobileParty.MapEvent != null ||
+            !objectManager.TryGetId(playerParty, out var playerPartyId) ||
+            !conversationPartyTracker.TryGetEngagement(peer, out var engagement) ||
+            engagement.PartyId != request.ContextId ||
+            engagement.EngagerPartyId != playerPartyId)
+        {
+            return false;
+        }
+
+        reason = null;
+        return true;
+    }
+
+    private bool IsLocationConversationLive(
+        NetPeer peer, NetworkRequestLordBarter request, Hero targetHero, ref string reason)
+    {
+        if (targetHero.CharacterObject == null ||
+            !objectManager.TryGetId(targetHero.CharacterObject, out var characterId) ||
+            !locationConversationTracker.TryGetEngagement(peer, out var npcKey) ||
+            npcKey != LocationConversationTracker.ComposeKey(request.ContextId, characterId))
+        {
+            return false;
+        }
+
+        reason = null;
         return true;
     }
 
@@ -688,10 +828,7 @@ internal sealed partial class LordBarterHandler : IHandler
         {
             case PeaceBarterTermType.Gold: return barterable is GoldBarterable;
             case PeaceBarterTermType.Item:
-                if (!(barterable is ItemBarterable item)) return false;
-                var equipment = item.ItemRosterElement.EquipmentElement;
-                if (!objectManager.TryGetId(equipment.Item, out var itemId) || itemId != term.ObjectId || (equipment.ItemModifier == null) != term.ItemModifierNull) return false;
-                return equipment.ItemModifier == null || (objectManager.TryGetId(equipment.ItemModifier, out var modifierId) && modifierId == term.ItemModifierId);
+                return barterable is ItemBarterable item && MatchesItem(item, term);
             case PeaceBarterTermType.Fief:
                 return barterable is FiefBarterable fief && objectManager.TryGetId(fief.TargetSettlement, out var settlementId) && settlementId == term.ObjectId;
             case PeaceBarterTermType.TransferPrisoner:
@@ -700,6 +837,26 @@ internal sealed partial class LordBarterHandler : IHandler
                 return barterable is SetPrisonerFreeBarterable release && MatchesPrisoner(release._prisonerCharacter, term);
             default: return false;
         }
+    }
+
+    /// <summary>
+    /// The item must be the same one, and carry the same modifier - or the same absence of one,
+    /// since an unmodified item and a modified one are different goods at a different price.
+    /// </summary>
+    private bool MatchesItem(ItemBarterable item, PeaceBarterTerm term)
+    {
+        var equipment = item.ItemRosterElement.EquipmentElement;
+
+        if (!objectManager.TryGetId(equipment.Item, out var itemId) ||
+            itemId != term.ObjectId ||
+            (equipment.ItemModifier == null) != term.ItemModifierNull)
+        {
+            return false;
+        }
+
+        return equipment.ItemModifier == null ||
+               (objectManager.TryGetId(equipment.ItemModifier, out var modifierId) &&
+                modifierId == term.ItemModifierId);
     }
 
     private bool MatchesPrisoner(Hero prisoner, PeaceBarterTerm term) => prisoner?.CharacterObject != null && objectManager.TryGetId(prisoner.CharacterObject, out var id) && id == term.ObjectId;

--- a/source/GameInterface/Services/Barters/Handlers/MarriageBarterHandler.cs
+++ b/source/GameInterface/Services/Barters/Handlers/MarriageBarterHandler.cs
@@ -208,33 +208,15 @@ internal sealed class MarriageBarterHandler : IHandler
                 return;
             }
 
-            var offeredBarterables = barterData.GetOfferedBarterables();
-            foreach (var barterable in offeredBarterables)
-                barterable.Apply();
-            // Past this point the marriage and any gold have already moved on the authoritative
-            // server. Anything that fails from here must NOT be reported as a rejection, or the
-            // client rolls its UI back and the two sides disagree about a change that really
-            // happened.
-            mutationApplied = true;
-            CampaignEventDispatcher.Instance.OnBarterAccepted(playerHero, barterData.OtherHero, offeredBarterables);
-            ApplyOverpayRelationBonus(playerHero, barterData.OtherHero, MathF.Max(0f, offerValue));
-            if (heroBeingProposedTo.Spouse != proposingHero || proposingHero.Spouse != heroBeingProposedTo)
-            {
-                // The barterables have already been applied and any gold has already moved, so this
-                // cannot be reported as a rejection - that is the desync, not the fix. Report success
-                // and let the replicated state stand; log it, because a spouse link that did not take
-                // is a real problem worth seeing even though the client must not roll back.
-                Logger.Error(
-                    "Marriage barter applied but the spouse links did not take: {Proposing} <-> {Proposed}",
-                    proposingHero?.StringId,
-                    heroBeingProposedTo?.StringId);
-            }
-
-            FlushHeroGold(playerHero);
-            FlushHeroGold(barterData.OtherHero);
-            FlushHeroGold(heroBeingProposedTo);
-            FlushHeroGold(proposingHero);
-            Accept(peer, request, playerHero.Gold);
+            ApplyMarriage(
+                peer,
+                request,
+                playerHero,
+                barterData,
+                heroBeingProposedTo,
+                proposingHero,
+                offerValue,
+                ref mutationApplied);
         }
         catch (Exception exception)
         {
@@ -253,6 +235,52 @@ internal sealed class MarriageBarterHandler : IHandler
                 playerHero.Gold,
                 "The server could not process the marriage offer.");
         }
+    }
+
+    /// <summary>
+    /// Commits the marriage and reports success.
+    /// </summary>
+    /// <remarks>
+    /// Sets <paramref name="mutationApplied"/> as soon as the barterables land. Past that point the
+    /// marriage and any gold have already moved on the authoritative server, so nothing here may be
+    /// reported as a rejection - the client would roll its UI back over a change that really happened.
+    /// </remarks>
+    private void ApplyMarriage(
+        NetPeer peer,
+        NetworkRequestMarriageBarter request,
+        Hero playerHero,
+        BarterData barterData,
+        Hero heroBeingProposedTo,
+        Hero proposingHero,
+        float offerValue,
+        ref bool mutationApplied)
+    {
+        var offeredBarterables = barterData.GetOfferedBarterables();
+        foreach (var barterable in offeredBarterables)
+            barterable.Apply();
+
+        mutationApplied = true;
+
+        CampaignEventDispatcher.Instance.OnBarterAccepted(playerHero, barterData.OtherHero, offeredBarterables);
+        ApplyOverpayRelationBonus(playerHero, barterData.OtherHero, MathF.Max(0f, offerValue));
+
+        if (heroBeingProposedTo.Spouse != proposingHero || proposingHero.Spouse != heroBeingProposedTo)
+        {
+            // The barterables have already been applied and any gold has already moved, so this
+            // cannot be reported as a rejection - that is the desync, not the fix. Report success
+            // and let the replicated state stand; log it, because a spouse link that did not take
+            // is a real problem worth seeing even though the client must not roll back.
+            Logger.Error(
+                "Marriage barter applied but the spouse links did not take: {Proposing} <-> {Proposed}",
+                proposingHero?.StringId,
+                heroBeingProposedTo?.StringId);
+        }
+
+        FlushHeroGold(playerHero);
+        FlushHeroGold(barterData.OtherHero);
+        FlushHeroGold(heroBeingProposedTo);
+        FlushHeroGold(proposingHero);
+        Accept(peer, request, playerHero.Gold);
     }
 
     private void ProcessAuthorization(NetPeer peer, NetworkAuthorizeMarriageBarter request)

--- a/source/GameInterface/Services/Barters/Handlers/MarriageBarterHandler.cs
+++ b/source/GameInterface/Services/Barters/Handlers/MarriageBarterHandler.cs
@@ -211,6 +211,10 @@ internal sealed class MarriageBarterHandler : IHandler
             var offeredBarterables = barterData.GetOfferedBarterables();
             foreach (var barterable in offeredBarterables)
                 barterable.Apply();
+            // Past this point the marriage and any gold have already moved on the authoritative
+            // server. Anything that fails from here must NOT be reported as a rejection, or the
+            // client rolls its UI back and the two sides disagree about a change that really
+            // happened.
             mutationApplied = true;
             CampaignEventDispatcher.Instance.OnBarterAccepted(playerHero, barterData.OtherHero, offeredBarterables);
             ApplyOverpayRelationBonus(playerHero, barterData.OtherHero, MathF.Max(0f, offerValue));
@@ -231,6 +235,8 @@ internal sealed class MarriageBarterHandler : IHandler
             Logger.Error(exception, "Failed to apply an authoritative marriage barter");
             if (mutationApplied)
             {
+                // The marriage is already done server-side; telling the client it failed would be
+                // the desync, not the fix. Report success and let the replicated state stand.
                 Accept(peer, request, playerHero.Gold);
                 return;
             }

--- a/source/GameInterface/Services/Barters/Handlers/MarriageBarterHandler.cs
+++ b/source/GameInterface/Services/Barters/Handlers/MarriageBarterHandler.cs
@@ -220,8 +220,14 @@ internal sealed class MarriageBarterHandler : IHandler
             ApplyOverpayRelationBonus(playerHero, barterData.OtherHero, MathF.Max(0f, offerValue));
             if (heroBeingProposedTo.Spouse != proposingHero || proposingHero.Spouse != heroBeingProposedTo)
             {
-                Reject(peer, request, playerHero.Gold, "The marriage could not be completed.");
-                return;
+                // The barterables have already been applied and any gold has already moved, so this
+                // cannot be reported as a rejection - that is the desync, not the fix. Report success
+                // and let the replicated state stand; log it, because a spouse link that did not take
+                // is a real problem worth seeing even though the client must not roll back.
+                Logger.Error(
+                    "Marriage barter applied but the spouse links did not take: {Proposing} <-> {Proposed}",
+                    proposingHero?.StringId,
+                    heroBeingProposedTo?.StringId);
             }
 
             FlushHeroGold(playerHero);

--- a/source/GameInterface/Services/Barters/Handlers/PeaceBarterHandler.cs
+++ b/source/GameInterface/Services/Barters/Handlers/PeaceBarterHandler.cs
@@ -1,4 +1,4 @@
-using Common;
+﻿using Common;
 using Common.Logging;
 using Common.Messaging;
 using Common.Network;
@@ -171,6 +171,7 @@ internal sealed class PeaceBarterHandler : IHandler
             Logger.Error(exception, "Failed to apply an authoritative peace barter");
             if (mutationApplied)
             {
+                // Peace is already made server-side; reporting failure would be the desync.
                 Accept(peer, request, playerHero?.Gold ?? 0);
                 return;
             }

--- a/source/GameInterface/Services/Barters/Messages/PeaceBarterMessages.cs
+++ b/source/GameInterface/Services/Barters/Messages/PeaceBarterMessages.cs
@@ -1,4 +1,4 @@
-using Common.Messaging;
+﻿using Common.Messaging;
 using ProtoBuf;
 using System;
 
@@ -17,6 +17,17 @@ internal enum PeaceConversationContext
 {
     MapParty,
     Location,
+
+    /// <summary>
+    /// A conversation held inside a settlement without a location mission - the settlement menu.
+    /// </summary>
+    /// <remarks>
+    /// Talking to a lord from a castle or town menu creates no agent interaction and no
+    /// CampaignMission.Current.Location, so neither the map-party hold nor the location lock is ever
+    /// acquired and every barter from such a conversation was refused. There is nothing to lock here;
+    /// the server instead verifies both parties are in the settlement it was told about.
+    /// Appended, never reordered: the value travels as an int on the wire.
+    /// </remarks>
     Settlement,
 }
 

--- a/source/GameInterface/Services/Barters/Patches/LordBarterPatch.cs
+++ b/source/GameInterface/Services/Barters/Patches/LordBarterPatch.cs
@@ -336,19 +336,25 @@ internal static class LordBarterPatch
             return true;
         }
 
+        if (barterData.OtherParty?.MobileParty?.IsActive == true && manager.TryGetId(barterData.OtherParty, out contextId))
+        {
+            context = PeaceConversationContext.MapParty;
+            return true;
+        }
+
+        // Last: a settlement-menu conversation. There is no location mission and no map party to
+        // point at, so identify the conversation by the settlement both sides are standing in.
+        // Checked after the two above so an ordinary map or location conversation keeps its stronger
+        // context - this only catches what would otherwise have no context at all.
         var settlement = barterData.OffererParty?.MobileParty?.CurrentSettlement;
-        if (settlement != null && barterData.OtherHero?.CurrentSettlement == settlement &&
+        if (settlement != null &&
+            barterData.OtherHero?.CurrentSettlement == settlement &&
             manager.TryGetId(settlement, out contextId))
         {
             context = PeaceConversationContext.Settlement;
             return true;
         }
 
-        if (barterData.OtherParty?.MobileParty?.IsActive == true && manager.TryGetId(barterData.OtherParty, out contextId))
-        {
-            context = PeaceConversationContext.MapParty;
-            return true;
-        }
         context = default;
         contextId = null;
         return false;

--- a/source/GameInterface/Services/Barters/Patches/LordBarterPatch.cs
+++ b/source/GameInterface/Services/Barters/Patches/LordBarterPatch.cs
@@ -336,22 +336,24 @@ internal static class LordBarterPatch
             return true;
         }
 
-        if (barterData.OtherParty?.MobileParty?.IsActive == true && manager.TryGetId(barterData.OtherParty, out contextId))
-        {
-            context = PeaceConversationContext.MapParty;
-            return true;
-        }
-
-        // Last: a settlement-menu conversation. There is no location mission and no map party to
-        // point at, so identify the conversation by the settlement both sides are standing in.
-        // Checked after the two above so an ordinary map or location conversation keeps its stronger
-        // context - this only catches what would otherwise have no context at all.
+        // Settlement BEFORE map party, and the order matters. A lord's party stays IsActive while the
+        // lord is inside a settlement - IsActive is only cleared by RemoveParty, captivity and load -
+        // so checking the map party first classifies every settlement-menu barter as MapParty. The
+        // server then demands a conversation hold that a settlement menu never acquires, and rejects
+        // the barter. This cannot steal an ordinary map conversation, because it requires BOTH sides
+        // to be inside the SAME settlement, and a party talking on the map has no CurrentSettlement.
         var settlement = barterData.OffererParty?.MobileParty?.CurrentSettlement;
         if (settlement != null &&
             barterData.OtherHero?.CurrentSettlement == settlement &&
             manager.TryGetId(settlement, out contextId))
         {
             context = PeaceConversationContext.Settlement;
+            return true;
+        }
+
+        if (barterData.OtherParty?.MobileParty?.IsActive == true && manager.TryGetId(barterData.OtherParty, out contextId))
+        {
+            context = PeaceConversationContext.MapParty;
             return true;
         }
 

--- a/source/GameInterface/Services/Barters/Patches/LordBarterPatch.cs
+++ b/source/GameInterface/Services/Barters/Patches/LordBarterPatch.cs
@@ -172,40 +172,8 @@ internal static class LordBarterPatch
             presentation.SynchronizeMainHeroGold(result.PlayerGold);
             if (shouldCompleteUi && BarterManager.Instance != null)
                 BarterManager.Instance.HandleHeroCooldown(barter.OtherHero);
-            if (shouldCompleteUi && kind == LordBarterKind.SafePassage &&
-                context == PeaceConversationContext.MapParty &&
-                PlayerEncounter.Current != null &&
-                barter.OtherParty == MobileParty.ConversationParty?.Party)
-            {
-                var siegeEvent = barter.OtherParty?.SiegeEvent;
-                var mainParty = MobileParty.MainParty;
-                using (new AllowedThread())
-                {
-                    var faction = barter.OtherParty.MapFaction;
-                    if (faction != null)
-                        faction.NotAttackableByPlayerUntilTime = CampaignTime.DaysFromNow(5f);
-                }
-                if (siegeEvent != null &&
-                    siegeEvent.BesiegerCamp.HasInvolvedPartyForEventType(barter.OtherParty) &&
-                    siegeEvent.BesiegedSettlement.HasInvolvedPartyForEventType(PartyBase.MainParty))
-                {
-                    using (new AllowedThread())
-                    {
-                        Campaign.Current.GameMenuManager.SetNextMenu("menu_siege_safe_passage_accepted");
-                        PlayerSiege.FinalizePlayerSiege();
-                    }
-                }
-                else
-                {
-                    PlayerEncounter.LeaveEncounter = true;
-                    if (mainParty.SiegeEvent != null &&
-                        mainParty.SiegeEvent.BesiegerCamp
-                            .HasInvolvedPartyForEventType(PartyBase.MainParty))
-                    {
-                        mainParty.BesiegerCamp = null;
-                    }
-                }
-            }
+            if (shouldCompleteUi && IsSafePassageEncounterConclusion(kind, context, barter))
+                ApplySafePassageAftermath(barter);
         }
         catch
         {
@@ -213,20 +181,76 @@ internal static class LordBarterPatch
         }
 
         if (shouldCompleteUi)
-            TrySetConclusionLine(kind);
-
-        if (shouldCompleteUi && Campaign.Current?.ConversationManager?.IsConversationInProgress == true)
         {
-            try
-            {
-                Campaign.Current.ConversationManager.ContinueConversation();
-            }
-            catch
-            {
-                // The authoritative result has already closed the barter UI.
-            }
+            TrySetConclusionLine(kind);
+            ContinueConversationIfInProgress();
         }
+
         MBInformationManager.AddQuickInformation(GameTexts.FindText("str_offer_accepted"));
+    }
+
+    /// <summary>
+    /// Whether this accepted barter is the safe passage that ends the encounter the player is
+    /// standing in, rather than one agreed elsewhere.
+    /// </summary>
+    private static bool IsSafePassageEncounterConclusion(
+        LordBarterKind kind, PeaceConversationContext context, BarterData barter)
+    {
+        return kind == LordBarterKind.SafePassage &&
+               context == PeaceConversationContext.MapParty &&
+               PlayerEncounter.Current != null &&
+               barter.OtherParty == MobileParty.ConversationParty?.Party;
+    }
+
+    /// <summary>
+    /// Leaves the encounter the safe passage just bought: the seller stops being attackable, and a
+    /// siege the player was party to is finalized rather than simply walked away from.
+    /// </summary>
+    private static void ApplySafePassageAftermath(BarterData barter)
+    {
+        var siegeEvent = barter.OtherParty?.SiegeEvent;
+        var mainParty = MobileParty.MainParty;
+
+        using (new AllowedThread())
+        {
+            var faction = barter.OtherParty.MapFaction;
+            if (faction != null)
+                faction.NotAttackableByPlayerUntilTime = CampaignTime.DaysFromNow(5f);
+        }
+
+        if (siegeEvent != null &&
+            siegeEvent.BesiegerCamp.HasInvolvedPartyForEventType(barter.OtherParty) &&
+            siegeEvent.BesiegedSettlement.HasInvolvedPartyForEventType(PartyBase.MainParty))
+        {
+            using (new AllowedThread())
+            {
+                Campaign.Current.GameMenuManager.SetNextMenu("menu_siege_safe_passage_accepted");
+                PlayerSiege.FinalizePlayerSiege();
+            }
+
+            return;
+        }
+
+        PlayerEncounter.LeaveEncounter = true;
+        if (mainParty.SiegeEvent != null &&
+            mainParty.SiegeEvent.BesiegerCamp.HasInvolvedPartyForEventType(PartyBase.MainParty))
+        {
+            mainParty.BesiegerCamp = null;
+        }
+    }
+
+    private static void ContinueConversationIfInProgress()
+    {
+        if (Campaign.Current?.ConversationManager?.IsConversationInProgress != true) return;
+
+        try
+        {
+            Campaign.Current.ConversationManager.ContinueConversation();
+        }
+        catch
+        {
+            // The authoritative result has already closed the barter UI.
+        }
     }
 
     internal static void ClearPendingRequest()
@@ -372,33 +396,56 @@ internal static class LordBarterPatch
             if (barterable == null || barterable.CurrentAmount <= 0 || !manager.TryGetId(barterable.OriginalOwner, out var ownerId))
                 return false;
 
-            PeaceBarterTerm term;
-            switch (barterable)
-            {
-                case GoldBarterable:
-                    term = new PeaceBarterTerm(PeaceBarterTermType.Gold, ownerId, null, null, true, barterable.CurrentAmount);
-                    break;
-                case ItemBarterable item:
-                    var equipment = item.ItemRosterElement.EquipmentElement;
-                    if (equipment.Item == null || !manager.TryGetId(equipment.Item, out var itemId)) return false;
-                    string modifierId = null;
-                    if (equipment.ItemModifier != null && !manager.TryGetId(equipment.ItemModifier, out modifierId)) return false;
-                    term = new PeaceBarterTerm(PeaceBarterTermType.Item, ownerId, itemId, modifierId, equipment.ItemModifier == null, barterable.CurrentAmount);
-                    break;
-                case FiefBarterable fief when manager.TryGetId(fief.TargetSettlement, out var settlementId):
-                    term = new PeaceBarterTerm(PeaceBarterTermType.Fief, ownerId, settlementId, null, true, barterable.CurrentAmount);
-                    break;
-                case TransferPrisonerBarterable transfer when transfer._prisonerCharacter?.CharacterObject != null && manager.TryGetId(transfer._prisonerCharacter.CharacterObject, out var transferPrisonerId):
-                    term = new PeaceBarterTerm(PeaceBarterTermType.TransferPrisoner, ownerId, transferPrisonerId, null, true, barterable.CurrentAmount);
-                    break;
-                case SetPrisonerFreeBarterable release when release._prisonerCharacter?.CharacterObject != null && manager.TryGetId(release._prisonerCharacter.CharacterObject, out var releasePrisonerId):
-                    term = new PeaceBarterTerm(PeaceBarterTermType.ReleasePrisoner, ownerId, releasePrisonerId, null, true, barterable.CurrentAmount);
-                    break;
-                default:
-                    return false;
-            }
+            if (!TryCreateTerm(barterable, ownerId, manager, out var term))
+                return false;
+
             terms.Add(term);
         }
+        return true;
+    }
+
+    /// <summary>
+    /// Describes one barterable as a wire term. Anything whose referenced object cannot be
+    /// identified is refused rather than sent as a partial term.
+    /// </summary>
+    private static bool TryCreateTerm(
+        Barterable barterable, string ownerId, IObjectManager manager, out PeaceBarterTerm term)
+    {
+        term = default;
+        switch (barterable)
+        {
+            case GoldBarterable:
+                term = new PeaceBarterTerm(PeaceBarterTermType.Gold, ownerId, null, null, true, barterable.CurrentAmount);
+                return true;
+            case ItemBarterable item:
+                return TryCreateItemTerm(item, ownerId, manager, out term);
+            case FiefBarterable fief when manager.TryGetId(fief.TargetSettlement, out var settlementId):
+                term = new PeaceBarterTerm(PeaceBarterTermType.Fief, ownerId, settlementId, null, true, barterable.CurrentAmount);
+                return true;
+            case TransferPrisonerBarterable transfer when transfer._prisonerCharacter?.CharacterObject != null && manager.TryGetId(transfer._prisonerCharacter.CharacterObject, out var transferPrisonerId):
+                term = new PeaceBarterTerm(PeaceBarterTermType.TransferPrisoner, ownerId, transferPrisonerId, null, true, barterable.CurrentAmount);
+                return true;
+            case SetPrisonerFreeBarterable release when release._prisonerCharacter?.CharacterObject != null && manager.TryGetId(release._prisonerCharacter.CharacterObject, out var releasePrisonerId):
+                term = new PeaceBarterTerm(PeaceBarterTermType.ReleasePrisoner, ownerId, releasePrisonerId, null, true, barterable.CurrentAmount);
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static bool TryCreateItemTerm(
+        ItemBarterable item, string ownerId, IObjectManager manager, out PeaceBarterTerm term)
+    {
+        term = default;
+
+        var equipment = item.ItemRosterElement.EquipmentElement;
+        if (equipment.Item == null || !manager.TryGetId(equipment.Item, out var itemId)) return false;
+
+        string modifierId = null;
+        if (equipment.ItemModifier != null && !manager.TryGetId(equipment.ItemModifier, out modifierId)) return false;
+
+        term = new PeaceBarterTerm(
+            PeaceBarterTermType.Item, ownerId, itemId, modifierId, equipment.ItemModifier == null, item.CurrentAmount);
         return true;
     }
 

--- a/source/GameInterface/Services/Barters/Patches/PeaceBarterPatch.cs
+++ b/source/GameInterface/Services/Barters/Patches/PeaceBarterPatch.cs
@@ -210,22 +210,23 @@ internal static class PeaceBarterPatch
             return true;
         }
 
-        if (barterData.OtherParty?.MobileParty?.IsActive == true &&
-            objectManager.TryGetId(barterData.OtherParty, out contextId))
-        {
-            context = PeaceConversationContext.MapParty;
-            return true;
-        }
-
-        // A settlement-menu conversation: no location mission and no map party, so identify it by
-        // the settlement both sides stand in. Checked last so map and location conversations keep
-        // their stronger context.
+        // Settlement BEFORE map party: a lord's party stays IsActive while the lord is inside a
+        // settlement, so checking the map party first classifies every settlement-menu barter as
+        // MapParty, and the server rejects it for having no conversation hold. Requiring BOTH sides
+        // in the SAME settlement means this cannot steal an ordinary map conversation.
         var settlement = barterData.OffererParty?.MobileParty?.CurrentSettlement;
         if (settlement != null &&
             barterData.OtherHero?.CurrentSettlement == settlement &&
             objectManager.TryGetId(settlement, out contextId))
         {
             context = PeaceConversationContext.Settlement;
+            return true;
+        }
+
+        if (barterData.OtherParty?.MobileParty?.IsActive == true &&
+            objectManager.TryGetId(barterData.OtherParty, out contextId))
+        {
+            context = PeaceConversationContext.MapParty;
             return true;
         }
 

--- a/source/GameInterface/Services/Barters/Patches/PeaceBarterPatch.cs
+++ b/source/GameInterface/Services/Barters/Patches/PeaceBarterPatch.cs
@@ -1,4 +1,4 @@
-using Common;
+﻿using Common;
 using Common.Network;
 using GameInterface.Policies;
 using GameInterface.Services.Barters.Messages;
@@ -210,18 +210,22 @@ internal static class PeaceBarterPatch
             return true;
         }
 
-        var settlement = barterData.OffererParty?.MobileParty?.CurrentSettlement;
-        if (settlement != null && barterData.OtherHero?.CurrentSettlement == settlement &&
-            objectManager.TryGetId(settlement, out contextId))
-        {
-            context = PeaceConversationContext.Settlement;
-            return true;
-        }
-
         if (barterData.OtherParty?.MobileParty?.IsActive == true &&
             objectManager.TryGetId(barterData.OtherParty, out contextId))
         {
             context = PeaceConversationContext.MapParty;
+            return true;
+        }
+
+        // A settlement-menu conversation: no location mission and no map party, so identify it by
+        // the settlement both sides stand in. Checked last so map and location conversations keep
+        // their stronger context.
+        var settlement = barterData.OffererParty?.MobileParty?.CurrentSettlement;
+        if (settlement != null &&
+            barterData.OtherHero?.CurrentSettlement == settlement &&
+            objectManager.TryGetId(settlement, out contextId))
+        {
+            context = PeaceConversationContext.Settlement;
             return true;
         }
 

--- a/source/GameInterface/Services/MapEvents/ConversationPartyHold.cs
+++ b/source/GameInterface/Services/MapEvents/ConversationPartyHold.cs
@@ -134,7 +134,12 @@ internal static class ConversationPartyHold
         if (interactor?.Party != null)
             objectManager.TryGetId(interactor.Party, out interactorId);
 
-        // Every contender registered for a shared hostile encounter may interact with the target.
+        // A held party belongs to exactly one player: the tracker now refuses a second engagement on
+        // the same party, so only the holder may interact and everyone else is blocked. This used to
+        // let every contender in a shared hostile encounter through, which meant two players could
+        // each run the same one-shot outcome against one lord. Simultaneous attackers still converge
+        // on one MapEvent - see ConversationRequestHandler, where the contender's retry is approved
+        // once the holder has started the battle.
         if (tracker.TryGetEngagement(targetPartyId, out _))
             return !tracker.IsEngagerParty(targetPartyId, interactorId);
 

--- a/source/GameInterface/Services/MapEvents/ConversationPartyHold.cs
+++ b/source/GameInterface/Services/MapEvents/ConversationPartyHold.cs
@@ -50,7 +50,8 @@ internal static class ConversationPartyHold
     }
 
     /// <summary>
-    /// Marks the party as engaged and holds it in place. The tracker decides whether the engagement can be shared.
+    /// Marks the party as engaged and holds it in place. The tracker refuses a party another player already holds,
+    /// so a successful call means this engager owns it alone.
     /// </summary>
     public static bool TryEngage(
         ConversationPartyTracker tracker,

--- a/source/GameInterface/Services/MapEvents/ConversationPartyHold.cs
+++ b/source/GameInterface/Services/MapEvents/ConversationPartyHold.cs
@@ -117,7 +117,7 @@ internal static class ConversationPartyHold
     }
 
     /// <summary>
-    /// [Server] True when the target is held and the interacting party is not one of its registered contenders.
+    /// [Server] True when the target is held and the interacting party is not the single player holding it.
     /// </summary>
     public static bool IsInteractionBlocked(PartyBase targetParty, MobileParty interactor)
     {

--- a/source/GameInterface/Services/MapEvents/ConversationPartyTracker.cs
+++ b/source/GameInterface/Services/MapEvents/ConversationPartyTracker.cs
@@ -12,8 +12,9 @@ namespace GameInterface.Services.MapEvents;
 /// Server-side registry of AI parties currently held in a conversation/encounter with a player.
 /// </summary>
 /// <remarks>
-/// Each player can engage one target. Hostile contenders may share a target, which stays held until the last
-/// engagement ends.
+/// One engagement per player, and one player per target: a party someone else already holds cannot be engaged,
+/// hostile or not. Every server-side consequence of a map conversation is authorised only as "this peer holds an
+/// engagement with this party", so a shared hold would let two players each apply the same one-shot outcome.
 /// </remarks>
 internal sealed class ConversationPartyTracker : IHandler
 {
@@ -128,8 +129,9 @@ internal sealed class ConversationPartyTracker : IHandler
     }
 
     /// <summary>
-    /// Begins or refreshes an engagement. A player cannot replace a live engagement with a different target, and
-    /// every player sharing a target preserves the AI state recorded by its first engagement.
+    /// Begins or refreshes an engagement. A player cannot replace a live engagement with a different target, and a
+    /// target another player already holds is refused. Refreshing keeps the AI state recorded when the engagement
+    /// began, so releasing it restores what the party was doing before.
     /// </summary>
     public bool TryBeginEngagement(
         object engagerKey,

--- a/source/GameInterface/Services/MapEvents/ConversationPartyTracker.cs
+++ b/source/GameInterface/Services/MapEvents/ConversationPartyTracker.cs
@@ -158,8 +158,12 @@ internal sealed class ConversationPartyTracker : IHandler
                 return true;
             }
 
-            var existing = engagements.Values.FirstOrDefault(x => x.PartyId == partyId);
-            if (existing.PartyId != null) wasAiDisabled = existing.WasAiDisabled;
+            // One engager per party. Every server-side consequence of a map conversation is validated
+            // only as "this peer holds an engagement with this party" (LordBarterHandler,
+            // PeaceBarterHandler, MarriageBarterHandler, BanditBarterHandler), so a shared hold lets
+            // two players each apply the same one-shot outcome - e.g. two players persuading the same
+            // lord, both paying, and the lord defecting twice.
+            if (engagements.Values.Any(x => x.PartyId == partyId)) return false;
 
             engagements.Add(engagerKey, new Engagement(
                 engagerKey,

--- a/source/GameInterface/Services/MapEvents/Handlers/ConversationRequestHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/ConversationRequestHandler.cs
@@ -32,8 +32,8 @@ namespace GameInterface.Services.MapEvents.Handlers;
 /// both parties are players or either party is already in a <see cref="TaleWorlds.CampaignSystem.MapEvents.MapEvent"/>.
 /// Client (on approval): re-runs <c>PlayerEncounter.RestartPlayerEncounter</c> with the same parameters under an
 /// <see cref="AllowedThread"/> so the now-approved original executes.
-/// Server (additionally): while a conversation is open, the AI party is held in place. Hostile players may share
-/// that hold so simultaneous attack attempts can converge on one MapEvent.
+/// Server (additionally): while a conversation is open, the AI party is held in place for exactly one player. A
+/// second player is refused the hold rather than sharing it, hostile or not.
 /// </remarks>
 internal class ConversationRequestHandler : IHandler
 {

--- a/source/GameInterface/Services/MapEvents/Handlers/ConversationRequestHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/ConversationRequestHandler.cs
@@ -403,17 +403,22 @@ internal class ConversationRequestHandler : IHandler
             return;
         }
 
-        if (conversationPartyTracker.IsEngagedByOther(aiPartyId, requestingPeer) &&
-            !AreHostile(playerPartyBase, aiPartyBase))
+        // A map conversation is exclusive to one player, like a settlement conversation. The
+        // hostility carve-out that used to live here existed so simultaneous attackers converge on
+        // one MapEvent, but it also let two players hold a diplomacy conversation with the same lord
+        // and both apply its one-shot outcome. Attackers still converge: once the holder starts the
+        // battle, the attackerInMapEvent/defenderInMapEvent branch above approves the contender's
+        // retry so it joins that MapEvent.
+        if (conversationPartyTracker.IsEngagedByOther(aiPartyId, requestingPeer))
         {
             Logger.Debug(
-                "Rejecting shared conversation for a non-hostile party. PartyId={PartyId}",
+                "Rejecting conversation request: the party is already conversing with another player. PartyId={PartyId}",
                 aiPartyId);
             network.Send(requestingPeer, new NetworkConversationDenied(ConversationDeniedReason.PartyEngaged, request.RequestId));
             return;
         }
 
-        // A requester may share this hostile target but cannot replace its own live engagement with another target.
+        // A requester cannot replace its own live engagement with another target.
         if (!ConversationPartyHold.TryEngage(
                 conversationPartyTracker,
                 requestingPeer,

--- a/source/GameInterface/Services/MapEvents/Handlers/ConversationRequestHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/ConversationRequestHandler.cs
@@ -33,7 +33,9 @@ namespace GameInterface.Services.MapEvents.Handlers;
 /// Client (on approval): re-runs <c>PlayerEncounter.RestartPlayerEncounter</c> with the same parameters under an
 /// <see cref="AllowedThread"/> so the now-approved original executes.
 /// Server (additionally): while a conversation is open, the AI party is held in place for exactly one player. A
-/// second player is refused the hold rather than sharing it, hostile or not.
+/// second player is refused the hold rather than sharing it, hostile or not. Simultaneous attackers still converge
+/// on one MapEvent, but by retrying rather than by sharing: once the holder has started the battle, the map-event
+/// branch approves the contender's next request so it joins that MapEvent.
 /// </remarks>
 internal class ConversationRequestHandler : IHandler
 {

--- a/source/GameInterface/Services/MapEvents/Handlers/ConversationRequestHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/ConversationRequestHandler.cs
@@ -292,51 +292,10 @@ internal class ConversationRequestHandler : IHandler
             return true;
         }
 
-        if (attackerIsPlayer && defenderIsPlayer &&
-            (IsInSiege(attacker.MobileParty) || IsInSiege(defender.MobileParty)))
-        {
-            Logger.Debug(
-                "Rejecting PvP conversation: a player is participating in a siege. AttackerId={AttackerId}, DefenderId={DefenderId}",
-                request.AttackerId, request.DefenderId);
-            network.Send(requestingPeer, new NetworkConversationDenied(ConversationDeniedReason.PlayerUnavailable, request.RequestId));
-            return false;
-        }
-        
         // PvP: two human players are allowed to open the encounter so they can fight each other. Neither side is AI,
         // so there is nothing to hold; the defending player is shown a "hold on" popup instead.
         if (attackerIsPlayer && defenderIsPlayer)
-        {
-            // Checks if there is a request to open army menu and executes if true
-            if (attacker.MobileParty?.ActualClan?.Kingdom != null
-                && attacker.MobileParty?.ActualClan?.Kingdom == defender.MobileParty?.ActualClan?.Kingdom
-                && defender.MobileParty?.Army != null
-                && defender.MobileParty?.Army?.LeaderParty == defender.MobileParty
-                && defender.MobileParty.Army.LeaderParty.AttachedParties.Contains(attacker.MobileParty) == false
-                && !request.ArmyTalkEncounter)
-            {
-                Logger.Debug(
-                "Allowing army join. AttackerId={AttackerId}, DefenderId={DefenderId}",
-                request.AttackerId, request.DefenderId);
-                return true;
-            }
-            // Reject if either player is already conversing with someone else (first interaction wins) — otherwise a
-            // third player could open an encounter with a defender already locked in a conversation.
-            if (IsConversingWithOther(request.DefenderId, request.AttackerId) ||
-                IsConversingWithOther(request.AttackerId, request.DefenderId))
-            {
-                Logger.Debug(
-                    "Rejecting PvP conversation: a party is already conversing with another player. AttackerId={AttackerId}, DefenderId={DefenderId}",
-                    request.AttackerId, request.DefenderId);
-                network.Send(requestingPeer, new NetworkConversationDenied(ConversationDeniedReason.PartyEngaged, request.RequestId));
-                return false;
-            }
-
-            Logger.Debug(
-                "Starting custom player-party interaction. AttackerId={AttackerId}, DefenderId={DefenderId}",
-                request.AttackerId, request.DefenderId);
-            playerPartyInteractionHandler.TryStartSession(requestingPeer, request, attacker, defender);
-            return false;
-        }
+            return TryAcceptPlayerVersusPlayer(requestingPeer, request, attacker, defender);
 
         // Reject: both parties are already in (separate) battles; do not (re)open an encounter conversation.
         if (attackerInMapEvent || defenderInMapEvent)
@@ -369,6 +328,67 @@ internal class ConversationRequestHandler : IHandler
         request.AttackerId, request.DefenderId);
 
         return true;
+    }
+
+    /// <summary>
+    /// [Server] Resolves a request where both sides are human players.
+    /// </summary>
+    /// <remarks>
+    /// Returning false does NOT always mean refused: the custom interaction session is started here
+    /// and driven from there, so this returns false to stop the caller also approving it.
+    /// </remarks>
+    private bool TryAcceptPlayerVersusPlayer(
+        NetPeer requestingPeer, NetworkRequestConversation request, PartyBase attacker, PartyBase defender)
+    {
+        if (IsInSiege(attacker.MobileParty) || IsInSiege(defender.MobileParty))
+        {
+            Logger.Debug(
+                "Rejecting PvP conversation: a player is participating in a siege. AttackerId={AttackerId}, DefenderId={DefenderId}",
+                request.AttackerId, request.DefenderId);
+            network.Send(requestingPeer, new NetworkConversationDenied(ConversationDeniedReason.PlayerUnavailable, request.RequestId));
+            return false;
+        }
+
+        if (IsArmyJoinRequest(request, attacker, defender))
+        {
+            Logger.Debug(
+                "Allowing army join. AttackerId={AttackerId}, DefenderId={DefenderId}",
+                request.AttackerId, request.DefenderId);
+            return true;
+        }
+
+        // Reject if either player is already conversing with someone else (first interaction wins) — otherwise a
+        // third player could open an encounter with a defender already locked in a conversation.
+        if (IsConversingWithOther(request.DefenderId, request.AttackerId) ||
+            IsConversingWithOther(request.AttackerId, request.DefenderId))
+        {
+            Logger.Debug(
+                "Rejecting PvP conversation: a party is already conversing with another player. AttackerId={AttackerId}, DefenderId={DefenderId}",
+                request.AttackerId, request.DefenderId);
+            network.Send(requestingPeer, new NetworkConversationDenied(ConversationDeniedReason.PartyEngaged, request.RequestId));
+            return false;
+        }
+
+        Logger.Debug(
+            "Starting custom player-party interaction. AttackerId={AttackerId}, DefenderId={DefenderId}",
+            request.AttackerId, request.DefenderId);
+        playerPartyInteractionHandler.TryStartSession(requestingPeer, request, attacker, defender);
+        return false;
+    }
+
+    /// <summary>
+    /// Whether the attacker is asking to join the defender's army rather than to fight it: same
+    /// kingdom, the defender leads an army, and the attacker is not already attached to it.
+    /// </summary>
+    private static bool IsArmyJoinRequest(
+        NetworkRequestConversation request, PartyBase attacker, PartyBase defender)
+    {
+        return attacker.MobileParty?.ActualClan?.Kingdom != null
+            && attacker.MobileParty?.ActualClan?.Kingdom == defender.MobileParty?.ActualClan?.Kingdom
+            && defender.MobileParty?.Army != null
+            && defender.MobileParty?.Army?.LeaderParty == defender.MobileParty
+            && defender.MobileParty.Army.LeaderParty.AttachedParties.Contains(attacker.MobileParty) == false
+            && !request.ArmyTalkEncounter;
     }
 
     /// <summary>


### PR DESCRIPTION
Four ways an authoritative barter could be refused, double-applied, or misreported.

### One player at a time on a conversation target

Two players both at war with the same lord could each open a conversation with him and each run the persuasion, then both pay for a barter and see him defect twice. The hostility carve-out that allowed this exists so simultaneous attackers converge on one `MapEvent`, which is right for combat and wrong for diplomacy: every server-side conversation outcome is authorised only as "this peer holds an engagement with this party", so a shared hold lets two players apply the same one-shot result.

A party is now held by exactly one player. Attackers still converge — once the holder starts the battle, the contender's retry joins that `MapEvent` through the existing attacker/defender branch.

### Barters started from a settlement menu

Talking to a lord from a castle or town menu opens a conversation with no agent interaction and no `CampaignMission.Current.Location`, so neither the map-party hold nor the location lock was ever acquired and every barter from such a conversation was refused with "the conversation is no longer active" — after the player had already played out the persuasion.

Adds a `Settlement` conversation context. There is nothing to lock, so authority comes from co-location instead: the server checks that both the requesting party and the target are inside the settlement named by the request, which a player who is not there cannot fake. The context is tried last, so map and location conversations keep their stronger hold. An unrecognised context is refused rather than validated as a settlement.

Applies to the lord defection and peace barters, which shared the gap.

### An applied barter reported as rejected

Both the marriage and peace handlers applied their mutation and could then still fall into the `catch` and send a rejection. The client rolled its UI back while the server had already married the pair or ended the war, leaving the two sides disagreeing about a change that really happened — and for marriage the gold had moved too.

They now track whether the mutation was committed and, once it has been, report success even if a later step throws. The authoritative state stands; claiming failure is the desync, not the fix. `LordBarterHandler` already did this and is unchanged.

### Dispose no longer blocks container teardown

`LordBarterHandler.Dispose` marshalled its cleanup to the game thread and waited. During teardown the loop may already have stopped pumping, so the wait ran its full 30s timeout and failed teardown, taking three conversation tests with it. The queued clear is discardable — the handler is being thrown away anyway — so it no longer waits.

---

### Depends on #2748

This PR targets `coop/lord-defection` rather than `development`, because its `Dispose` fix flips `blocking: true` to `false` on the `GameThread.RunSafe` marshalling that #2748 introduces — on plain `development` that call does not exist yet. Merge #2748 first.

The rest of the work was split out of #2668 into PRs that each fix a single problem; the others target `development` directly.


---

### Verification

Each of the three behavioural fixes was proven by removing the fix and confirming its test goes red, then restoring it and confirming green again — not merely asserted.

| # | Case | Covered by | Result |
|---|------|-----------|--------|
| 1 | Settlement context resolves when the lord leads an **active** party | `SettlementConversation_WithLordLeadingAnActiveParty_StillResolvesSettlementContext` | Pass — fails without the fix |
| 2 | Map-party context still resolves when neither side is in a settlement | `MapConversation_WithNeitherSideInASettlement_StillResolvesMapPartyContext` | Pass |
| 3 | Settlement barter accepted end to end | `GenericLordBarter_StationarySettlementConversation_ValidatesCurrentPresence` | Pass |
| 4 | A second player is refused the same lord, and the holder is unaffected | `SettlementConversation_WhenAnotherPlayerHoldsTheLord_RefusesTheSecondAuthorization` | Pass — fails without the fix |
| 5 | Cancelling releases the lord for the next player | `SettlementConversation_AfterTheHolderCancels_TheLordIsAvailableAgain` | Pass |
| 6 | Marriage reports success when the spouse links do not take after apply | `PersonalMarriageBarter_WhenSpouseLinksDoNotTakeAfterApply_StillReportsSuccess` | Pass — fails without the fix |
| 7 | Full suite | `Common`, `Coop`, `Coop.Tests`, `GameInterface.Tests`, `Coop.IntegrationTests`, `E2E.Tests` | 2742 passed, 0 failed, 18 skipped |

The existing settlement test asserted `Assert.Null(targetHero.PartyBelongedTo)`, so the map-party branch could never be reached and the misclassification stayed invisible. Case 1 gives the lord a real party, which is the in-game situation.

Also exercised live on a server with two connected clients, with a lord staying inside a town while leading an active 242-man party:

| # | Scenario | Result |
|---|----------|--------|
| 1 | Player barters with a lord from the town menu while that lord leads an active party | Accepted, gold transferred |
| 2 | Second player opens a barter with the same lord while the first player's barter screen is still open | Refused; the first player's barter completed unaffected, gold charged once |
| 3 | Both players barter with a lord on the campaign map, neither side in a settlement | Both accepted — the reordering leaves map conversations intact |

One thing this does not change: the reservation refuses the second player server-side without notifying them, so their barter screen still opens and is only refused on accept. Worth a follow-up, but it is a presentation issue rather than a correctness one.
