### PR TITLE
Uncomment settings

### DIFF
--- a/deploy/mod-config.default.json
+++ b/deploy/mod-config.default.json
@@ -2,30 +2,29 @@
   // Bannerlord Coop gameplay configuration — owned by the Coop mod itself and
   // applied wherever the coop server runs (dedicated server or player-hosted
   // session). Settings for how a dedicated server PROCESS runs (save name,
-  // password, ports, autosaves) live in server-config.json instead, next to
-  // the server executable. Comments and trailing commas are allowed here.
+  // password, ports, autosaves) live in the dedicated server's own
+  // DedicatedServer\server-config.json instead. Comments and trailing commas
+  // are allowed here.
 
   // Campaign difficulty, applied by the HOSTING side at every boot; joining
-  // players inherit the values with the save transfer. A commented-out key
-  // keeps the save's own setting. Levels: "VeryEasy" | "Easy" | "Realistic".
+  // players inherit the values with the save transfer.
+  // Levels: "VeryEasy" | "Easy" | "Realistic".
   "difficulty": {
-    // Damage players take. Left unset on a HEADLESS server (dedicated/container)
-    // this defaults to Realistic — the headless profile would otherwise push
-    // quarter damage to every joining player. On a player-hosted session the
-    // host's own game setting stays in charge unless set here.
-    // "playerReceivedDamage": "Realistic",
+    // Damage players take. Realistic avoids the dedicated server's headless
+    // profile pushing quarter damage to every joining player.
+    "playerReceivedDamage": "Realistic",
 
-    // "playerTroopsReceivedDamage": "VeryEasy",
-    // "combatAIDifficulty": "VeryEasy",
-    // "recruitmentDifficulty": "VeryEasy",
-    // "playerMapMovementSpeed": "VeryEasy",
-    // "stealthAndDisguiseDifficulty": "VeryEasy",
-    // "persuasionSuccessChance": "VeryEasy",
-    // "clanMemberDeathChance": "VeryEasy",
-    // "battleDeath": "VeryEasy",
+    "playerTroopsReceivedDamage": "VeryEasy",
+    "combatAIDifficulty": "VeryEasy",
+    "recruitmentDifficulty": "VeryEasy",
+    "playerMapMovementSpeed": "VeryEasy",
+    "stealthAndDisguiseDifficulty": "VeryEasy",
+    "persuasionSuccessChance": "VeryEasy",
+    "clanMemberDeathChance": "VeryEasy",
+    "battleDeath": "VeryEasy",
 
-    // "birthAndDeath": true,                 // aging, births, natural deaths
-    // "autoAllocateClanMemberPerks": false,
+    "birthAndDeath": true,                 // aging, births, natural deaths
+    "autoAllocateClanMemberPerks": false,
   },
   "modOptions": {
     // Toggle fast forward (2x speed) being enabled

--- a/deploy/mod-config.default.json
+++ b/deploy/mod-config.default.json
@@ -7,12 +7,12 @@
   // are allowed here.
 
   // Campaign difficulty, applied by the HOSTING side at every boot; joining
-  // players inherit the values with the save transfer.
+  // players inherit the values with the save transfer. These values mirror a
+  // newly created vanilla Bannerlord campaign.
   // Levels: "VeryEasy" | "Easy" | "Realistic".
   "difficulty": {
-    // Damage players take. Realistic avoids the dedicated server's headless
-    // profile pushing quarter damage to every joining player.
-    "playerReceivedDamage": "Realistic",
+    // Damage players take. VeryEasy is Bannerlord's new-campaign default.
+    "playerReceivedDamage": "VeryEasy",
 
     "playerTroopsReceivedDamage": "VeryEasy",
     "combatAIDifficulty": "VeryEasy",

--- a/source/GameInterface.Tests/Configuration/ModConfigTests.cs
+++ b/source/GameInterface.Tests/Configuration/ModConfigTests.cs
@@ -46,42 +46,316 @@ public class ModConfigTests : IDisposable
 
         Assert.True(File.Exists(ConfigPath), "first load should create mod-config.json");
         Assert.Equal(File.ReadAllText(ShippedTemplatePath), File.ReadAllText(ConfigPath));
-        Assert.Null(config.Difficulty.PlayerReceivedDamage);
-        Assert.Null(config.Difficulty.BirthAndDeath);
+        Assert.Equal(DifficultyLevel.Realistic, config.Difficulty.PlayerReceivedDamage);
+        Assert.True(config.Difficulty.BirthAndDeath);
     }
 
     [Fact]
-    public void ShippedTemplate_ShipsEveryKeyCommentedOut()
+    public void ShippedTemplate_ShipsEveryDifficultyKeyActive()
     {
-        // The template must stay behaviorally identical to no file at all, so
-        // seeding into an existing deployment can never change a live world.
         File.Copy(ShippedTemplatePath, ConfigPath);
 
         var config = NewModConfig().Data;
 
-        Assert.Null(config.Difficulty.PlayerReceivedDamage);
-        Assert.Null(config.Difficulty.PlayerTroopsReceivedDamage);
-        Assert.Null(config.Difficulty.CombatAIDifficulty);
-        Assert.Null(config.Difficulty.BattleDeath);
-        Assert.Null(config.Difficulty.BirthAndDeath);
-        Assert.Null(config.Difficulty.AutoAllocateClanMemberPerks);
+        Assert.Equal(DifficultyLevel.Realistic, config.Difficulty.PlayerReceivedDamage);
+        Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.PlayerTroopsReceivedDamage);
+        Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.CombatAIDifficulty);
+        Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.BattleDeath);
+        Assert.True(config.Difficulty.BirthAndDeath);
+        Assert.False(config.Difficulty.AutoAllocateClanMemberPerks);
         Assert.True(config.UnknownKeys == null || config.UnknownKeys.Count == 0);
         Assert.True(config.Difficulty.UnknownKeys == null || config.Difficulty.UnknownKeys.Count == 0);
     }
 
     [Fact]
