### PR TITLE
Harden client replication input handling

### DIFF
--- a/source/E2E.Tests/Environment/MockEngine/MockAnimationActionCountProvider.cs
+++ b/source/E2E.Tests/Environment/MockEngine/MockAnimationActionCountProvider.cs
@@ -1,0 +1,12 @@
+﻿using Missions.Agents.Handlers;
+
+namespace E2E.Tests.Environment.MockEngine;
+
+public sealed class MockAnimationActionCountProvider :
+    IAnimationActionCountProvider
+{
+    public int GetActionCount()
+    {
+        return 10000;
+    }
+}

--- a/source/E2E.Tests/Environment/MockEngine/MockMission.cs
+++ b/source/E2E.Tests/Environment/MockEngine/MockMission.cs
@@ -2,6 +2,7 @@
 using System.Runtime.CompilerServices;
 using Common.Util;
 using TaleWorlds.Core;
+using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
 
 namespace E2E.Tests.Environment.MockEngine;
@@ -122,6 +123,7 @@ public sealed class MockMission
             Index = nextIndex++,
             Controller = AgentControllerType.None,
             IsMount = true,
+            LookDirection = new Vec3(0f, 1f, 0f),
             Mission = Shell,
         };
         AgentMirror.Bind(horse, mirror);

--- a/source/E2E.Tests/Environment/TestEnvironment.cs
+++ b/source/E2E.Tests/Environment/TestEnvironment.cs
@@ -111,6 +111,9 @@ public class TestEnvironment
         builder.RegisterType<MockAgentVisualActionAccessor>()
             .As<IAgentVisualActionAccessor>()
             .InstancePerDependency();
+        builder.RegisterType<MockAnimationActionCountProvider>()
+            .As<IAnimationActionCountProvider>()
+            .InstancePerDependency();
         builder.RegisterType<MockGuardReactionActionResolver>()
             .As<IGuardReactionActionResolver>()
             .InstancePerDependency();

--- a/source/E2E.Tests/Services/Missions/ClientReplicationResilienceTests.cs
+++ b/source/E2E.Tests/Services/Missions/ClientReplicationResilienceTests.cs
@@ -1,0 +1,229 @@
+﻿using Common.Util;
+using Missions.Agents.Handlers;
+using Missions.Agents.Packets;
+using Missions.Data;
+using Missions.Messages;
+using System.Reflection;
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+using Xunit;
+
+namespace E2E.Tests.Services.Missions;
+
+public sealed class ClientReplicationResilienceTests
+{
+    [Fact]
+    public void ReplicationValidator_AcceptsValidMovementWithoutAllocatingAfterWarmup()
+    {
+        var validator = new AgentReplicationValidator(2000, 1000);
+        var packet = new MovementPacket(
+            new[] { Guid.NewGuid() },
+            new[] { AgentFrame() });
+        for (int i = 0; i < 100; i++)
+            Assert.True(validator.TryValidate(packet, out _));
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < 10000; i++)
+        {
+            if (!validator.TryValidate(packet, out _))
+                throw new InvalidOperationException("valid movement was rejected");
+        }
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.Equal(0, allocated);
+    }
+
+    [Fact]
+    public void ReplicationValidator_RejectsDuplicateIdsAndInvalidNumbers()
+    {
+        var validator = new AgentReplicationValidator(4, 1000);
+        Guid duplicate = Guid.NewGuid();
+        var duplicates = new MovementPacket(
+            new[] { duplicate, duplicate },
+            new[] { AgentFrame(), AgentFrame() });
+        Assert.False(validator.TryValidate(duplicates, out string duplicateFailure));
+        Assert.Contains("duplicated", duplicateFailure);
+
+        var nanPosition = new MovementPacket(
+            new[] { Guid.NewGuid() },
+            new[] { AgentFrame(position: new Vec3(float.NaN, 0f, 0f)) });
+        Assert.False(validator.TryValidate(nanPosition, out string positionFailure));
+        Assert.Contains("nonfinite", positionFailure);
+
+        var infiniteSpeed = new MovementPacket(
+            new[] { Guid.NewGuid() },
+            new[] { AgentFrame(speed: float.PositiveInfinity) });
+        Assert.False(validator.TryValidate(infiniteSpeed, out string speedFailure));
+        Assert.Contains("nonfinite", speedFailure);
+
+        var invalidMount = MountFrame();
+        SetBackingField(
+            invalidMount,
+            nameof(AgentMountData.MountPosition),
+            new Vec3(0f, float.PositiveInfinity, 0f));
+        var mountPacket = new MountMovementPacket(
+            new[] { Guid.NewGuid() },
+            new[] { invalidMount });
+        Assert.False(validator.TryValidate(mountPacket, out string mountFailure));
+        Assert.Contains("nonfinite", mountFailure);
+    }
+
+    [Fact]
+    public void ReplicationValidator_RejectsInvalidActionAndJoinStructure()
+    {
+        var validator = new AgentReplicationValidator(4, 1000);
+        var action = ObjectHelper.SkipConstructor<AgentActionData>();
+        SetBackingField(action, nameof(AgentActionData.MovementFlag), uint.MaxValue);
+        var actionPacket = new AgentActionPacket(
+            "controller",
+            new[] { Guid.NewGuid() },
+            new[] { action },
+            new[] { 1L });
+        Assert.False(validator.TryValidate(actionPacket, out string actionFailure));
+        Assert.Contains("unsupported", actionFailure);
+
+        var validAction = ObjectHelper.SkipConstructor<AgentActionData>();
+        var unreasonableEpoch = new AgentActionPacket(
+            "controller",
+            new[] { Guid.NewGuid() },
+            new[] { validAction },
+            new[] { 1L },
+            int.MaxValue);
+        Assert.False(validator.TryValidate(unreasonableEpoch, out string epochFailure));
+        Assert.Contains("unreasonable", epochFailure);
+
+        var unreasonableSequence = new AgentActionPacket(
+            "controller",
+            new[] { Guid.NewGuid() },
+            new[] { validAction },
+            new[] { long.MaxValue });
+        Assert.False(validator.TryValidate(unreasonableSequence, out string sequenceFailure));
+        Assert.Contains("reasonable", sequenceFailure);
+
+        Guid duplicate = Guid.NewGuid();
+        var join = Join("controller", duplicate, duplicate);
+        Assert.False(validator.TryValidate(join, out string joinFailure));
+        Assert.Contains("duplicated", joinFailure);
+
+        var invalidJoin = new NetworkMissionJoinInfo(
+            "controller",
+            isPlayerAlive: true,
+            new[]
+            {
+                new CoopAgentSpawnData(
+                    Guid.NewGuid(),
+                    "npc_character",
+                    Vec3.Zero,
+                    float.NaN,
+                    isPlayer: false),
+            });
+        Assert.False(validator.TryValidate(invalidJoin, out string healthFailure));
+        Assert.Contains("nonfinite", healthFailure);
+    }
+
+    [Fact]
+    public void ReplicationValidator_AcceptsKnownNativeFlagsAndRejectsUnknownActionIndices()
+    {
+        var validator = new AgentReplicationValidator(4, 1000);
+        var validFlags = ObjectHelper.SkipConstructor<AgentActionData>();
+        SetBackingField(
+            validFlags,
+            nameof(AgentActionData.Action0Flag),
+            (ulong)(AnimFlags.anf_restart | AnimFlags.anf_synch_with_movement));
+        var validPacket = new AgentActionPacket(
+            "controller",
+            new[] { Guid.NewGuid() },
+            new[] { validFlags },
+            new[] { 1L });
+        Assert.True(validator.TryValidate(validPacket, out _));
+
+        var unknownAction = ObjectHelper.SkipConstructor<AgentActionData>();
+        SetBackingField(unknownAction, nameof(AgentActionData.Action0Index), 1000);
+        var unknownPacket = new AgentActionPacket(
+            "controller",
+            new[] { Guid.NewGuid() },
+            new[] { unknownAction },
+            new[] { 1L });
+        Assert.False(validator.TryValidate(unknownPacket, out string failure));
+        Assert.Contains("action index", failure);
+    }
+
+    [Fact]
+    public void ReplicationValidator_RejectsAmbiguousMountIdentities()
+    {
+        var validator = new AgentReplicationValidator(4, 1000);
+        AgentMountData bothIds = MountFrame();
+        SetBackingField(bothIds, nameof(AgentMountData.MountMovementId), (ushort)5);
+        SetBackingField(bothIds, nameof(AgentMountData.MountAgentId), Guid.NewGuid());
+        var bothIdsPacket = new MountMovementPacket(
+            new[] { Guid.NewGuid() },
+            new[] { bothIds });
+        Assert.False(validator.TryValidate(bothIdsPacket, out string bothIdsFailure));
+        Assert.Contains("cannot both", bothIdsFailure);
+
+        AgentMountData scopeWithoutCompactId = MountFrame();
+        SetBackingField(
+            scopeWithoutCompactId,
+            nameof(AgentMountData.MountIdentityScopeId),
+            "other-controller");
+        var scopePacket = new MountMovementPacket(
+            new[] { Guid.NewGuid() },
+            new[] { scopeWithoutCompactId });
+        Assert.False(validator.TryValidate(scopePacket, out string scopeFailure));
+        Assert.Contains("requires a compact id", scopeFailure);
+    }
+
+    [Fact]
+    public void ReplicationValidator_RateLimitsApplicationFailureLogs()
+    {
+        var validator = new AgentReplicationValidator(4, 1000);
+
+        Assert.True(validator.ShouldLogApplicationFailure(out int firstSuppressed));
+        Assert.Equal(0, firstSuppressed);
+        Assert.False(validator.ShouldLogApplicationFailure(out int secondSuppressed));
+        Assert.Equal(0, secondSuppressed);
+    }
+
+    private static NetworkMissionJoinInfo Join(string controllerId, params Guid[] ids) =>
+        new NetworkMissionJoinInfo(
+            controllerId,
+            isPlayerAlive: true,
+            ids.Select(id => new CoopAgentSpawnData(
+                id,
+                "npc_character",
+                Vec3.Zero,
+                health: 100f,
+                isPlayer: false)).ToArray());
+
+    private static AgentData AgentFrame(Vec3? position = null, float speed = 0f)
+    {
+        object boxed = default(AgentData);
+        SetBackingField(boxed, nameof(AgentData.Position), position ?? Vec3.Zero);
+        SetBackingField(boxed, nameof(AgentData.LookDirection), new Vec3(0f, 1f, 0f));
+        SetBackingField(boxed, nameof(AgentData.MovementDirection), Vec2.Zero);
+        SetBackingField(boxed, nameof(AgentData.InputVector), Vec2.Zero);
+        SetBackingField(boxed, nameof(AgentData.Speed), speed);
+        return (AgentData)boxed;
+    }
+
+    private static AgentMountData MountFrame()
+    {
+        var data = ObjectHelper.SkipConstructor<AgentMountData>();
+        SetBackingField(data, nameof(AgentMountData.MountPosition), Vec3.Zero);
+        SetBackingField(data, nameof(AgentMountData.MountLookDirection), new Vec3(0f, 1f, 0f));
+        SetBackingField(data, nameof(AgentMountData.MountMovementDirection), Vec2.Zero);
+        SetBackingField(data, nameof(AgentMountData.MountInputVector), Vec2.Zero);
+        SetBackingField(data, nameof(AgentMountData.MountAction0Speed), 1f);
+        return data;
+    }
+
+    private static void SetBackingField(object instance, string propertyName, object value)
+    {
+        FieldInfo field = instance.GetType().GetField(
+            $"<{propertyName}>k__BackingField",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        if (field == null)
+            throw new MissingFieldException(instance.GetType().FullName, propertyName);
+        field.SetValue(instance, value);
+    }
+}

--- a/source/E2E.Tests/Services/Missions/MountedPuppetMovementTests.cs
+++ b/source/E2E.Tests/Services/Missions/MountedPuppetMovementTests.cs
@@ -1,13 +1,18 @@
 ﻿using System;
 using System.Linq;
 using System.Reflection;
