### PR TITLE
[2708] Make alley recruitment server-authoritative

### DIFF
--- a/source/GameInterface.Tests/Services/Alleys/SessionAlleyPlayerDataInterfaceTests.cs
+++ b/source/GameInterface.Tests/Services/Alleys/SessionAlleyPlayerDataInterfaceTests.cs
@@ -1,0 +1,64 @@
+﻿using GameInterface.CoopSessionData;
+using GameInterface.CoopSessionData.Save.Data;
+using GameInterface.Services.Alleys;
+using GameInterface.Services.Alleys.Interfaces;
+using GameInterface.Services.TroopRosters.Data;
+using Moq;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace GameInterface.Tests.Services.Alleys;
+
+public class SessionAlleyPlayerDataInterfaceTests
+{
+    [Fact]
+    public void SetManagementData_PreservesLastRecruitTime()
+    {
+        const long lastRecruitTimeTicks = 12345;
+        var existing = new AlleyManagementData("old-overseer", Array.Empty<TroopRosterElementData>())
+        {
+            LastRecruitTimeTicks = lastRecruitTimeTicks
+        };
+        var sessionInterface = CreateInterface(new Dictionary<string, AlleyManagementData>
+        {
+            ["alley"] = existing
+        });
+
+        sessionInterface.SetManagementData(
+            "alley",
+            "new-overseer",
+            new[] { new TroopRosterElementData("troop", 3, 0, 0) });
+
+        Assert.True(sessionInterface.TryGetManagementData("alley", out var updated));
+        Assert.Equal("new-overseer", updated.OverseerId);
+        Assert.Equal(lastRecruitTimeTicks, updated.LastRecruitTimeTicks);
+    }
+
+    [Fact]
+    public void SetLastRecruitTimeTicks_UpdatesExistingEntry()
+    {
+        var sessionInterface = CreateInterface(new Dictionary<string, AlleyManagementData>
+        {
+            ["alley"] = new AlleyManagementData("overseer", Array.Empty<TroopRosterElementData>())
+        });
+        const long lastRecruitTimeTicks = 67890;
+
+        sessionInterface.SetLastRecruitTimeTicks("alley", lastRecruitTimeTicks);
+
+        Assert.True(sessionInterface.TryGetManagementData("alley", out var updated));
+        Assert.Equal(lastRecruitTimeTicks, updated.LastRecruitTimeTicks);
+    }
+
+    private static SessionAlleyPlayerDataInterface CreateInterface(
+        Dictionary<string, AlleyManagementData> managementData)
+    {
+        var coopSession = new Mock<ICoopSession>();
+        coopSession.SetupGet(session => session.AlleyPlayerData)
+            .Returns(new AlleyPlayerData(managementData));
+
+        var provider = new Mock<ICoopSessionProvider>();
+        provider.SetupGet(session => session.CoopSession).Returns(coopSession.Object);
+        return new SessionAlleyPlayerDataInterface(provider.Object);
+    }
+}

--- a/source/GameInterface/Services/Alleys/AlleyPlayerData.cs
+++ b/source/GameInterface/Services/Alleys/AlleyPlayerData.cs
@@ -47,6 +47,9 @@ public class AlleyManagementData
     [ProtoMember(4)]
     public CampaignTime AttackResponseDueDate { get; set; }
 
+    [ProtoMember(5)]
+    public long LastRecruitTimeTicks { get; set; }
+
     public AlleyManagementData(string overseerId, TroopRosterElementData[] garrison)
     {
         OverseerId = overseerId;

--- a/source/GameInterface/Services/Alleys/Commands/AlleyDebugCommand.cs
+++ b/source/GameInterface/Services/Alleys/Commands/AlleyDebugCommand.cs
@@ -170,6 +170,9 @@ public class AlleyDebugCommand
         {
             sb.AppendLine($"  overseerId={data.OverseerId ?? "none"}");
             sb.AppendLine($"  garrison entries={data.Garrison?.Length ?? 0}");
+            var lastRecruitTime = new CampaignTime(data.LastRecruitTimeTicks);
+            sb.AppendLine($"  lastRecruitTimeTicks={data.LastRecruitTimeTicks}");
+            sb.AppendLine($"  recruitCooldownElapsedDays={lastRecruitTime.ElapsedDaysUntilNow:R}");
         }
 
         return sb.ToString();

--- a/source/GameInterface/Services/Alleys/Commands/AlleyRecruitDebugCommand.cs
+++ b/source/GameInterface/Services/Alleys/Commands/AlleyRecruitDebugCommand.cs
@@ -170,7 +170,6 @@ public class AlleyRecruitDebugCommand
 
             RestoreRoster(fixture.PlayerParty.MemberRoster, fixture.MemberRoster);
             sendCoalescer.DropInstance(Compact(rosterId, typeof(TroopRoster)));
-            fixture.PlayerParty.MemberRoster.RemoveZeroCounts();
             foreach (var resetCharacter in resetCharacters)
             {
                 var index = fixture.PlayerParty.MemberRoster.FindIndexOfTroop(resetCharacter.Character);
@@ -193,6 +192,7 @@ public class AlleyRecruitDebugCommand
                         new[] { TroopRosterElementOperation.SetXp(element.Xp) }));
                 }
             }
+            fixture.PlayerParty.MemberRoster.RemoveZeroCounts();
             network.SendAll(new NetworkTroopRosterRemoveZeroCounts(rosterId));
             fixture.Alley.SetOwner(fixture.OriginalOwner);
 

--- a/source/GameInterface/Services/Alleys/Commands/AlleyRecruitDebugCommand.cs
+++ b/source/GameInterface/Services/Alleys/Commands/AlleyRecruitDebugCommand.cs
@@ -462,15 +462,17 @@ public class AlleyRecruitDebugCommand
             var element = roster.GetElementCopyAtIndex(index);
             roster.AddToCountsAtIndex(index, -element.Number, -element.WoundedNumber, -element.Xp, false);
         }
-        foreach (var element in elements)
+        for (var index = 0; index < elements.Length; index++)
         {
+            var element = elements[index];
             roster.AddToCounts(
                 element.Character,
                 element.Number,
                 false,
                 element.WoundedNumber,
                 element.Xp,
-                true);
+                true,
+                index);
         }
     }
 