-    public void SeededTemplate_ParsesBackAsAllDefaults()
+    public void ExistingCommentedDifficulty_IsMigratedInPlace_WithoutOverwritingUserValues()
     {
-        _ = NewModConfig().Data;                     // seeds
+        File.WriteAllText(ConfigPath, @"{
+  // keep this operator comment
+  ""difficulty"": {
+    // ""playerReceivedDamage"": ""Realistic"",
+    ""battleDeath"": ""Easy"",
+    // ""birthAndDeath"": true,
+  },
+  ""modOptions"": { ""autoPauseEnabled"": false },
+}");
 
-        var config = NewModConfig().Data;            // fresh instance reads the seeded file
+        var config = NewModConfig().Data;
+        string migrated = File.ReadAllText(ConfigPath);
 
-        Assert.Null(config.Difficulty.PlayerReceivedDamage);
-        Assert.Null(config.Difficulty.PlayerTroopsReceivedDamage);
+        Assert.Equal(DifficultyLevel.Realistic, config.Difficulty.PlayerReceivedDamage);
+        Assert.Equal(DifficultyLevel.Easy, config.Difficulty.BattleDeath);
+        Assert.True(config.Difficulty.BirthAndDeath);
+        Assert.False(config.ModOptions.AutoPauseEnabled);
+        Assert.Contains("// keep this operator comment", migrated);
+        Assert.Contains("\"playerReceivedDamage\": \"Realistic\"", migrated);
+        Assert.DoesNotContain("// \"playerReceivedDamage\"", migrated);
+        Assert.Contains("\"battleDeath\": \"Easy\"", migrated);
+    }
+
+    [Fact]
+    public void LegacyServerDifficulty_IsPortedOverCommentedModDefaults()
+    {
+        File.WriteAllText(ConfigPath, @"{
+  // keep this mod comment
+  ""difficulty"": {
+    // ""playerReceivedDamage"": ""Realistic"",
+    // ""battleDeath"": ""VeryEasy"",
+    // ""birthAndDeath"": true,
+  },
+  ""modOptions"": { ""autoPauseEnabled"": false },
+}");
+        File.WriteAllText(Path.Combine(tempDir, "server-config.json"), @"{
+  // old dedicated-server settings
+  ""playerReceivedDamage"": ""Easy"",
+  ""battleDeath"": ""Realistic"",
+  ""birthAndDeath"": false,
+}");
+
+        var config = NewModConfig().Data;
+        string migrated = File.ReadAllText(ConfigPath);
+
+        Assert.Equal(DifficultyLevel.Easy, config.Difficulty.PlayerReceivedDamage);
+        Assert.Equal(DifficultyLevel.Realistic, config.Difficulty.BattleDeath);
+        Assert.False(config.Difficulty.BirthAndDeath);
+        Assert.False(config.ModOptions.AutoPauseEnabled);
+        Assert.Contains("// keep this mod comment", migrated);
+        Assert.Contains("\"playerReceivedDamage\": \"Easy\"", migrated);
+        Assert.Contains("\"battleDeath\": \"Realistic\"", migrated);
+        Assert.Contains("\"birthAndDeath\": false", migrated);
+    }
+
+    [Fact]
+    public void ExistingModDifficulty_WinsOverLegacyServerDifficulty()
+    {
+        File.WriteAllText(ConfigPath, @"{
+  ""difficulty"": {
+    ""battleDeath"": ""Easy"",
+    // ""birthAndDeath"": true,
+  },
+}");
+        File.WriteAllText(Path.Combine(tempDir, "server-config.json"), @"{
+  ""battleDeath"": ""Realistic"",
+  ""birthAndDeath"": false,
+}");
+
+        var config = NewModConfig().Data;
+
+        Assert.Equal(DifficultyLevel.Easy, config.Difficulty.BattleDeath);
+        Assert.False(config.Difficulty.BirthAndDeath);
+    }
+
+    [Fact]
+    public void LegacyServerDifficulty_IsInsertedWhenModConfigHasNoMatchingComment()
+    {
+        File.WriteAllText(ConfigPath, @"{
+  ""difficulty"": {
+    // unrelated operator note
+  },
+  ""modOptions"": { ""clientsCanUseCheats"": true },
+}");
+        File.WriteAllText(Path.Combine(tempDir, "server-config.json"), @"{
+  ""battleDeath"": ""Easy"",
+  // ""birthAndDeath"": false,
+}");
+
+        var config = NewModConfig().Data;
+        string firstMigration = File.ReadAllText(ConfigPath);
+        _ = NewModConfig().Data;
+
+        Assert.Equal(DifficultyLevel.Easy, config.Difficulty.BattleDeath);
+        Assert.False(config.Difficulty.BirthAndDeath);
+        Assert.Equal(DifficultyLevel.Realistic, config.Difficulty.PlayerReceivedDamage);
+        Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.CombatAIDifficulty);
+        Assert.True(config.ModOptions.ClientsCanUseCheats);
+        Assert.Contains("// unrelated operator note", firstMigration);
+        Assert.Equal(firstMigration, File.ReadAllText(ConfigPath));
+    }
+
+    [Fact]
+    public void LegacyServerDifficulty_CreatesDifficultyBlockWhenModConfigHasNone()
+    {
+        File.WriteAllText(ConfigPath, @"{
+  // preserve this operator file
+  ""modOptions"": { ""clientsCanUseCheats"": true },
+}");
+        File.WriteAllText(Path.Combine(tempDir, "server-config.json"), @"{
+  ""battleDeath"": ""Easy"",
+  // ""birthAndDeath"": false,
+}");
+
+        var config = NewModConfig().Data;
+        string firstMigration = File.ReadAllText(ConfigPath);
+        _ = NewModConfig().Data;
+
+        Assert.Equal(DifficultyLevel.Easy, config.Difficulty.BattleDeath);
+        Assert.False(config.Difficulty.BirthAndDeath);
+        Assert.Equal(DifficultyLevel.Realistic, config.Difficulty.PlayerReceivedDamage);
+        Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.CombatAIDifficulty);
+        Assert.True(config.ModOptions.ClientsCanUseCheats);
+        Assert.Contains("// preserve this operator file", firstMigration);
+        Assert.Contains("\"difficulty\"", firstMigration);
+        Assert.Equal(firstMigration, File.ReadAllText(ConfigPath));
+        Assert.Empty(Directory.GetFiles(tempDir, "*.tmp", SearchOption.AllDirectories));
+    }
+
+    [Fact]
+    public void InvalidDifficultyBlockIsNotDuplicatedByMigration()
+    {
+        const string invalid = "{ \"difficulty\": false }";
+        File.WriteAllText(ConfigPath, invalid);
+        File.WriteAllText(Path.Combine(tempDir, "server-config.json"),
+            "{ \"battleDeath\": \"Easy\" }");
+
+        _ = NewModConfig().Data;
+
+        Assert.Equal(invalid, File.ReadAllText(ConfigPath));
+    }
+
+    [Fact]
+    public void FreshlySeededTemplate_PrefersLegacyServerDifficulty()
+    {
+        File.WriteAllText(Path.Combine(tempDir, "server-config.json"), @"{
+  ""playerReceivedDamage"": ""Easy"",
+  ""battleDeath"": ""Realistic"",
+  ""birthAndDeath"": false,
+}");
+
+        var config = NewModConfig().Data;
+
+        Assert.Equal(DifficultyLevel.Easy, config.Difficulty.PlayerReceivedDamage);
+        Assert.Equal(DifficultyLevel.Realistic, config.Difficulty.BattleDeath);
+        Assert.False(config.Difficulty.BirthAndDeath);
+    }
+
+    [Fact]
+    public void PreexistingPristineTemplate_PrefersLegacyServerDifficulty()
+    {
+        File.Copy(ShippedTemplatePath, ConfigPath);
+        File.WriteAllText(Path.Combine(tempDir, "server-config.json"), @"{
+  ""playerReceivedDamage"": ""Easy"",
+  ""battleDeath"": ""Realistic"",
+  ""birthAndDeath"": false,
+}");
+
+        var config = NewModConfig().Data;
+
+        Assert.Equal(DifficultyLevel.Easy, config.Difficulty.PlayerReceivedDamage);
+        Assert.Equal(DifficultyLevel.Realistic, config.Difficulty.BattleDeath);
+        Assert.False(config.Difficulty.BirthAndDeath);
+    }
+
+    [Fact]
+    public void OriginalShippedDifficultyBlock_MigratesEveryCommentedSetting_AndIsIdempotent()
+    {
+        File.WriteAllText(ConfigPath, @"{
+  ""difficulty"": {
+    // ""playerReceivedDamage"": ""Realistic"",
+    // ""playerTroopsReceivedDamage"": ""VeryEasy"",
+    // ""combatAIDifficulty"": ""VeryEasy"",
+    // ""recruitmentDifficulty"": ""VeryEasy"",
+    // ""playerMapMovementSpeed"": ""VeryEasy"",
+    // ""stealthAndDisguiseDifficulty"": ""VeryEasy"",
+    // ""persuasionSuccessChance"": ""VeryEasy"",
+    // ""clanMemberDeathChance"": ""VeryEasy"",
+    // ""battleDeath"": ""VeryEasy"",
+    // ""birthAndDeath"": true,
+    // ""autoAllocateClanMemberPerks"": false,
+  },
+  ""modOptions"": { ""clientsCanUseCheats"": true }
+}");
+
+        var config = NewModConfig().Data;
+        string firstMigration = File.ReadAllText(ConfigPath);
+        _ = NewModConfig().Data;
+        string secondLoad = File.ReadAllText(ConfigPath);
+
+        Assert.Equal(DifficultyLevel.Realistic, config.Difficulty.PlayerReceivedDamage);
+        Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.PlayerTroopsReceivedDamage);
+        Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.CombatAIDifficulty);
+        Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.RecruitmentDifficulty);
+        Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.PlayerMapMovementSpeed);
+        Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.StealthAndDisguiseDifficulty);
+        Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.PersuasionSuccessChance);
+        Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.ClanMemberDeathChance);
+        Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.BattleDeath);
+        Assert.True(config.Difficulty.BirthAndDeath);
+        Assert.False(config.Difficulty.AutoAllocateClanMemberPerks);
+        Assert.True(config.ModOptions.ClientsCanUseCheats);
+        Assert.DoesNotContain("// \"", firstMigration);
+        Assert.Equal(firstMigration, secondLoad);
+    }
+
+    [Fact]
+    public void MalformedConfig_IsNotChangedByMigration()
+    {
+        const string broken = "{ // \"birthAndDeath\": true,\r\n this is not JSON";
+        File.WriteAllText(ConfigPath, broken);
+
+        var config = NewModConfig().Data;
+
+        Assert.Equal(broken, File.ReadAllText(ConfigPath));
         Assert.Null(config.Difficulty.BirthAndDeath);
-        Assert.Null(config.Difficulty.AutoAllocateClanMemberPerks);
-        Assert.True(config.UnknownKeys == null || config.UnknownKeys.Count == 0);
-        Assert.True(config.Difficulty.UnknownKeys == null || config.Difficulty.UnknownKeys.Count == 0);
+    }
+
+    [Fact]
+    public void LegacyUserRootConfig_IsCopiedIntoCoopData_AndPreserved()
+    {
+        string userRoot = Path.Combine(tempDir, "Mount and Blade II Bannerlord");
+        string coopData = Path.Combine(userRoot, "CoopData");
+        Directory.CreateDirectory(userRoot);
+        string legacyPath = Path.Combine(userRoot, "mod-config.json");
+        string migratedPath = Path.Combine(coopData, "mod-config.json");
+        const string legacy = @"{
+  ""difficulty"": { ""battleDeath"": ""Easy"" },
+  ""modOptions"": { ""autoPauseEnabled"": false }
+}";
+        File.WriteAllText(legacyPath, legacy);
+
+        var config = new ModConfig(coopData).Data;
+
+        Assert.Equal(DifficultyLevel.Easy, config.Difficulty.BattleDeath);
+        Assert.False(config.ModOptions.AutoPauseEnabled);
+        Assert.True(File.Exists(legacyPath), "the recoverable legacy copy should remain");
+        Assert.Equal(legacy, File.ReadAllText(legacyPath));
+        Assert.Contains("\"battleDeath\": \"Easy\"", File.ReadAllText(migratedPath));
+    }
+
+    [Fact]
+    public void ExistingCoopDataConfig_WinsOverLegacyUserRootConfig()
+    {
+        string userRoot = Path.Combine(tempDir, "Mount and Blade II Bannerlord");
+        string coopData = Path.Combine(userRoot, "CoopData");
+        Directory.CreateDirectory(coopData);
+        string legacyPath = Path.Combine(userRoot, "mod-config.json");
+        string currentPath = Path.Combine(coopData, "mod-config.json");
+        File.WriteAllText(legacyPath, @"{ ""difficulty"": { ""battleDeath"": ""Easy"" } }");
+        File.WriteAllText(currentPath, @"{ ""difficulty"": { ""battleDeath"": ""Realistic"" } }");
+
+        var config = new ModConfig(coopData).Data;
+
+        Assert.Equal(DifficultyLevel.Realistic, config.Difficulty.BattleDeath);
+        Assert.Contains("Realistic", File.ReadAllText(currentPath));
+        Assert.Contains("Easy", File.ReadAllText(legacyPath));
+    }
+
+    [Fact]
+    public void CurrentNestedServerConfigWinsOverLegacySharedRootServerConfig()
+    {
+        string userRoot = Path.Combine(tempDir, "Mount and Blade II Bannerlord");
+        string coopData = Path.Combine(userRoot, "CoopData");
+        string dedicatedData = Path.Combine(coopData, "DedicatedServer");
+        Directory.CreateDirectory(dedicatedData);
+        File.WriteAllText(Path.Combine(coopData, "mod-config.json"),
+            "{ \"difficulty\": { } }");
+        File.WriteAllText(Path.Combine(coopData, "server-config.json"),
+            "{ \"battleDeath\": \"Easy\" }");
+        File.WriteAllText(Path.Combine(dedicatedData, "server-config.json"),
+            "{ \"battleDeath\": \"Realistic\" }");
+
+        var config = new ModConfig(coopData).Data;
+
+        Assert.Equal(DifficultyLevel.Realistic, config.Difficulty.BattleDeath);
     }
 
     /// <summary>