+using Common.Messaging;
 using Common.PacketHandlers;
 using Common.Serialization;
 using E2E.Tests.Environment.Mock;
 using E2E.Tests.Environment.MockEngine;
+using E2E.Tests.Environment.Instance;
+using GameInterface.Services.Entity;
 using Missions;
 using Missions.Agents;
+using Missions.Agents.Handlers;
 using Missions.Agents.Packets;
+using Moq;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
@@ -2194,6 +2199,130 @@ public class MountedPuppetMovementTests : MissionTestEnvironment
             Assert.Equal(0, horseMirror.SetTargetPositionAndDirectionCalls);
             Assert.Equal(0, horseMirror.TeleportToPositionCalls);
         });
+    }
+
+    [Fact]
+    public void MountMovementApplier_PreservesEveryAcceptedIntermediarySampleInOrder()
+    {
+        using var fixture = new MissionEngineFixture();
+        var peer = Clients.First();
+        SetControllerId(peer, "peer");
+
+        peer.Call(() =>
+        {
+            var mock = fixture.CreateMission(peer);
+            var registry = peer.Resolve<INetworkAgentRegistry>();
+            Guid horseId = Guid.NewGuid();
+            Agent puppetHorse = mock.SpawnMount();
+            Assert.True(registry.TryRegisterAgent("owner", horseId, puppetHorse));
+
+            Agent sourceHorse = mock.SpawnMount();
+            Assert.True(AgentMirror.TryGet(sourceHorse, out var sourceMirror));
+            sourceMirror.Position = new Vec3(1f, 0f, 0f);
+            sourceMirror.RealGlobalVelocity = new Vec3(2f, 0f, 0f);
+            var first = new AgentMountData(sourceHorse, horseId);
+            sourceMirror.Position = new Vec3(3f, 0f, 0f);
+            sourceMirror.RealGlobalVelocity = new Vec3(4f, 0f, 0f);
+            var second = new AgentMountData(sourceHorse, horseId);
+
+            var observed = new List<(Vec3 Position, float Speed)>();
+            var interpolator = new Mock<IAgentPositionInterpolator>();
+            interpolator
+                .Setup(x => x.SetMountTarget(
+                    It.IsAny<Agent>(),
+                    It.IsAny<AgentMountData>()))
+                .Callback<Agent, AgentMountData>((_, data) =>
+                    observed.Add((data.MountPosition, data.MountSpeed)));
+            using var handler = CreateAgentMovementHandler(
+                peer,
+                registry,
+                interpolator.Object);
+            var applier = handler.MountMovementApplier;
+
+            applier.HandlePacket(
+                null,
+                new MountMovementPacket(new[] { horseId }, new[] { first }));
+            applier.HandlePacket(
+                null,
+                new MountMovementPacket(new[] { horseId }, new[] { second }));
+
+            Assert.Equal(2, observed.Count);
+            Assert.Equal(1f, observed[0].Position.X);
+            Assert.Equal(2f, observed[0].Speed);
+            Assert.Equal(3f, observed[1].Position.X);
+            Assert.Equal(4f, observed[1].Speed);
+        });
+    }
+
+    [Fact]
+    public void MountMovementApplier_ContinuesAfterOneEntryThrows()
+    {
+        using var fixture = new MissionEngineFixture();
+        var peer = Clients.First();
+        SetControllerId(peer, "peer");
+
+        peer.Call(() =>
+        {
+            var mock = fixture.CreateMission(peer);
+            var registry = peer.Resolve<INetworkAgentRegistry>();
+            Guid firstId = Guid.NewGuid();
+            Guid secondId = Guid.NewGuid();
+            Assert.True(registry.TryRegisterAgent("owner", firstId, mock.SpawnMount()));
+            Assert.True(registry.TryRegisterAgent("owner", secondId, mock.SpawnMount()));
+
+            Agent firstSource = mock.SpawnMount();
+            Agent secondSource = mock.SpawnMount();
+            var first = new AgentMountData(firstSource, firstId);
+            var second = new AgentMountData(secondSource, secondId);
+            int calls = 0;
+            var successful = new List<Guid>();
+            var interpolator = new Mock<IAgentPositionInterpolator>();
+            interpolator
+                .Setup(x => x.SetMountTarget(
+                    It.IsAny<Agent>(),
+                    It.IsAny<AgentMountData>()))
+                .Callback<Agent, AgentMountData>((_, data) =>
+                {
+                    calls++;
+                    if (calls == 1)
+                        throw new InvalidOperationException("isolated test failure");
+                    successful.Add(data.MountAgentId);
+                });
+            using var handler = CreateAgentMovementHandler(
+                peer,
+                registry,
+                interpolator.Object);
+            var applier = handler.MountMovementApplier;
+
+            applier.HandlePacket(
+                null,
+                new MountMovementPacket(
+                    new[] { firstId, secondId },
+                    new[] { first, second }));
+
+            Assert.Equal(2, calls);
+            Assert.Equal(new[] { secondId }, successful);
+        });
+    }
+
+    private static AgentMovementHandler CreateAgentMovementHandler(
+        EnvironmentInstance peer,
+        INetworkAgentRegistry registry,
+        IAgentPositionInterpolator interpolator)
+    {
+        peer.Resolve<ICoopMissionComponent>().AgentMovementHandler.Dispose();
+        return new AgentMovementHandler(
+            peer.Resolve<IBattleNetwork>(),
+            peer.Resolve<IPacketManager>(),
+            peer.Resolve<IMessageBroker>(),
+            registry,
+            peer.Resolve<IControllerIdProvider>(),
+            peer.Resolve<IAgentEquipmentApplier>(),
+            peer.Resolve<IMovementBatchSender>(),
+            peer.Resolve<IPuppetMountStateRepairer>(),
+            peer.Resolve<IAgentVisualActionAccessor>(),
+            peer.Resolve<IAgentReplicationValidator>(),
+            interpolator);
     }
 
     private static Agent SpawnRider(MockMission mock)

--- a/source/E2E.Tests/Services/Missions/MovementTrafficTests.cs
+++ b/source/E2E.Tests/Services/Missions/MovementTrafficTests.cs
@@ -321,7 +321,9 @@ public class MovementTrafficTests : MissionTestEnvironment
                 peer.Resolve<IAgentEquipmentApplier>(),
                 new MovementBatchSender(network, compressor),
                 peer.Resolve<IPuppetMountStateRepairer>(),