--- a/source/GameInterface/Services/Alleys/Commands/AlleyRecruitDebugCommand.cs
+++ b/source/GameInterface/Services/Alleys/Commands/AlleyRecruitDebugCommand.cs
@@ -1,0 +1,387 @@
+﻿using Common;
+using Common.Network;
+using GameInterface.Services.Alleys.Interfaces;
+using GameInterface.Services.Alleys.Messages;
+using GameInterface.Services.ObjectManager;
+using GameInterface.Services.TroopRosters.Data;
+using Helpers;
+using SandBox.CampaignBehaviors;
+using SandBox.Conversation.MissionLogics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Conversation;
+using TaleWorlds.CampaignSystem.GameState;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Roster;
+using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.Core;
+using TaleWorlds.MountAndBlade;
+using static TaleWorlds.Library.CommandLineFunctionality;
+
+namespace GameInterface.Services.Alleys.Commands;
+
+/// <summary>DEBUG commands for the exact alley-recruitment inventory, trade, and loot regression.</summary>
+public class AlleyRecruitDebugCommand
+{
+    private const string AskForVolunteersOptionId = "alley_talk_start_player_owned_alley_manager_answer_2";
+    private const string AcceptVolunteersOptionId = "alley_talk_start_player_owned_alley_manager_volunteers_3";
+
+    private static AlleyRecruitFixture fixture;
+
+    [CommandLineArgumentFunction("recruit_fixture_start", "coop.debug.alley")]
+    public static string StartFixture(List<string> args)
+    {
+        if (ModInformation.IsClient) return "Run this command on the server.";
+        if (args.Count != 3)
+            return "Usage: coop.debug.alley.recruit_fixture_start <settlementId> <alleyIndex> <heroRegistryId>";
+        if (fixture != null) return "The alley recruit fixture is already active.";
+
+        if (!TryGetAlley(args[0], args[1], out var alley, out var error)) return error;
+        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager) ||
+            !ContainerProvider.TryResolve<ISessionAlleyPlayerDataInterface>(out var sessionInterface) ||
+            !ContainerProvider.TryResolve<INetwork>(out var network))
+            return "Unable to resolve the alley recruit fixture services.";
+        if (!objectManager.TryGetObjectWithLogging<Hero>(args[2], out var owner)) return $"Hero '{args[2]}' not found.";
+        if (owner.PartyBelongedTo == null) return $"Hero '{args[2]}' has no party.";
+        if (!objectManager.TryGetIdWithLogging(alley, out var alleyId) ||
+            !objectManager.TryGetIdWithLogging(owner, out var ownerId) ||
+            !objectManager.TryGetIdWithLogging(owner.CharacterObject, out var ownerCharacterId))
+            return "Unable to resolve the alley recruit fixture ids.";
+
+        sessionInterface.TryGetManagementData(alleyId, out var originalManagementData);
+        fixture = new AlleyRecruitFixture(
+            alley,
+            alleyId,
+            alley.Owner,
+            CloneManagementData(originalManagementData),
+            owner.PartyBelongedTo,
+            owner.PartyBelongedTo.MemberRoster.GetTroopRoster().ToArray());
+
+        try
+        {
+            alley.SetOwner(owner);
+            sessionInterface.SetManagementData(
+                alleyId,
+                ownerId,
+                new[] { new TroopRosterElementData(ownerCharacterId, 1, 0, 0) });
+            sessionInterface.ClearUnderAttackByAi(alleyId);
+            sessionInterface.SetLastRecruitTimeTicks(alleyId, 0);
+            if (!sessionInterface.TryGetManagementData(alleyId, out var managementData))
+                throw new InvalidOperationException("The fixture management data was not stored.");
+
+            network.SendAll(new NetworkAlleyManagementUpdated(
+                alleyId,
+                managementData.OverseerId,
+                managementData.Garrison,
+                managementData.LastRecruitTimeTicks));
+            network.SendAll(new NetworkAlleyUnderAttack(alleyId, null, default, showNotification: false));
+
+            return $"ALLEY_RECRUIT_FIXTURE_STARTED settlement={args[0]} alley={args[1]} " +
+                   $"owner={owner.StringId} party={owner.PartyBelongedTo.StringId} " +
+                   $"originalOwner={fixture.OriginalOwner?.StringId ?? "none"} " +
+                   $"originalRosterEntries={fixture.MemberRoster.Length}";
+        }
+        catch (Exception e)
+        {
+            var rollback = RestoreFixture(new List<string>());
+            return $"Alley recruit fixture setup failed: {e.Message}. Rollback: {rollback}";
+        }
+    }
+
+    [CommandLineArgumentFunction("recruit_fixture_state", "coop.debug.alley")]
+    public static string FixtureState(List<string> args)
+    {
+        if (args.Count != 0) return "Usage: coop.debug.alley.recruit_fixture_state";
+        if (fixture == null) return "The alley recruit fixture is not active.";
+
+        var party = fixture.PlayerParty;
+        return $"ALLEY_RECRUIT_FIXTURE_STATE alley={fixture.AlleyId} owner={fixture.Alley.Owner?.StringId ?? "none"} " +
+               $"party={party.StringId} rosterEntries={party.MemberRoster.Count} totalMembers={party.MemberRoster.TotalManCount} " +
+               $"mapEvent={(party.MapEvent == null ? "none" : "active")}";
+    }
+
+    [CommandLineArgumentFunction("recruit_roster", "coop.debug.alley")]
+    public static string RecruitRoster(List<string> args)
+    {
+        if (args.Count != 1) return "Usage: coop.debug.alley.recruit_roster <heroRegistryId>";
+        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
+            return "Unable to resolve IObjectManager.";
+        if (!objectManager.TryGetObjectWithLogging<Hero>(args[0], out var hero))
+            return $"Hero '{args[0]}' not found.";
+        if (hero.PartyBelongedTo == null) return $"Hero '{args[0]}' has no party.";
+
+        var roster = hero.PartyBelongedTo.MemberRoster;
+        var result = new StringBuilder();
+        result.AppendLine(
+            $"ALLEY_RECRUIT_ROSTER hero={hero.StringId} registry={args[0]} " +
+            $"party={hero.PartyBelongedTo.StringId} total={roster.TotalManCount}");
+        for (var index = 0; index < roster.Count; index++)
+        {
+            var element = roster.GetElementCopyAtIndex(index);
+            result.AppendLine(
+                $"{element.Character.StringId}: number={element.Number} " +
+                $"wounded={element.WoundedNumber} xp={element.Xp} hero={element.Character.IsHero}");
+        }
+        return result.ToString();
+    }
+
+    [CommandLineArgumentFunction("recruit_fixture_restore", "coop.debug.alley")]
+    public static string RestoreFixture(List<string> args)
+    {
+        if (ModInformation.IsClient) return "Run this command on the server.";
+        if (args.Count != 0) return "Usage: coop.debug.alley.recruit_fixture_restore";
+        if (fixture == null) return "The alley recruit fixture is not active.";
+        if (fixture.PlayerParty.MapEvent != null) return "Finish the player's map event before restoring the fixture.";
+
+        if (!ContainerProvider.TryResolve<ISessionAlleyPlayerDataInterface>(out var sessionInterface) ||
+            !ContainerProvider.TryResolve<INetwork>(out var network))
+            return "Unable to resolve the alley recruit fixture services.";
+
+        try
+        {
+            RestoreRoster(fixture.PlayerParty.MemberRoster, fixture.MemberRoster);
+            fixture.Alley.SetOwner(fixture.OriginalOwner);
+
+            if (fixture.OriginalManagementData == null)
+            {
+                sessionInterface.RemoveManagementData(fixture.AlleyId);
+                network.SendAll(new NetworkAlleyManagementRemoved(fixture.AlleyId));
+            }
+            else
+            {
+                var data = fixture.OriginalManagementData;
+                sessionInterface.SetManagementData(fixture.AlleyId, data.OverseerId, data.Garrison);
+                sessionInterface.SetLastRecruitTimeTicks(fixture.AlleyId, data.LastRecruitTimeTicks);
+                if (data.UnderAttackByAlleyId != null)
+                {
+                    sessionInterface.SetUnderAttackByAi(
+                        fixture.AlleyId,
+                        data.UnderAttackByAlleyId,
+                        data.AttackResponseDueDate);
+                }
+                else
+                {
+                    sessionInterface.ClearUnderAttackByAi(fixture.AlleyId);
+                }
+                if (!sessionInterface.TryGetManagementData(fixture.AlleyId, out var restored))
+                    throw new InvalidOperationException("The original alley management data was not restored.");
+
+                network.SendAll(new NetworkAlleyManagementUpdated(
+                    fixture.AlleyId,
+                    restored.OverseerId,
+                    restored.Garrison,
+                    restored.LastRecruitTimeTicks));
+                network.SendAll(new NetworkAlleyUnderAttack(
+                    fixture.AlleyId,
+                    restored.UnderAttackByAlleyId,
+                    restored.AttackResponseDueDate,
+                    showNotification: false));
+            }
+
+            var restoredTotal = fixture.PlayerParty.MemberRoster.TotalManCount;
+            fixture = null;
+            return $"ALLEY_RECRUIT_FIXTURE_RESTORED totalMembers={restoredTotal}";
+        }
+        catch (Exception e)
+        {
+            return $"Alley recruit fixture restore failed: {e.Message}";
+        }
+    }
+
+    [CommandLineArgumentFunction("recruit_conversation_start", "coop.debug.alley")]
+    public static string StartRecruitConversation(List<string> args)
+    {
+        if (ModInformation.IsServer) return "Run this command on the owning client.";
+        if (args.Count != 2)
+            return "Usage: coop.debug.alley.recruit_conversation_start <settlementId> <alleyIndex>";
+        if (!TryGetAlley(args[0], args[1], out var alley, out var error)) return error;
+        if (Mission.Current == null) return "Enter the alley location before starting the conversation.";
+
+        var behavior = Campaign.Current?.GetCampaignBehavior<AlleyCampaignBehavior>();
+        var playerAlleyData = behavior?._playerOwnedCommonAreaData.FirstOrDefault(data => data.Alley == alley);
+        if (playerAlleyData == null) return "The local player does not own this alley.";
+
+        var overseerAgent = Mission.Current.Agents.FirstOrDefault(candidate =>
+            candidate.Character is CharacterObject character &&
+            character.HeroObject == playerAlleyData.AssignedClanMember);
+        if (overseerAgent == null) return "The assigned alley overseer is not present in the mission.";
+
+        var conversation = Mission.Current.GetMissionBehavior<MissionConversationLogic>();
+        if (conversation == null) return "The mission conversation behavior is unavailable.";
+        if (Campaign.Current.ConversationManager.IsConversationInProgress)
+            return "A conversation is already in progress.";
+
+        conversation.StartConversation(overseerAgent, setActionsInstantly: false);
+        return $"ALLEY_RECRUIT_CONVERSATION_STARTED overseer={playerAlleyData.AssignedClanMember.StringId}";
+    }
+
+    [CommandLineArgumentFunction("recruit_conversation", "coop.debug.alley")]
+    public static string RecruitConversation(List<string> args)
+    {
+        if (ModInformation.IsServer) return "Run this command on the owning client.";
+        if (args.Count != 1) return "Usage: coop.debug.alley.recruit_conversation <state|ask|accept>";
+
+        var manager = Campaign.Current?.ConversationManager;
+        if (manager?.IsConversationInProgress != true) return "No alley conversation is active.";
+
+        switch (args[0].ToLowerInvariant())
+        {
+            case "state":
+                return FormatConversationState(manager);
+            case "ask":
+                if (!manager.CurOptions.Any(option => option.Id == AskForVolunteersOptionId))
+                    return $"Conversation option '{AskForVolunteersOptionId}' is not available. {FormatConversationState(manager)}";
+                manager.DoOption(AskForVolunteersOptionId);
+                return $"ALLEY_RECRUIT_ASKED {FormatConversationState(manager)}";
+            case "accept":
+                if (!manager.CurOptions.Any(option => option.Id == AcceptVolunteersOptionId))
+                    return $"Conversation option '{AcceptVolunteersOptionId}' is not available. {FormatConversationState(manager)}";
+                var offer = FormatCurrentOffer();
+                manager.DoOption(AcceptVolunteersOptionId);
+                return $"ALLEY_RECRUIT_ACCEPTED offer={offer} {FormatConversationState(manager)}";
+            default:
+                return "Usage: coop.debug.alley.recruit_conversation <state|ask|accept>";
+        }
+    }
+
+    [CommandLineArgumentFunction("recruit_inventory", "coop.debug.alley")]
+    public static string RecruitInventory(List<string> args)
+    {
+        if (ModInformation.IsServer) return "Run this command on the owning client.";
+        if (args.Count != 1) return "Usage: coop.debug.alley.recruit_inventory <open|trade|complete|state>";
+
+        switch (args[0].ToLowerInvariant())
+        {
+            case "open":
+                InventoryScreenHelper.OpenScreenAsInventory();
+                return "ALLEY_RECRUIT_INVENTORY_OPENED";
+            case "trade":
+                if (Settlement.CurrentSettlement?.StringId != "town_ES1")
+                    return "Enter Danustica (town_ES1) before opening its trade screen.";
+                InventoryScreenHelper.ActivateTradeWithCurrentSettlement();
+                return "ALLEY_RECRUIT_TRADE_OPENED settlement=town_ES1";
+            case "complete":
+                if (!(GameStateManager.Current?.ActiveState is InventoryState))
+                    return "No inventory or trade screen is active.";
+                InventoryScreenHelper.CloseScreen(fromCancel: false);
+                return GameStateManager.Current?.ActiveState is InventoryState
+                    ? "ALLEY_RECRUIT_INVENTORY_COMPLETE_REJECTED"
+                    : "ALLEY_RECRUIT_INVENTORY_COMPLETED";
+            case "state":
+                var state = GameStateManager.Current?.ActiveState;
+                var inventoryState = state as InventoryState;
+                return $"ALLEY_RECRUIT_SCREEN_STATE active={state?.GetType().Name ?? "none"} " +
+                       $"mode={inventoryState?.InventoryMode.ToString() ?? "none"} " +
+                       $"settlement={Settlement.CurrentSettlement?.StringId ?? "none"}";
+            default:
+                return "Usage: coop.debug.alley.recruit_inventory <open|trade|complete|state>";
+        }
+    }
+
+    private static bool TryGetAlley(string settlementId, string indexArg, out Alley alley, out string error)
+    {
+        alley = null;
+        error = null;
+        var settlement = Settlement.Find(settlementId);
+        if (settlement == null)
+        {
+            error = $"Settlement with id '{settlementId}' not found.";
+            return false;
+        }
+        if (!int.TryParse(indexArg, out var index) ||
+            settlement.Alleys == null ||
+            index < 0 ||
+            index >= settlement.Alleys.Count)
+        {
+            error = "The alley index is invalid.";
+            return false;
+        }
+
+        alley = settlement.Alleys[index];
+        return true;
+    }
+
+    private static string FormatConversationState(ConversationManager manager)
+    {
+        var options = manager.CurOptions == null
+            ? "none"
+            : string.Join(",", manager.CurOptions.Select(option => option.Id));
+        return $"sentence={manager.CurrentSentenceText} options={options}";
+    }
+
+    private static string FormatCurrentOffer()
+    {
+        var behavior = Campaign.Current.GetCampaignBehavior<AlleyCampaignBehavior>();
+        var data = behavior._playerOwnedCommonAreaData.First(
+            item => item.Alley?.Settlement == Settlement.CurrentSettlement);
+        var troops = Campaign.Current.Models.AlleyModel.GetTroopsToRecruitFromAlleyDependingOnAlleyRandom(
+            data.Alley,
+            data.RandomFloatWeekly);
+        return string.Join(",", troops.GetTroopRoster().Select(
+            element => $"{element.Character.StringId}:{element.Number}"));
+    }
+
+    private static AlleyManagementData CloneManagementData(AlleyManagementData data)
+    {
+        if (data == null) return null;
+        return new AlleyManagementData(data.OverseerId, data.Garrison?.ToArray() ?? Array.Empty<TroopRosterElementData>())
+        {
+            UnderAttackByAlleyId = data.UnderAttackByAlleyId,
+            AttackResponseDueDate = data.AttackResponseDueDate,
+            LastRecruitTimeTicks = data.LastRecruitTimeTicks,
+        };
+    }
+
+    internal static bool IsFixtureAlley(string alleyId)
+    {
+        return fixture?.AlleyId == alleyId;
+    }
+
+    private static void RestoreRoster(TroopRoster roster, TroopRosterElement[] elements)
+    {
+        for (var index = roster.Count - 1; index >= 0; index--)
+        {
+            var element = roster.GetElementCopyAtIndex(index);
+            roster.AddToCountsAtIndex(index, -element.Number, -element.WoundedNumber, 0, false);
+        }
+        foreach (var element in elements)
+        {
+            roster.AddToCounts(
+                element.Character,
+                element.Number,
+                false,
+                element.WoundedNumber,
+                element.Xp,
+                true);
+        }
+    }
+
+    private sealed class AlleyRecruitFixture
+    {
+        public Alley Alley { get; }
+        public string AlleyId { get; }
+        public Hero OriginalOwner { get; }
+        public AlleyManagementData OriginalManagementData { get; }
+        public MobileParty PlayerParty { get; }
+        public TroopRosterElement[] MemberRoster { get; }
+
+        public AlleyRecruitFixture(
+            Alley alley,
+            string alleyId,
+            Hero originalOwner,
+            AlleyManagementData originalManagementData,
+            MobileParty playerParty,
+            TroopRosterElement[] memberRoster)
+        {
+            Alley = alley;
+            AlleyId = alleyId;
+            OriginalOwner = originalOwner;
+            OriginalManagementData = originalManagementData;
+            PlayerParty = playerParty;
+            MemberRoster = memberRoster;
+        }
+    }
+}

