### PR TITLE
[2709] Restore player party on reconnect

### DIFF
--- a/source/Coop.Core/Client/Services/Heroes/Handlers/RemotePlayerHeroHandler.cs
+++ b/source/Coop.Core/Client/Services/Heroes/Handlers/RemotePlayerHeroHandler.cs
@@ -39,11 +39,13 @@ internal class RemotePlayerHeroHandler : IHandler
         this.playerRegistry = playerRegistry;
 
         messageBroker.Subscribe<NetworkNewPlayerHeroCreated>(Handle_NetworkNewPlayerHeroCreated);
+        messageBroker.Subscribe<NetworkPlayerRegistrationUpdated>(Handle_NetworkPlayerRegistrationUpdated);
     }
 
     public void Dispose()
     {
         messageBroker.Unsubscribe<NetworkNewPlayerHeroCreated>(Handle_NetworkNewPlayerHeroCreated);
+        messageBroker.Unsubscribe<NetworkPlayerRegistrationUpdated>(Handle_NetworkPlayerRegistrationUpdated);
     }
 
     private void Handle_NetworkNewPlayerHeroCreated(MessagePayload<NetworkNewPlayerHeroCreated> payload)
@@ -69,5 +71,23 @@ internal class RemotePlayerHeroHandler : IHandler
             if (!playerRegistry.AddPlayer(player))
                 Logger.Error("Player {HeroId} has already been added.", player.HeroId);
         }, blocking: true);
+    }
+
+    private void Handle_NetworkPlayerRegistrationUpdated(MessagePayload<NetworkPlayerRegistrationUpdated> payload)
+    {
+        var replacement = payload.What.Player;
+
+        // Party creation and this update both defer from the ordered receive stream to the same
+        // game-thread queue, so the replacement resolves after its party has been registered.
+        GameThread.RunSafe(() =>
+        {
+            if (!playerRegistry.TryGetPlayer(replacement.ControllerId, out var registered) ||
+                !playerRegistry.ReplacePlayer(registered, replacement))
+            {
+                Logger.Error(
+                    "Could not replace player registration for controller {ControllerId}",
+                    replacement.ControllerId);
+            }
+        }, blocking: true, context: nameof(Handle_NetworkPlayerRegistrationUpdated));
     }
 }

--- a/source/Coop.Core/Client/Services/Heroes/Messages/NetworkPlayerRegistrationUpdated.cs
+++ b/source/Coop.Core/Client/Services/Heroes/Messages/NetworkPlayerRegistrationUpdated.cs
@@ -1,0 +1,20 @@
+﻿using Common.Messaging;
+using GameInterface.Services.Players.Data;
+using ProtoBuf;
+
+namespace Coop.Core.Client.Services.Heroes.Messages;
+
+/// <summary>
+/// Replaces a remote player's party mapping after the server repairs a stale registration.
+/// </summary>
+[ProtoContract]
+public readonly struct NetworkPlayerRegistrationUpdated : IEvent
+{
+    [ProtoMember(1)]
+    public readonly Player Player;
+
+    public NetworkPlayerRegistrationUpdated(Player player)
+    {
+        Player = player;
+    }
+}

--- a/source/Coop.Core/Server/Connections/ConnectionContext.cs
+++ b/source/Coop.Core/Server/Connections/ConnectionContext.cs
@@ -25,6 +25,7 @@ public class ConnectionContext
         IModuleValidator moduleValidator,
         IModuleInfoProvider moduleInfoProvider,
         IPlayerManager playerManager,
+        IPlayerPartyRestorer playerPartyRestorer,
         IObjectManager objectManager,
         IHeroInterface heroInterface,
         ICoopSessionProvider coopSessionProvider,
@@ -41,6 +42,7 @@ public class ConnectionContext
         ModuleValidator = moduleValidator;
         ModuleInfoProvider = moduleInfoProvider;
         PlayerManager = playerManager;
+        PlayerPartyRestorer = playerPartyRestorer;
         ObjectManager = objectManager;
         HeroInterface = heroInterface;
         CoopSessionProvider = coopSessionProvider;
@@ -58,6 +60,7 @@ public class ConnectionContext
     public IModuleValidator ModuleValidator { get; }
     public IModuleInfoProvider ModuleInfoProvider { get; }
     public IPlayerManager PlayerManager { get; }
+    public IPlayerPartyRestorer PlayerPartyRestorer { get; }
     public IObjectManager ObjectManager { get; }
     public IHeroInterface HeroInterface { get; }
     public ICoopSessionProvider CoopSessionProvider { get; }