@@ -155,7 +429,7 @@ public class ModConfigTests : IDisposable
         Assert.Equal(DifficultyLevel.Realistic, config.Difficulty.PlayerReceivedDamage);
         Assert.Equal(DifficultyLevel.Easy, config.Difficulty.PlayerTroopsReceivedDamage);
         Assert.False(config.Difficulty.BirthAndDeath);
-        Assert.Null(config.Difficulty.CombatAIDifficulty);
+        Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.CombatAIDifficulty);
     }
 
     [Fact]

--- a/source/GameInterface.Tests/Configuration/ModConfigTests.cs
+++ b/source/GameInterface.Tests/Configuration/ModConfigTests.cs
@@ -94,45 +94,14 @@ public class ModConfigTests : IDisposable
     }
 
     [Fact]
-    public void LegacyServerDifficulty_IsPortedOverCommentedModDefaults()
+    public void SiblingServerConfig_IsIgnoredDuringInPlaceMigration()
     {
         File.WriteAllText(ConfigPath, @"{
-  // keep this mod comment
   ""difficulty"": {
-    // ""playerReceivedDamage"": ""Realistic"",
-    // ""battleDeath"": ""VeryEasy"",
+    // ""battleDeath"": ""Easy"",
     // ""birthAndDeath"": true,
   },
   ""modOptions"": { ""autoPauseEnabled"": false },
-}");
-        File.WriteAllText(Path.Combine(tempDir, "server-config.json"), @"{
-  // old dedicated-server settings
-  ""playerReceivedDamage"": ""Easy"",
-  ""battleDeath"": ""Realistic"",
-  ""birthAndDeath"": false,
-}");
-
-        var config = NewModConfig().Data;
-        string migrated = File.ReadAllText(ConfigPath);
-
-        Assert.Equal(DifficultyLevel.Easy, config.Difficulty.PlayerReceivedDamage);
-        Assert.Equal(DifficultyLevel.Realistic, config.Difficulty.BattleDeath);
-        Assert.False(config.Difficulty.BirthAndDeath);
-        Assert.False(config.ModOptions.AutoPauseEnabled);
-        Assert.Contains("// keep this mod comment", migrated);
-        Assert.Contains("\"playerReceivedDamage\": \"Easy\"", migrated);
-        Assert.Contains("\"battleDeath\": \"Realistic\"", migrated);
-        Assert.Contains("\"birthAndDeath\": false", migrated);
-    }
-
-    [Fact]
-    public void ExistingModDifficulty_WinsOverLegacyServerDifficulty()
-    {
-        File.WriteAllText(ConfigPath, @"{
-  ""difficulty"": {
-    ""battleDeath"": ""Easy"",
-    // ""birthAndDeath"": true,
-  },
 }");
         File.WriteAllText(Path.Combine(tempDir, "server-config.json"), @"{
   ""battleDeath"": ""Realistic"",
@@ -142,21 +111,20 @@ public class ModConfigTests : IDisposable
         var config = NewModConfig().Data;
 
         Assert.Equal(DifficultyLevel.Easy, config.Difficulty.BattleDeath);
-        Assert.False(config.Difficulty.BirthAndDeath);
+        Assert.True(config.Difficulty.BirthAndDeath);
+        Assert.False(config.ModOptions.AutoPauseEnabled);
+        Assert.Contains("Realistic", File.ReadAllText(Path.Combine(tempDir, "server-config.json")));
     }
 
     [Fact]
-    public void LegacyServerDifficulty_IsInsertedWhenModConfigHasNoMatchingComment()
+    public void MissingDifficultySettings_ReceiveDefaultsWithoutChangingActiveValues()
     {
         File.WriteAllText(ConfigPath, @"{
   ""difficulty"": {
     // unrelated operator note
+    ""battleDeath"": ""Easy"",
   },
   ""modOptions"": { ""clientsCanUseCheats"": true },
-}");
-        File.WriteAllText(Path.Combine(tempDir, "server-config.json"), @"{
-  ""battleDeath"": ""Easy"",
-  // ""birthAndDeath"": false,
 }");
 
         var config = NewModConfig().Data;
@@ -164,7 +132,7 @@ public class ModConfigTests : IDisposable
         _ = NewModConfig().Data;
 
         Assert.Equal(DifficultyLevel.Easy, config.Difficulty.BattleDeath);
-        Assert.False(config.Difficulty.BirthAndDeath);
+        Assert.True(config.Difficulty.BirthAndDeath);
         Assert.Equal(DifficultyLevel.Realistic, config.Difficulty.PlayerReceivedDamage);
         Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.CombatAIDifficulty);
         Assert.True(config.ModOptions.ClientsCanUseCheats);
@@ -173,23 +141,18 @@ public class ModConfigTests : IDisposable
     }
 
     [Fact]