--- a/source/GameInterface/Services/Alleys/Commands/AlleyRecruitDebugCommand.cs
+++ b/source/GameInterface/Services/Alleys/Commands/AlleyRecruitDebugCommand.cs
@@ -170,6 +170,7 @@ public class AlleyRecruitDebugCommand
 
             RestoreRoster(fixture.PlayerParty.MemberRoster, fixture.MemberRoster);
             sendCoalescer.DropInstance(Compact(rosterId, typeof(TroopRoster)));
+            fixture.PlayerParty.MemberRoster.RemoveZeroCounts();
             foreach (var resetCharacter in resetCharacters)
             {
                 var index = fixture.PlayerParty.MemberRoster.FindIndexOfTroop(resetCharacter.Character);

--- a/source/GameInterface/Services/Alleys/Commands/AlleyRecruitDebugCommand.cs
+++ b/source/GameInterface/Services/Alleys/Commands/AlleyRecruitDebugCommand.cs
@@ -184,6 +184,13 @@ public class AlleyRecruitDebugCommand
                     rosterId,
                     resetCharacter.Id,
                     index >= 0 ? element.Number : 0));
+                if (index >= 0)
+                {
+                    network.SendAll(new NetworkTroopRosterElementBatch(
+                        rosterId,
+                        resetCharacter.Id,
+                        new[] { TroopRosterElementOperation.SetXp(element.Xp) }));
+                }
             }
             network.SendAll(new NetworkTroopRosterRemoveZeroCounts(rosterId));
             fixture.Alley.SetOwner(fixture.OriginalOwner);