--- a/source/Coop.Core/Server/Connections/ConnectionLogic.cs
+++ b/source/Coop.Core/Server/Connections/ConnectionLogic.cs
@@ -80,7 +80,7 @@ public class ConnectionLogic : IConnectionLogic
     private IReadOnlyDictionary<Type, Func<IConnectionState>> CreateStateFactories() =>
         new Dictionary<Type, Func<IConnectionState>>
         {
-            [typeof(ResolveCharacterState)] = () => new ResolveCharacterState(this, context.MessageBroker, context.Network, context.ModuleValidator, context.PlayerManager, context.ObjectManager, context.ModuleInfoProvider, context.ExistingPlayerSender),
+            [typeof(ResolveCharacterState)] = () => new ResolveCharacterState(this, context.MessageBroker, context.Network, context.ModuleValidator, context.PlayerManager, context.PlayerPartyRestorer, context.ObjectManager, context.ModuleInfoProvider, context.ExistingPlayerSender),
             [typeof(CreateCharacterState)] = () => new CreateCharacterState(this, context.ObjectManager, context.MessageBroker, context.Network, context.HeroInterface, context.PlayerManager, context.ExistingPlayerSender),
             [typeof(TransferSaveState)] = () => new TransferSaveState(this, context.MessageBroker, context.Network, context.CoopSessionProvider, context.SaveInterface, context.ConnectionMessageQueue, context.Coalescer, context.AttachmentIdMapper, context.ServerOptionsProvider),
             [typeof(LoadingState)] = () => new LoadingState(this, context.MessageBroker, context.Network, context.JoinCampaignBaselineSender, context.ConnectionMessageQueue, context.Coalescer),

--- a/source/Coop.Core/Server/Connections/States/ResolveCharacterState.cs
+++ b/source/Coop.Core/Server/Connections/States/ResolveCharacterState.cs
@@ -1,6 +1,8 @@
+﻿using Common;
 using Common.Logging;
 using Common.Messaging;
 using Common.Network;
+using Coop.Core.Client.Services.Heroes.Messages;
 using Coop.Core.Server.Connections.Messages;
 using GameInterface.Services.Modules;
 using GameInterface.Services.Modules.Validators;
@@ -27,6 +29,7 @@ public class ResolveCharacterState : ConnectionStateBase
     private readonly INetwork network;
     private readonly IModuleValidator moduleValidator;
     private readonly IPlayerManager playerManager;
+    private readonly IPlayerPartyRestorer playerPartyRestorer;
     private readonly IObjectManager objectManager;
     private readonly IModuleInfoProvider moduleInfoProvider;
     private readonly IExistingPlayerSender existingPlayerSender;
@@ -36,6 +39,7 @@ public class ResolveCharacterState : ConnectionStateBase
         INetwork network,
         IModuleValidator moduleValidator,
         IPlayerManager playerManager,
+        IPlayerPartyRestorer playerPartyRestorer,
         IObjectManager objectManager,
         IModuleInfoProvider moduleInfoProvider,
         IExistingPlayerSender existingPlayerSender)
@@ -45,6 +49,7 @@ public class ResolveCharacterState : ConnectionStateBase
         this.network = network;
         this.moduleValidator = moduleValidator;
         this.playerManager = playerManager;
+        this.playerPartyRestorer = playerPartyRestorer;
         this.objectManager = objectManager;
         this.moduleInfoProvider = moduleInfoProvider;
         this.existingPlayerSender = existingPlayerSender;
@@ -125,12 +130,44 @@ public class ResolveCharacterState : ConnectionStateBase
     {
         if (playerManager.TryGetPlayer(controllerId, out var player))
         {
-            if (objectManager.TryGetObjectWithLogging(player.HeroId, out Hero _)) // If new save, player hero will not exist
+            var heroExists = false;
+            var partyRestored = false;
+            var registrationReplaced = false;
+            var restoredPlayer = player;
+
+            // Resolve campaign objects and repair the registration on the game thread. A loaded
+            // party can be registered by an earlier queued apply even though this poll-thread
+            // validation has already arrived.
+            GameThread.Run(() =>
             {
+                heroExists = objectManager.TryGetObjectWithLogging(player.HeroId, out Hero _);
+                if (!heroExists) return;
+
+                partyRestored = playerPartyRestorer.TryRestore(player, out restoredPlayer);
+                if (!partyRestored || ReferenceEquals(restoredPlayer, player)) return;
+
+                registrationReplaced = playerManager.ReplacePlayer(player, restoredPlayer);
+            }, blocking: true);
+
+            if (heroExists)
+            {
+                if (!partyRestored || (!ReferenceEquals(restoredPlayer, player) && !registrationReplaced))
+                {
+                    Logger.Error(
+                        "Controller {ControllerId} hero {HeroId} has no recoverable player party; disconnecting the joiner",
+                        controllerId,
+                        player.HeroId);
+                    peer.Disconnect();
+                    return;
+                }
+
+                if (registrationReplaced)
+                    network.SendAllBut(peer, new NetworkPlayerRegistrationUpdated(restoredPlayer));
+
                 // This peer is a new NetPeer for an already registered player, so the
                 // peer-Player link must be established here
                 playerManager.SetPeer(controllerId, peer);
-                network.SendImmediate(peer, new NetworkClientValidated(true, player));
+                network.SendImmediate(peer, new NetworkClientValidated(true, restoredPlayer));
                 ConnectionLogic.TransferSave();
 
                 existingPlayerSender.SendExistingPlayers(peer, controllerId);

--- a/source/Coop.Core/Server/Services/Save/Handlers/SaveGameHandler.cs
+++ b/source/Coop.Core/Server/Services/Save/Handlers/SaveGameHandler.cs
@@ -135,12 +135,21 @@ internal class SaveGameHandler : IHandler
 
         foreach (var player in SelectOneRegistrationPerController(savedSession.Players))
         {
-            playerPartyRestorer.Restore(player);
-            if (!playerRegistry.AddPlayer(player))
+            if (!playerPartyRestorer.TryRestore(player, out var registration))
+            {
+                Logger.Error(
+                    "Skipped saved registration for controller {ControllerId} (hero {HeroId}): " +
+                    "the player graph could not be restored",
+                    player.ControllerId,
+                    player.HeroId);
+                continue;
+            }
+
+            if (!playerRegistry.AddPlayer(registration))
                 Logger.Warning(
                     "Skipped saved registration for controller {ControllerId} (hero {HeroId}): " +
                     "that controller is already registered",
-                    player?.ControllerId, player?.HeroId);
+                    registration?.ControllerId, registration?.HeroId);
         }
     }
 
@@ -164,7 +173,9 @@ internal class SaveGameHandler : IHandler
                 continue;
             }
 
-            var live = registrations.FirstOrDefault(PlayerGraphExists) ?? registrations[0];
+            var live = registrations.FirstOrDefault(PlayerGraphExists) ??
+                registrations.FirstOrDefault(PlayerHeroExists) ??
+                registrations[0];
 
             Logger.Warning(
                 "Save carries {Count} registrations for controller {ControllerId} (heroes {HeroIds}); " +
@@ -183,4 +194,8 @@ internal class SaveGameHandler : IHandler
         !string.IsNullOrEmpty(player.MobilePartyId) &&
         objectManager.TryGetObject<Hero>(player.HeroId, out _) &&
         objectManager.TryGetObject<MobileParty>(player.MobilePartyId, out _);
+
+    private bool PlayerHeroExists(Player player) =>
+        !string.IsNullOrEmpty(player.HeroId) &&
+        objectManager.TryGetObject<Hero>(player.HeroId, out _);
 }

