### PR TITLE
Add client join-baseline diagnostics

### DIFF
--- a/source/GameInterface.Tests/Services/MobileParties/MobilePartyBehaviorSnapshotTests.cs
+++ b/source/GameInterface.Tests/Services/MobileParties/MobilePartyBehaviorSnapshotTests.cs
@@ -3,6 +3,7 @@ using GameInterface.Services.MobileParties.Data;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Tests.Services.SiegeEvents;
 using Moq;
+using System;
 using System.Collections.Generic;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
@@ -289,6 +290,170 @@ public class MobilePartyBehaviorSnapshotTests
 
         Assert.False(created);
         Assert.Equal("party AI is unavailable", failure);
+    }
+
+    [Fact]
+    public void TryApplyJoinBaseline_MismatchedPartyCount_ReportsCounts()
+    {
+        Campaign previousCampaign = Campaign.Current;
+        try
+        {
+            var campaign = ObjectHelper.SkipConstructor<Campaign>();
+            campaign.CampaignObjectManager = new CampaignObjectManager
+            {
+                Settlements = new MBReadOnlyList<Settlement>(new List<Settlement>()),
+            };
+            Campaign.Current = campaign;
+            var snapshot = new MobilePartyBehaviorSnapshot(Mock.Of<IObjectManager>());
+
+            bool applied = snapshot.TryApplyJoinBaseline(
+                new MobilePartyJoinState[1],
+                () => { });
+
+            Assert.False(applied);
+            Assert.Equal(
+                "party count mismatch (baseline=1, client=0)",
+                snapshot.LastJoinBaselineFailure);
+        }
+        finally
+        {
+            Campaign.Current = previousCampaign;
+        }
+    }
+
+    [Fact]
+    public void TryApplyJoinBaseline_MissingPartyId_ReportsStateIndex()
+    {
+        Campaign previousCampaign = Campaign.Current;
+        try
+        {
+            var campaign = ObjectHelper.SkipConstructor<Campaign>();
+            var campaignObjectManager = new CampaignObjectManager
+            {
+                Settlements = new MBReadOnlyList<Settlement>(new List<Settlement>()),
+            };
+            campaignObjectManager._mobileParties.Add(CreateParty());
+            campaign.CampaignObjectManager = campaignObjectManager;
+            Campaign.Current = campaign;
+            var snapshot = new MobilePartyBehaviorSnapshot(Mock.Of<IObjectManager>());
+
+            bool applied = snapshot.TryApplyJoinBaseline(
+                new[] { new MobilePartyJoinState() },
+                () => { });
+
+            Assert.False(applied);
+            Assert.Equal("state 0 has no mobile-party id", snapshot.LastJoinBaselineFailure);
+        }
+        finally
+        {
+            Campaign.Current = previousCampaign;
+        }
+    }
+
+    [Fact]
+    public void TryApplyJoinBaseline_UnresolvedInteractable_ReportsPartyAndDependency()
+    {
+        Campaign previousCampaign = Campaign.Current;
+        try
+        {
+            var party = CreateParty();
+            var campaign = ObjectHelper.SkipConstructor<Campaign>();
+            var campaignObjectManager = new CampaignObjectManager
+            {
+                Settlements = new MBReadOnlyList<Settlement>(new List<Settlement>()),
+            };
+            campaignObjectManager._mobileParties.Add(party);
+            campaign.CampaignObjectManager = campaignObjectManager;
+            Campaign.Current = campaign;
+
+            var objectManager = new Mock<IObjectManager>();
+            MobileParty resolvedParty = party;
+            objectManager
+                .Setup(m => m.TryGetObject("Created_1", out resolvedParty))
+                .Returns(true);
+            var snapshot = new MobilePartyBehaviorSnapshot(objectManager.Object);
+            var behavior = new PartyBehaviorUpdateData(
+                "Created_1",
+                AiBehavior.Hold,
+                "MissingPartyBase",
+                default,
+                default,
+                AiBehavior.Hold,
+                default,
+                default);
+
+            bool applied = snapshot.TryApplyJoinBaseline(
+                new[] { new MobilePartyJoinState { Behavior = behavior } },
+                () => { });
+
+            Assert.False(applied);
+            Assert.Equal(
+                "state 0 party 'Created_1' failed validation: " +
+                "interactable 'MissingPartyBase' could not be resolved",
+                snapshot.LastJoinBaselineFailure);
+        }
+        finally
+        {
+            Campaign.Current = previousCampaign;
+        }
+    }
+
+    [Fact]
+    public void TryApplyJoinBaseline_SuccessClearsPreviousFailure()
+    {
+        Campaign previousCampaign = Campaign.Current;
+        try
+        {
+            var campaign = ObjectHelper.SkipConstructor<Campaign>();
+            campaign.CampaignObjectManager = new CampaignObjectManager
+            {
+                Settlements = new MBReadOnlyList<Settlement>(new List<Settlement>()),
+            };
+            Campaign.Current = campaign;
+            var snapshot = new MobilePartyBehaviorSnapshot(Mock.Of<IObjectManager>());
+
+            Assert.False(snapshot.TryApplyJoinBaseline(new MobilePartyJoinState[1], () => { }));
+            Assert.NotNull(snapshot.LastJoinBaselineFailure);
+            Assert.Equal(1, snapshot.LoggedJoinBaselineFailureCount);
+
+            Assert.True(snapshot.TryApplyJoinBaseline(Array.Empty<MobilePartyJoinState>(), () => { }));
+            Assert.Null(snapshot.LastJoinBaselineFailure);
+            Assert.Equal(0, snapshot.LoggedJoinBaselineFailureCount);
+        }
+        finally
+        {
+            Campaign.Current = previousCampaign;
+        }
+    }
+
+    [Fact]
+    public void TryApplyJoinBaseline_AlternatingRetriesTrackEachFailureOnce()
+    {
+        Campaign previousCampaign = Campaign.Current;
+        try
+        {
+            var campaign = ObjectHelper.SkipConstructor<Campaign>();
+            var campaignObjectManager = new CampaignObjectManager
+            {
+                Settlements = new MBReadOnlyList<Settlement>(new List<Settlement>()),
+            };
+            campaignObjectManager._mobileParties.Add(CreateParty());
+            campaign.CampaignObjectManager = campaignObjectManager;
+            Campaign.Current = campaign;
+            var snapshot = new MobilePartyBehaviorSnapshot(Mock.Of<IObjectManager>());
+            var missingIdBaseline = new[] { new MobilePartyJoinState() };
+
+            Assert.False(snapshot.TryApplyJoinBaseline(missingIdBaseline, () => { }));
+            Assert.False(snapshot.TryApplyJoinBaseline(Array.Empty<MobilePartyJoinState>(), () => { }));
+            Assert.False(snapshot.TryApplyJoinBaseline(missingIdBaseline, () => { }));
+
+            Assert.Equal("state 0 has no mobile-party id", snapshot.LastJoinBaselineFailure);
+            Assert.Equal(2, snapshot.LoggedJoinBaselineFailureCount);
+        }
+        finally
+        {
+            Campaign.Current = previousCampaign;
+        }
     }
 
     [Fact]