--- a/source/GameInterface/Services/Alleys/Commands/AlleyRecruitDebugCommand.cs
+++ b/source/GameInterface/Services/Alleys/Commands/AlleyRecruitDebugCommand.cs
@@ -345,7 +345,7 @@ public class AlleyRecruitDebugCommand
         for (var index = roster.Count - 1; index >= 0; index--)
         {
             var element = roster.GetElementCopyAtIndex(index);
-            roster.AddToCountsAtIndex(index, -element.Number, -element.WoundedNumber, 0, false);
+            roster.AddToCountsAtIndex(index, -element.Number, -element.WoundedNumber, -element.Xp, false);
         }
         foreach (var element in elements)
         {

--- a/source/GameInterface/Services/Alleys/Commands/AlleyRecruitDebugCommand.cs
+++ b/source/GameInterface/Services/Alleys/Commands/AlleyRecruitDebugCommand.cs
@@ -4,6 +4,7 @@ using GameInterface.Services.Alleys.Interfaces;
 using GameInterface.Services.Alleys.Messages;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.TroopRosters.Data;
+using GameInterface.Services.TroopRosters.Messages;
 using Helpers;
 using SandBox.CampaignBehaviors;
 using SandBox.Conversation.MissionLogics;
@@ -132,17 +133,54 @@ public class AlleyRecruitDebugCommand
     public static string RestoreFixture(List<string> args)
     {
         if (ModInformation.IsClient) return "Run this command on the server.";
-        if (args.Count != 0) return "Usage: coop.debug.alley.recruit_fixture_restore";
         if (fixture == null) return "The alley recruit fixture is not active.";
         if (fixture.PlayerParty.MapEvent != null) return "Finish the player's map event before restoring the fixture.";
 
-        if (!ContainerProvider.TryResolve<ISessionAlleyPlayerDataInterface>(out var sessionInterface) ||
+        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager) ||
+            !ContainerProvider.TryResolve<ISessionAlleyPlayerDataInterface>(out var sessionInterface) ||
             !ContainerProvider.TryResolve<INetwork>(out var network))
             return "Unable to resolve the alley recruit fixture services.";
 
         try
         {
+            var charactersToReset = fixture.PlayerParty.MemberRoster.GetTroopRoster()
+                .Select(element => element.Character)
+                .Concat(fixture.MemberRoster.Select(element => element.Character))
+                .ToList();
+            foreach (var characterId in args)
+            {
+                if (!objectManager.TryGetObjectWithLogging<CharacterObject>(characterId, out var character))
+                    return $"Character '{characterId}' not found.";
+                charactersToReset.Add(character);
+            }
+
+            if (!objectManager.TryGetIdWithLogging(fixture.PlayerParty.MemberRoster, out var rosterId))
+                return "Unable to resolve the fixture roster id.";
+            var resetCharacters = new List<(CharacterObject Character, string Id)>();
+            foreach (var character in charactersToReset.Distinct())
+            {
+                if (!objectManager.TryGetIdWithLogging(character, out var characterId))
+                    return $"Unable to resolve the fixture character id for '{character.StringId}'.";
+                resetCharacters.Add((character, characterId));
+            }
+
             RestoreRoster(fixture.PlayerParty.MemberRoster, fixture.MemberRoster);
+            foreach (var resetCharacter in resetCharacters)
+            {
+                var index = fixture.PlayerParty.MemberRoster.FindIndexOfTroop(resetCharacter.Character);
+                var element = index >= 0
+                    ? fixture.PlayerParty.MemberRoster.GetElementCopyAtIndex(index)
+                    : default;
+                network.SendAll(new NetworkTroopRosterSetWoundedNumber(
+                    rosterId,
+                    resetCharacter.Id,
+                    index >= 0 ? element.WoundedNumber : 0));
+                network.SendAll(new NetworkTroopRosterSetNumber(
+                    rosterId,
+                    resetCharacter.Id,
+                    index >= 0 ? element.Number : 0));
+            }
+            network.SendAll(new NetworkTroopRosterRemoveZeroCounts(rosterId));
             fixture.Alley.SetOwner(fixture.OriginalOwner);
 
             if (fixture.OriginalManagementData == null)
@@ -257,11 +295,13 @@ public class AlleyRecruitDebugCommand
         {
             case "open":
                 InventoryScreenHelper.OpenScreenAsInventory();
+                RepairLocalPlayerInventoryContext();
                 return "ALLEY_RECRUIT_INVENTORY_OPENED";
             case "trade":
                 if (Settlement.CurrentSettlement?.StringId != "town_ES1")
                     return "Enter Danustica (town_ES1) before opening its trade screen.";
                 InventoryScreenHelper.ActivateTradeWithCurrentSettlement();
+                RepairLocalPlayerInventoryContext();
                 return "ALLEY_RECRUIT_TRADE_OPENED settlement=town_ES1";
             case "complete":
                 if (!(GameStateManager.Current?.ActiveState is InventoryState))
@@ -279,6 +319,17 @@ public class AlleyRecruitDebugCommand
             default:
                 return "Usage: coop.debug.alley.recruit_inventory <open|trade|complete|state>";
         }
+    }
+
+    private static void RepairLocalPlayerInventoryContext()
+    {
+        var character = Hero.MainHero?.CharacterObject;
+        var inventoryLogic = InventoryScreenHelper.GetActiveInventoryState()?.InventoryLogic;
+        if (character == null || inventoryLogic == null)
+            throw new InvalidOperationException("The local player inventory context is unavailable.");
+
+        inventoryLogic.OwnerCharacter = character;
+        inventoryLogic.InitialEquipmentCharacter = character;
     }
 
     private static bool TryGetAlley(string settlementId, string indexArg, out Alley alley, out string error)

--- a/source/GameInterface/Services/Alleys/Commands/AlleyRecruitDebugCommand.cs
+++ b/source/GameInterface/Services/Alleys/Commands/AlleyRecruitDebugCommand.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.Conversation;
 using TaleWorlds.CampaignSystem.GameState;
 using TaleWorlds.CampaignSystem.Party;
@@ -339,6 +340,37 @@ public class AlleyRecruitDebugCommand
             default:
                 return "Usage: coop.debug.alley.recruit_inventory <open|trade|complete|state>";
         }
+    }
+
+    [CommandLineArgumentFunction("recruit_start_looter_battle", "coop.debug.alley")]
+    public static string StartLooterBattle(List<string> args)
+    {
+        if (ModInformation.IsClient) return "Run this command on the server.";
+        if (args.Count != 1)
+            return "Usage: coop.debug.alley.recruit_start_looter_battle <heroRegistryId>";
+        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
+            return "Unable to resolve IObjectManager.";
+        if (!objectManager.TryGetObjectWithLogging<Hero>(args[0], out var owner))
+            return $"Hero '{args[0]}' not found.";
+        var playerParty = owner.PartyBelongedTo;
+        if (playerParty == null || playerParty.MapEvent != null)
+            return "The fixture owner must lead a party outside a map event.";
+
+        if (playerParty.CurrentSettlement != null)
+            LeaveSettlementAction.ApplyForParty(playerParty);
+        var position = playerParty.Position.ToVec2();
+        var banditParty = MobileParty.All
+            .Where(candidate => candidate.IsActive && candidate.IsBandit && candidate != playerParty &&
+                candidate.MapEvent == null && candidate.CurrentSettlement == null &&
+                candidate.MemberRoster.TotalManCount > 0)
+            .OrderBy(candidate => candidate.Position.ToVec2().DistanceSquared(position))
+            .FirstOrDefault();
+        if (banditParty == null) return "No active bandit party is available for the loot fixture.";
+
+        StartBattleAction.Apply(banditParty.Party, playerParty.Party);
+        if (playerParty.MapEvent == null) return "The looter battle map event was not created.";
+        return $"ALLEY_RECRUIT_LOOTER_BATTLE_STARTED party={banditParty.StringId} " +
+               $"troops={banditParty.MemberRoster.TotalManCount}";
     }
 
     private static void RepairLocalPlayerInventoryContext()