--- a/source/Coop.Tests/Client/Services/Heroes/Handlers/RemotePlayerHeroHandlerTests.cs
+++ b/source/Coop.Tests/Client/Services/Heroes/Handlers/RemotePlayerHeroHandlerTests.cs
@@ -71,4 +71,20 @@ public class RemotePlayerHeroHandlerTests
         heroInterface.Verify(x => x.ClientUnpackHero(It.IsAny<byte[]>(), It.IsAny<Player>()), Times.Never);
         playerManager.Verify(x => x.AddPlayer(It.IsAny<Player>()), Times.Never);
     }
+
+    [Fact]
+    public void PlayerRegistrationUpdated_ReplacesExistingMapping()
+    {
+        var registered = new Player("ctrl", "hero1", "staleParty", "clan1", "char1");
+        var replacement = new Player("ctrl", "hero1", "party1", "clan1", "char1");
+        var resolvedPlayer = registered;
+        playerManager
+            .Setup(manager => manager.TryGetPlayer(registered.ControllerId, out resolvedPlayer))
+            .Returns(true);
+        playerManager.Setup(manager => manager.ReplacePlayer(registered, replacement)).Returns(true);
+
+        messageBroker.Publish(this, new NetworkPlayerRegistrationUpdated(replacement));
+
+        playerManager.Verify(manager => manager.ReplacePlayer(registered, replacement), Times.Once);
+    }
 }

--- a/source/Coop.Tests/Server/Connections/States/ResolveCharacterStateTests.cs
+++ b/source/Coop.Tests/Server/Connections/States/ResolveCharacterStateTests.cs
@@ -1,5 +1,6 @@
 ﻿using Autofac;
 using Common.Messaging;
+using Coop.Core.Client.Services.Heroes.Messages;
 using Coop.Core.Server.Connections;
 using Coop.Core.Server.Connections.Messages;
 using Coop.Core.Server.Connections.States;
@@ -211,6 +212,12 @@ namespace Coop.Tests.Server.Connections.States
             var objectManager = serverComponent.Container.Resolve<IObjectManager>();
             var hero = (Hero)FormatterServices.GetUninitializedObject(typeof(Hero));
             Assert.True(objectManager.AddExisting(player.HeroId, hero));
+            var restoredPlayer = player;
+
+            serverComponent.Container
+                .Resolve<Mock<IPlayerPartyRestorer>>()
+                .Setup(restorer => restorer.TryRestore(player, out restoredPlayer))
+                .Returns(true);
 
             // Act
             var payload = new MessagePayload<NetworkClientValidate>(
@@ -226,6 +233,48 @@ namespace Coop.Tests.Server.Connections.States
 
             Assert.True(message.HeroExists);
             Assert.Equal(player, message.Player);
+        }
+
+        [Fact]
+        public void NetworkClientValidate_RegisteredHeroWithStaleParty_RepairsWithoutCreatingCharacter()
+        {
+            var currentState = connectionLogic.SetState<ResolveCharacterState>();
+            var player = new Player("MyPlayer", "MyHero", "MissingParty", "MyClan", "MyCharacter");
+            var repaired = new Player("MyPlayer", "MyHero", "RecoveredParty", "MyClan", "MyCharacter");
+            var playerManager = serverComponent.Container.Resolve<Mock<IPlayerManager>>();
+            var registeredPlayer = player;
+            playerManager
+                .Setup(manager => manager.TryGetPlayer(player.ControllerId, out registeredPlayer))
+                .Returns(true);
+            playerManager.Setup(manager => manager.ReplacePlayer(player, repaired)).Returns(true);
+
+            var objectManager = serverComponent.Container.Resolve<IObjectManager>();
+            var hero = (Hero)FormatterServices.GetUninitializedObject(typeof(Hero));
+            Assert.True(objectManager.AddExisting(player.HeroId, hero));
+            var restoredPlayer = repaired;
+
+            serverComponent.Container
+                .Resolve<Mock<IPlayerPartyRestorer>>()
+                .Setup(restorer => restorer.TryRestore(player, out restoredPlayer))
+                .Returns(true);
+
+            currentState.Handle_ClientValidate(new MessagePayload<NetworkClientValidate>(
+                playerPeer,
+                new NetworkClientValidate(player.ControllerId)));
+
+            playerManager.Verify(manager => manager.ReplacePlayer(player, repaired), Times.Once);
+            playerManager.Verify(manager => manager.RemovePlayer(It.IsAny<Player>()), Times.Never);
+
+            var validation = Assert.Single(
+                serverComponent.TestNetwork.GetPeerMessages(playerPeer).OfType<NetworkClientValidated>());
+            Assert.True(validation.HeroExists);
+            Assert.Same(repaired, validation.Player);
+
+            var update = Assert.Single(
+                serverComponent.TestNetwork.GetPeerMessages(differentPeer)
+                    .OfType<NetworkPlayerRegistrationUpdated>());
+            Assert.Same(repaired, update.Player);
+            Assert.IsNotType<CreateCharacterState>(connectionLogic.State);
         }
 
         [Fact]

--- a/source/Coop.Tests/Server/Services/Save/SaveGameHandlerTests.cs
+++ b/source/Coop.Tests/Server/Services/Save/SaveGameHandlerTests.cs
@@ -99,7 +99,7 @@ public class SaveGameHandlerTests
     }
 
     [Fact]
-    public void AllGameObjectsRegistered_DuplicateControllerWithNoLiveHero_RestoresExactlyOne()
+    public void AllGameObjectsRegistered_DuplicateControllerWithNoLiveHero_RegistersNeither()
     {
         var first = new Player(ControllerId, MissingHeroId, "Party_A", "Clan_One", "Character_A");
         var second = new Player(ControllerId, "Hero_AlsoMissing", "Party_B", "Clan_One", "Character_B");
@@ -109,14 +109,11 @@ public class SaveGameHandlerTests
 
         using var handler = CreateHandler(playerRegistry, new[] { first, second });
 
-        // Neither hero resolves, so there is nothing to prefer — but the controller must still end
-        // up with one registration, which its owner heals by joining.
-        playerRegistry.Verify(registry => registry.AddPlayer(It.IsAny<Player>()), Times.Once);
-        playerRegistry.Verify(registry => registry.AddPlayer(first), Times.Once);
+        playerRegistry.Verify(registry => registry.AddPlayer(It.IsAny<Player>()), Times.Never);
     }
 
     [Fact]