-    public void LegacyServerDifficulty_CreatesDifficultyBlockWhenModConfigHasNone()
+    public void MissingDifficultyBlock_ReceivesDefaultsAndIsIdempotent()
     {
         File.WriteAllText(ConfigPath, @"{
   // preserve this operator file
   ""modOptions"": { ""clientsCanUseCheats"": true },
 }");
-        File.WriteAllText(Path.Combine(tempDir, "server-config.json"), @"{
-  ""battleDeath"": ""Easy"",
-  // ""birthAndDeath"": false,
-}");
-
         var config = NewModConfig().Data;
         string firstMigration = File.ReadAllText(ConfigPath);
         _ = NewModConfig().Data;
 
-        Assert.Equal(DifficultyLevel.Easy, config.Difficulty.BattleDeath);
-        Assert.False(config.Difficulty.BirthAndDeath);
+        Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.BattleDeath);
+        Assert.True(config.Difficulty.BirthAndDeath);
         Assert.Equal(DifficultyLevel.Realistic, config.Difficulty.PlayerReceivedDamage);
         Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.CombatAIDifficulty);
         Assert.True(config.ModOptions.ClientsCanUseCheats);
@@ -204,45 +167,10 @@ public class ModConfigTests : IDisposable
     {
         const string invalid = "{ \"difficulty\": false }";
         File.WriteAllText(ConfigPath, invalid);
-        File.WriteAllText(Path.Combine(tempDir, "server-config.json"),
-            "{ \"battleDeath\": \"Easy\" }");
 
         _ = NewModConfig().Data;
 
         Assert.Equal(invalid, File.ReadAllText(ConfigPath));
-    }
-
-    [Fact]
-    public void FreshlySeededTemplate_PrefersLegacyServerDifficulty()
-    {
-        File.WriteAllText(Path.Combine(tempDir, "server-config.json"), @"{
-  ""playerReceivedDamage"": ""Easy"",
-  ""battleDeath"": ""Realistic"",
-  ""birthAndDeath"": false,
-}");
-
-        var config = NewModConfig().Data;
-
-        Assert.Equal(DifficultyLevel.Easy, config.Difficulty.PlayerReceivedDamage);
-        Assert.Equal(DifficultyLevel.Realistic, config.Difficulty.BattleDeath);
-        Assert.False(config.Difficulty.BirthAndDeath);
-    }
-
-    [Fact]
-    public void PreexistingPristineTemplate_PrefersLegacyServerDifficulty()
-    {
-        File.Copy(ShippedTemplatePath, ConfigPath);
-        File.WriteAllText(Path.Combine(tempDir, "server-config.json"), @"{
-  ""playerReceivedDamage"": ""Easy"",
-  ""battleDeath"": ""Realistic"",
-  ""birthAndDeath"": false,
-}");
-
-        var config = NewModConfig().Data;
-
-        Assert.Equal(DifficultyLevel.Easy, config.Difficulty.PlayerReceivedDamage);
-        Assert.Equal(DifficultyLevel.Realistic, config.Difficulty.BattleDeath);
-        Assert.False(config.Difficulty.BirthAndDeath);
     }
 
     [Fact]
@@ -299,7 +227,7 @@ public class ModConfigTests : IDisposable
     }
 
     [Fact]
-    public void LegacyUserRootConfig_IsCopiedIntoCoopData_AndPreserved()
+    public void ConfigFromAnotherDirectory_IsNotMovedOrRead()
     {
         string userRoot = Path.Combine(tempDir, "Mount and Blade II Bannerlord");
         string coopData = Path.Combine(userRoot, "CoopData");
@@ -314,48 +242,11 @@ public class ModConfigTests : IDisposable
 
         var config = new ModConfig(coopData).Data;
 
-        Assert.Equal(DifficultyLevel.Easy, config.Difficulty.BattleDeath);
-        Assert.False(config.ModOptions.AutoPauseEnabled);
-        Assert.True(File.Exists(legacyPath), "the recoverable legacy copy should remain");
+        Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.BattleDeath);
+        Assert.True(config.ModOptions.AutoPauseEnabled);
         Assert.Equal(legacy, File.ReadAllText(legacyPath));
-        Assert.Contains("\"battleDeath\": \"Easy\"", File.ReadAllText(migratedPath));
-    }
-
-    [Fact]
-    public void ExistingCoopDataConfig_WinsOverLegacyUserRootConfig()
-    {
-        string userRoot = Path.Combine(tempDir, "Mount and Blade II Bannerlord");
-        string coopData = Path.Combine(userRoot, "CoopData");
-        Directory.CreateDirectory(coopData);
-        string legacyPath = Path.Combine(userRoot, "mod-config.json");
-        string currentPath = Path.Combine(coopData, "mod-config.json");
-        File.WriteAllText(legacyPath, @"{ ""difficulty"": { ""battleDeath"": ""Easy"" } }");
-        File.WriteAllText(currentPath, @"{ ""difficulty"": { ""battleDeath"": ""Realistic"" } }");
-
-        var config = new ModConfig(coopData).Data;
-
-        Assert.Equal(DifficultyLevel.Realistic, config.Difficulty.BattleDeath);
-        Assert.Contains("Realistic", File.ReadAllText(currentPath));
-        Assert.Contains("Easy", File.ReadAllText(legacyPath));
-    }
-
-    [Fact]
-    public void CurrentNestedServerConfigWinsOverLegacySharedRootServerConfig()
-    {
-        string userRoot = Path.Combine(tempDir, "Mount and Blade II Bannerlord");
-        string coopData = Path.Combine(userRoot, "CoopData");
-        string dedicatedData = Path.Combine(coopData, "DedicatedServer");
-        Directory.CreateDirectory(dedicatedData);
-        File.WriteAllText(Path.Combine(coopData, "mod-config.json"),
-            "{ \"difficulty\": { } }");
-        File.WriteAllText(Path.Combine(coopData, "server-config.json"),
-            "{ \"battleDeath\": \"Easy\" }");
-        File.WriteAllText(Path.Combine(dedicatedData, "server-config.json"),
-            "{ \"battleDeath\": \"Realistic\" }");
-
-        var config = new ModConfig(coopData).Data;
-
-        Assert.Equal(DifficultyLevel.Realistic, config.Difficulty.BattleDeath);
+        Assert.True(File.Exists(migratedPath), "the selected config location should still be seeded");
+        Assert.DoesNotContain("\"battleDeath\": \"Easy\"", File.ReadAllText(migratedPath));
     }
 
     /// <summary>

--- a/source/GameInterface.Tests/Configuration/ModConfigTests.cs
+++ b/source/GameInterface.Tests/Configuration/ModConfigTests.cs
@@ -46,7 +46,7 @@ public class ModConfigTests : IDisposable
 
         Assert.True(File.Exists(ConfigPath), "first load should create mod-config.json");
         Assert.Equal(File.ReadAllText(ShippedTemplatePath), File.ReadAllText(ConfigPath));
-        Assert.Equal(DifficultyLevel.Realistic, config.Difficulty.PlayerReceivedDamage);
+        Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.PlayerReceivedDamage);
         Assert.True(config.Difficulty.BirthAndDeath);
     }
 
@@ -57,9 +57,14 @@ public class ModConfigTests : IDisposable
 
         var config = NewModConfig().Data;
 
-        Assert.Equal(DifficultyLevel.Realistic, config.Difficulty.PlayerReceivedDamage);
+        Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.PlayerReceivedDamage);
         Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.PlayerTroopsReceivedDamage);
         Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.CombatAIDifficulty);
+        Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.RecruitmentDifficulty);
+        Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.PlayerMapMovementSpeed);
+        Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.StealthAndDisguiseDifficulty);
+        Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.PersuasionSuccessChance);
+        Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.ClanMemberDeathChance);
         Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.BattleDeath);
         Assert.True(config.Difficulty.BirthAndDeath);
         Assert.False(config.Difficulty.AutoAllocateClanMemberPerks);