--- a/source/GameInterface/Services/Alleys/Commands/AlleyRecruitDebugCommand.cs
+++ b/source/GameInterface/Services/Alleys/Commands/AlleyRecruitDebugCommand.cs
@@ -1,5 +1,6 @@
 ﻿using Common;
 using Common.Network;
+using Common.Network.Coalescing;
 using GameInterface.Services.Alleys.Interfaces;
 using GameInterface.Services.Alleys.Messages;
 using GameInterface.Services.ObjectManager;
@@ -139,7 +140,8 @@ public class AlleyRecruitDebugCommand
 
         if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager) ||
             !ContainerProvider.TryResolve<ISessionAlleyPlayerDataInterface>(out var sessionInterface) ||
-            !ContainerProvider.TryResolve<INetwork>(out var network))
+            !ContainerProvider.TryResolve<INetwork>(out var network) ||
+            !ContainerProvider.TryResolve<ISendCoalescer>(out var sendCoalescer))
             return "Unable to resolve the alley recruit fixture services.";
 
         try
@@ -166,6 +168,7 @@ public class AlleyRecruitDebugCommand
             }
 
             RestoreRoster(fixture.PlayerParty.MemberRoster, fixture.MemberRoster);
+            sendCoalescer.FlushInstance(rosterId, network);
             foreach (var resetCharacter in resetCharacters)
             {
                 var index = fixture.PlayerParty.MemberRoster.FindIndexOfTroop(resetCharacter.Character);

--- a/source/GameInterface/Services/Alleys/Commands/AlleyRecruitDebugCommand.cs
+++ b/source/GameInterface/Services/Alleys/Commands/AlleyRecruitDebugCommand.cs
@@ -229,6 +229,26 @@ public class AlleyRecruitDebugCommand
         }
     }
 
+    [CommandLineArgumentFunction("recruit_overseer_state", "coop.debug.alley")]
+    public static string RecruitOverseerState(List<string> args)
+    {
+        if (ModInformation.IsServer) return "Run this command on the owning client.";
+        if (args.Count != 2)
+            return "Usage: coop.debug.alley.recruit_overseer_state <settlementId> <alleyIndex>";
+        if (!TryGetAlley(args[0], args[1], out var alley, out var error)) return error;
+        if (Mission.Current == null) return "ALLEY_RECRUIT_OVERSEER_STATE mission=False present=False";
+
+        var behavior = Campaign.Current?.GetCampaignBehavior<AlleyCampaignBehavior>();
+        var playerAlleyData = behavior?._playerOwnedCommonAreaData.FirstOrDefault(data => data.Alley == alley);
+        if (playerAlleyData == null) return "ALLEY_RECRUIT_OVERSEER_STATE mission=True present=False owner=False";
+
+        var overseerAgent = Mission.Current.Agents.FirstOrDefault(candidate =>
+            candidate.Character is CharacterObject character &&
+            character.HeroObject == playerAlleyData.AssignedClanMember);
+        return $"ALLEY_RECRUIT_OVERSEER_STATE mission=True present={overseerAgent != null} " +
+               $"owner=True overseer={playerAlleyData.AssignedClanMember.StringId}";
+    }
+
     [CommandLineArgumentFunction("recruit_conversation_start", "coop.debug.alley")]
     public static string StartRecruitConversation(List<string> args)
     {

--- a/source/GameInterface/Services/Alleys/Commands/AlleyRecruitDebugCommand.cs
+++ b/source/GameInterface/Services/Alleys/Commands/AlleyRecruitDebugCommand.cs
@@ -22,6 +22,7 @@ using TaleWorlds.CampaignSystem.Roster;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Core;
 using TaleWorlds.MountAndBlade;
+using static GameInterface.Services.ObjectManager.ObjectManager;
 using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Alleys.Commands;
@@ -168,7 +169,7 @@ public class AlleyRecruitDebugCommand
             }
 
             RestoreRoster(fixture.PlayerParty.MemberRoster, fixture.MemberRoster);
-            sendCoalescer.FlushInstance(rosterId, network);
+            sendCoalescer.DropInstance(Compact(rosterId, typeof(TroopRoster)));
             foreach (var resetCharacter in resetCharacters)
             {
                 var index = fixture.PlayerParty.MemberRoster.FindIndexOfTroop(resetCharacter.Character);

--- a/source/GameInterface/Services/Alleys/Handlers/AlleyHandler.cs
+++ b/source/GameInterface/Services/Alleys/Handlers/AlleyHandler.cs
@@ -3,6 +3,7 @@ using Common.Logging;
 using Common.Messaging;
 using Common.Network;
 using Common.Util;
+using GameInterface.Services.Alleys.Commands;
 using GameInterface.Services.Alleys.Interfaces;
 using GameInterface.Services.Alleys.Messages;
 using GameInterface.Services.ObjectManager;
@@ -137,6 +138,7 @@ internal class AlleyHandler : IHandler
         foreach (var alley in behaviorInterface.GetPlayerOwnedAlleys())
         {
             if (!objectManager.TryGetId(alley, out var alleyId)) continue;
+            if (AlleyRecruitDebugCommand.IsFixtureAlley(alleyId)) continue;
             if (!sessionInterface.TryGetManagementData(alleyId, out var data)) continue;
 
             // Isolate per-alley failures so one bad alley doesn't skip the rest of the day's tick.
@@ -241,7 +243,14 @@ internal class AlleyHandler : IHandler
 
         var newGarrison = result.ToArray();
         sessionInterface.SetManagementData(alleyId, data.OverseerId, newGarrison);
-        network.SendAll(new NetworkAlleyManagementUpdated(alleyId, data.OverseerId, newGarrison));
+        if (sessionInterface.TryGetManagementData(alleyId, out var updated))
+        {
+            network.SendAll(new NetworkAlleyManagementUpdated(
+                alleyId,
+                updated.OverseerId,
+                updated.Garrison,
+                updated.LastRecruitTimeTicks));
+        }
     }
 
     /// <summary>
@@ -301,7 +310,7 @@ internal class AlleyHandler : IHandler
             ChangeRelationAction.ApplyRelationChangeBetweenHeroes(alley.Owner, attacker.Owner, -5, showQuickNotification: false);
         }
 
-        network.SendAll(new NetworkAlleyUnderAttack(alleyId, attackerId, dueDate));
+        network.SendAll(new NetworkAlleyUnderAttack(alleyId, attackerId, dueDate, showNotification: true));
     }
 
     /// <summary>
@@ -447,7 +456,7 @@ internal class AlleyHandler : IHandler
             objectManager.TryGetObject<Alley>(data.UnderAttackByAlleyId, out var attacker) && attacker.Owner == victim)
         {
             sessionInterface.ClearUnderAttackByAi(alleyId);
-            network.SendAll(new NetworkAlleyUnderAttack(alleyId, null, default));
+            network.SendAll(new NetworkAlleyUnderAttack(alleyId, null, default, showNotification: false));
         }
     }
 
@@ -472,7 +481,11 @@ internal class AlleyHandler : IHandler
             }
 
             if (!objectManager.TryGetObjectWithLogging<Alley>(data.AttackerAlleyId, out var attacker)) return;
-            behaviorInterface.SetPlayerAlleyUnderAttackByAi(alley, attacker, data.DueDate, showNotification: true);
+            behaviorInterface.SetPlayerAlleyUnderAttackByAi(
+                alley,
+                attacker,
+                data.DueDate,
+                data.ShowNotification);
         });
     }
 