-    public void AllGameObjectsRegistered_DistinctControllers_RestoresEvery()
+    public void AllGameObjectsRegistered_DistinctControllers_SkipsUnrestoredRegistration()
     {
         var first = new Player("PlayerOne", LiveHeroId, "Party_A", "Clan_One", "Character_A");
         var second = new Player("PlayerTwo", MissingHeroId, "Party_B", "Clan_Two", "Character_B");
@@ -126,31 +123,56 @@ public class SaveGameHandlerTests
 
         using var handler = CreateHandler(playerRegistry, new[] { first, second });
 
-        // A missing hero is only a tie-breaker between duplicates; on its own it must not cost a
-        // controller its registration, or that player is sent to character creation for nothing.
         playerRegistry.Verify(registry => registry.AddPlayer(first), Times.Once);
-        playerRegistry.Verify(registry => registry.AddPlayer(second), Times.Once);
+        playerRegistry.Verify(registry => registry.AddPlayer(second), Times.Never);
     }
 
     [Fact]
     public void AllGameObjectsRegistered_RepairsSavedPlayerBeforeRegistration()
     {
         var player = new Player(ControllerId, LiveHeroId, LivePartyId, "Clan_One", "Character_Live");
+        var repaired = new Player(ControllerId, LiveHeroId, "Party_Repaired", "Clan_One", "Character_Live");
         var calls = new List<string>();
         var playerPartyRestorer = new Mock<IPlayerPartyRestorer>();
         var playerRegistry = new Mock<IPlayerManager>();
+        var restoredPlayer = repaired;
 
         playerPartyRestorer
-            .Setup(restorer => restorer.Restore(player))
-            .Callback(() => calls.Add("repair"));
+            .Setup(restorer => restorer.TryRestore(player, out restoredPlayer))
+            .Callback(() => calls.Add("repair"))
+            .Returns(true);
         playerRegistry
-            .Setup(registry => registry.AddPlayer(player))
+            .Setup(registry => registry.AddPlayer(repaired))
             .Callback(() => calls.Add("register"))
             .Returns(true);
 
         using var handler = CreateHandler(playerRegistry, new[] { player }, playerPartyRestorer);
 
         Assert.Equal(new[] { "repair", "register" }, calls);
+    }
+
+    [Fact]
+    public void AllGameObjectsRegistered_DuplicateStaleParties_PrefersResolvableHeroForRepair()
+    {
+        var missing = new Player(ControllerId, MissingHeroId, "Party_Missing", "Clan_One", "Character_Missing");
+        var recoverable = new Player(ControllerId, LiveHeroId, "Party_Stale", "Clan_One", "Character_Live");
+        var repaired = new Player(ControllerId, LiveHeroId, LivePartyId, "Clan_One", "Character_Live");
+        var playerPartyRestorer = new Mock<IPlayerPartyRestorer>();
+        var playerRegistry = new Mock<IPlayerManager>();
+        var restoredPlayer = repaired;
+
+        playerPartyRestorer
+            .Setup(restorer => restorer.TryRestore(recoverable, out restoredPlayer))
+            .Returns(true);
+        playerRegistry.Setup(registry => registry.AddPlayer(repaired)).Returns(true);
+
+        using var handler = CreateHandler(
+            playerRegistry,
+            new[] { missing, recoverable },
+            playerPartyRestorer);
+
+        playerRegistry.Verify(registry => registry.AddPlayer(repaired), Times.Once);
+        playerRegistry.Verify(registry => registry.AddPlayer(missing), Times.Never);
     }
 
     /// <summary>
@@ -165,7 +187,16 @@ public class SaveGameHandlerTests
     {
         var messageBroker = new TestMessageBroker();
         if (playerPartyRestorer == null)
+        {
             playerPartyRestorer = new Mock<IPlayerPartyRestorer>();
+            foreach (var player in savedPlayers)
+            {
+                var restoredPlayer = player;
+                playerPartyRestorer
+                    .Setup(restorer => restorer.TryRestore(player, out restoredPlayer))
+                    .Returns(player.HeroId == LiveHeroId || player.HeroId == StaleHeroId);
+            }
+        }
 
         var objectManager = new Mock<IObjectManager>();
         Hero liveHero = null!;

--- a/source/E2E.Tests/Services/MapEvents/MapEventCollectionTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/MapEventCollectionTests.cs
@@ -1,5 +1,6 @@
 ﻿using Common;
 using Common.Network.Messages;
+using Common.Util;
 using Coop.Core.Server.Connections.Messages;
 using E2E.Tests.Environment.Instance;
 using E2E.Tests.Util;

--- a/source/GameInterface.Tests/Services/Players/PlayerManagerTests.cs
+++ b/source/GameInterface.Tests/Services/Players/PlayerManagerTests.cs
@@ -223,6 +223,80 @@ public class PlayerManagerTests
         Assert.Same(current, resolved);
     }
 