--- a/source/GameInterface/Services/Heroes/Interfaces/HeroInterface.cs
+++ b/source/GameInterface/Services/Heroes/Interfaces/HeroInterface.cs
@@ -117,6 +117,8 @@ internal class HeroInterface : IHeroInterface
         if (!objectManager.TryGetObjectWithLogging(player.MobilePartyId, out MobileParty playerParty))
             return;
 
+        LogPlayerSwitchState("before", player, playerHero, playerParty);
+
         Campaign.Current.MainParty = playerParty;
         Campaign.Current.PlayerDefaultFaction = playerHero.Clan;
 
@@ -125,8 +127,6 @@ internal class HeroInterface : IHeroInterface
         // This is needed because if the player is captured the PartyBelongedTo is null
         // Causing ChangePlayerCharacterAction to fail
         playerHero.PartyBelongedTo = playerParty;
-
-        Logger.Information("Switching to new hero: {heroName}", playerHero.Name.ToString());
 
         // Vanilla's character change ejects a main hero from its settlement, which would pop the
         // reloaded party outside on this client only (the server's save keeps it inside); keep it
@@ -140,6 +140,8 @@ internal class HeroInterface : IHeroInterface
         {
             LeaveSettlementActionPatches.SuppressForPlayerSwitch = false;
         }