@@ -537,7 +550,14 @@ internal class AlleyHandler : IHandler
         if (garrison != null)
         {
             sessionInterface.SetManagementData(alleyId, overseerId, garrison);
-            network.SendAll(new NetworkAlleyManagementUpdated(alleyId, overseerId, garrison));
+            if (sessionInterface.TryGetManagementData(alleyId, out var updated))
+            {
+                network.SendAll(new NetworkAlleyManagementUpdated(
+                    alleyId,
+                    updated.OverseerId,
+                    updated.Garrison,
+                    updated.LastRecruitTimeTicks));
+            }
         }
 
         if (alley.Owner != null)

--- a/source/GameInterface/Services/Alleys/Handlers/AlleyInitializationHandler.cs
+++ b/source/GameInterface/Services/Alleys/Handlers/AlleyInitializationHandler.cs
@@ -66,7 +66,11 @@ internal class AlleyInitializationHandler : IHandler
                 Hero overseer = null;
                 if (pair.Value.OverseerId != null) objectManager.TryGetObjectWithLogging(pair.Value.OverseerId, out overseer);
 
-                behaviorInterface.AddOrUpdatePlayerAlleyData(alley, overseer, AlleyGarrisonData.FromData(pair.Value.Garrison, objectManager));
+                behaviorInterface.AddOrUpdatePlayerAlleyData(
+                    alley,
+                    overseer,
+                    AlleyGarrisonData.FromData(pair.Value.Garrison, objectManager),
+                    new CampaignTime(pair.Value.LastRecruitTimeTicks));
 
                 // Restore an in-progress attack so the confront-alley menu works after joining mid-attack;
                 // no map notice, it would be stale.

--- a/source/GameInterface/Services/Alleys/Handlers/AlleyManagementHandler.cs
+++ b/source/GameInterface/Services/Alleys/Handlers/AlleyManagementHandler.cs
@@ -8,6 +8,7 @@ using GameInterface.Services.Heroes.Extensions;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.TroopRosters.Data;
 using Serilog;
+using System;
 using System.Collections.Generic;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Actions;
@@ -50,11 +51,13 @@ internal class AlleyManagementHandler : IHandler
         messageBroker.Subscribe<AbandonAlleyRequested>(Handle_AbandonAlleyRequested);
         messageBroker.Subscribe<ChangeAlleyOverseerRequested>(Handle_ChangeAlleyOverseerRequested);
         messageBroker.Subscribe<SetAlleyGarrisonRequested>(Handle_SetAlleyGarrisonRequested);
+        messageBroker.Subscribe<RecruitAlleyTroopsRequested>(Handle_RecruitAlleyTroopsRequested);
 
         messageBroker.Subscribe<RequestAcquireAlley>(Handle_RequestAcquireAlley);
         messageBroker.Subscribe<RequestAbandonAlley>(Handle_RequestAbandonAlley);
         messageBroker.Subscribe<RequestChangeAlleyOverseer>(Handle_RequestChangeAlleyOverseer);
         messageBroker.Subscribe<RequestSetAlleyGarrison>(Handle_RequestSetAlleyGarrison);
+        messageBroker.Subscribe<RequestRecruitAlleyTroops>(Handle_RequestRecruitAlleyTroops);
 
         messageBroker.Subscribe<NetworkAlleyManagementUpdated>(Handle_NetworkAlleyManagementUpdated);
         messageBroker.Subscribe<NetworkAlleyManagementRemoved>(Handle_NetworkAlleyManagementRemoved);
@@ -66,11 +69,13 @@ internal class AlleyManagementHandler : IHandler
         messageBroker.Unsubscribe<AbandonAlleyRequested>(Handle_AbandonAlleyRequested);
         messageBroker.Unsubscribe<ChangeAlleyOverseerRequested>(Handle_ChangeAlleyOverseerRequested);
         messageBroker.Unsubscribe<SetAlleyGarrisonRequested>(Handle_SetAlleyGarrisonRequested);
+        messageBroker.Unsubscribe<RecruitAlleyTroopsRequested>(Handle_RecruitAlleyTroopsRequested);
 
         messageBroker.Unsubscribe<RequestAcquireAlley>(Handle_RequestAcquireAlley);
         messageBroker.Unsubscribe<RequestAbandonAlley>(Handle_RequestAbandonAlley);
         messageBroker.Unsubscribe<RequestChangeAlleyOverseer>(Handle_RequestChangeAlleyOverseer);
         messageBroker.Unsubscribe<RequestSetAlleyGarrison>(Handle_RequestSetAlleyGarrison);
+        messageBroker.Unsubscribe<RequestRecruitAlleyTroops>(Handle_RequestRecruitAlleyTroops);
 
         messageBroker.Unsubscribe<NetworkAlleyManagementUpdated>(Handle_NetworkAlleyManagementUpdated);
         messageBroker.Unsubscribe<NetworkAlleyManagementRemoved>(Handle_NetworkAlleyManagementRemoved);
@@ -113,6 +118,16 @@ internal class AlleyManagementHandler : IHandler
         network.SendAll(new RequestSetAlleyGarrison(alleyId, AlleyGarrisonData.ToData(payload.What.NewGarrison, objectManager)));
     }
 
+    private void Handle_RecruitAlleyTroopsRequested(MessagePayload<RecruitAlleyTroopsRequested> payload)
+    {
+        if (ModInformation.IsServer) return;
+        if (!objectManager.TryGetIdWithLogging(payload.What.Alley, out var alleyId)) return;
+
+        network.SendAll(new RequestRecruitAlleyTroops(
+            alleyId,
+            AlleyGarrisonData.ToData(payload.What.Troops, objectManager)));
+    }
+
     // --- Network requests (server, authoritative) ---
 
     private void Handle_RequestAcquireAlley(MessagePayload<RequestAcquireAlley> payload)
@@ -126,7 +141,7 @@ internal class AlleyManagementHandler : IHandler
             if (!objectManager.TryGetObjectWithLogging<Hero>(data.OwnerId, out var owner)) return;
             if (!objectManager.TryGetObjectWithLogging<Hero>(data.OverseerId, out var overseer)) return;
 
-            var garrison = data.Garrison ?? new TroopRosterElementData[0];
+            var garrison = data.Garrison ?? Array.Empty<TroopRosterElementData>();
 
             // The take-over is authoritative: the alley is owned by the acquiring player (owner) and
             // run by the chosen clan member (overseer). The garrison + overseer are stored, the overseer
@@ -138,7 +153,8 @@ internal class AlleyManagementHandler : IHandler
             sessionInterface.SetManagementData(data.AlleyId, data.OverseerId, garrison);
             TeleportOverseerToAlley(overseer, alley);
 
-            network.SendAll(new NetworkAlleyManagementUpdated(data.AlleyId, data.OverseerId, garrison));
+            if (sessionInterface.TryGetManagementData(data.AlleyId, out var stored))
+                BroadcastManagementUpdate(data.AlleyId, stored);
         });
     }
 
@@ -211,7 +227,8 @@ internal class AlleyManagementHandler : IHandler
             sessionInterface.SetManagementData(data.AlleyId, data.NewOverseerId, garrison);
             TeleportOverseerToAlley(newOverseer, alley);
 
-            network.SendAll(new NetworkAlleyManagementUpdated(data.AlleyId, data.NewOverseerId, garrison));
+            if (sessionInterface.TryGetManagementData(data.AlleyId, out var updated))
+                BroadcastManagementUpdate(data.AlleyId, updated);
         });
     }
 