+    [Fact]
+    public void ReplacePlayer_CurrentRegistration_UpdatesControllerAndPeerAtomically()
+    {
+        var playerManager = CreatePlayerManager(out _);
+        var registered = new Player(ControllerId, "Hero", "StaleParty", "Clan", "Character");
+        var replacement = new Player(ControllerId, "Hero", "RecoveredParty", "Clan", "Character");
+        var peer = new TestNetwork().CreatePeer();
+
+        Assert.True(playerManager.AddPlayer(registered));
+        playerManager.SetPeer(ControllerId, peer);
+
+        Assert.True(playerManager.ReplacePlayer(registered, replacement));
+
+        Assert.True(playerManager.TryGetPlayer(ControllerId, out var byController));
+        Assert.Same(replacement, byController);
+        Assert.True(playerManager.TryGetPlayer(peer, out var byPeer));
+        Assert.Same(replacement, byPeer);
+        Assert.Same(replacement, Assert.Single(playerManager.Players));
+    }
+
+    [Fact]
+    public void ReplacePlayer_ChangedParty_ReplacesControlledObjectMarker()
+    {
+        var staleParty = ObjectHelper.SkipConstructor<MobileParty>();
+        var recoveredParty = ObjectHelper.SkipConstructor<MobileParty>();
+        var playerManager = CreatePlayerManager(out var objectManager);
+        var registered = new Player(ControllerId, string.Empty, "StaleParty", string.Empty, string.Empty);
+        var replacement = new Player(ControllerId, string.Empty, "RecoveredParty", string.Empty, string.Empty);
+        MobileParty resolvedStaleParty = staleParty;
+        MobileParty resolvedRecoveredParty = recoveredParty;
+        objectManager
+            .Setup(manager => manager.TryGetObjectWithLogging("StaleParty", out resolvedStaleParty))
+            .Returns(true);
+        objectManager
+            .Setup(manager => manager.TryGetObject("StaleParty", out resolvedStaleParty))
+            .Returns(true);
+        objectManager
+            .Setup(manager => manager.TryGetObjectWithLogging("RecoveredParty", out resolvedRecoveredParty))
+            .Returns(true);
+
+        var playerObjects = GetPlayerObjects();
+        try
+        {
+            Assert.True(playerManager.AddPlayer(registered));
+            Assert.True(playerManager.Contains(staleParty));
+
+            Assert.True(playerManager.ReplacePlayer(registered, replacement));
+
+            Assert.False(playerManager.Contains(staleParty));
+            Assert.True(playerManager.Contains(recoveredParty));
+        }
+        finally
+        {
+            playerObjects.Remove(staleParty);
+            playerObjects.Remove(recoveredParty);
+        }
+    }
+
+    [Fact]
+    public void ReplacePlayer_SupersededRegistration_LeavesCurrentRegistrationIntact()
+    {
+        var playerManager = CreatePlayerManager(out _);
+        var superseded = new Player(ControllerId, "OldHero", string.Empty, string.Empty, string.Empty);
+        var current = new Player(ControllerId, "CurrentHero", string.Empty, string.Empty, string.Empty);
+        var replacement = new Player(ControllerId, "ReplacementHero", string.Empty, string.Empty, string.Empty);
+
+        Assert.True(playerManager.AddPlayer(superseded));
+        Assert.True(playerManager.RemovePlayer(superseded));
+        Assert.True(playerManager.AddPlayer(current));
+
+        Assert.False(playerManager.ReplacePlayer(superseded, replacement));
+        Assert.Same(current, Assert.Single(playerManager.Players));
+    }
+
     private static ConditionalWeakTable<object, ControlledObjectInfo> GetPlayerObjects() =>
         (ConditionalWeakTable<object, ControlledObjectInfo>)AccessTools
             .Field(typeof(PlayerManager), "PlayerObjects")

--- a/source/GameInterface.Tests/Services/Players/PlayerPartyRestorerTests.cs
+++ b/source/GameInterface.Tests/Services/Players/PlayerPartyRestorerTests.cs
@@ -1,13 +1,17 @@
 ﻿using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
+using GameInterface.Services.Players.Data;
 using GameInterface.Tests.Bootstrap;
 using Moq;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Party.PartyComponents;
 using TaleWorlds.CampaignSystem.Roster;
+using TaleWorlds.Core;
 using TaleWorlds.Library;
 using Xunit;
 
@@ -33,6 +37,7 @@ public class PlayerPartyRestorerTests
         Assert.Equal(1, party.MemberRoster.GetTroopCount(character));
         Assert.Same(hero, party.LeaderHero);
         Assert.Same(hero, party.LordPartyComponent.Owner);
+        Assert.Same(party, hero.PartyBelongedTo);
     }
 
     [Fact]
@@ -48,6 +53,180 @@ public class PlayerPartyRestorerTests
         Assert.Equal(1, clan.AliveLords.Count(x => x == hero));
         Assert.Equal(1, party.MemberRoster.GetTroopCount(character));
         Assert.Same(hero, party.LeaderHero);