-                peer.Resolve<IAgentVisualActionAccessor>());
+                peer.Resolve<IAgentVisualActionAccessor>(),
+                peer.Resolve<IAgentReplicationValidator>(),
+                peer.Resolve<IAgentPositionInterpolator>());
             network.MaxUnreliablePayloadBytes = LiteNetP2PClient.CalculateMaxRelayPayloadBytes(
                 serializer,
                 "MapEvent_Created_0000",

--- a/source/GameInterface.Tests/Serialization/BanditPartyComponentSerializationTest.cs
+++ b/source/GameInterface.Tests/Serialization/BanditPartyComponentSerializationTest.cs
@@ -14,6 +14,7 @@ using Xunit;
 
 namespace GameInterface.Tests.Serialization.SerializerTests
 {
+    [Collection("Hideout serialization")]
     public class BanditPartyComponentSerializationTest
     {
         readonly IContainer container;
@@ -48,7 +49,6 @@ namespace GameInterface.Tests.Serialization.SerializerTests
         {
             Hideout hideout = (Hideout)FormatterServices.GetUninitializedObject(typeof(Hideout));
 
-            // TODO make atomic to not interfere with other tests that use Hideout.All
             MBList<Hideout> allhideouts = Campaign.Current?._hideouts ?? new MBList<Hideout>();
 
             allhideouts.Add(hideout);

--- a/source/GameInterface.Tests/Serialization/HideoutSerializationTest.cs
+++ b/source/GameInterface.Tests/Serialization/HideoutSerializationTest.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace GameInterface.Tests.Serialization.SerializerTests
 {
+    [Collection("Hideout serialization")]
     public class HideoutSerializationTest
     {
         IContainer container;

--- a/source/GameInterface/Services/GameDebug/Commands/GameThreadDebugCommand.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/GameThreadDebugCommand.cs
@@ -1,5 +1,6 @@
 ﻿using Common;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using System.Threading;
 using static TaleWorlds.Library.CommandLineFunctionality;
 
@@ -66,4 +67,33 @@ public class GameThreadDebugCommand
         Thread.Sleep(milliseconds);
         return $"Stalled the server game thread for {milliseconds} ms";
     }
+
+#if DEBUG
+    [CommandLineArgumentFunction("stall_client", "coop.debug.gamethread")]
+    public static string StallClient(List<string> args)
+    {
+        if (ModInformation.IsServer)
+            return "gamethread.stall_client must be run on a client";
+
+        if ((args.Count != 1 && args.Count != 2) ||
+            !int.TryParse(args[0], out int milliseconds) ||
+            milliseconds < 1 ||
+            milliseconds > 2500 ||
+            (args.Count == 2 && !Regex.IsMatch(
+                args[1],
+                @"^Local\\CoopMovementStall-[A-Za-z0-9_-]{1,64}$")))
+        {
+            return "Usage: coop.debug.gamethread.stall_client " +
+                   "<milliseconds from 1 to 2500> [start-event]";
+        }
+
+        if (args.Count == 2)
+        {
+            using (EventWaitHandle started = EventWaitHandle.OpenExisting(args[1]))
+                started.Set();
+        }
+        Thread.Sleep(milliseconds);
+        return $"Stalled the client game thread for {milliseconds} ms";
+    }
+#endif
 }

--- a/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
@@ -253,6 +253,104 @@ public class MapEventDebugCommands
             $"OriginalWarState: {fixture.WasAtWar}";
     }
 
+    [CommandLineArgumentFunction("player_field_battle_fixture_state", "coop.debug.mapevent")]
+    public static string PlayerFieldBattleFixtureState(List<string> args)
+    {
+        if (!ModInformation.IsServer)
+            return "Run this command on the server.";
+
+        if (args.Count != 2)
+            return "Usage: coop.debug.mapevent.player_field_battle_fixture_state <attackerMobilePartyId> <defenderMobilePartyId>";
+
+        if (!TryGetObjectManager(out var objectManager))
+            return "Unable to resolve ObjectManager.";
+
+        var attackerError = string.Empty;
+        if ((!objectManager.TryGetObject(args[0], out MobileParty attacker) &&
+             !CommandHelpers.TryGetMobileParty(args[0], out attacker, out attackerError)) ||
+            attacker?.Party == null)
+            return "Unable to resolve attacker party: " + attackerError;
+
+        var defenderError = string.Empty;
+        if ((!objectManager.TryGetObject(args[1], out MobileParty defender) &&
+             !CommandHelpers.TryGetMobileParty(args[1], out defender, out defenderError)) ||
+            defender?.Party == null)
+            return "Unable to resolve defender party: " + defenderError;
+
+        var attackerMapEvent = attacker.MapEvent;
+        var defenderMapEvent = defender.MapEvent;
+        var sharedMapEvent = attackerMapEvent != null && attackerMapEvent == defenderMapEvent
+            ? attackerMapEvent
+            : null;
+        var sharedMapEventIdResolved = sharedMapEvent != null &&
+                                       objectManager.TryGetId(sharedMapEvent, out string _);
+        var attackerSide = sharedMapEvent == null
+            ? BattleSideEnum.None
+            : GetPartySide(sharedMapEvent, attacker.Party);
+        var defenderSide = sharedMapEvent == null
+            ? BattleSideEnum.None
+            : GetPartySide(sharedMapEvent, defender.Party);
+        var factionsAtWar = attacker.MapFaction != null &&
+                            defender.MapFaction != null &&
+                            AreFactionsAtWar(attacker.MapFaction, defender.MapFaction);
+        var canCreate = attacker != defender &&
+                        attacker.IsActive &&
+                        defender.IsActive &&
+                        attackerMapEvent == null &&
+                        defenderMapEvent == null &&
+                        attacker.CurrentSettlement == null &&
+                        defender.CurrentSettlement == null &&
+                        attacker.MapFaction != null &&
+                        defender.MapFaction != null &&
+                        attacker.MapFaction != defender.MapFaction;
+        var canReuse = attacker != defender &&
+                       attacker.IsActive &&
+                       defender.IsActive &&
+                       sharedMapEvent != null &&
+                       !sharedMapEvent.IsFinalized &&
+                       sharedMapEvent.BattleState == BattleState.None &&
+                       sharedMapEvent.IsFieldBattle &&
+                       !sharedMapEvent.IsNavalMapEvent &&
+                       sharedMapEvent.MapEventSettlement == null &&
+                       sharedMapEventIdResolved &&
+                       attackerSide != BattleSideEnum.None &&
+                       defenderSide != BattleSideEnum.None &&
+                       attackerSide != defenderSide;
+        var mode = canCreate ? "create" : canReuse ? "reuse" : "invalid";
+
+        return
+            $"Mode: {mode}\n" +
+            $"AttackerActive: {attacker.IsActive}\n" +
+            $"DefenderActive: {defender.IsActive}\n" +
+            $"AttackerMapEventId: {FormatMapEventId(attackerMapEvent, objectManager)}\n" +
+            $"DefenderMapEventId: {FormatMapEventId(defenderMapEvent, objectManager)}\n" +
+            $"SharedFieldBattle: {sharedMapEvent?.IsFieldBattle == true}\n" +
+            $"SharedBattleState: {sharedMapEvent?.BattleState.ToString() ?? "none"}\n" +
+            $"AttackerSide: {attackerSide}\n" +
+            $"DefenderSide: {defenderSide}\n" +
+            $"FactionsAtWar: {factionsAtWar}\n" +
+            $"AttackerSettlement: {attacker.CurrentSettlement?.StringId ?? "none"}\n" +
+            $"DefenderSettlement: {defender.CurrentSettlement?.StringId ?? "none"}";
+    }
+
+    private static BattleSideEnum GetPartySide(MapEvent mapEvent, PartyBase party)
+    {
+        if (mapEvent.AttackerSide.Parties.Any(mapEventParty => mapEventParty.Party == party))
+            return BattleSideEnum.Attacker;
+        if (mapEvent.DefenderSide.Parties.Any(mapEventParty => mapEventParty.Party == party))
+            return BattleSideEnum.Defender;
+
+        return BattleSideEnum.None;
+    }
+
+    private static string FormatMapEventId(MapEvent mapEvent, IObjectManager objectManager)
+    {
+        if (mapEvent == null)
+            return "none";
+
+        return objectManager.TryGetId(mapEvent, out string id) ? id : "unresolved";
+    }
+
     [CommandLineArgumentFunction("restore_player_field_battle", "coop.debug.mapevent")]
     public static string RestorePlayerFieldBattle(List<string> args)
     {

--- a/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
@@ -314,8 +314,7 @@ public class MapEventDebugCommands
                        sharedMapEvent.MapEventSettlement == null &&
                        sharedMapEventIdResolved &&
                        attackerSide != BattleSideEnum.None &&
-                       defenderSide != BattleSideEnum.None &&
-                       attackerSide != defenderSide;
+                       defenderSide != BattleSideEnum.None;
         var mode = canCreate ? "create" : canReuse ? "reuse" : "invalid";
 
         return

--- a/source/Missions/Agents/Handlers/AgentMovementHandler.cs
+++ b/source/Missions/Agents/Handlers/AgentMovementHandler.cs
@@ -8,6 +8,9 @@ using GameInterface.Services.MapEvents;
 using LiteNetLib;
 using Missions.Agents;
 using Missions.Agents.Packets;
+#if DEBUG
+using Missions.Diagnostics;
+#endif
 using Missions.Messages;
 using Serilog;
 using System;
@@ -61,6 +64,7 @@ public class AgentMovementHandler : IAgentMovementHandler
     private readonly IMovementBatchSender movementBatchSender;
     private readonly IPuppetMountStateRepairer puppetMountStateRepairer;
     private readonly IAgentVisualActionAccessor visualActionAccessor;
+    private readonly IAgentReplicationValidator replicationValidator;
     private readonly Dictionary<Guid, AgentEquipmentData> lastEquipment = new Dictionary<Guid, AgentEquipmentData>();
     // A puppet's horse, remembered when its owner dismounts, so a later re-mount can put it back on the
     // same one. Touched only on the game thread (inside HandlePacket's apply), so no lock; per-mission
@@ -181,7 +185,7 @@ public class AgentMovementHandler : IAgentMovementHandler
 
     // Per-frame position smoothing for received puppets. Fed the latest target on each packet apply (below) and
     // ticked from CoopMissionController.OnMissionTick, so the ease is decoupled from the bursty poll cadence.
-    private readonly AgentPositionInterpolator _interpolator = new AgentPositionInterpolator();
+    private readonly IAgentPositionInterpolator _interpolator;
     public IAgentPositionInterpolator Interpolator => _interpolator;
 
     // Masterless-horse movement receive side. Owned here (registered/removed with this handler) so both
@@ -203,7 +207,9 @@ public class AgentMovementHandler : IAgentMovementHandler
         IAgentEquipmentApplier equipmentApplier,
         IMovementBatchSender movementBatchSender,
         IPuppetMountStateRepairer puppetMountStateRepairer,
-        IAgentVisualActionAccessor visualActionAccessor)
+        IAgentVisualActionAccessor visualActionAccessor,
+        IAgentReplicationValidator replicationValidator,
+        IAgentPositionInterpolator interpolator)
     {
         Logger.Verbose("Creating {handlerType}", typeof(AgentMovementHandler));
 
@@ -216,6 +222,8 @@ public class AgentMovementHandler : IAgentMovementHandler
         this.movementBatchSender = movementBatchSender;
         this.puppetMountStateRepairer = puppetMountStateRepairer;
         this.visualActionAccessor = visualActionAccessor;
+        this.replicationValidator = replicationValidator;
+        this._interpolator = interpolator;
         // Server-mediated membership. A peer entering is the cue to clear any STALE party it left behind
         // on a missed disconnect (so its rejoin re-spawns clean); a leave/disconnect releases its party.
         this.messageBroker.Subscribe<NetworkMissionPeerEntered>(Handle_PeerEntered);
@@ -230,7 +238,8 @@ public class AgentMovementHandler : IAgentMovementHandler
             _interpolator,
             puppetMountStateRepairer,
             UpdateRemoteSyntheticMountTurn,
-            QueueMountMovement);
+            QueueMountMovement,
+            replicationValidator);
         this.packetManager.RegisterPacketHandler(_mountMovementApplier);
     }
 
@@ -462,6 +471,83 @@ public class AgentMovementHandler : IAgentMovementHandler
                 mountResult.DeferredCount,
             GetMaximumDeferredAge());
     }