@@ -133,7 +138,7 @@ public class ModConfigTests : IDisposable
 
         Assert.Equal(DifficultyLevel.Easy, config.Difficulty.BattleDeath);
         Assert.True(config.Difficulty.BirthAndDeath);
-        Assert.Equal(DifficultyLevel.Realistic, config.Difficulty.PlayerReceivedDamage);
+        Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.PlayerReceivedDamage);
         Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.CombatAIDifficulty);
         Assert.True(config.ModOptions.ClientsCanUseCheats);
         Assert.Contains("// unrelated operator note", firstMigration);
@@ -153,7 +158,7 @@ public class ModConfigTests : IDisposable
 
         Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.BattleDeath);
         Assert.True(config.Difficulty.BirthAndDeath);
-        Assert.Equal(DifficultyLevel.Realistic, config.Difficulty.PlayerReceivedDamage);
+        Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.PlayerReceivedDamage);
         Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.CombatAIDifficulty);
         Assert.True(config.ModOptions.ClientsCanUseCheats);
         Assert.Contains("// preserve this operator file", firstMigration);

--- a/source/GameInterface/Configuration/ModConfig.cs
+++ b/source/GameInterface/Configuration/ModConfig.cs
@@ -6,6 +6,7 @@ using Serilog;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 using TaleWorlds.Library;
 
 namespace GameInterface.Configuration;
@@ -19,8 +20,8 @@ namespace GameInterface.Configuration;
 /// client-hosted session that is Documents\Mount and Blade II
 /// Bannerlord\CoopData, beside the mod's CoopMapData. Seeds it from the
 /// module's template when absent, and falls back to defaults if it cannot be
-/// read. Never touches the dedicated server's server-config.json — the two
-/// configs are independent by design.
+/// read. During the one-time schema migration it reads legacy difficulty values
+/// from the dedicated server's config; server-process settings remain independent.
 /// </summary>
 internal sealed class ModConfig : IModConfig
 {
@@ -32,6 +33,37 @@ internal sealed class ModConfig : IModConfig
 
     /// <summary>Ships in the module root — the only copy of the defaults.</summary>
     private const string TemplateFileName = "mod-config.default.json";
+
+    private static readonly string[] FormerlyCommentedDifficultyKeys =
+    {
+        "playerReceivedDamage",
+        "playerTroopsReceivedDamage",
+        "combatAIDifficulty",
+        "recruitmentDifficulty",
+        "playerMapMovementSpeed",
+        "stealthAndDisguiseDifficulty",
+        "persuasionSuccessChance",
+        "clanMemberDeathChance",
+        "battleDeath",
+        "birthAndDeath",
+        "autoAllocateClanMemberPerks",
+    };
+
+    private static readonly IDictionary<string, JToken> DifficultyDefaults =
+        new Dictionary<string, JToken>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["playerReceivedDamage"] = "Realistic",
+            ["playerTroopsReceivedDamage"] = "VeryEasy",
+            ["combatAIDifficulty"] = "VeryEasy",
+            ["recruitmentDifficulty"] = "VeryEasy",
+            ["playerMapMovementSpeed"] = "VeryEasy",
+            ["stealthAndDisguiseDifficulty"] = "VeryEasy",
+            ["persuasionSuccessChance"] = "VeryEasy",
+            ["clanMemberDeathChance"] = "VeryEasy",
+            ["battleDeath"] = "VeryEasy",
+            ["birthAndDeath"] = true,
+            ["autoAllocateClanMemberPerks"] = false,
+        };
 
     private static readonly ILogger Logger = LogManager.GetLogger<ModConfig>();
 
@@ -62,12 +94,22 @@ internal sealed class ModConfig : IModConfig
         string path = Path.Combine(dir, FileName);
         try
         {
+            bool seeded = false;
+            if (!File.Exists(path))
+            {
+                MigrateLegacyLocation(dir, path);
+            }
             if (!File.Exists(path))
             {
                 Seed(path);
-                // Template keys are all commented out: identical to defaults.
-                return new ModConfigData();
+                seeded = File.Exists(path);
+                if (!File.Exists(path))
+                {
+                    return new ModConfigData();
+                }
             }
+
+            MigrateDifficultySettings(dir, path, seeded || MatchesShippedTemplate(path));
 
             var loaded = JsonConvert.DeserializeObject<ModConfigData>(File.ReadAllText(path), MakeSettings())
                 ?? new ModConfigData();
@@ -81,6 +123,345 @@ internal sealed class ModConfig : IModConfig
             Logger.Error("mod-config.json UNREADABLE ({Path}) — continuing on defaults: {Reason}", path, ex.Message);
             return new ModConfigData();
         }