+    }
+
+    [Fact]
+    public void Restore_StaleHeroPartyRoot_PointsHeroAtRestoredParty()
+    {
+        var (hero, party, _, _) = CreatePlayerGraph();
+        var (_, staleParty, _, _) = CreatePlayerGraph();
+        var restorer = new PlayerPartyRestorer(Mock.Of<IObjectManager>());
+        restorer.Restore(hero, party);
+        hero._partyBelongedTo = staleParty;
+
+        restorer.Restore(hero, party);
+
+        Assert.Same(party, hero.PartyBelongedTo);
+    }
+
+    [Fact]
+    public void TryRestore_StalePartyId_ReassociatesOwnedPartyWithoutReplacingHero()
+    {
+        var (hero, party, _, _) = CreatePlayerGraph();
+        var player = new Player("Controller", "Hero_Saved", "MobileParty_Stale", "Clan_Stale", "Character_Stale");
+        var objectManager = new Mock<IObjectManager>();
+        Hero resolvedHero = hero;
+        MobileParty missingParty = null;
+        string partyId = "MobileParty_Recovered";
+        string clanId = "Clan_Recovered";
+        string characterId = "Character_Recovered";
+        objectManager
+            .Setup(manager => manager.TryGetObjectWithLogging(player.HeroId, out resolvedHero))
+            .Returns(true);
+        objectManager
+            .Setup(manager => manager.TryGetObject(player.MobilePartyId, out missingParty))
+            .Returns(false);
+        objectManager.Setup(manager => manager.TryGetId(party, out partyId)).Returns(true);
+        objectManager.Setup(manager => manager.TryGetIdWithLogging(party, out partyId)).Returns(true);
+        objectManager.Setup(manager => manager.TryGetIdWithLogging(hero.Clan, out clanId)).Returns(true);
+        objectManager.Setup(manager => manager.TryGetIdWithLogging(hero.CharacterObject, out characterId)).Returns(true);
+
+        var restorer = new PlayerPartyRestorer(
+            objectManager.Object,
+            () => new[] { party },
+            _ => throw new InvalidOperationException("A live owned party should be reused"));
+
+        Assert.True(restorer.TryRestore(player, out var restored));
+
+        Assert.Equal(player.ControllerId, restored.ControllerId);
+        Assert.Equal(player.HeroId, restored.HeroId);
+        Assert.Equal(partyId, restored.MobilePartyId);
+        Assert.Equal(clanId, restored.ClanId);
+        Assert.Equal(characterId, restored.CharacterObjectId);
+        Assert.Equal(1, party.MemberRoster.GetTroopCount(hero.CharacterObject));
+        Assert.Same(hero, party.LeaderHero);
+    }
+
+    [Fact]
+    public void TryRestore_MissingCaptiveParty_CreatesParkedLeaderlessParty()
+    {
+        var (hero, party, _, _) = CreatePlayerGraph();
+        var captor = (PartyBase)FormatterServices.GetUninitializedObject(typeof(PartyBase));
+        var captorParty = (MobileParty)FormatterServices.GetUninitializedObject(typeof(MobileParty));
+        var captivePosition = new CampaignVec2(new Vec2(12f, 34f), isOnLand: true);
+        captor.MobileParty = captorParty;
+        captorParty.Party = captor;
+        captorParty.Position = captivePosition;
+        party._position = captivePosition;
+        hero._heroState = Hero.CharacterStates.Prisoner;
+        hero.PartyBelongedToAsPrisoner = captor;
+        party.IsActive = true;
+
+        var player = new Player("Controller", "Hero_Saved", "MobileParty_Missing", "Clan_Saved", "Character_Saved");
+        var objectManager = new Mock<IObjectManager>();
+        Hero resolvedHero = hero;
+        MobileParty missingParty = null;
+        string partyId = "MobileParty_Recovered";
+        string clanId = "Clan_Saved";
+        string characterId = "Character_Saved";
+        objectManager
+            .Setup(manager => manager.TryGetObjectWithLogging(player.HeroId, out resolvedHero))
+            .Returns(true);
+        objectManager
+            .Setup(manager => manager.TryGetObject(player.MobilePartyId, out missingParty))
+            .Returns(false);
+        objectManager.Setup(manager => manager.TryGetId(party, out partyId)).Returns(true);
+        objectManager.Setup(manager => manager.TryGetIdWithLogging(party, out partyId)).Returns(true);
+        objectManager.Setup(manager => manager.TryGetIdWithLogging(hero.Clan, out clanId)).Returns(true);
+        objectManager.Setup(manager => manager.TryGetIdWithLogging(hero.CharacterObject, out characterId)).Returns(true);
+
+        var restorer = new PlayerPartyRestorer(
+            objectManager.Object,
+            () => Array.Empty<MobileParty>(),
+            _ => party);
+
+        Assert.True(restorer.TryRestore(player, out var restored));
+
+        Assert.Equal(player.HeroId, restored.HeroId);
+        Assert.Equal(partyId, restored.MobilePartyId);
+        Assert.Same(captor, hero.PartyBelongedToAsPrisoner);
+        Assert.Equal(0, party.MemberRoster.GetTroopCount(hero.CharacterObject));
+        Assert.Null(party.LeaderHero);
+        Assert.Null(hero.PartyBelongedTo);
+        Assert.Equal(captivePosition, party.Position);
+        Assert.False(party.IsActive);
+    }
+
+    [Fact]
+    public void TryRestore_NullPartyComponentBacklink_RepairsBacklink()
+    {
+        var (hero, party, _, _) = CreatePlayerGraph();
+        party.PartyComponent.MobileParty = null;
+        var player = new Player("Controller", "Hero_Saved", "MobileParty_Saved", "Clan_Saved", "Character_Saved");
+        var objectManager = CreateObjectManager(player, hero, party);
+
+        var restorer = new PlayerPartyRestorer(
+            objectManager.Object,
+            () => Array.Empty<MobileParty>(),
+            _ => throw new InvalidOperationException("The saved party should be reused"));
+
+        Assert.True(restorer.TryRestore(player, out _));
+        Assert.Same(party, party.PartyComponent.MobileParty);
+    }
+
+    [Fact]
+    public void TryRestore_PartyComponentBacklinkToDifferentParty_RejectsParty()
+    {
+        var (hero, party, _, _) = CreatePlayerGraph();
+        party.PartyComponent.MobileParty =
+            (MobileParty)FormatterServices.GetUninitializedObject(typeof(MobileParty));
+        var player = new Player("Controller", "Hero_Saved", "MobileParty_Saved", "Clan_Saved", "Character_Saved");
+        var objectManager = CreateObjectManager(player, hero, party);
+
+        var restorer = new PlayerPartyRestorer(
+            objectManager.Object,
+            () => new[] { party },
+            _ => null);
+
+        Assert.False(restorer.TryRestore(player, out _));
+    }
+
+    [Fact]
+    public void TryRestore_PartyOwnedByAnotherHero_DoesNotReassociateIt()
+    {
+        var (hero, party, _, _) = CreatePlayerGraph();
+        var otherHero = (Hero)FormatterServices.GetUninitializedObject(typeof(Hero));
+        var otherOwnerComponent = new LordPartyComponent(otherHero, null, null);
+        otherOwnerComponent.MobileParty = party;
+        party._partyComponent = otherOwnerComponent;
+
+        var player = new Player("Controller", "Hero_Saved", "MobileParty_Stale", "Clan_Saved", "Character_Saved");
+        var objectManager = new Mock<IObjectManager>();
+        Hero resolvedHero = hero;
+        MobileParty missingParty = null;
+        string clanId = "Clan_Saved";
+        string characterId = "Character_Saved";
+        objectManager
+            .Setup(manager => manager.TryGetObjectWithLogging(player.HeroId, out resolvedHero))
+            .Returns(true);
+        objectManager
+            .Setup(manager => manager.TryGetObject(player.MobilePartyId, out missingParty))
+            .Returns(false);
+        objectManager.Setup(manager => manager.TryGetIdWithLogging(hero.Clan, out clanId)).Returns(true);
+        objectManager.Setup(manager => manager.TryGetIdWithLogging(hero.CharacterObject, out characterId)).Returns(true);
+
+        var createCalled = false;
+        var restorer = new PlayerPartyRestorer(
+            objectManager.Object,
+            () => new[] { party },
+            _ =>
+            {
+                createCalled = true;
+                return null;
+            });
+
+        Assert.False(restorer.TryRestore(player, out _));
+        Assert.True(createCalled);
     }
 
     private static (Hero Hero, MobileParty Party, Clan Clan, CharacterObject Character) CreatePlayerGraph()