+
+#if DEBUG
+    internal int SendDiagnosticsMovementBurst(int sampleCount)
+    {
+        if (_disposed || Mission.Current == null || sampleCount <= 0)
+            return 0;
+
+        Agent agent = Agent.Main;
+        if (agent == null || !agent.IsActive() || !agent.HasMount ||
+            agent.MountAgent == null || !agent.MountAgent.IsActive() ||
+            !agentRegistry.TryGetAgentInfo(agent, out CoopAgentInfo info) ||
+            !agentRegistry.IsLocallyControlled(agent))
+        {
+            return 0;
+        }
+
+        GetRegisteredMountIdentity(
+            agent,
+            info.MovementScopeId,
+            out ushort mountMovementId,
+            out string mountIdentityScopeId,
+            out Guid mountAgentId);
+        var baseline = new AgentData(
+            agent,
+            mountMovementId,
+            mountIdentityScopeId,
+            mountAgentId);
+        if (baseline.MountData == null) return 0;
+
+        for (int i = 0; i < sampleCount; i++)
+        {
+            AgentData sample = baseline;
+            if (i + 1 < sampleCount)
+            {
+                float offset = (i + 1) * 0.001f;
+                bool alternate = (i & 1) != 0;
+                Vec3 look = alternate
+                    ? new Vec3(0f, 1f, 0f)
+                    : new Vec3(1f, 0f, 0f);
+                Vec2 direction = alternate
+                    ? new Vec2(0f, 1f)
+                    : new Vec2(1f, 0f);
+                Vec2 input = alternate
+                    ? new Vec2(0.25f, 0.75f)
+                    : new Vec2(0.75f, 0.25f);
+                float speed = 1f + (i % 5);
+                uint movementFlag = (uint)(alternate
+                    ? Agent.MovementControlFlag.Forward
+                    : Agent.MovementControlFlag.StrafeLeft);
+                AgentMountData mount = baseline.MountData.WithStateForDiagnostics(
+                    baseline.MountData.MountPosition + new Vec3(-offset, offset, 0f),
+                    input,
+                    look,
+                    direction,
+                    speed + 1f,
+                    movementFlag);
+                sample = baseline.WithStateForDiagnostics(
+                    baseline.Position + new Vec3(offset, -offset, 0f),
+                    input,
+                    look,
+                    direction,
+                    mount,
+                    speed,
+                    movementFlag);
+            }
+
+            bool usesCompactId = info.MovementId != 0;
+            client.SendAll(CreateMovementPacket(
+                usesCompactId ? info.MovementScopeId : null,
+                usesCompactId ? new[] { info.MovementId } : null,
+                usesCompactId ? null : new[] { info.AgentId },
+                new[] { sample }));
+        }
+
+        return sampleCount;
+    }
+#endif
 
     private bool ShouldSendMovement(Guid agentId, AgentData current)
     {
@@ -976,12 +1062,20 @@ public class AgentMovementHandler : IAgentMovementHandler
     public void HandlePacket(NetPeer peer, IPacket packet)
     {
         var movement = (MovementPacket)packet;
-        int idCount = movement.AgentIds?.Length ?? movement.AgentGuids?.Length ?? 0;
-        if (idCount == 0 || movement.Agents == null ||
-            movement.Agents.Length != idCount)
+        if (!replicationValidator.TryValidate(movement, out string validationFailure))
         {
+#if DEBUG
+            ClientReplicationDiagnostics.RecordValidationRejection(movement);
+#endif
+            LogRejectedMovement(validationFailure);
             return;
         }
+        int idCount = movement.Agents.Length;
+
+#if DEBUG
+        for (int i = 0; i < idCount; i++)
+            ClientReplicationDiagnostics.RecordAccepted(movement, i);
+#endif
 
         if (_disposed) return;
 
@@ -1036,73 +1130,162 @@ public class AgentMovementHandler : IAgentMovementHandler
 
         using (new AllowedThread())
         {
-            foreach (ReceivedMovement snapshot in snapshots)
+            for (int i = 0; i < snapshots.Count; i++)
             {
-                if (snapshot.IsMount)
+                ReceivedMovement snapshot = snapshots[i];
+                try
                 {
-                    _mountMovementApplier.ApplySnapshot(
-                        snapshot.IdentityScopeId,
-                        snapshot.CompactId,
-                        snapshot.CanonicalId,
-                        snapshot.UsesCompactId,
-                        snapshot.MountData);
-                    continue;
+#if DEBUG
+                    if (ClientReplicationDiagnostics.ConsumeInjectedEntryFailure())
+                        throw new InvalidOperationException("Injected movement entry failure");
+#endif
+                    ApplyMovementSnapshot(snapshot);
+#if DEBUG
+                    RecordProcessed(snapshot);
+#endif
                 }
-
-                CoopAgentInfo agentInfo;
-                bool found = snapshot.UsesCompactId
-                    ? agentRegistry.TryGetAgentInfo(
-                        snapshot.IdentityScopeId, snapshot.CompactId, out agentInfo)
-                    : agentRegistry.TryGetAgentInfo(snapshot.CanonicalId, out agentInfo);
-                if (!found) continue;
-
-                Agent agent = agentInfo.Agent;
-                AgentData data = snapshot.Data;
-
-                // The agent may have become invalid (player left, mission torn down) between queueing
-                // and running; only apply while it is still active in the current mission.
-                if (agent == null || agent.Mission != Mission.Current || agent.IsActive() == false)
-                    continue;
-
-                // Re-check authority ON the game thread: a packet from the previous owner can be queued
-                // behind a host-migration adoption (both are game-thread actions queued from the network
-                // thread), and applying it after the transfer would re-pin the freshly adopted agent to a
-                // stale position/input snapshot the AI then fights.
-                if (agentRegistry.IsLocallyControlled(agent))
-                    continue;
-
-                Agent previousMount = agent.MountAgent;
-                SyncMountState(
-                    agent,
-                    snapshot.IdentityScopeId ?? agentInfo.MovementScopeId,
-                    data);
-                if (previousMount != null && !ReferenceEquals(previousMount, agent.MountAgent))
-                    UpdateRemoteSyntheticMountTurn(previousMount, null);
-
-                // A puppet horse must not run local AI between owner snapshots and fight their heading/input.
-                if (agent.MountAgent is Agent puppetMount && puppetMount.Controller != AgentControllerType.None)
+                catch (Exception ex)
                 {
-                    puppetMount.Controller = AgentControllerType.None;
-                    puppetMountStateRepairer.PreserveRiderlessPuppet(puppetMount);
-                }
-
-                data.Apply(agent);
-                if (data.MountData != null && agent.MountAgent is Agent remoteMount)
-                    UpdateRemoteSyntheticMountTurn(remoteMount, data.MountData);
-
-                // Position is reconciled per-frame by the interpolator (smoother than a per-packet
-                // correction bound to the ~10ms poll cadence); push the latest targets it eases toward.
-                if (agent.HasMount && data.MountData != null)
-                {
-                    _interpolator.Forget(agent.MountAgent);
-                    _interpolator.SetMountedRiderTarget(agent, data);
-                }
-                else
-                {
-                    _interpolator.SetRiderTarget(agent, data);
+#if DEBUG
+                    RecordFailed(snapshot);
+#endif
+                    if (replicationValidator.ShouldLogApplicationFailure(
+                            out int suppressedFailures))
+                    {
+                        Logger.Warning(
+                            ex,
+                            "Failed to apply movement entry {EntryIndex}; continuing the packet " +
+                            "(suppressed since last log: {Suppressed})",
+                            i,
+                            suppressedFailures);
+                    }
                 }
             }
         }
+    }
+
+    private void ApplyMovementSnapshot(ReceivedMovement snapshot)
+    {
+        if (snapshot.IsMount)
+        {
+            _mountMovementApplier.ApplySnapshot(
+                snapshot.IdentityScopeId,
+                snapshot.CompactId,
+                snapshot.CanonicalId,
+                snapshot.UsesCompactId,
+                snapshot.MountData);
+            return;
+        }
+
+        CoopAgentInfo agentInfo;
+        bool found = snapshot.UsesCompactId
+            ? agentRegistry.TryGetAgentInfo(
+                snapshot.IdentityScopeId, snapshot.CompactId, out agentInfo)
+            : agentRegistry.TryGetAgentInfo(snapshot.CanonicalId, out agentInfo);
+        if (!found) return;
+
+        Agent agent = agentInfo.Agent;
+        AgentData data = snapshot.Data;
+
+        // The agent may have become invalid (player left, mission torn down) between queueing
+        // and running; only apply while it is still active in the current mission.
+        if (agent == null || agent.Mission != Mission.Current || !agent.IsActive())
+            return;
+
+        // Re-check authority ON the game thread: a packet from the previous owner can be queued
+        // behind a host-migration adoption and must not overwrite the newly local agent.
+        if (agentRegistry.IsLocallyControlled(agent))
+            return;
+
+#if DEBUG
+        ClientReplicationDiagnostics.RecordNativeApplication(
+            snapshot.IdentityScopeId,
+            snapshot.CompactId,
+            snapshot.CanonicalId,
+            snapshot.UsesCompactId,
+            data);
+#endif
+        Agent previousMount = agent.MountAgent;
+        SyncMountState(
+            agent,
+            snapshot.IdentityScopeId ?? agentInfo.MovementScopeId,
+            data);
+        if (previousMount != null && !ReferenceEquals(previousMount, agent.MountAgent))
+            UpdateRemoteSyntheticMountTurn(previousMount, null);
+
+        if (agent.MountAgent is Agent puppetMount &&
+            puppetMount.Controller != AgentControllerType.None)
+        {
+            puppetMount.Controller = AgentControllerType.None;
+            puppetMountStateRepairer.PreserveRiderlessPuppet(puppetMount);
+        }
+
+        data.Apply(agent);
+        if (data.MountData != null && agent.MountAgent is Agent remoteMount)
+            UpdateRemoteSyntheticMountTurn(remoteMount, data.MountData);
+
+        if (agent.HasMount && data.MountData != null)
+        {
+            _interpolator.Forget(agent.MountAgent);
+            _interpolator.SetMountedRiderTarget(agent, data);
+        }
+        else
+        {
+            _interpolator.SetRiderTarget(agent, data);
+        }
+    }
+
+#if DEBUG
+    private static void RecordProcessed(ReceivedMovement snapshot)
+    {
+        if (snapshot.IsMount)
+        {
+            ClientReplicationDiagnostics.RecordProcessed(
+                snapshot.IdentityScopeId,
+                snapshot.CompactId,
+                snapshot.CanonicalId,
+                snapshot.UsesCompactId,
+                snapshot.MountData);
+            return;
+        }
+
+        ClientReplicationDiagnostics.RecordProcessed(
+            snapshot.IdentityScopeId,
+            snapshot.CompactId,
+            snapshot.CanonicalId,
+            snapshot.UsesCompactId,
+            snapshot.Data);
+    }
+
+    private static void RecordFailed(ReceivedMovement snapshot)
+    {
+        if (snapshot.IsMount)
+        {
+            ClientReplicationDiagnostics.RecordFailed(
+                snapshot.IdentityScopeId,
+                snapshot.CompactId,
+                snapshot.CanonicalId,
+                snapshot.UsesCompactId,
+                snapshot.MountData);
+            return;
+        }
+
+        ClientReplicationDiagnostics.RecordFailed(
+            snapshot.IdentityScopeId,
+            snapshot.CompactId,
+            snapshot.CanonicalId,
+            snapshot.UsesCompactId,
+            snapshot.Data);
+    }
+#endif
+
+    private void LogRejectedMovement(string failure)
+    {
+        if (!replicationValidator.ShouldLogRejection(out int suppressed)) return;
+        Logger.Warning(
+            "Discarding invalid movement packet: {Failure} (suppressed since last log: {Suppressed})",
+            failure,
+            suppressed);
     }
 
     // [Game thread] Replicate the owner's mount/dismount onto its puppet. The per-tick AgentData reports

--- a/source/Missions/Agents/Handlers/AgentReplicationValidator.cs
+++ b/source/Missions/Agents/Handlers/AgentReplicationValidator.cs
@@ -1,0 +1,581 @@
+﻿using GameInterface.Services.MapEvents;
+using Missions.Agents.Packets;
+using Missions.Data;
+using Missions.Messages;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+
+namespace Missions.Agents.Handlers;
+
+public interface IAgentReplicationValidator
+{
+    bool TryValidate(MovementPacket packet, out string failure);
+    bool TryValidate(MountMovementPacket packet, out string failure);
+    bool TryValidate(AgentActionPacket packet, out string failure);
+    bool TryValidate(NetworkMissionJoinInfo joinInfo, out string failure);
+    bool ShouldLogRejection(out int suppressedRejections);
+    bool ShouldLogApplicationFailure(out int suppressedFailures);
+}
+
+public sealed class AgentReplicationValidator : IAgentReplicationValidator
+{
+    internal const int MaximumControllerIdLength = 128;
+    internal const int MaximumObjectIdLength = 256;
+    internal const float MaximumCoordinateMagnitude = 1000000f;
+    internal const float MaximumMovementSpeed = 100f;
+    internal const float MaximumHealth = 10000f;
+    internal const int MaximumBattleHostEpoch = 1000000;
+    internal const long MaximumActionSequence = 1000000000L;
+    private const int LinearDuplicateCheckLimit = 16;
+
+    private static readonly long RejectionLogIntervalTicks =
+        Stopwatch.Frequency;
+    private static readonly ulong AllowedAnimationFlags =
+        (ulong)AnimFlags.anf_animation_layer_flags_mask |
+        ((ulong)AnimFlags.anf_animation_layer_flags_mask - 1UL) |
+        (ulong)AnimFlags.anf_randomization_weight_mask;
+    private static readonly uint AllowedEventFlags = 0x7FFFFu;
+    private static readonly uint AllowedLocomotionFlags =
+        (uint)Agent.MovementControlFlag.MoveMask;
+    private static readonly uint AllowedActionMovementFlags =
+        (uint)AgentActionData.DefendMovementFlagsMask;
+
+    private readonly object validationGate = new object();
+    private readonly int maximumMissionAgents;
+    private readonly int maximumActionCount;
+    private readonly HashSet<ushort> compactIds = new HashSet<ushort>();
+    private readonly HashSet<Guid> canonicalIds = new HashSet<Guid>();
+    private long nextRejectionLog;
+    private int suppressedRejections;
+    private long nextApplicationFailureLog;
+    private int suppressedApplicationFailures;
+
+    public AgentReplicationValidator(
+        IBattleAgentBudget agentBudget,
+        IAnimationActionCountProvider actionCountProvider)
+        : this(
+            agentBudget?.MaxRenderedAgents ?? 2000,
+            actionCountProvider?.GetActionCount() ?? 0)
+    {
+    }
+
+    internal AgentReplicationValidator(
+        int maximumMissionAgents,
+        int maximumActionCount)
+    {
+        if (maximumMissionAgents <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maximumMissionAgents));
+        if (maximumActionCount <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maximumActionCount));
+        this.maximumMissionAgents = maximumMissionAgents;
+        this.maximumActionCount = maximumActionCount;
+    }
+
+    public bool TryValidate(MovementPacket packet, out string failure)
+    {
+#if DEBUG
+        lock (validationGate)
+#endif
+        {
+            if (!TryValidateIds(
+                    packet.IdentityScopeId,
+                    packet.AgentIds,
+                    packet.AgentGuids,
+                    packet.Agents?.Length ?? 0,
+                    out failure))
+            {
+                return false;
+            }
+
+            if (packet.Agents == null)
+            {
+                failure = "movement data is missing";
+                return false;
+            }
+
+            for (int i = 0; i < packet.Agents.Length; i++)
+            {
+                AgentData data = packet.Agents[i];
+                if (!TryValidateAgentData(data, out failure))
+                {
+                    failure = $"movement entry {i}: {failure}";
+                    return false;
+                }
+            }
+
+            failure = null;
+            return true;
+        }
+    }
+
+    public bool TryValidate(MountMovementPacket packet, out string failure)
+    {
+#if DEBUG
+        lock (validationGate)
+#endif
+        {
+            if (!TryValidateIds(
+                    packet.IdentityScopeId,
+                    packet.MountIds,
+                    packet.MountGuids,
+                    packet.Mounts?.Length ?? 0,
+                    out failure))
+            {
+                return false;
+            }
+
+            if (packet.Mounts == null)
+            {
+                failure = "mount movement data is missing";
+                return false;
+            }
+
+            for (int i = 0; i < packet.Mounts.Length; i++)
+            {
+                if (!TryValidateMountData(packet.Mounts[i], out failure))
+                {
+                    failure = $"mount movement entry {i}: {failure}";
+                    return false;
+                }
+            }
+
+            failure = null;
+            return true;
+        }
+    }
+
+    public bool TryValidate(AgentActionPacket packet, out string failure)
+    {
+#if DEBUG
+        lock (validationGate)
+#endif
+        {
+            int count = packet.AgentIds?.Length ?? 0;
+            if (!IsValidRequiredId(packet.ControllerId, MaximumControllerIdLength))
+            {
+                failure = "action controller id is missing or too long";
+                return false;
+            }
+            if (count == 0 || count > maximumMissionAgents ||
+                packet.Actions == null || packet.Sequences == null ||
+                packet.Actions.Length != count || packet.Sequences.Length != count)
+            {
+                failure = "action arrays are missing, empty, excessive, or mismatched";
+                return false;
+            }
+            if (packet.BattleHostEpoch < 0 ||
+                packet.BattleHostEpoch > MaximumBattleHostEpoch)
+            {
+                failure = "action host epoch is negative or unreasonable";
+                return false;
+            }
+
+            canonicalIds.Clear();
+            for (int i = 0; i < count; i++)
+            {
+                Guid agentId = packet.AgentIds[i];
+                if (agentId == Guid.Empty || !canonicalIds.Add(agentId))
+                {
+                    failure = $"action agent id {i} is empty or duplicated";
+                    return false;
+                }
+                if (packet.Sequences[i] <= 0 ||
+                    packet.Sequences[i] > MaximumActionSequence)
+                {
+                    failure = $"action sequence {i} is not positive or reasonable";
+                    return false;
+                }
+                if (!TryValidateActionData(packet.Actions[i], out failure))
+                {
+                    failure = $"action entry {i}: {failure}";
+                    return false;
+                }
+            }
+
+            failure = null;
+            return true;
+        }
+    }
+
+    public bool TryValidate(NetworkMissionJoinInfo joinInfo, out string failure)
+    {
+#if DEBUG
+        lock (validationGate)
+#endif
+        {
+            if (joinInfo == null)
+            {
+                failure = "join info is missing";
+                return false;
+            }
+            if (!IsValidRequiredId(joinInfo.ControllerId, MaximumControllerIdLength))
+            {
+                failure = "join controller id is missing or too long";
+                return false;
+            }
+
+            CoopAgentSpawnData[] agents = joinInfo.AiAgentData;
+            if (agents == null || agents.Length == 0 || agents.Length > maximumMissionAgents)
+            {
+                failure = "join agent array is missing, empty, or excessive";
+                return false;
+            }
+
+            canonicalIds.Clear();
+            for (int i = 0; i < agents.Length; i++)
+            {
+                CoopAgentSpawnData agent = agents[i];
+                if (agent == null || agent.AgentId == Guid.Empty ||
+                    !canonicalIds.Add(agent.AgentId))
+                {
+                    failure = $"join agent {i} is missing, empty, or duplicated";
+                    return false;
+                }
+                if (!IsValidRequiredId(agent.CharacterObjectId, MaximumObjectIdLength))
+                {
+                    failure = $"join character id {i} is missing or too long";
+                    return false;
+                }
+                if (!IsReasonablePosition(agent.Position) ||
+                    !IsFinite(agent.Health) || agent.Health < 0f || agent.Health > MaximumHealth)
+                {
+                    failure = $"join spawn state {i} is nonfinite or unreasonable";
+                    return false;
+                }
+            }
+
+            failure = null;
+            return true;
+        }
+    }
+
+    public bool ShouldLogRejection(out int suppressed)
+    {
+        lock (validationGate)
+        {
+            long now = Stopwatch.GetTimestamp();
+            if (now < nextRejectionLog)
+            {
+                suppressedRejections++;
+                suppressed = 0;
+                return false;
+            }
+
+            nextRejectionLog = now + RejectionLogIntervalTicks;
+            suppressed = suppressedRejections;
+            suppressedRejections = 0;
+            return true;
+        }
+    }
+
+    public bool ShouldLogApplicationFailure(out int suppressed)
+    {
+        lock (validationGate)
+        {
+            long now = Stopwatch.GetTimestamp();
+            if (now < nextApplicationFailureLog)
+            {
+                suppressedApplicationFailures++;
+                suppressed = 0;
+                return false;
+            }
+
+            nextApplicationFailureLog = now + RejectionLogIntervalTicks;
+            suppressed = suppressedApplicationFailures;
+            suppressedApplicationFailures = 0;
+            return true;
+        }
+    }
+
+    private bool TryValidateIds(
+        string identityScopeId,
+        ushort[] ids,
+        Guid[] guids,
+        int dataCount,
+        out string failure)
+    {
+        bool compact = ids != null;
+        bool canonical = guids != null;
+        if (compact == canonical)
+        {
+            failure = "exactly one id representation is required";
+            return false;
+        }
+
+        int idCount = compact ? ids.Length : guids.Length;
+        if (idCount == 0 || idCount > maximumMissionAgents || dataCount != idCount)
+        {
+            failure = "id and data arrays are empty, excessive, or mismatched";
+            return false;
+        }
+
+        if (compact)
+        {
+            if (!IsValidRequiredId(identityScopeId, MaximumControllerIdLength))
+            {
+                failure = "compact ids require a bounded identity scope";
+                return false;
+            }
+
+            if (ids.Length <= LinearDuplicateCheckLimit)
+            {
+                for (int i = 0; i < ids.Length; i++)
+                {
+                    if (ids[i] == 0 || HasEarlier(ids, i))
+                    {
+                        failure = $"compact id {i} is zero or duplicated";
+                        return false;
+                    }
+                }
+            }
+            else
+            {
+                compactIds.Clear();
+                for (int i = 0; i < ids.Length; i++)
+                {
+                    if (ids[i] == 0 || !compactIds.Add(ids[i]))
+                    {
+                        failure = $"compact id {i} is zero or duplicated";
+                        return false;
+                    }
+                }
+            }
+        }
+        else
+        {
+            if (!string.IsNullOrEmpty(identityScopeId))
+            {
+                failure = "canonical ids cannot include an identity scope";
+                return false;
+            }
+
+            if (guids.Length <= LinearDuplicateCheckLimit)
+            {
+                for (int i = 0; i < guids.Length; i++)
+                {
+                    if (guids[i] == Guid.Empty || HasEarlier(guids, i))
+                    {
+                        failure = $"canonical id {i} is empty or duplicated";
+                        return false;
+                    }
+                }
+            }
+            else
+            {
+                canonicalIds.Clear();
+                for (int i = 0; i < guids.Length; i++)
+                {
+                    if (guids[i] == Guid.Empty || !canonicalIds.Add(guids[i]))
+                    {
+                        failure = $"canonical id {i} is empty or duplicated";
+                        return false;
+                    }
+                }
+            }
+        }
+
+        failure = null;
+        return true;
+    }
+
+    private bool TryValidateAgentData(AgentData data, out string failure)
+    {
+        if (!IsReasonablePosition(data.Position) ||
+            !IsReasonableDirection(data.LookDirection, allowZero: false) ||
+            !IsReasonableDirection(data.MovementDirection, allowZero: true) ||
+            !IsReasonableInput(data.InputVector) ||
+            !IsFinite(data.Speed) || data.Speed < 0f || data.Speed > MaximumMovementSpeed)
+        {
+            failure = "rider position, direction, input, or speed is nonfinite or unreasonable";
+            return false;
+        }
+        if ((data.MovementFlag & ~AllowedLocomotionFlags) != 0)
+        {
+            failure = "rider locomotion flags contain unsupported bits";
+            return false;
+        }
+        if (data.MountData != null && !TryValidateMountData(data.MountData, out failure))
+            return false;
+
+        failure = null;
+        return true;
+    }
+
+    private bool TryValidateMountData(AgentMountData data, out string failure)
+    {
+        if (data == null)
+        {
+            failure = "mount data is missing";
+            return false;
+        }
+        if (!IsReasonablePosition(data.MountPosition) ||
+            !IsReasonableDirection(data.MountLookDirection, allowZero: false) ||
+            !IsReasonableDirection(data.MountMovementDirection, allowZero: true) ||
+            !IsReasonableInput(data.MountInputVector) ||
+            !IsFinite(data.MountSpeed) || data.MountSpeed < 0f ||
+            data.MountSpeed > MaximumMovementSpeed)
+        {
+            failure = "mount position, direction, input, or speed is nonfinite or unreasonable";
+            return false;
+        }
+        if ((data.MountMovementFlag & ~AllowedLocomotionFlags) != 0)
+        {
+            failure = "mount locomotion flags contain unsupported bits";
+            return false;
+        }
+        if (!IsProgress(data.MountAction0Progress) ||
+            !IsProgress(data.MountAction1Progress) ||
+            !IsFinite(data.MountAction0Speed) || data.MountAction0Speed < 0f ||
+            data.MountAction0Speed > 8f)
+        {
+            failure = "mount action progress or speed is nonfinite or unreasonable";
+            return false;
+        }
+        if (!IsActionIndex(data.MountAction0Index) ||
+            !IsActionIndex(data.MountAction1Index) ||
+            !IsActionIndex(data.MountAction0TurnActionIndex))
+        {
+            failure = "mount action index is outside the bounded wire range";
+            return false;
+        }
+        if ((data.MountAction0Flag & ~AllowedAnimationFlags) != 0 ||
+            (data.MountAction1Flag & ~AllowedAnimationFlags) != 0)
+        {
+            failure = "mount animation flags contain unsupported bits";
+            return false;
+        }
+        if (data.MountAction0TurnDirection < AgentMountData.TurnLeft ||
+            data.MountAction0TurnDirection > AgentMountData.TurnRight)
+        {
+            failure = "mount turn direction is invalid";
+            return false;
+        }
+        if (!string.IsNullOrEmpty(data.MountIdentityScopeId) &&
+            data.MountIdentityScopeId.Length > MaximumControllerIdLength)
+        {
+            failure = "mount identity scope is too long";
+            return false;
+        }
+        if (data.MountMovementId != 0 && data.MountAgentId != Guid.Empty)
+        {
+            failure = "mount compact and canonical ids cannot both be set";
+            return false;
+        }
+        if (data.MountMovementId == 0 &&
+            !string.IsNullOrEmpty(data.MountIdentityScopeId))
+        {
+            failure = "mount identity scope requires a compact id";
+            return false;
+        }
+
+        failure = null;
+        return true;
+    }
+
+    private bool TryValidateActionData(AgentActionData data, out string failure)
+    {
+        if (data == null)
+        {
+            failure = "action data is missing";
+            return false;
+        }
+        if (!IsProgress(data.Action0Progress) || !IsProgress(data.Action1Progress))
+        {
+            failure = "action progress is nonfinite or outside 0..1";
+            return false;
+        }
+        if (!IsActionIndex(data.Action0Index) || !IsActionIndex(data.Action1Index))
+        {
+            failure = "action index is outside the bounded wire range";
+            return false;
+        }
+        if ((data.Action0Flag & ~AllowedAnimationFlags) != 0 ||
+            (data.Action1Flag & ~AllowedAnimationFlags) != 0)
+        {
+            failure = "action animation flags contain unsupported bits";
+            return false;
+        }
+        if ((data.MovementFlag & ~AllowedActionMovementFlags) != 0 ||
+            (data.EventFlag & ~AllowedEventFlags) != 0)
+        {
+            failure = "action movement or event flags contain unsupported bits";
+            return false;
+        }
+        if (data.GuardState < 0 || data.GuardState > 4 ||
+            !IsChannel(data.GuardPresentationChannel) ||
+            !IsChannel(data.GuardActionChannel))
+        {
+            failure = "action guard state or channel is invalid";
+            return false;
+        }
+        if ((data.GuardActionIsDefending || data.GuardActionIsReaction) &&
+            data.GuardActionChannel < 0)
+        {
+            failure = "action guard metadata has no action channel";
+            return false;
+        }
+
+        failure = null;
+        return true;
+    }
+
+    private static bool IsValidRequiredId(string value, int maximumLength) =>
+        !string.IsNullOrWhiteSpace(value) && value.Length <= maximumLength;
+
+    private static bool HasEarlier(ushort[] values, int index)
+    {
+        ushort value = values[index];
+        for (int i = 0; i < index; i++)
+        {
+            if (values[i] == value) return true;
+        }
+        return false;
+    }
+
+    private static bool HasEarlier(Guid[] values, int index)
+    {
+        Guid value = values[index];
+        for (int i = 0; i < index; i++)
+        {
+            if (values[i] == value) return true;
+        }
+        return false;
+    }
+
+    private static bool IsReasonablePosition(Vec3 value) =>
+        IsFinite(value.X) && IsFinite(value.Y) && IsFinite(value.Z) &&
+        Math.Abs(value.X) <= MaximumCoordinateMagnitude &&
+        Math.Abs(value.Y) <= MaximumCoordinateMagnitude &&
+        Math.Abs(value.Z) <= MaximumCoordinateMagnitude;
+
+    private static bool IsReasonableDirection(Vec2 value, bool allowZero)
+    {
+        if (!IsFinite(value.X) || !IsFinite(value.Y)) return false;
+        float lengthSquared = value.LengthSquared;
+        return lengthSquared <= 1.21f && (allowZero || lengthSquared >= 0.01f);
+    }
+
+    private static bool IsReasonableDirection(Vec3 value, bool allowZero)
+    {
+        if (!IsFinite(value.X) || !IsFinite(value.Y) || !IsFinite(value.Z)) return false;
+        float lengthSquared = value.LengthSquared;
+        return lengthSquared <= 1.21f && (allowZero || lengthSquared >= 0.01f);
+    }
+
+    private static bool IsReasonableInput(Vec2 value) =>
+        IsFinite(value.X) && IsFinite(value.Y) && value.LengthSquared <= 2.25f;
+
+    private static bool IsProgress(float value) =>
+        IsFinite(value) && value >= 0f && value <= 1f;
+
+    private bool IsActionIndex(int value) =>
+        value >= AgentMountData.NoActionIndex && value < maximumActionCount;
+
+    private static bool IsChannel(int value) => value >= -1 && value <= 1;
+
+    private static bool IsFinite(float value) =>
+        !float.IsNaN(value) && !float.IsInfinity(value);
+}