+
+        LogPlayerSwitchState("after", player, playerHero, playerParty);
 
         if (playerParty.CurrentSettlement != null || playerParty.BesiegerCamp != null)
         {
@@ -169,6 +171,49 @@ internal class HeroInterface : IHeroInterface
         // icons would stay revealed forever. Queued so it runs once the campaign state is entered
         // and the hero switched to above is the local main party.
         GameThread.RunSafe(partyVisibilitySweep.RebuildAroundMainParty);
+    }
+
+    private void LogPlayerSwitchState(
+        string phase,
+        Player player,
+        Hero playerHero,
+        MobileParty playerParty)
+    {
+        bool heroRegistered = objectManager.TryGetId(playerHero, out string registeredHeroId);
+        bool partyRegistered = objectManager.TryGetId(playerParty, out string registeredPartyId);
+        bool partyInCampaign = Campaign.Current?.MobileParties?.Contains(playerParty) == true;
+
+        Logger.Information(
+            "Player switch {Phase}: hero={HeroName} requestedHero={RequestedHeroId} " +
+            "registeredHero={RegisteredHeroId} heroRegistered={HeroRegistered} " +
+            "heroParty={HeroPartyId} requestedParty={RequestedPartyId} " +
+            "registeredParty={RegisteredPartyId} partyRegistered={PartyRegistered} " +
+            "mainHero={MainHeroId} mainParty={MainPartyId} inCampaign={PartyInCampaign} " +
+            "active={PartyActive} roster={RosterCount} mapEvent={MapEventId} " +
+            "settlement={SettlementId} moveMode={MoveMode} targetParty={TargetPartyId} " +
+            "targetSettlement={TargetSettlementId} moveTargetParty={MoveTargetPartyId} " +
+            "interactable={InteractableType}",
+            phase,
+            playerHero.Name?.ToString(),
+            player.HeroId,
+            heroRegistered ? registeredHeroId : "missing",
+            heroRegistered,
+            playerHero.PartyBelongedTo?.StringId,
+            player.MobilePartyId,
+            partyRegistered ? registeredPartyId : "missing",
+            partyRegistered,
+            Hero.MainHero?.StringId,
+            MobileParty.MainParty?.StringId,
+            partyInCampaign,
+            playerParty.IsActive,
+            playerParty.MemberRoster?.TotalManCount ?? -1,
+            playerParty.MapEvent?.StringId,
+            playerParty.CurrentSettlement?.StringId,
+            playerParty.PartyMoveMode,
+            playerParty.TargetParty?.StringId,
+            playerParty.TargetSettlement?.StringId,
+            playerParty.MoveTargetParty?.StringId,
+            playerParty.Ai?.AiBehaviorInteractable?.GetType().Name);
     }
 
     private void SetupNewHero(Hero hero, Action<Hero> assignNetworkIds)

--- a/source/GameInterface/Services/MobileParties/Data/MobilePartyBehaviorSnapshot.cs
+++ b/source/GameInterface/Services/MobileParties/Data/MobilePartyBehaviorSnapshot.cs
@@ -34,6 +34,11 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
     private static readonly ILogger Logger = LogManager.GetLogger<MobilePartyBehaviorSnapshot>();
 
     private readonly IObjectManager objectManager;
+    private readonly HashSet<string> loggedJoinBaselineFailures = new HashSet<string>();
+    private string lastJoinBaselineFailure;
+
+    internal string LastJoinBaselineFailure => lastJoinBaselineFailure;
+    internal int LoggedJoinBaselineFailureCount => loggedJoinBaselineFailures.Count;
 
     public MobilePartyBehaviorSnapshot(IObjectManager objectManager) => this.objectManager = objectManager;
 