@@ -224,14 +241,63 @@ internal class AlleyManagementHandler : IHandler
         {
             if (!objectManager.TryGetObjectWithLogging<Alley>(data.AlleyId, out _)) return;
 
-            var newGarrison = data.Garrison ?? new TroopRosterElementData[0];
+            var newGarrison = data.Garrison ?? Array.Empty<TroopRosterElementData>();
             // The alley party screen already moved the troops between the owner's party and the alley
             // roster, and that party-roster change replicates through the existing party-screen sync, so
             // the server only records the new garrison snapshot (for persistence and abandon-return).
             sessionInterface.TryGetManagementData(data.AlleyId, out var stored);
             sessionInterface.SetManagementData(data.AlleyId, stored?.OverseerId, newGarrison);
 
-            network.SendAll(new NetworkAlleyManagementUpdated(data.AlleyId, stored?.OverseerId, newGarrison));
+            if (sessionInterface.TryGetManagementData(data.AlleyId, out var updated))
+                BroadcastManagementUpdate(data.AlleyId, updated);
+        });
+    }
+
+    private void Handle_RequestRecruitAlleyTroops(MessagePayload<RequestRecruitAlleyTroops> payload)
+    {
+        if (ModInformation.IsClient) return;
+
+        var data = payload.What;
+        GameThread.RunSafe(() =>
+        {
+            if (!objectManager.TryGetObjectWithLogging<Alley>(data.AlleyId, out var alley)) return;
+            if (!sessionInterface.TryGetManagementData(data.AlleyId, out var managementData)) return;
+            var lastRecruitTime = new CampaignTime(managementData.LastRecruitTimeTicks);
+            if (lastRecruitTime.ElapsedDaysUntilNow <= CampaignTime.DaysInWeek) return;
+
+            var ownerParty = alley.Owner?.PartyBelongedTo;
+            if (ownerParty == null)
+            {
+                Logger.Error("Could not recruit alley troops: owner of {AlleyId} has no party", data.AlleyId);
+                return;
+            }
+
+            var recruits = new List<(CharacterObject character, int count)>();
+            var uniqueCharacters = new HashSet<CharacterObject>();
+            foreach (var troop in data.Troops ?? Array.Empty<TroopRosterElementData>())
+            {
+                if (troop.Number <= 0 || troop.WoundedNumber != 0 || troop.Xp != 0) return;
+                if (!objectManager.TryGetObjectWithLogging<CharacterObject>(troop.CharacterId, out var character)) return;
+                if (character.IsHero || !uniqueCharacters.Add(character)) return;
+                recruits.Add((character, troop.Number));
+            }
+            if (recruits.Count == 0) return;
+
+            foreach (var recruit in recruits)
+            {
+                ownerParty.MemberRoster.AddToCounts(
+                    recruit.character,
+                    recruit.count,
+                    false,
+                    0,
+                    0,
+                    true,
+                    -1);
+            }
+
+            sessionInterface.SetLastRecruitTimeTicks(data.AlleyId, CampaignTime.Now.NumTicks);
+            if (sessionInterface.TryGetManagementData(data.AlleyId, out var updated))
+                BroadcastManagementUpdate(data.AlleyId, updated);
         });
     }
 
@@ -258,8 +324,21 @@ internal class AlleyManagementHandler : IHandler
             Hero overseer = null;
             if (data.OverseerId != null) objectManager.TryGetObjectWithLogging(data.OverseerId, out overseer);
 
-            behaviorInterface.AddOrUpdatePlayerAlleyData(alley, overseer, AlleyGarrisonData.FromData(data.Garrison, objectManager));
+            behaviorInterface.AddOrUpdatePlayerAlleyData(
+                alley,
+                overseer,
+                AlleyGarrisonData.FromData(data.Garrison, objectManager),
+                new CampaignTime(data.LastRecruitTimeTicks));
         });
+    }
+
+    private void BroadcastManagementUpdate(string alleyId, AlleyManagementData data)
+    {
+        network.SendAll(new NetworkAlleyManagementUpdated(
+            alleyId,
+            data.OverseerId,
+            data.Garrison,
+            data.LastRecruitTimeTicks));
     }
 
     private void Handle_NetworkAlleyManagementRemoved(MessagePayload<NetworkAlleyManagementRemoved> payload)
@@ -321,7 +400,7 @@ internal class AlleyManagementHandler : IHandler
     /// </summary>
     private TroopRosterElementData[] SwapOverseerInGarrison(TroopRosterElementData[] garrison, string oldOverseerId, string newOverseerId)
     {
-        var list = new List<TroopRosterElementData>(garrison ?? new TroopRosterElementData[0]);
+        var list = new List<TroopRosterElementData>(garrison ?? Array.Empty<TroopRosterElementData>());
 
         if (TryGetHeroCharacterId(oldOverseerId, out var oldCharId))
             list.RemoveAll(e => e.CharacterId == oldCharId);

--- a/source/GameInterface/Services/Alleys/Interfaces/AlleyCampaignBehaviorInterface.cs
+++ b/source/GameInterface/Services/Alleys/Interfaces/AlleyCampaignBehaviorInterface.cs
@@ -20,7 +20,7 @@ namespace GameInterface.Services.Alleys.Interfaces;
 /// </summary>
 public interface IAlleyCampaignBehaviorInterface : IGameAbstraction
 {
-    void AddOrUpdatePlayerAlleyData(Alley alley, Hero overseer, TroopRoster garrison);
+    void AddOrUpdatePlayerAlleyData(Alley alley, Hero overseer, TroopRoster garrison, CampaignTime lastRecruitTime);
     void RemovePlayerAlleyData(Alley alley);
     bool TryGetCurrentSettlementAlley(out Alley alley);
 
@@ -52,7 +52,7 @@ public class AlleyCampaignBehaviorInterface : IAlleyCampaignBehaviorInterface
 
     private static AlleyCampaignBehavior Behavior => Campaign.Current?.GetCampaignBehavior<AlleyCampaignBehavior>();
 
-    public void AddOrUpdatePlayerAlleyData(Alley alley, Hero overseer, TroopRoster garrison)
+    public void AddOrUpdatePlayerAlleyData(Alley alley, Hero overseer, TroopRoster garrison, CampaignTime lastRecruitTime)
     {
         if (alley == null || garrison == null)
         {
@@ -95,6 +95,7 @@ public class AlleyCampaignBehaviorInterface : IAlleyCampaignBehaviorInterface
                 RemoveByAlley(list, alley);
                 var data = new AlleyCampaignBehavior.PlayerAlleyData(alley, garrison);
                 if (overseer != null) data.AssignedClanMember = overseer;
+                data.LastRecruitTime = lastRecruitTime;
                 if (underAttackBy != null)
                 {
                     data.UnderAttackBy = underAttackBy;

--- a/source/GameInterface/Services/Alleys/Interfaces/SessionAlleyPlayerDataInterface.cs
+++ b/source/GameInterface/Services/Alleys/Interfaces/SessionAlleyPlayerDataInterface.cs
@@ -18,6 +18,7 @@ public interface ISessionAlleyPlayerDataInterface : IGameAbstraction
 {
     bool TryGetManagementData(string alleyId, out AlleyManagementData data);
     void SetManagementData(string alleyId, string overseerId, TroopRosterElementData[] garrison);
+    void SetLastRecruitTimeTicks(string alleyId, long lastRecruitTimeTicks);
     void RemoveManagementData(string alleyId);
 
     /// <summary>Records that a rival alley is attacking this player alley, with the answer deadline.</summary>
@@ -68,9 +69,16 @@ public class SessionAlleyPlayerDataInterface : ISessionAlleyPlayerDataInterface
         {
             entry.UnderAttackByAlleyId = existing.UnderAttackByAlleyId;
             entry.AttackResponseDueDate = existing.AttackResponseDueDate;
+            entry.LastRecruitTimeTicks = existing.LastRecruitTimeTicks;
         }
 
         map[alleyId] = entry;
+    }
+
+    public void SetLastRecruitTimeTicks(string alleyId, long lastRecruitTimeTicks)
+    {
+        if (!TryGetManagementData(alleyId, out var data)) return;
+        data.LastRecruitTimeTicks = lastRecruitTimeTicks;
     }
 
     public void RemoveManagementData(string alleyId)

--- a/source/GameInterface/Services/Alleys/Messages/AlleyAiMessages.cs
+++ b/source/GameInterface/Services/Alleys/Messages/AlleyAiMessages.cs
@@ -74,11 +74,18 @@ public readonly struct NetworkAlleyUnderAttack : ICommand
     public readonly string AttackerAlleyId;
     [ProtoMember(3)]
     public readonly CampaignTime DueDate;
-    public NetworkAlleyUnderAttack(string alleyId, string attackerAlleyId, CampaignTime dueDate)
+    [ProtoMember(4)]
+    public readonly bool ShowNotification;
+    public NetworkAlleyUnderAttack(
+        string alleyId,
+        string attackerAlleyId,
+        CampaignTime dueDate,
+        bool showNotification)
     {
         AlleyId = alleyId;
         AttackerAlleyId = attackerAlleyId;
         DueDate = dueDate;
+        ShowNotification = showNotification;
     }
 }
 

--- a/source/GameInterface/Services/Alleys/Messages/AlleyManagementMessages.cs
+++ b/source/GameInterface/Services/Alleys/Messages/AlleyManagementMessages.cs
@@ -49,6 +49,18 @@ public readonly struct SetAlleyGarrisonRequested : IEvent
     }
 }
 
+/// <summary>The player accepted the troop offer from their alley overseer.</summary>
+public readonly struct RecruitAlleyTroopsRequested : IEvent
+{
+    public readonly Alley Alley;
+    public readonly TroopRoster Troops;
+    public RecruitAlleyTroopsRequested(Alley alley, TroopRoster troops)
+    {
+        Alley = alley;
+        Troops = troops;
+    }
+}
+
 /// <summary>
 /// Player won the alley fight and took over the alley. The alley is owned by the acquiring player
 /// (<see cref="Owner"/>) and run by the chosen clan member (<see cref="Overseer"/>) - these are
@@ -134,6 +146,20 @@ public readonly struct RequestSetAlleyGarrison : ICommand
     }
 }
 