--- a/source/Missions/Agents/Handlers/AnimationActionCountProvider.cs
+++ b/source/Missions/Agents/Handlers/AnimationActionCountProvider.cs
@@ -1,0 +1,17 @@
+﻿using TaleWorlds.MountAndBlade;
+
+namespace Missions.Agents.Handlers;
+
+public interface IAnimationActionCountProvider
+{
+    int GetActionCount();
+}
+
+public sealed class AnimationActionCountProvider :
+    IAnimationActionCountProvider
+{
+    public int GetActionCount()
+    {
+        return MBAnimation.GetNumActionCodes();
+    }
+}

--- a/source/Missions/Agents/Handlers/MountMovementApplier.cs
+++ b/source/Missions/Agents/Handlers/MountMovementApplier.cs
@@ -1,7 +1,12 @@
 ﻿using Common;
+using Common.Logging;
 using Common.PacketHandlers;
 using LiteNetLib;
 using Missions.Agents.Packets;
+#if DEBUG
+using Missions.Diagnostics;
+#endif
+using Serilog;
 using System;
 using TaleWorlds.MountAndBlade;
 using AgentControllerType = TaleWorlds.Core.AgentControllerType;
@@ -18,24 +23,29 @@ namespace Missions.Agents.Handlers;
 /// </summary>
 public class MountMovementApplier : IPacketHandler
 {
+    private static readonly ILogger Logger = LogManager.GetLogger<MountMovementApplier>();
+
     private readonly INetworkAgentRegistry agentRegistry;
     private readonly IAgentPositionInterpolator interpolator;
     private readonly IPuppetMountStateRepairer puppetMountStateRepairer;
     private readonly Action<Agent, AgentMountData> updateSyntheticTurn;
     private readonly Action<MountMovementPacket> queueMovement;
+    private readonly IAgentReplicationValidator replicationValidator;
 
     public MountMovementApplier(
         INetworkAgentRegistry agentRegistry,
         IAgentPositionInterpolator interpolator,
         IPuppetMountStateRepairer puppetMountStateRepairer,
         Action<Agent, AgentMountData> updateSyntheticTurn,
-        Action<MountMovementPacket> queueMovement)
+        Action<MountMovementPacket> queueMovement,
+        IAgentReplicationValidator replicationValidator)
     {
         this.agentRegistry = agentRegistry;
         this.interpolator = interpolator;
         this.puppetMountStateRepairer = puppetMountStateRepairer;
         this.updateSyntheticTurn = updateSyntheticTurn;
         this.queueMovement = queueMovement;
+        this.replicationValidator = replicationValidator;
     }
 
     public PacketType PacketType => PacketType.MountMovement;