@@ -255,7 +260,14 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
     public bool TryApply(MobileParty party, PartyBehaviorUpdateData data, out IInteractablePoint interactable)
     {
         interactable = null;
-        if (!TryPrepare(party, data, null, null, out ResolvedBehaviorUpdate resolved))
+        if (!TryPrepare(
+            party,
+            data,
+            null,
+            null,
+            logLookupFailures: true,
+            out ResolvedBehaviorUpdate resolved,
+            out _))
             return false;
 
         interactable = resolved.Interactable;
@@ -265,13 +277,23 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
 
     public bool TryApplyJoinBaseline(MobilePartyJoinState[] states, Action beforeApply)
     {
-        if (states == null || beforeApply == null) return false;
+        if (states == null)
+            return RejectJoinBaseline("the baseline party-state array is null");
+        if (beforeApply == null)
+            return RejectJoinBaseline("the before-apply callback is null");
 
         var objectManager = Campaign.Current?.CampaignObjectManager;
         var parties = objectManager?.MobileParties;
         var settlements = objectManager?.Settlements;
-        if (parties == null || settlements == null || states.Length != parties.Count)
-            return false;
+        if (parties == null)
+            return RejectJoinBaseline("the client campaign mobile-party collection is unavailable");
+        if (settlements == null)
+            return RejectJoinBaseline("the client campaign settlement collection is unavailable");
+        if (states.Length != parties.Count)
+        {
+            return RejectJoinBaseline(
+                $"party count mismatch (baseline={states.Length}, client={parties.Count})");
+        }
 
         var liveParties = new HashSet<MobileParty>(parties);
         var liveSettlements = new HashSet<Settlement>(settlements);
@@ -281,17 +303,41 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
         for (int i = 0; i < states.Length; i++)
         {
             PartyBehaviorUpdateData behavior = states[i].Behavior;
-            if (string.IsNullOrEmpty(behavior.MobilePartyId) ||
-                !this.objectManager.TryGetObjectWithLogging(behavior.MobilePartyId, out MobileParty party) ||
-                !liveParties.Contains(party) ||
-                !seenParties.Add(party) ||
-                !TryPrepare(party, behavior, liveParties, liveSettlements, out resolved[i]))
+            if (string.IsNullOrEmpty(behavior.MobilePartyId))
+                return RejectJoinBaseline($"state {i} has no mobile-party id");
+            if (!this.objectManager.TryGetObject(
+                behavior.MobilePartyId,
+                out MobileParty party))
             {
-                return false;
+                return RejectJoinBaseline(
+                    $"state {i} references missing mobile party '{behavior.MobilePartyId}'");
+            }
+            if (!liveParties.Contains(party))
+            {
+                return RejectJoinBaseline(
+                    $"state {i} party '{behavior.MobilePartyId}' is not in the client campaign collection");
+            }
+            if (!seenParties.Add(party))
+                return RejectJoinBaseline($"state {i} duplicates party '{behavior.MobilePartyId}'");
+            if (!TryPrepare(
+                party,
+                behavior,
+                liveParties,
+                liveSettlements,
+                logLookupFailures: false,
+                out resolved[i],
+                out string failure))
+            {
+                return RejectJoinBaseline(
+                    $"state {i} party '{behavior.MobilePartyId}' failed validation: {failure}");
             }
         }
 
-        if (seenParties.Count != liveParties.Count) return false;
+        if (seenParties.Count != liveParties.Count)
+        {
+            return RejectJoinBaseline(
+                $"party coverage mismatch (baseline={seenParties.Count}, client={liveParties.Count})");
+        }
 
         try
         {
@@ -305,13 +351,38 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
                 }
             }
 
+            lastJoinBaselineFailure = null;
+            loggedJoinBaselineFailures.Clear();
             return true;
         }
         catch (Exception ex)
         {
-            Logger.Error(ex, "Failed to apply a complete mobile-party join baseline");
-            return false;
+            return RejectJoinBaseline(
+                $"application threw {ex.GetType().Name}: {ex.Message}",
+                ex);
         }