+    }
+
+    /// <summary>
+    /// Difficulty originally lived as flat properties in the dedicated server's
+    /// server-config.json, then moved into mod-config.json. Existing mod-config
+    /// values win; otherwise a legacy server value is ported, then a formerly
+    /// commented mod-config default is activated. The edit is deliberately textual
+    /// so operator comments, ordering and unrelated settings remain untouched.
+    /// </summary>
+    private static void MigrateDifficultySettings(string directory, string path, bool legacyWins)
+    {
+        string original = File.ReadAllText(path);
+        JObject root;
+        try
+        {
+            root = JObject.Parse(original);
+        }
+        catch
+        {
+            // Leave malformed input byte-for-byte intact; Load owns its warning and
+            // default fallback below.
+            return;
+        }
+
+        IDictionary<string, JToken> legacyValues = ReadLegacyServerDifficulty(directory);
+        JToken difficultyToken = root.GetValue("difficulty", StringComparison.OrdinalIgnoreCase);
+        if (difficultyToken == null)
+        {
+            int rootBrace = original.IndexOf('{');
+            var properties = new List<string>();
+            foreach (string key in FormerlyCommentedDifficultyKeys)
+            {
+                JToken value = legacyValues.TryGetValue(key, out JToken legacyValue)
+                    ? legacyValue
+                    : DifficultyDefaults[key];
+                properties.Add("    \"" + key + "\": " +
+                    value.ToString(Formatting.None) + ",");
+            }
+            string block = Environment.NewLine + "  \"difficulty\": {" +
+                Environment.NewLine + string.Join(Environment.NewLine, properties) +
+                Environment.NewLine + "  },";
+            WriteIfValidMigration(path, original, original.Insert(rootBrace + 1, block));
+            return;
+        }
+        if (!(difficultyToken is JObject difficulty))
+        {
+            // Do not create a duplicate property beside an operator's invalid
+            // difficulty value. The normal loader will report the bad config.
+            return;
+        }
+
+        Match difficultyMatch = Regex.Match(original,
+            "(?:^|[{,])[\\t ]*(?<property>\\\"difficulty\\\"[\\t ]*:[\\t ]*\\{)",
+            RegexOptions.Multiline | RegexOptions.IgnoreCase);
+        if (!difficultyMatch.Success)
+        {
+            return;
+        }
+        int openBrace = original.IndexOf('{', difficultyMatch.Groups["property"].Index);
+        int closeBrace = FindMatchingBrace(original, openBrace);
+        if (closeBrace < 0)
+        {
+            return;
+        }
+
+        string migrated = original;
+        var insertions = new List<string>();
+        foreach (string key in FormerlyCommentedDifficultyKeys)
+        {
+            legacyValues.TryGetValue(key, out JToken legacyValue);
+            JToken existing = difficulty.GetValue(key, StringComparison.OrdinalIgnoreCase);
+            if (existing != null)
+            {
+                if (legacyWins && legacyValue != null)
+                {
+                    string activeBlock = migrated.Substring(openBrace, closeBrace - openBrace + 1);
+                    string activePattern = "^(?<indent>[\\t ]*)(?<setting>\\\"" +
+                        Regex.Escape(key) + "\\\"[\\t ]*:[\\t ]*)(?<value>\\\"[^\\\"\\r\\n]*\\\"|true|false)(?<rest>[\\t ]*,?.*)$";
+                    Match activeLine = Regex.Match(activeBlock, activePattern,
+                        RegexOptions.Multiline | RegexOptions.IgnoreCase);
+                    if (activeLine.Success)
+                    {
+                        string replacement = activeLine.Groups["indent"].Value +
+                            activeLine.Groups["setting"].Value + legacyValue.ToString(Formatting.None) +
+                            activeLine.Groups["rest"].Value;
+                        int absolute = openBrace + activeLine.Index;
+                        migrated = migrated.Remove(absolute, activeLine.Length).Insert(absolute, replacement);
+                        closeBrace += replacement.Length - activeLine.Length;
+                    }
+                }
+                continue;
+            }
+
+            string commentedBlock = migrated.Substring(openBrace, closeBrace - openBrace + 1);
+            string pattern = "^(?<indent>[\\t ]*)//[\\t ]*(?<setting>\\\"" +
+                Regex.Escape(key) + "\\\"[\\t ]*:[\\t ]*)(?<value>\\\"[^\\\"\\r\\n]*\\\"|true|false)(?<rest>[\\t ]*,?.*)$";
+            Match commented = Regex.Match(commentedBlock, pattern,
+                RegexOptions.Multiline | RegexOptions.IgnoreCase);
+            if (commented.Success)
+            {
+                string value = legacyValue == null
+                    ? commented.Groups["value"].Value
+                    : legacyValue.ToString(Formatting.None);
+                string replacement = commented.Groups["indent"].Value +
+                    commented.Groups["setting"].Value + value + commented.Groups["rest"].Value;
+                int absolute = openBrace + commented.Index;
+                migrated = migrated.Remove(absolute, commented.Length).Insert(absolute, replacement);
+                int delta = replacement.Length - commented.Length;
+                closeBrace += delta;
+                continue;
+            }
+
+            JToken insertedValue = legacyValue ?? DifficultyDefaults[key];
+            insertions.Add("    \"" + key + "\": " +
+                insertedValue.ToString(Formatting.None) + ",");
+        }
+
+        if (insertions.Count > 0)
+        {
+            string insertion = Environment.NewLine + string.Join(Environment.NewLine, insertions);
+            migrated = migrated.Insert(openBrace + 1, insertion);
+        }
+
+        WriteIfValidMigration(path, original, migrated);
+    }
+
+    private static void WriteIfValidMigration(string path, string original, string migrated)
+    {
+        if (migrated == original)
+        {
+            return;
+        }
+        try
+        {
+            // Never replace a parseable user config with a bad migration.
+            JObject.Parse(migrated);
+            ReplaceFile(path, migrated);
+            Logger.Information("mod-config.json migrated in place: legacy/server difficulty activated ({Path})", path);
+        }
+        catch (Exception ex)
+        {
+            // A read-only config still needs to load its active user settings.
+            Logger.Warning("could not migrate mod-config.json in place ({Path}): {Reason} — loading the existing file",
+                path, ex.Message);
+        }
+    }
+
+    private static IDictionary<string, JToken> ReadLegacyServerDifficulty(string directory)
+    {
+        var values = new Dictionary<string, JToken>(StringComparer.OrdinalIgnoreCase);
+        string direct = Path.Combine(directory, "server-config.json");
+        string nested = Path.Combine(directory, "DedicatedServer", "server-config.json");
+        string[] candidates = new DirectoryInfo(directory).Name.Equals(
+                CoopDataFolderName, StringComparison.OrdinalIgnoreCase)
+            ? new[] { nested, direct }
+            : new[] { direct, nested };
+        string serverPath = Array.Find(candidates, File.Exists);
+        if (serverPath == null)
+        {
+            return values;
+        }
+
+        string text;
+        JObject server;
+        try
+        {
+            text = File.ReadAllText(serverPath);
+            server = JObject.Parse(text);
+        }
+        catch
+        {
+            return values;
+        }
+
+        foreach (string key in FormerlyCommentedDifficultyKeys)
+        {
+            JToken active = server.GetValue(key, StringComparison.OrdinalIgnoreCase);
+            if (IsValidDifficultyValue(key, active))
+            {
+                values[key] = active.DeepClone();
+                continue;
+            }
+
+            string pattern = "^[\\t ]*//[\\t ]*\\\"" + Regex.Escape(key) +
+                "\\\"[\\t ]*:[\\t ]*(?<value>\\\"[^\\\"\\r\\n]*\\\"|true|false)";
+            Match commented = Regex.Match(text, pattern,
+                RegexOptions.Multiline | RegexOptions.IgnoreCase);
+            if (commented.Success)
+            {
+                try
+                {
+                    JToken value = JToken.Parse(commented.Groups["value"].Value);
+                    if (IsValidDifficultyValue(key, value))
+                    {
+                        values[key] = value;
+                    }
+                }
+                catch
+                {
+                    // Ignore an invalid legacy comment and use the mod default.
+                }
+            }
+        }
+        return values;
+    }
+
+    private static bool MatchesShippedTemplate(string path)
+    {
+        string template = ResolveTemplatePath();
+        if (template == null)
+        {
+            return false;
+        }
+        try
+        {
+            return string.Equals(File.ReadAllText(path), File.ReadAllText(template),
+                StringComparison.Ordinal);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static void ReplaceFile(string path, string contents)
+    {
+        string temporary = path + ".migration-" + Guid.NewGuid().ToString("N") + ".tmp";
+        try
+        {
+            File.WriteAllText(temporary, contents);
+            JObject.Parse(File.ReadAllText(temporary));
+            File.Replace(temporary, path, null);
+        }
+        finally
+        {
+            if (File.Exists(temporary))
+            {
+                File.Delete(temporary);
+            }
+        }
+    }
+
+    private static bool IsValidDifficultyValue(string key, JToken value)
+    {
+        if (value == null)
+        {
+            return false;
+        }
+        if (key.Equals("birthAndDeath", StringComparison.OrdinalIgnoreCase) ||
+            key.Equals("autoAllocateClanMemberPerks", StringComparison.OrdinalIgnoreCase))
+        {
+            return value.Type == JTokenType.Boolean;
+        }
+        if (value.Type != JTokenType.String)
+        {
+            return false;
+        }
+        return Enum.TryParse(value.Value<string>(), true, out DifficultyLevel _);
+    }
+
+    private static int FindMatchingBrace(string text, int openBrace)
+    {
+        bool inString = false;
+        bool escaped = false;
+        bool lineComment = false;
+        bool blockComment = false;
+        int depth = 0;
+        for (int i = openBrace; i < text.Length; i++)
+        {
+            char current = text[i];
+            char next = i + 1 < text.Length ? text[i + 1] : '\0';
+            if (lineComment)
+            {
+                if (current == '\n') lineComment = false;
+                continue;
+            }
+            if (blockComment)
+            {
+                if (current == '*' && next == '/')
+                {
+                    blockComment = false;
+                    i++;
+                }
+                continue;
+            }
+            if (inString)
+            {
+                if (escaped) escaped = false;
+                else if (current == '\\') escaped = true;
+                else if (current == '"') inString = false;
+                continue;
+            }
+            if (current == '/' && next == '/')
+            {
+                lineComment = true;
+                i++;
+                continue;
+            }
+            if (current == '/' && next == '*')
+            {
+                blockComment = true;
+                i++;
+                continue;
+            }
+            if (current == '"')
+            {
+                inString = true;
+                continue;
+            }
+            if (current == '{') depth++;
+            else if (current == '}' && --depth == 0) return i;
+        }
+        return -1;
+    }
+
+    /// <summary>
+    /// Builds before CoopData was introduced stored mod-config.json directly in
+    /// Bannerlord's user-data root. Copy that file forward once, but only for the
+    /// recognizable CoopData layout and never over an existing destination.
+    /// Keeping the source makes the migration recoverable if a launch is interrupted.
+    /// </summary>
+    private static void MigrateLegacyLocation(string directory, string path)
+    {
+        var targetDir = new DirectoryInfo(directory);
+        if (!targetDir.Name.Equals(CoopDataFolderName, StringComparison.OrdinalIgnoreCase) ||
+            targetDir.Parent == null)
+        {
+            return;
+        }
+
+        string legacyPath = Path.Combine(targetDir.Parent.FullName, FileName);
+        if (!File.Exists(legacyPath) || File.Exists(path))
+        {
+            return;
+        }
+
+        Directory.CreateDirectory(directory);
+        File.Copy(legacyPath, path);
+        Logger.Information("mod-config.json copied from its legacy user-data location into {Path}", path);
     }
 
     private string ResolveDirectory()
@@ -160,8 +541,9 @@ internal sealed class ModConfig : IModConfig
         }
     }
 