@@ -46,7 +56,29 @@ public class MountMovementApplier : IPacketHandler
 
     public void HandlePacket(NetPeer peer, IPacket packet)
     {
-        queueMovement((MountMovementPacket)packet);
+        var movement = (MountMovementPacket)packet;
+        if (!replicationValidator.TryValidate(movement, out string validationFailure))
+        {
+#if DEBUG
+            ClientReplicationDiagnostics.RecordValidationRejection();
+#endif
+            if (replicationValidator.ShouldLogRejection(out int suppressed))
+            {
+                Logger.Warning(
+                    "Discarding invalid mount movement packet: {Failure} " +
+                    "(suppressed since last log: {Suppressed})",
+                    validationFailure,
+                    suppressed);
+            }
+            return;
+        }
+
+        int idCount = movement.Mounts.Length;
+#if DEBUG
+        for (int i = 0; i < idCount; i++)
+            ClientReplicationDiagnostics.RecordAccepted(movement, i);
+#endif
+        queueMovement(movement);
     }
 
     internal void ApplySnapshot(
@@ -58,7 +90,8 @@ public class MountMovementApplier : IPacketHandler
     {
         CoopAgentInfo mountInfo;
         bool found = usesCompactId
-            ? agentRegistry.TryGetAgentInfo(identityScopeId, compactId, out mountInfo)
+            ? agentRegistry.TryGetAgentInfo(
+                identityScopeId, compactId, out mountInfo)
             : agentRegistry.TryGetAgentInfo(canonicalId, out mountInfo);
         if (!found) return;
 
@@ -68,8 +101,6 @@ public class MountMovementApplier : IPacketHandler
         if (agentRegistry.IsLocallyControlled(horse))
             return;
 
-        // A stale loose-horse packet can arrive after a rider packet remounts it. Drop the direct target so
-        // the rider and masterless-mount interpolators cannot fight.
         if (horse.RiderAgent is Agent rider && rider.IsActive())
         {
             interpolator.Forget(horse);

--- a/source/Missions/Agents/Handlers/RemoteAgentActionProcessor.cs
+++ b/source/Missions/Agents/Handlers/RemoteAgentActionProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using Common;
+using Common.Logging;
 using Common.Util;
 using GameInterface.Services.Entity;
 using GameInterface.Services.MapEvents;
@@ -8,6 +9,7 @@ using Missions.Diagnostics;
 #endif
 using Missions.Messages;
 using Missions.Services.Network;
+using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -30,6 +32,7 @@ public interface IRemoteAgentActionProcessor : IDisposable
 
 public class RemoteAgentActionProcessor : IRemoteAgentActionProcessor
 {
+    private static readonly ILogger Logger = LogManager.GetLogger<RemoteAgentActionProcessor>();
     private const float RetainedGuardReleaseBlendPeriod = 0.4f;
 
     private readonly INetworkAgentRegistry agentRegistry;
@@ -37,6 +40,7 @@ public class RemoteAgentActionProcessor : IRemoteAgentActionProcessor
     private readonly IBattleHostRegistry battleHostRegistry;
     private readonly IMissionContext missionContext;
     private readonly IAgentVisualActionAccessor agentVisualActionAccessor;
+    private readonly IAgentReplicationValidator replicationValidator;
 
     // All receive-side state for one agent stays together so authority changes clear it atomically.
     private readonly Dictionary<Guid, RemoteAgentActionState> _agentStates =
@@ -215,13 +219,15 @@ public class RemoteAgentActionProcessor : IRemoteAgentActionProcessor
         IControllerIdProvider controllerIdProvider,
         IBattleHostRegistry battleHostRegistry,
         IMissionContext missionContext,
-        IAgentVisualActionAccessor agentVisualActionAccessor)
+        IAgentVisualActionAccessor agentVisualActionAccessor,
+        IAgentReplicationValidator replicationValidator)
     {
         this.agentRegistry = agentRegistry;
         this.controllerIdProvider = controllerIdProvider;
         this.battleHostRegistry = battleHostRegistry;
         this.missionContext = missionContext;
         this.agentVisualActionAccessor = agentVisualActionAccessor;
+        this.replicationValidator = replicationValidator;
     }
 
     public int GetOutgoingBattleHostEpoch()
@@ -406,13 +412,16 @@ public class RemoteAgentActionProcessor : IRemoteAgentActionProcessor
 
     public void Receive(AgentActionPacket packet)
     {
-        if (packet.AgentIds == null
-            || packet.Actions == null
-            || packet.Sequences == null
-            || packet.AgentIds.Length != packet.Actions.Length
-            || packet.AgentIds.Length != packet.Sequences.Length
-            || string.IsNullOrEmpty(packet.ControllerId))
+        if (!replicationValidator.TryValidate(packet, out string validationFailure))
         {
+            if (replicationValidator.ShouldLogRejection(out int suppressed))
+            {
+                Logger.Warning(
+                    "Discarding invalid remote action packet: {Failure} " +
+                    "(suppressed since last log: {Suppressed})",
+                    validationFailure,
+                    suppressed);
+            }
             return;
         }
 

--- a/source/Missions/Agents/Packets/AgentActionData.cs
+++ b/source/Missions/Agents/Packets/AgentActionData.cs
@@ -397,7 +397,7 @@ namespace Missions.Agents.Packets
             movementFlags &= ~DefendMovementFlagsMask;
             movementFlags |= defendFlags;
 
-            MovementFlag = (uint)movementFlags;
+            MovementFlag = (uint)GetDefendMovementFlags(movementFlags);
             EventFlag = (uint)agent.EventControlFlags;
             CrouchMode = agent.CrouchMode;
             GuardState = ToWireGuardState(guardMode);

--- a/source/Missions/Agents/Packets/AgentData.cs
+++ b/source/Missions/Agents/Packets/AgentData.cs
@@ -73,6 +73,45 @@ namespace Missions.Agents.Packets
         {
         }
 
+#if DEBUG
+        internal AgentData WithStateForDiagnostics(
+            Vec3 position,
+            Vec2 inputVector,
+            Vec3 lookDirection,
+            Vec2 movementDirection,
+            AgentMountData mountData,
+            float speed,
+            uint movementFlag)
+        {
+            return new AgentData(
+                position,
+                inputVector,
+                lookDirection,
+                movementDirection,
+                mountData,
+                speed,
+                movementFlag);
+        }
+
+        private AgentData(
+            Vec3 position,
+            Vec2 inputVector,
+            Vec3 lookDirection,
+            Vec2 movementDirection,
+            AgentMountData mountData,
+            float speed,
+            uint movementFlag)
+        {
+            Position = position;
+            InputVector = inputVector;
+            LookDirection = lookDirection;
+            MovementDirection = movementDirection;
+            MountData = mountData;
+            Speed = speed;
+            MovementFlag = movementFlag;
+        }
+#endif
+
         public void Apply(Agent agent)
         {
             // if the player is dead, dont sync anything

--- a/source/Missions/Agents/Packets/AgentMountData.cs
+++ b/source/Missions/Agents/Packets/AgentMountData.cs
@@ -94,6 +94,57 @@ namespace Missions.Agents.Packets
         {
         }
 
+#if DEBUG
+        internal AgentMountData WithStateForDiagnostics(
+            Vec3 position,
+            Vec2 inputVector,
+            Vec3 lookDirection,
+            Vec2 movementDirection,
+            float speed,
+            uint movementFlag)
+        {
+            return new AgentMountData(
+                this,
+                position,
+                inputVector,
+                lookDirection,
+                movementDirection,
+                speed,
+                movementFlag);
+        }
+
+        private AgentMountData(
+            AgentMountData source,
+            Vec3 position,
+            Vec2 inputVector,
+            Vec3 lookDirection,
+            Vec2 movementDirection,
+            float speed,
+            uint movementFlag)
+        {
+            MountInputVector = inputVector;
+            MountAction1Flag = source.MountAction1Flag;
+            MountAction1Progress = source.MountAction1Progress;
+            MountAction1Index = source.MountAction1Index;
+            MountLookDirection = lookDirection;
+            MountMovementDirection = movementDirection;
+            MountPosition = position;
+            MountMovementId = source.MountMovementId;
+            MountAction0Flag = source.MountAction0Flag;
+            MountAction0Progress = source.MountAction0Progress;
+            MountAction0Index = source.MountAction0Index;
+            MountSpeed = speed;
+            MountIdentityScopeId = source.MountIdentityScopeId;
+            MountAgentId = source.MountAgentId;
+            MountMovementFlag = movementFlag;
+            MountAction0Speed = source.MountAction0Speed;
+            MountAction0IsLocomotion = source.MountAction0IsLocomotion;
+            MountAction0TurnDirection = source.MountAction0TurnDirection;
+            MountAction0TurnActionIndexWire = source.MountAction0TurnActionIndexWire;
+            MountAction0IsSyntheticTurn = source.MountAction0IsSyntheticTurn;
+        }
+#endif
+
         public void ApplyMount(Agent mountAgent)
         {
             // NOTE: mount position is NOT applied here — it is reconciled per-frame by AgentPositionInterpolator

--- a/source/Missions/Battles/BattleDebugCommands.cs
+++ b/source/Missions/Battles/BattleDebugCommands.cs
@@ -2,6 +2,8 @@
 using GameInterface;
 using GameInterface.Services.MapEvents;
 using GameInterface.Services.MapEvents.TroopSupply;
+using Missions.Agents;
+using Missions.Agents.Handlers;
 using Missions.Agents.Packets;
 #if DEBUG
 using Missions.Diagnostics;
@@ -19,6 +21,7 @@ using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.View.Screens;
 using TaleWorlds.ScreenSystem;
 using static TaleWorlds.Library.CommandLineFunctionality;
+using MovementAgentData = Missions.Agents.Packets.AgentData;
 
 namespace Missions.Battles;
 
@@ -100,6 +103,120 @@ internal static class BattleDebugCommands
     private static Guid wieldTestAgentId;
     private static EquipmentIndex wieldTestOriginalMainHand;
     private static bool wieldTestActive;
+
+    [CommandLineArgumentFunction("movement_resilience", "coop.debug.battle")]
+    public static string MovementResilience(List<string> args)
+    {
+        if (args.Count != 1)
+        {
+            return "Usage: coop.debug.battle.movement_resilience " +
+                   "<start|snapshot|stop|ready|burst|invalid|isolate>";
+        }
+
+        if (ModInformation.IsServer)
+            return "movement_resilience must be run on a client";
+
+        string operation = args[0].ToLowerInvariant();
+        if (operation == "start")
+        {
+            ClientReplicationDiagnostics.Start();
+            return "MOVEMENT_RESILIENCE " +
+                   ClientReplicationDiagnostics.Snapshot(stop: false);
+        }
+        if (operation == "snapshot" || operation == "stop")
+        {
+            return "MOVEMENT_RESILIENCE " +
+                   ClientReplicationDiagnostics.Snapshot(
+                       stop: operation == "stop");
+        }
+
+        Mission mission = Mission.Current;
+        CoopBattleController controller =
+            mission?.GetMissionBehavior<CoopBattleController>();
+        if (mission == null || controller == null)
+            return "No active coop battle mission";
+        if (!(controller.DebugMovementHandler is AgentMovementHandler handler))
+            return "Movement handler is unavailable";
+        if (!ContainerProvider.TryResolve<INetworkAgentRegistry>(out var registry))
+            return "Network agent registry is unavailable";
+
+        CoopAgentInfo[] remoteAgents = registry.GetControllerIds()
+            .SelectMany(registry.GetAgents)
+            .Where(info =>
+                info.Agent != null &&
+                info.Agent.IsHuman &&
+                info.Agent.IsActive() &&
+                !registry.IsLocallyControlled(info.Agent))
+            .OrderBy(info => info.AgentId)
+            .ToArray();
+
+        if (operation == "ready")
+        {
+            Agent local = Agent.Main;
+            bool localReady = local != null && local.IsActive() &&
+                registry.TryGetAgentInfo(local, out _) &&
+                registry.IsLocallyControlled(local);
+            bool mounted = localReady && local.HasMount &&
+                local.MountAgent != null && local.MountAgent.IsActive();
+            return $"MOVEMENT_RESILIENCE_READY localAgent={localReady} " +
+                   $"mounted={mounted} remoteHumans={remoteAgents.Length}";
+        }
+
+        if (operation == "burst")
+        {
+            const int sampleCount = 4500;
+            int emitted = handler.SendDiagnosticsMovementBurst(sampleCount);
+            return $"MOVEMENT_RESILIENCE_BURST emitted={emitted} requested={sampleCount}";
+        }
+
+        if (operation == "invalid")
+        {
+            if (remoteAgents.Length == 0)
+                return "No active remote human agent is available";
+
+            CoopAgentInfo target = remoteAgents[0];
+            MovementAgentData baseline = new MovementAgentData(target.Agent);
+            MovementAgentData invalid = baseline.WithStateForDiagnostics(
+                new Vec3(float.NaN, 0f, 0f),
+                baseline.InputVector,
+                baseline.LookDirection,
+                baseline.MovementDirection,
+                baseline.MountData,
+                baseline.Speed,
+                baseline.MovementFlag);
+            var invalidPacket = new MovementPacket(
+                new[] { target.AgentId },
+                new[] { invalid });
+            ClientReplicationDiagnostics.ArmInvalidProbe(invalidPacket);
+            handler.HandlePacket(null, invalidPacket);
+            return "MOVEMENT_RESILIENCE_INVALID " +
+                   ClientReplicationDiagnostics.Snapshot(stop: false);
+        }
+
+        if (operation == "isolate")
+        {
+            if (remoteAgents.Length < 2)
+                return "At least two active remote human agents are required";
+
+            CoopAgentInfo[] targets = remoteAgents.Take(2).ToArray();
+            var data = new[]
+            {
+                new MovementAgentData(targets[0].Agent),
+                new MovementAgentData(targets[1].Agent),
+            };
+            ClientReplicationDiagnostics.ArmSingleEntryFailure();
+            handler.HandlePacket(
+                null,
+                new MovementPacket(
+                    targets.Select(info => info.AgentId).ToArray(),
+                    data));
+            return "MOVEMENT_RESILIENCE_ISOLATED " +
+                   ClientReplicationDiagnostics.Snapshot(stop: false);
+        }
+
+        return "Usage: coop.debug.battle.movement_resilience " +
+               "<start|snapshot|stop|ready|burst|invalid|isolate>";
+    }
 
     [CommandLineArgumentFunction("action_performance", "coop.debug.battle")]
     public static string ActionPerformance(List<string> args)

--- a/source/Missions/Battles/CoopBattleController.cs
+++ b/source/Missions/Battles/CoopBattleController.cs
@@ -8,6 +8,7 @@ using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
 using LiteNetLib;
 using Missions.Agents;
+using Missions.Agents.Handlers;
 using Missions.Data;
 using Missions.Messages;
 using Missions.Services.Network;
@@ -58,6 +59,11 @@ public class CoopBattleController : CoopMissionController
 
     /// <summary>Reports final siege engine state before the shared result is applied.</summary>
     public ISiegeEngineStateReporter SiegeEngineStateReporter { get; }
+
+#if DEBUG
+    internal IAgentMovementHandler DebugMovementHandler =>
+        coopMissionComponent.AgentMovementHandler;
+#endif
 
     private readonly IBattleInstanceLifecycle lifecycle;
     private readonly IOwnedAgentReplicator replicator;

--- a/source/Missions/Diagnostics/ClientReplicationDiagnostics.cs
+++ b/source/Missions/Diagnostics/ClientReplicationDiagnostics.cs
@@ -1,0 +1,389 @@
+﻿#if DEBUG
+using Missions.Agents.Packets;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Missions.Diagnostics;
+
+internal static class ClientReplicationDiagnostics
+{
+    private const int MaximumTrackedSamples = 12000;
+    private static readonly object Gate = new object();
+    private static readonly Queue<int> ExpectedSamples = new Queue<int>();
+
+    private static bool enabled;
+    private static long acceptedSamples;
+    private static long processedSamples;
+    private static long failedSamples;
+    private static long orderMismatches;
+    private static long validationRejections;
+    private static int injectedEntryFailures;
+    private static int invalidProbeFingerprint;
+    private static bool invalidProbeArmed;
+    private static long invalidProbeRejections;
+    private static long invalidProbeNativeApplications;
+    private static long isolationFailures;
+    private static long isolationRecoveries;
+    private static bool awaitingIsolationRecovery;
+
+    public static bool Enabled
+    {
+        get
+        {
+            lock (Gate) return enabled;
+        }
+    }
+
+    public static void Start()
+    {
+        lock (Gate)
+        {
+            enabled = true;
+            acceptedSamples = 0;
+            processedSamples = 0;
+            failedSamples = 0;
+            orderMismatches = 0;
+            validationRejections = 0;
+            injectedEntryFailures = 0;
+            invalidProbeFingerprint = 0;
+            invalidProbeArmed = false;
+            invalidProbeRejections = 0;
+            invalidProbeNativeApplications = 0;
+            isolationFailures = 0;
+            isolationRecoveries = 0;
+            awaitingIsolationRecovery = false;
+            ExpectedSamples.Clear();
+        }
+    }
+
+    public static string Snapshot(bool stop)
+    {
+        lock (Gate)
+        {
+            string result = string.Format(
+                CultureInfo.InvariantCulture,
+                "enabled={0} accepted={1} processed={2} failed={3} pendingOrder={4} " +
+                "orderMismatches={5} rejected={6} invalidRejected={7} " +
+                "invalidNative={8} isolationFailures={9} isolationRecoveries={10}",
+                enabled,
+                acceptedSamples,
+                processedSamples,
+                failedSamples,
+                ExpectedSamples.Count,
+                orderMismatches,
+                validationRejections,
+                invalidProbeRejections,
+                invalidProbeNativeApplications,
+                isolationFailures,
+                isolationRecoveries);
+            if (stop) enabled = false;
+            return result;
+        }
+    }
+
+    public static void RecordAccepted(MovementPacket packet, int index) =>
+        RecordAccepted(Fingerprint(packet, index));
+
+    public static void RecordAccepted(MountMovementPacket packet, int index) =>
+        RecordAccepted(Fingerprint(packet, index));
+
+    public static void RecordProcessed(MovementPacket packet, int index) =>
+        RecordProcessed(Fingerprint(packet, index), failed: false);
+
+    public static void RecordProcessed(MountMovementPacket packet, int index) =>
+        RecordProcessed(Fingerprint(packet, index), failed: false);
+
+    public static void RecordProcessed(
+        string scope,
+        ushort compactId,
+        Guid canonicalId,
+        bool usesCompactId,
+        AgentData data) =>
+        RecordProcessed(
+            Fingerprint(scope, compactId, canonicalId, usesCompactId, data),
+            failed: false);
+
+    public static void RecordProcessed(
+        string scope,
+        ushort compactId,
+        Guid canonicalId,
+        bool usesCompactId,
+        AgentMountData data) =>
+        RecordProcessed(
+            Fingerprint(scope, compactId, canonicalId, usesCompactId, data),
+            failed: false);
+
+    public static void RecordFailed(MovementPacket packet, int index) =>
+        RecordProcessed(Fingerprint(packet, index), failed: true);
+
+    public static void RecordFailed(MountMovementPacket packet, int index) =>
+        RecordProcessed(Fingerprint(packet, index), failed: true);
+
+    public static void RecordFailed(
+        string scope,
+        ushort compactId,
+        Guid canonicalId,
+        bool usesCompactId,
+        AgentData data) =>
+        RecordProcessed(
+            Fingerprint(scope, compactId, canonicalId, usesCompactId, data),
+            failed: true);
+
+    public static void RecordFailed(
+        string scope,
+        ushort compactId,
+        Guid canonicalId,
+        bool usesCompactId,
+        AgentMountData data) =>
+        RecordProcessed(
+            Fingerprint(scope, compactId, canonicalId, usesCompactId, data),
+            failed: true);
+
+    public static void RecordValidationRejection()
+    {
+        lock (Gate)
+        {
+            if (enabled) validationRejections++;
+        }
+    }
+
+    public static void RecordValidationRejection(MovementPacket packet)
+    {
+        lock (Gate)
+        {
+            if (!enabled) return;
+            validationRejections++;
+            if (invalidProbeArmed && Fingerprint(packet, 0) == invalidProbeFingerprint)
+            {
+                invalidProbeRejections++;
+                invalidProbeArmed = false;
+            }
+        }
+    }
+
+    public static void ArmInvalidProbe(MovementPacket packet)
+    {
+        lock (Gate)
+        {
+            invalidProbeFingerprint = Fingerprint(packet, 0);
+            invalidProbeArmed = true;
+        }
+    }
+
+    public static void RecordNativeApplication(MovementPacket packet)
+    {
+        lock (Gate)
+        {
+            if (enabled && invalidProbeArmed &&
+                Fingerprint(packet, 0) == invalidProbeFingerprint)
+            {
+                invalidProbeNativeApplications++;
+                invalidProbeArmed = false;
+            }
+        }
+    }
+
+    public static void RecordNativeApplication(
+        string scope,
+        ushort compactId,
+        Guid canonicalId,
+        bool usesCompactId,
+        AgentData data)
+    {
+        lock (Gate)
+        {
+            if (enabled && invalidProbeArmed &&
+                Fingerprint(scope, compactId, canonicalId, usesCompactId, data) ==
+                    invalidProbeFingerprint)
+            {
+                invalidProbeNativeApplications++;
+                invalidProbeArmed = false;
+            }
+        }
+    }
+
+    public static void ArmSingleEntryFailure()
+    {
+        lock (Gate)
+        {
+            injectedEntryFailures = 1;
+        }
+    }
+
+    public static bool ConsumeInjectedEntryFailure()
+    {
+        lock (Gate)
+        {
+            if (injectedEntryFailures == 0) return false;
+            injectedEntryFailures--;
+            isolationFailures++;
+            awaitingIsolationRecovery = true;
+            return true;
+        }
+    }
+
+    private static void RecordAccepted(int fingerprint)
+    {
+        lock (Gate)
+        {
+            if (!enabled) return;
+            acceptedSamples++;
+            if (ExpectedSamples.Count >= MaximumTrackedSamples)
+            {
+                ExpectedSamples.Dequeue();
+                orderMismatches++;
+            }
+            ExpectedSamples.Enqueue(fingerprint);
+        }
+    }
+
+    private static void RecordProcessed(int fingerprint, bool failed)
+    {
+        lock (Gate)
+        {
+            if (!enabled) return;
+            if (ExpectedSamples.Count == 0 || ExpectedSamples.Dequeue() != fingerprint)
+                orderMismatches++;
+            if (failed)
+                failedSamples++;
+            else
+            {
+                processedSamples++;
+                if (awaitingIsolationRecovery)
+                {
+                    isolationRecoveries++;
+                    awaitingIsolationRecovery = false;
+                }
+            }
+        }
+    }
+
+    private static int Fingerprint(MovementPacket packet, int index)
+    {
+        AgentData data = packet.Agents[index];
+        int hash = StartFingerprint(packet.IdentityScopeId, packet.AgentIds, packet.AgentGuids, index);
+        hash = Add(hash, data.Position.X);
+        hash = Add(hash, data.Position.Y);
+        hash = Add(hash, data.Position.Z);
+        hash = Add(hash, data.LookDirection.X);
+        hash = Add(hash, data.LookDirection.Y);
+        hash = Add(hash, data.LookDirection.Z);
+        hash = Add(hash, data.MovementDirection.X);
+        hash = Add(hash, data.MovementDirection.Y);
+        hash = Add(hash, data.InputVector.X);
+        hash = Add(hash, data.InputVector.Y);
+        hash = Add(hash, data.Speed);
+        hash = Add(hash, data.MovementFlag);
+        if (data.MountData != null)
+            hash = AddMount(hash, data.MountData);
+        return hash;
+    }
+
+    private static int Fingerprint(MountMovementPacket packet, int index)
+    {
+        int hash = StartFingerprint(packet.IdentityScopeId, packet.MountIds, packet.MountGuids, index);
+        return AddMount(hash, packet.Mounts[index]);
+    }
+
+    private static int Fingerprint(
+        string scope,
+        ushort compactId,
+        Guid canonicalId,
+        bool usesCompactId,
+        AgentData data)
+    {
+        int hash = StartFingerprint(scope, compactId, canonicalId, usesCompactId);
+        hash = Add(hash, data.Position.X);
+        hash = Add(hash, data.Position.Y);
+        hash = Add(hash, data.Position.Z);
+        hash = Add(hash, data.LookDirection.X);
+        hash = Add(hash, data.LookDirection.Y);
+        hash = Add(hash, data.LookDirection.Z);
+        hash = Add(hash, data.MovementDirection.X);
+        hash = Add(hash, data.MovementDirection.Y);
+        hash = Add(hash, data.InputVector.X);
+        hash = Add(hash, data.InputVector.Y);
+        hash = Add(hash, data.Speed);
+        hash = Add(hash, data.MovementFlag);
+        if (data.MountData != null)
+            hash = AddMount(hash, data.MountData);
+        return hash;
+    }
+
+    private static int Fingerprint(
+        string scope,
+        ushort compactId,
+        Guid canonicalId,
+        bool usesCompactId,
+        AgentMountData data)
+    {
+        int hash = StartFingerprint(scope, compactId, canonicalId, usesCompactId);
+        return AddMount(hash, data);
+    }
+
+    private static int StartFingerprint(
+        string scope,
+        ushort[] compactIds,
+        Guid[] canonicalIds,
+        int index)
+    {
+        unchecked
+        {
+            int hash = 17;
+            hash = (hash * 31) + (scope?.GetHashCode() ?? 0);
+            hash = (hash * 31) + (compactIds != null
+                ? compactIds[index].GetHashCode()
+                : canonicalIds[index].GetHashCode());
+            return hash;
+        }
+    }
+
+    private static int StartFingerprint(
+        string scope,
+        ushort compactId,
+        Guid canonicalId,
+        bool usesCompactId)
+    {
+        unchecked
+        {
+            int hash = 17;
+            hash = (hash * 31) + (scope?.GetHashCode() ?? 0);
+            hash = (hash * 31) + (usesCompactId
+                ? compactId.GetHashCode()
+                : canonicalId.GetHashCode());
+            return hash;
+        }
+    }
+
+    private static int AddMount(int hash, AgentMountData data)
+    {
+        hash = Add(hash, data.MountPosition.X);
+        hash = Add(hash, data.MountPosition.Y);
+        hash = Add(hash, data.MountPosition.Z);
+        hash = Add(hash, data.MountLookDirection.X);
+        hash = Add(hash, data.MountLookDirection.Y);
+        hash = Add(hash, data.MountLookDirection.Z);
+        hash = Add(hash, data.MountMovementDirection.X);
+        hash = Add(hash, data.MountMovementDirection.Y);
+        hash = Add(hash, data.MountInputVector.X);
+        hash = Add(hash, data.MountInputVector.Y);
+        hash = Add(hash, data.MountSpeed);
+        return Add(hash, data.MountMovementFlag);
+    }
+
+    private static int Add(int hash, float value) =>
+        Add(hash, value.GetHashCode());
+
+    private static int Add(int hash, uint value) =>
+        Add(hash, unchecked((int)value));
+
+    private static int Add(int hash, int value)
+    {
+        unchecked
+        {
+            return (hash * 31) + value;
+        }
+    }
+}
+#endif

--- a/source/Missions/MissionModule.cs
+++ b/source/Missions/MissionModule.cs
@@ -53,6 +53,15 @@ public class MissionModule : Module
         builder.RegisterType<BattleAgentSpawnBatchCodec>()
             .As<IBattleAgentSpawnBatchCodec>()
             .InstancePerDependency();
+        builder.RegisterType<AgentReplicationValidator>()
+            .As<IAgentReplicationValidator>()
+            .InstancePerDependency();
+        builder.RegisterType<AnimationActionCountProvider>()
+            .As<IAnimationActionCountProvider>()
+            .InstancePerDependency();
+        builder.RegisterType<AgentPositionInterpolator>()
+            .As<IAgentPositionInterpolator>()
+            .InstancePerDependency();
         builder.RegisterType<CompressedMovementPacketHandler>()
             .AsSelf()
             .InstancePerLifetimeScope()

--- a/source/Missions/Taverns/CoopLocationsController.cs
+++ b/source/Missions/Taverns/CoopLocationsController.cs
@@ -1,4 +1,4 @@
-using Common;
+﻿using Common;
 using Common.Logging;
 using Common.Messaging;
 using Common.Network;
@@ -9,6 +9,7 @@ using GameInterface.Services.Locations.Messages;
 using GameInterface.Services.ObjectManager;
 using LiteNetLib;
 using Missions.Data;
+using Missions.Agents.Handlers;
 using Serilog;
 using System;
 using System.Collections.Concurrent;
@@ -26,6 +27,7 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
     private static readonly ILogger Logger = LogManager.GetLogger<CoopLocationsController>();
     private readonly INetwork relayNetwork;
     private readonly IControllerIdProvider controllerIdProvider;
+    private readonly IAgentReplicationValidator replicationValidator;
     //private readonly BoardGameManager boardGameManager;
 
     private string instanceId;
@@ -36,11 +38,13 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
         IControllerIdProvider controllerIdProvider,
         //BoardGameManager boardGameManager,
         IObjectManager objectManager,
-        ICoopMissionComponent coopMissionComponent)
+        ICoopMissionComponent coopMissionComponent,
+        IAgentReplicationValidator replicationValidator)
         : base(network, messageBroker, objectManager, coopMissionComponent)
     {
         this.relayNetwork = relayNetwork;
         this.controllerIdProvider = controllerIdProvider;
+        this.replicationValidator = replicationValidator;
         //this.boardGameManager = boardGameManager;
 
         messageBroker.Subscribe<NetworkMissionLeft>(Handle_LeaveMission);
@@ -51,7 +55,6 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
     {
         messageBroker.Unsubscribe<NetworkMissionLeft>(Handle_LeaveMission);
         messageBroker.Unsubscribe<PlayerEnteredLocation>(Handle_PlayerEnteredLocation);
-
         base.Dispose();
     }
 
@@ -244,6 +247,12 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
 
     protected override void HandleJoinInfo(NetPeer netPeer, NetworkMissionJoinInfo joinInfo)
     {
+        if (!replicationValidator.TryValidate(joinInfo, out string validationFailure))
+        {
+            LogRejectedJoin(validationFailure);
+            return;
+        }
+
         // Spawning needs the interior mission fully set up (player agent + teams). On a rejoin the join
         // info beats the mission setup, so buffer it and drain once we are ready (TryRegisterLocalAgent).
         // Re-check readiness after enqueuing to close the race with the main thread flipping it.
@@ -256,6 +265,16 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
         }
 
         ProcessJoinInfo(netPeer, joinInfo);
+    }
+
+    private void LogRejectedJoin(string failure)
+    {
+        if (!replicationValidator.ShouldLogRejection(out int suppressed)) return;
+        Logger.Warning(
+            "[LocationSync] Discarding invalid join info: {Failure} " +
+            "(suppressed since last log: {Suppressed})",
+            failure,
+            suppressed);
     }
 
     private void ProcessJoinInfo(NetPeer netPeer, NetworkMissionJoinInfo joinInfo)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Clients currently pass malformed or extreme movement, mount, action, and location-join updates into the game engine, where invalid values can cause errors. A failure while applying one replicated agent can also prevent later valid agents in the same update from being applied.

## What is the new behavior?

Clients now reject malformed, duplicate, non-finite, or unreasonable replication data before it reaches the game engine. A bad movement or mount entry is isolated so later valid agents still update, while valid packets keep their original order and every accepted intermediary movement sample.

## Bot Changelog Entry

- Improved client stability when receiving invalid movement, mount, action, or location updates.