@@ -70,6 +249,8 @@ public class PlayerPartyRestorerTests
         party.Party = partyBase;
         partyBase.MobileParty = party;
         partyBase.MemberRoster = new TroopRoster();
+        partyBase.PrisonRoster = new TroopRoster();
+        partyBase.ItemRoster = new ItemRoster();
         hero._partyBelongedTo = party;
 
         var component = new LordPartyComponent(hero, null, null);
@@ -77,5 +258,25 @@ public class PlayerPartyRestorerTests
         party._partyComponent = component;
 
         return (hero, party, clan, character);
+    }
+
+    private static Mock<IObjectManager> CreateObjectManager(Player player, Hero hero, MobileParty party)
+    {
+        var objectManager = new Mock<IObjectManager>();
+        Hero resolvedHero = hero;
+        MobileParty resolvedParty = party;
+        string partyId = player.MobilePartyId;
+        string clanId = player.ClanId;
+        string characterId = player.CharacterObjectId;
+        objectManager
+            .Setup(manager => manager.TryGetObjectWithLogging(player.HeroId, out resolvedHero))
+            .Returns(true);
+        objectManager
+            .Setup(manager => manager.TryGetObject(player.MobilePartyId, out resolvedParty))
+            .Returns(true);
+        objectManager.Setup(manager => manager.TryGetIdWithLogging(party, out partyId)).Returns(true);
+        objectManager.Setup(manager => manager.TryGetIdWithLogging(hero.Clan, out clanId)).Returns(true);
+        objectManager.Setup(manager => manager.TryGetIdWithLogging(hero.CharacterObject, out characterId)).Returns(true);
+        return objectManager;
     }
 }

--- a/source/GameInterface/Services/Players/PlayerManager.cs
+++ b/source/GameInterface/Services/Players/PlayerManager.cs
@@ -28,6 +28,7 @@ public interface IPlayerManager
     /// <param name="player">The player to be added to the registry</param>
     /// <returns>if the player was added to the registry</returns>
     bool AddPlayer(Player player);
+    bool ReplacePlayer(Player registeredPlayer, Player replacementPlayer);
     bool TryGetPlayer(string controllerId, out Player player);
 
     /// <summary>
@@ -164,6 +165,43 @@ public class PlayerManager : IPlayerManager
         AddPlayerObject<Clan>(player.ControllerId, player.ClanId);
 
         return true;
+    }
+
+    public bool ReplacePlayer(Player registeredPlayer, Player replacementPlayer)
+    {
+        if (registeredPlayer == null || replacementPlayer == null ||
+            string.IsNullOrEmpty(registeredPlayer.ControllerId) ||
+            registeredPlayer.ControllerId != replacementPlayer.ControllerId)
+            return false;
+
+        lock (registrySync)
+        {
+            if (!_players.TryGetValue(registeredPlayer.ControllerId, out var current) ||
+                !ReferenceEquals(current, registeredPlayer))
+                return false;
+
+            _players[registeredPlayer.ControllerId] = replacementPlayer;
+
+            foreach (var peer in peerToPlayer
+                .Where(kvp => ReferenceEquals(kvp.Value, registeredPlayer))
+                .Select(kvp => kvp.Key).ToArray())
+            {
+                peerToPlayer[peer] = replacementPlayer;
+            }
+        }
+
+        ReplacePlayerObject<MobileParty>(registeredPlayer.ControllerId, registeredPlayer.MobilePartyId, replacementPlayer.MobilePartyId);
+        ReplacePlayerObject<Hero>(registeredPlayer.ControllerId, registeredPlayer.HeroId, replacementPlayer.HeroId);
+        ReplacePlayerObject<Clan>(registeredPlayer.ControllerId, registeredPlayer.ClanId, replacementPlayer.ClanId);
+        return true;
+    }
+
+    private void ReplacePlayerObject<T>(string controllerId, string oldId, string newId)
+    {
+        if (oldId == newId) return;
+
+        RemovePlayerObject<T>(oldId);
+        AddPlayerObject<T>(controllerId, newId);
     }
 
     private void AddPlayerObject<T>(string controllerId, string networkId)