+[ProtoContract(SkipConstructor = true)]
+public readonly struct RequestRecruitAlleyTroops : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string AlleyId;
+    [ProtoMember(2)]
+    public readonly TroopRosterElementData[] Troops;
+    public RequestRecruitAlleyTroops(string alleyId, TroopRosterElementData[] troops)
+    {
+        AlleyId = alleyId;
+        Troops = troops;
+    }
+}
+
 // --- Networked server -> clients broadcasts ---
 
 [ProtoContract(SkipConstructor = true)]
@@ -145,11 +171,18 @@ public readonly struct NetworkAlleyManagementUpdated : ICommand
     public readonly string OverseerId;
     [ProtoMember(3)]
     public readonly TroopRosterElementData[] Garrison;
-    public NetworkAlleyManagementUpdated(string alleyId, string overseerId, TroopRosterElementData[] garrison)
+    [ProtoMember(4)]
+    public readonly long LastRecruitTimeTicks;
+    public NetworkAlleyManagementUpdated(
+        string alleyId,
+        string overseerId,
+        TroopRosterElementData[] garrison,
+        long lastRecruitTimeTicks)
     {
         AlleyId = alleyId;
         OverseerId = overseerId;
         Garrison = garrison;
+        LastRecruitTimeTicks = lastRecruitTimeTicks;
     }
 }
 

--- a/source/GameInterface/Services/Alleys/Patches/AlleyManagementPatches.cs
+++ b/source/GameInterface/Services/Alleys/Patches/AlleyManagementPatches.cs
@@ -107,27 +107,26 @@ internal class AlleyManagementPatches
     [HarmonyPrefix]
     private static bool PlayerRecruitedTroopsFromAlleyPrefix(AlleyCampaignBehavior __instance)
     {
-        if (ModInformation.IsClient)
-        {
-            var playerAlleyData = __instance._playerOwnedCommonAreaData.FirstOrDefault(
-                data => data.Alley?.Settlement == Settlement.CurrentSettlement);
-            if (playerAlleyData == null) return false;
+        if (ModInformation.IsServer) return false;
 
-            var troops = Campaign.Current.Models.AlleyModel.GetTroopsToRecruitFromAlleyDependingOnAlleyRandom(
-                playerAlleyData.Alley,
-                playerAlleyData.RandomFloatWeekly);
+        var playerAlleyData = __instance._playerOwnedCommonAreaData.FirstOrDefault(
+            data => data.Alley?.Settlement == Settlement.CurrentSettlement);
+        if (playerAlleyData == null) return false;
 
-            MessageBroker.Instance.Publish(
-                playerAlleyData.Alley,
-                new RecruitAlleyTroopsRequested(playerAlleyData.Alley, troops));
+        var troops = Campaign.Current.Models.AlleyModel.GetTroopsToRecruitFromAlleyDependingOnAlleyRandom(
+            playerAlleyData.Alley,
+            playerAlleyData.RandomFloatWeekly);
 
-            MBInformationManager.AddQuickInformation(
-                new TextObject("{=8CW2y0p3}Troops have been joined to your party"),
-                0,
-                null,
-                null,
-                string.Empty);
-        }
+        MessageBroker.Instance.Publish(
+            playerAlleyData.Alley,
+            new RecruitAlleyTroopsRequested(playerAlleyData.Alley, troops));
+
+        MBInformationManager.AddQuickInformation(
+            new TextObject("{=8CW2y0p3}Troops have been joined to your party"),
+            0,
+            null,
+            null,
+            string.Empty);
 
         return false;
     }

--- a/source/GameInterface/Services/Alleys/Patches/AlleyManagementPatches.cs
+++ b/source/GameInterface/Services/Alleys/Patches/AlleyManagementPatches.cs
@@ -11,6 +11,7 @@ using TaleWorlds.CampaignSystem.GameMenus;
 using TaleWorlds.CampaignSystem.Roster;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Core;
+using TaleWorlds.Localization;
 
 namespace GameInterface.Services.Alleys.Patches;
 
@@ -100,6 +101,35 @@ internal class AlleyManagementPatches
         {
             MessageBroker.Instance.Publish(alley, new SetAlleyGarrisonRequested(alley, leftMemberRoster));
         }
+    }
+
+    [HarmonyPatch("player_recruited_troops_from_alley")]
+    [HarmonyPrefix]
+    private static bool PlayerRecruitedTroopsFromAlleyPrefix(AlleyCampaignBehavior __instance)
+    {
+        if (ModInformation.IsClient)
+        {
+            var playerAlleyData = __instance._playerOwnedCommonAreaData.FirstOrDefault(
+                data => data.Alley?.Settlement == Settlement.CurrentSettlement);
+            if (playerAlleyData == null) return false;
+
+            var troops = Campaign.Current.Models.AlleyModel.GetTroopsToRecruitFromAlleyDependingOnAlleyRandom(
+                playerAlleyData.Alley,
+                playerAlleyData.RandomFloatWeekly);
+
+            MessageBroker.Instance.Publish(
+                playerAlleyData.Alley,
+                new RecruitAlleyTroopsRequested(playerAlleyData.Alley, troops));
+
+            MBInformationManager.AddQuickInformation(
+                new TextObject("{=8CW2y0p3}Troops have been joined to your party"),
+                0,
+                null,
+                null,
+                string.Empty);
+        }
+
+        return false;
     }
 
     private static bool TryGetCurrentSettlementAlley(out Alley alley)

--- a/source/GameInterface/Services/Locations/Commands/LocationDebugCommand.cs
+++ b/source/GameInterface/Services/Locations/Commands/LocationDebugCommand.cs
@@ -2,6 +2,7 @@
 using Common.Messaging;
 using GameInterface.Services.Locations.Messages;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Settlements.Interfaces;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -41,8 +42,13 @@ public class LocationDebugCommand
 
         if (PlayerEncounter.Current == null)
         {
-            EncounterManager.StartSettlementEncounter(MobileParty.MainParty, settlement);
-            return $"Requested an encounter with '{settlement.StringId}'.";
+            if (!ContainerProvider.TryResolve<ISettlementInterface>(out var settlementInterface))
+                return "Unable to resolve the settlement interface.";
+
+            settlementInterface.StartSettlementEncounter(MobileParty.MainParty, settlement);
+            return PlayerEncounter.Current == null
+                ? $"Unable to start a local encounter with '{settlement.StringId}'."
+                : $"Started a local encounter with '{settlement.StringId}'.";
         }
 
         if (PlayerEncounter.EncounterSettlement != settlement)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Accepting an alley recruitment offer adds the troops locally, then opening inventory, town trade, or post-battle loot duplicates them when the party roster synchronizes. Repeating recruitment increases the duplicated count, and reconnecting can reset the weekly recruitment cooldown.

## What is the new behavior?

Resolves #2708

Alley recruits are added once for the owning player and remain at the same count after inventory, town trade, and post-battle loot. Other players see the same roster, and the weekly recruitment cooldown remains in effect across alley updates and reconnects.

## Bot Changelog Entry

- Fixed alley recruits duplicating after opening inventory, trade, or loot menus.