+    }
+
+    private bool RejectJoinBaseline(string failure, Exception exception = null)
+    {
+        lastJoinBaselineFailure = failure;
+        if (!loggedJoinBaselineFailures.Add(failure))
+            return false;
+
+        if (exception == null)
+        {
+            Logger.Warning(
+                "Could not apply mobile-party join baseline: {Failure}. Identical retries will not be logged",
+                failure);
+        }
+        else
+        {
+            Logger.Error(
+                exception,
+                "Could not apply mobile-party join baseline: {Failure}. Identical retries will not be logged",
+                failure);
+        }
+        return false;
     }
 
     private bool TryPrepare(
@@ -319,34 +390,40 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
         PartyBehaviorUpdateData data,
         HashSet<MobileParty> liveParties,
         HashSet<Settlement> liveSettlements,
-        out ResolvedBehaviorUpdate resolved)
+        bool logLookupFailures,
+        out ResolvedBehaviorUpdate resolved,
+        out string failure)
     {
         resolved = default;
-        if (party?.Ai == null ||
-            !TryResolveInteractable(data, out IInteractablePoint interactable) ||
-            !TryResolve(data.TargetPartyId, out MobileParty targetParty) ||
-            !TryResolve(data.TargetSettlementId, out Settlement targetSettlement) ||
-            !TryResolve(data.MoveTargetPartyId, out MobileParty moveTargetParty))
-        {
-            return false;
-        }
+        failure = null;
+        if (party == null)
+            return FailPreparation("party is unavailable", out failure);
+        if (party.Ai == null)
+            return FailPreparation("party AI is unavailable", out failure);
+        if (!TryResolveInteractable(data, out IInteractablePoint interactable, logLookupFailures))
+            return FailPreparation($"interactable '{data.InteractablePointId}' could not be resolved", out failure);
+        if (!TryResolve(data.TargetPartyId, out MobileParty targetParty, logLookupFailures))
+            return FailPreparation($"target party '{data.TargetPartyId}' could not be resolved", out failure);
+        if (!TryResolve(data.TargetSettlementId, out Settlement targetSettlement, logLookupFailures))
+            return FailPreparation($"target settlement '{data.TargetSettlementId}' could not be resolved", out failure);
+        if (!TryResolve(data.MoveTargetPartyId, out MobileParty moveTargetParty, logLookupFailures))
+            return FailPreparation($"move target party '{data.MoveTargetPartyId}' could not be resolved", out failure);
 
         if (data.PartyMoveMode == MoveModeType.Party && moveTargetParty == null)
-            return false;
+            return FailPreparation("party movement mode requires a move target", out failure);
 
-        if (liveParties != null &&
-            ((targetParty != null && !liveParties.Contains(targetParty)) ||
-             (moveTargetParty != null && !liveParties.Contains(moveTargetParty)) ||
-             !IsLiveInteractable(interactable, liveParties, liveSettlements)))
-        {
-            return false;
-        }
+        if (liveParties != null && targetParty != null && !liveParties.Contains(targetParty))
+            return FailPreparation($"target party '{data.TargetPartyId}' is not live", out failure);
+        if (liveParties != null && moveTargetParty != null && !liveParties.Contains(moveTargetParty))
+            return FailPreparation($"move target party '{data.MoveTargetPartyId}' is not live", out failure);
+        if (liveParties != null && !IsLiveInteractable(interactable, liveParties, liveSettlements))
+            return FailPreparation($"interactable '{data.InteractablePointId}' is not live", out failure);
 
         if (liveSettlements != null &&
             targetSettlement != null &&
             !liveSettlements.Contains(targetSettlement))
         {
-            return false;
+            return FailPreparation($"target settlement '{data.TargetSettlementId}' is not live", out failure);
         }
 
         resolved = new ResolvedBehaviorUpdate(
@@ -357,6 +434,12 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
             targetSettlement,
             moveTargetParty);
         return true;
+    }
+
+    private static bool FailPreparation(string reason, out string failure)
+    {
+        failure = reason;
+        return false;
     }
 
     private static bool IsLiveInteractable(
@@ -431,22 +514,27 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
         }
     }
 
-    private bool TryResolveInteractable(PartyBehaviorUpdateData data, out IInteractablePoint interactable)
+    private bool TryResolveInteractable(
+        PartyBehaviorUpdateData data,
+        out IInteractablePoint interactable,
+        bool logLookupFailures = true)
     {
         interactable = null;
         if (data.InteractablePointId == null)
             return true;
         if (data.IsInteractableAnchor)
-            return TryResolve(data.InteractablePointId, out MobileParty owner) &&
+            return TryResolve(data.InteractablePointId, out MobileParty owner, logLookupFailures) &&
                 (interactable = owner.Anchor) != null;
-        return TryResolve(data.InteractablePointId, out PartyBase partyBase) &&
+        return TryResolve(data.InteractablePointId, out PartyBase partyBase, logLookupFailures) &&
             (interactable = partyBase) != null;
     }
 
-    private bool TryResolve<T>(string id, out T value) where T : class
+    private bool TryResolve<T>(string id, out T value, bool logLookupFailures = true) where T : class
     {
         value = null;
-        return id == null || objectManager.TryGetObjectWithLogging(id, out value);
+        return id == null || (logLookupFailures
+            ? objectManager.TryGetObjectWithLogging(id, out value)
+            : objectManager.TryGetObject(id, out value));
     }
 
     private bool TryGetInteractableReference(IInteractablePoint interactable, out string id, out bool isAnchor)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [x] Other... Please describe:

## What is the current behavior?

Clients that reject a complete campaign baseline can remain at Finishing synchronization while their logs do not identify the invalid party state or capture the player-party state around player switching.

## What is the new behavior?

Client logs now identify each distinct join-baseline rejection once, including the affected party or dependency, and record bounded player-party state before and after player switching so future stalls can be diagnosed without exposing save contents.

## Bot Changelog Entry

- Added clearer client logs for diagnosing stalls at Finishing synchronization.