--- a/source/GameInterface/Services/Players/PlayerPartyRestorer.cs
+++ b/source/GameInterface/Services/Players/PlayerPartyRestorer.cs
@@ -1,31 +1,121 @@
-﻿using GameInterface.Services.ObjectManager;
+﻿using Common.Logging;
+using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players.Data;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Party.PartyComponents;
 
 namespace GameInterface.Services.Players;
 
 public interface IPlayerPartyRestorer
 {
-    void Restore(Player player);
+    bool TryRestore(Player player, out Player restoredPlayer);
     void Restore(Hero hero, MobileParty party);
 }
 
 internal class PlayerPartyRestorer : IPlayerPartyRestorer
 {
+    private static readonly ILogger Logger = LogManager.GetLogger<PlayerPartyRestorer>();
+
     private readonly IObjectManager objectManager;
+    private readonly Func<IEnumerable<MobileParty>> getParties;
+    private readonly Func<Hero, MobileParty> createParty;
 
     public PlayerPartyRestorer(IObjectManager objectManager)
+        : this(objectManager, () => MobileParty.All, CreateReplacementParty)
     {
-        this.objectManager = objectManager;
     }
 
-    public void Restore(Player player)
+    internal PlayerPartyRestorer(
+        IObjectManager objectManager,
+        Func<IEnumerable<MobileParty>> getParties,
+        Func<Hero, MobileParty> createParty)
     {
-        if (!objectManager.TryGetObjectWithLogging(player.HeroId, out Hero hero)) return;
-        if (!objectManager.TryGetObjectWithLogging(player.MobilePartyId, out MobileParty party)) return;
+        this.objectManager = objectManager;
+        this.getParties = getParties;
+        this.createParty = createParty;
+    }
+
+    public bool TryRestore(Player player, out Player restoredPlayer)
+    {
+        restoredPlayer = player;
+        if (player == null) return false;
+        if (!objectManager.TryGetObjectWithLogging(player.HeroId, out Hero hero)) return false;
+        if (hero.Clan == null || hero.CharacterObject == null)
+        {
+            Logger.Error(
+                "Cannot restore player {ControllerId}: hero {HeroId} has no clan or character object",
+                player.ControllerId,
+                player.HeroId);
+            return false;
+        }
+        if (!objectManager.TryGetIdWithLogging(hero.Clan, out var clanId)) return false;
+        if (!objectManager.TryGetIdWithLogging(hero.CharacterObject, out var characterObjectId)) return false;
+
+        MobileParty party = null;
+        if (objectManager.TryGetObject(player.MobilePartyId, out MobileParty savedParty) &&
+            IsReadyPlayerParty(savedParty, hero))
+        {
+            party = savedParty;
+        }
+        else
+        {
+            party = getParties()
+                .FirstOrDefault(candidate =>
+                    IsReadyPlayerParty(candidate, hero) &&
+                    objectManager.TryGetId(candidate, out _));
+
+            if (party != null)
+            {
+                Logger.Warning(
+                    "Reassociating controller {ControllerId} hero {HeroId} from stale party {SavedPartyId} to {PartyId}",
+                    player.ControllerId,
+                    player.HeroId,
+                    player.MobilePartyId,
+                    party.StringId);
+            }
+        }
+
+        if (party == null)
+        {
+            party = createParty(hero);
+            if (party == null)
+            {
+                Logger.Error(
+                    "Cannot restore player {ControllerId} hero {HeroId}: no valid party or recovery position exists",
+                    player.ControllerId,
+                    player.HeroId);
+                return false;
+            }
+
+            Logger.Warning(
+                "Created replacement party {PartyId} for controller {ControllerId} hero {HeroId}",
+                party.StringId,
+                player.ControllerId,
+                player.HeroId);
+        }
+
+        if (!objectManager.TryGetIdWithLogging(party, out var partyId)) return false;
 
         Restore(hero, party);
+
+        if (partyId != player.MobilePartyId ||
+            clanId != player.ClanId ||
+            characterObjectId != player.CharacterObjectId)
+        {
+            restoredPlayer = new Player(
+                player.ControllerId,
+                player.HeroId,
+                partyId,
+                clanId,
+                characterObjectId);
+        }
+
+        return true;
     }
 
     public void Restore(Hero hero, MobileParty party)
@@ -34,10 +124,63 @@ internal class PlayerPartyRestorer : IPlayerPartyRestorer
         if (!hero.Clan.Heroes.Contains(hero))
             hero.Clan.OnLordAdded(hero);
 
+        if (hero.IsPrisoner || hero.PartyBelongedToAsPrisoner != null)
+        {
+            hero.PartyBelongedTo = null;
+
+            if (party.LeaderHero != null)
+                party.ChangePartyLeader(null);
+
+            var heroCount = party.MemberRoster.GetTroopCount(hero.CharacterObject);
+            if (heroCount > 0)
+                party.MemberRoster.AddToCounts(hero.CharacterObject, -heroCount);
+
+            var prisonerPosition = hero.GetCampaignPosition();
+            if (prisonerPosition.IsValid())
+                party.Position = prisonerPosition;
+
+            party.IsActive = false;
+            return;
+        }
+
+        hero.PartyBelongedTo = party;
+
         if (party.MemberRoster.GetTroopCount(hero.CharacterObject) == 0)
             party.MemberRoster.AddToCounts(hero.CharacterObject, 1, insertAtFront: true);
 
         if (party.LeaderHero != hero)
             party.ChangePartyLeader(hero);
+    }
+
+    private static bool IsReadyPlayerParty(MobileParty party, Hero hero)
+    {
+        if (party?.Party == null ||
+            party.Party.MobileParty != party ||
+            party.PartyComponent == null ||
+            party.MemberRoster == null ||
+            party.PrisonRoster == null ||
+            party.ItemRoster == null ||
+            party.LordPartyComponent?.Owner != hero)
+        {
+            return false;
+        }
+
+        if (party.PartyComponent.MobileParty == null)
+            party.PartyComponent.MobileParty = party;
+
+        return party.PartyComponent.MobileParty == party;
+    }
+
+    private static MobileParty CreateReplacementParty(Hero hero)
+    {
+        var position = hero.GetCampaignPosition();
+        if (!position.IsValid() && hero.LastKnownClosestSettlement != null)
+            position = hero.LastKnownClosestSettlement.GatePosition;
+        if (!position.IsValid()) return null;
+
+        var component = new LordPartyComponent(hero, null, null);
+        var party = MobileParty.CreateParty($"{hero.StringId}_recovered_{Guid.NewGuid():N}", component);
+        party.InitializeMobilePartyAtPosition(position);
+        return party;
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Restarting the dedicated server after a captured player escapes can reconnect that player as a random replacement character with an unusable party, leaving them unable to move and floating above a settlement.

## What is the new behavior?

Resolves #2709

Players reconnect with their original character and a valid party after the dedicated server restarts, including when the saved character is captive or has escaped captivity.

## Bot Changelog Entry

- Fixed players reconnecting as a random character with an unusable party after a server restart.