-    /// <summary>Copies the template out. Every key in it is commented out, so
-    /// seeding can never change an existing world.</summary>
+    /// <summary>Copies the template out on first run. Existing files are never
+    /// replaced; schema migrations above edit only settings that were previously
+    /// shipped as comments.</summary>
     private static void Seed(string path)
     {
         string template = ResolveTemplatePath();

--- a/source/GameInterface/Configuration/ModConfig.cs
+++ b/source/GameInterface/Configuration/ModConfig.cs
@@ -52,7 +52,7 @@ internal sealed class ModConfig : IModConfig
     private static readonly IDictionary<string, JToken> DifficultyDefaults =
         new Dictionary<string, JToken>(StringComparer.OrdinalIgnoreCase)
         {
-            ["playerReceivedDamage"] = "Realistic",
+            ["playerReceivedDamage"] = "VeryEasy",
             ["playerTroopsReceivedDamage"] = "VeryEasy",
             ["combatAIDifficulty"] = "VeryEasy",
             ["recruitmentDifficulty"] = "VeryEasy",

--- a/source/GameInterface/Configuration/ModConfig.cs
+++ b/source/GameInterface/Configuration/ModConfig.cs
@@ -20,8 +20,8 @@ namespace GameInterface.Configuration;
 /// client-hosted session that is Documents\Mount and Blade II
 /// Bannerlord\CoopData, beside the mod's CoopMapData. Seeds it from the
 /// module's template when absent, and falls back to defaults if it cannot be
-/// read. During the one-time schema migration it reads legacy difficulty values
-/// from the dedicated server's config; server-process settings remain independent.
+/// read. Existing files are migrated in place by activating formerly commented
+/// settings without replacing active operator values.
 /// </summary>
 internal sealed class ModConfig : IModConfig
 {
@@ -94,22 +94,16 @@ internal sealed class ModConfig : IModConfig
         string path = Path.Combine(dir, FileName);
         try
         {
-            bool seeded = false;
-            if (!File.Exists(path))
-            {
-                MigrateLegacyLocation(dir, path);
-            }
             if (!File.Exists(path))
             {
                 Seed(path);
-                seeded = File.Exists(path);
                 if (!File.Exists(path))
                 {
                     return new ModConfigData();
                 }
             }
 
-            MigrateDifficultySettings(dir, path, seeded || MatchesShippedTemplate(path));
+            MigrateDifficultySettings(path);
 
             var loaded = JsonConvert.DeserializeObject<ModConfigData>(File.ReadAllText(path), MakeSettings())
                 ?? new ModConfigData();
@@ -126,13 +120,12 @@ internal sealed class ModConfig : IModConfig
     }
 
     /// <summary>
-    /// Difficulty originally lived as flat properties in the dedicated server's
-    /// server-config.json, then moved into mod-config.json. Existing mod-config
-    /// values win; otherwise a legacy server value is ported, then a formerly
-    /// commented mod-config default is activated. The edit is deliberately textual
-    /// so operator comments, ordering and unrelated settings remain untouched.
+    /// Activates difficulty settings that older templates shipped as comments.
+    /// Existing active values win and entirely missing settings receive their
+    /// documented defaults. The edit is deliberately textual so operator comments,
+    /// ordering, and unrelated settings remain untouched.
     /// </summary>
-    private static void MigrateDifficultySettings(string directory, string path, bool legacyWins)
+    private static void MigrateDifficultySettings(string path)
     {
         string original = File.ReadAllText(path);
         JObject root;
@@ -147,7 +140,6 @@ internal sealed class ModConfig : IModConfig
             return;
         }
 
-        IDictionary<string, JToken> legacyValues = ReadLegacyServerDifficulty(directory);
         JToken difficultyToken = root.GetValue("difficulty", StringComparison.OrdinalIgnoreCase);
         if (difficultyToken == null)
         {
@@ -155,11 +147,8 @@ internal sealed class ModConfig : IModConfig
             var properties = new List<string>();
             foreach (string key in FormerlyCommentedDifficultyKeys)
             {
-                JToken value = legacyValues.TryGetValue(key, out JToken legacyValue)
-                    ? legacyValue
-                    : DifficultyDefaults[key];
                 properties.Add("    \"" + key + "\": " +
-                    value.ToString(Formatting.None) + ",");
+                    DifficultyDefaults[key].ToString(Formatting.None) + ",");
             }
             string block = Environment.NewLine + "  \"difficulty\": {" +
                 Environment.NewLine + string.Join(Environment.NewLine, properties) +
@@ -192,27 +181,9 @@ internal sealed class ModConfig : IModConfig
         var insertions = new List<string>();
         foreach (string key in FormerlyCommentedDifficultyKeys)
         {
-            legacyValues.TryGetValue(key, out JToken legacyValue);
             JToken existing = difficulty.GetValue(key, StringComparison.OrdinalIgnoreCase);
             if (existing != null)
             {
-                if (legacyWins && legacyValue != null)
-                {
-                    string activeBlock = migrated.Substring(openBrace, closeBrace - openBrace + 1);
-                    string activePattern = "^(?<indent>[\\t ]*)(?<setting>\\\"" +
-                        Regex.Escape(key) + "\\\"[\\t ]*:[\\t ]*)(?<value>\\\"[^\\\"\\r\\n]*\\\"|true|false)(?<rest>[\\t ]*,?.*)$";
-                    Match activeLine = Regex.Match(activeBlock, activePattern,
-                        RegexOptions.Multiline | RegexOptions.IgnoreCase);
-                    if (activeLine.Success)
-                    {
-                        string replacement = activeLine.Groups["indent"].Value +
-                            activeLine.Groups["setting"].Value + legacyValue.ToString(Formatting.None) +
-                            activeLine.Groups["rest"].Value;
-                        int absolute = openBrace + activeLine.Index;
-                        migrated = migrated.Remove(absolute, activeLine.Length).Insert(absolute, replacement);
-                        closeBrace += replacement.Length - activeLine.Length;
-                    }
-                }
                 continue;
             }
 
@@ -223,11 +194,9 @@ internal sealed class ModConfig : IModConfig
                 RegexOptions.Multiline | RegexOptions.IgnoreCase);
             if (commented.Success)
             {
-                string value = legacyValue == null
-                    ? commented.Groups["value"].Value
-                    : legacyValue.ToString(Formatting.None);
                 string replacement = commented.Groups["indent"].Value +
-                    commented.Groups["setting"].Value + value + commented.Groups["rest"].Value;
+                    commented.Groups["setting"].Value + commented.Groups["value"].Value +
+                    commented.Groups["rest"].Value;
                 int absolute = openBrace + commented.Index;
                 migrated = migrated.Remove(absolute, commented.Length).Insert(absolute, replacement);
                 int delta = replacement.Length - commented.Length;
@@ -235,9 +204,8 @@ internal sealed class ModConfig : IModConfig
                 continue;
             }
 
-            JToken insertedValue = legacyValue ?? DifficultyDefaults[key];
             insertions.Add("    \"" + key + "\": " +
-                insertedValue.ToString(Formatting.None) + ",");
+                DifficultyDefaults[key].ToString(Formatting.None) + ",");
         }
 
         if (insertions.Count > 0)
@@ -270,83 +238,6 @@ internal sealed class ModConfig : IModConfig
         }
     }
 
-    private static IDictionary<string, JToken> ReadLegacyServerDifficulty(string directory)
-    {
-        var values = new Dictionary<string, JToken>(StringComparer.OrdinalIgnoreCase);
-        string direct = Path.Combine(directory, "server-config.json");
-        string nested = Path.Combine(directory, "DedicatedServer", "server-config.json");
-        string[] candidates = new DirectoryInfo(directory).Name.Equals(
-                CoopDataFolderName, StringComparison.OrdinalIgnoreCase)
-            ? new[] { nested, direct }
-            : new[] { direct, nested };
-        string serverPath = Array.Find(candidates, File.Exists);
-        if (serverPath == null)
-        {
-            return values;
-        }
-
-        string text;
-        JObject server;
-        try
-        {
-            text = File.ReadAllText(serverPath);
-            server = JObject.Parse(text);
-        }
-        catch
-        {
-            return values;
-        }
-
-        foreach (string key in FormerlyCommentedDifficultyKeys)
-        {
-            JToken active = server.GetValue(key, StringComparison.OrdinalIgnoreCase);
-            if (IsValidDifficultyValue(key, active))
-            {
-                values[key] = active.DeepClone();
-                continue;
-            }
-
-            string pattern = "^[\\t ]*//[\\t ]*\\\"" + Regex.Escape(key) +
-                "\\\"[\\t ]*:[\\t ]*(?<value>\\\"[^\\\"\\r\\n]*\\\"|true|false)";
-            Match commented = Regex.Match(text, pattern,
-                RegexOptions.Multiline | RegexOptions.IgnoreCase);
-            if (commented.Success)
-            {
-                try
-                {
-                    JToken value = JToken.Parse(commented.Groups["value"].Value);
-                    if (IsValidDifficultyValue(key, value))
-                    {
-                        values[key] = value;
-                    }
-                }
-                catch
-                {
-                    // Ignore an invalid legacy comment and use the mod default.
-                }
-            }
-        }
-        return values;
-    }
-
-    private static bool MatchesShippedTemplate(string path)
-    {
-        string template = ResolveTemplatePath();
-        if (template == null)
-        {
-            return false;
-        }
-        try
-        {
-            return string.Equals(File.ReadAllText(path), File.ReadAllText(template),
-                StringComparison.Ordinal);
-        }
-        catch
-        {
-            return false;
-        }
-    }
-
     private static void ReplaceFile(string path, string contents)
     {
         string temporary = path + ".migration-" + Guid.NewGuid().ToString("N") + ".tmp";
@@ -363,24 +254,6 @@ internal sealed class ModConfig : IModConfig
                 File.Delete(temporary);
             }
         }
-    }
-
-    private static bool IsValidDifficultyValue(string key, JToken value)
-    {
-        if (value == null)
-        {
-            return false;
-        }
-        if (key.Equals("birthAndDeath", StringComparison.OrdinalIgnoreCase) ||
-            key.Equals("autoAllocateClanMemberPerks", StringComparison.OrdinalIgnoreCase))
-        {
-            return value.Type == JTokenType.Boolean;
-        }
-        if (value.Type != JTokenType.String)
-        {
-            return false;
-        }
-        return Enum.TryParse(value.Value<string>(), true, out DifficultyLevel _);
     }
 
     private static int FindMatchingBrace(string text, int openBrace)
@@ -436,32 +309,6 @@ internal sealed class ModConfig : IModConfig
             else if (current == '}' && --depth == 0) return i;
         }
         return -1;
-    }
-
-    /// <summary>
-    /// Builds before CoopData was introduced stored mod-config.json directly in
-    /// Bannerlord's user-data root. Copy that file forward once, but only for the
-    /// recognizable CoopData layout and never over an existing destination.
-    /// Keeping the source makes the migration recoverable if a launch is interrupted.
-    /// </summary>
-    private static void MigrateLegacyLocation(string directory, string path)
-    {
-        var targetDir = new DirectoryInfo(directory);
-        if (!targetDir.Name.Equals(CoopDataFolderName, StringComparison.OrdinalIgnoreCase) ||
-            targetDir.Parent == null)
-        {
-            return;
-        }
-
-        string legacyPath = Path.Combine(targetDir.Parent.FullName, FileName);
-        if (!File.Exists(legacyPath) || File.Exists(path))
-        {
-            return;
-        }
-
-        Directory.CreateDirectory(directory);
-        File.Copy(legacyPath, path);
-        Logger.Information("mod-config.json copied from its legacy user-data location into {Path}", path);
     }
 
     private string ResolveDirectory()

--- a/source/GameInterface/Configuration/ModConfigData.cs
+++ b/source/GameInterface/Configuration/ModConfigData.cs
@@ -25,12 +25,11 @@ public sealed class ModConfigData
 }
 
 /// <summary>
-/// The "difficulty" block. Every key nullable: absent (or commented out in the
-/// template) keeps the save's own setting. The CampaignOptions values live IN
-/// the save, so joining clients inherit them with the join-time save transfer —
-/// playerReceivedDamage is the exception (engine config, pushed to clients as a
-/// join-time ServerOption; see CampaignDifficultyHandler for its headless-host
-/// default).
+/// The "difficulty" block. Properties remain nullable so malformed or unreadable
+/// input can fall back safely, while ModConfig activates or fills the documented
+/// values before a normal load. CampaignOptions values live IN the save, so joining
+/// clients inherit them with the join-time save transfer. PlayerReceivedDamage is
+/// engine config and is pushed to clients as a join-time ServerOption.
 /// </summary>
 public sealed class DifficultyConfigData
 {

--- a/source/GameInterface/Services/Difficulties/Handlers/CampaignDifficultyHandler.cs
+++ b/source/GameInterface/Services/Difficulties/Handlers/CampaignDifficultyHandler.cs
@@ -18,14 +18,9 @@ namespace GameInterface.Services.Difficulties.Handlers;
 /// clients inherit them with the join-time save transfer and autosaves persist
 /// them — a client applying its own file would fight the server's world. A
 /// configured key overrides the loaded world on every boot; an absent key leaves
-/// the save's value alone. playerReceivedDamage is different twice over: it is
-/// engine config (BannerlordConfig), not save state, and the mod pushes the
-/// host's value to every client as a join-time ServerOption — on a HEADLESS host
-/// (BANNERLORD_USER_DIR set) the profile defaults it to VeryEasy, which would
-/// force quarter damage on every player, so unset there means Realistic. On a
-/// graphical host the player's own setting stays in charge unless configured.
-/// (Ported from the dedicated server's CampaignDifficulty, which owned this
-/// while the keys lived in server-config.json.)
+/// the save's value alone. playerReceivedDamage is engine config (BannerlordConfig),
+/// not save state, and the mod pushes the host's value to every client as a
+/// join-time ServerOption.
 /// </summary>
 internal class CampaignDifficultyHandler : IHandler
 {
@@ -65,14 +60,7 @@ internal class CampaignDifficultyHandler : IHandler
         DifficultyConfigData config = modConfig.Data.Difficulty ?? new DifficultyConfigData();
         var effective = new List<string>();
 
-        // Unset on a headless host still means Realistic — see the class summary.
-        DifficultyLevel? playerReceivedDamage = config.PlayerReceivedDamage;
-        if (playerReceivedDamage == null && IsHeadlessHost)
-        {
-            playerReceivedDamage = DifficultyLevel.Realistic;
-        }
-
-        ApplyOption("playerReceivedDamage", playerReceivedDamage, effective,
+        ApplyOption("playerReceivedDamage", config.PlayerReceivedDamage, effective,
             (CampaignOptions.Difficulty)BannerlordConfig.PlayerReceivedDamageDifficulty,
             v => BannerlordConfig.PlayerReceivedDamageDifficulty = (int)v);
         ApplyOption("playerTroopsReceivedDamage", config.PlayerTroopsReceivedDamage, effective,
@@ -101,11 +89,6 @@ internal class CampaignDifficultyHandler : IHandler
 
         Logger.Information("difficulty (effective): {Effective}", string.Join(" ", effective));
     }
-
-    /// <summary>Headless/container hosts set BANNERLORD_USER_DIR (the same marker
-    /// CoopSaveManager keys its data root on); graphical hosts never do.</summary>
-    private static bool IsHeadlessHost =>
-        string.IsNullOrEmpty(Environment.GetEnvironmentVariable("BANNERLORD_USER_DIR")) == false;
 
     /// <summary>By name, not ordinal — the game enum's numbering is not ours to rely on.</summary>
     private static CampaignOptions.Difficulty ToCampaign(DifficultyLevel level)


### PR DESCRIPTION
# **⚠️ Must be merged at the same time as [Dedicated Server #19](https://github.com/Bannerlord-Coop-Team/BannerlordCoop.DedicatedServer/pull/19)**

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Existing gameplay configurations can contain difficulty settings as commented lines, leaving those choices inactive even though their values are present in the file.

## What is the new behavior?

Upgrades update the existing gameplay configuration in place: commented difficulty values are activated exactly as written, active choices remain unchanged, and missing settings receive vanilla Bannerlord's new-campaign defaults. Other configurations and locations are untouched, new installations ship with active difficulty values, and repeat loads do not rewrite the file.

## Bot Changelog Entry
