### PR TITLE
Potential Fix to the Stop Game On Lost Focus

### DIFF
--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -498,6 +498,12 @@ namespace Coop
         protected override void OnBeforeInitialModuleScreenSetAsRoot()
         {
             base.OnBeforeInitialModuleScreenSetAsRoot();
+            
+            if (isServer)
+            {
+                ManagedOptions.SetConfig(ManagedOptions.ManagedOptionsType.StopGameOnFocusLost, 0f);
+            }
+
             CrashDiagnostics.SetPhase("main-menu");
             startupModuleWarningReady = true;
             InformationManager.DisplayMessage(new InformationMessage(ClientServerModeMessage));


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

No new classes were added. Automated tests were not added because this change directly configures Bannerlord's static runtime options API and requires a graphical host instance to verify. The behavior was manually tested with separate `/server` and `/client` instances, and the existing `Coop.Tests` suite passes.

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Graphical co-op server instances inherit Bannerlord's **Stop Game On Lost Focus** setting. When it is enabled, the host stops processing the campaign after its game window loses focus.

This prevents the host from using another window, such as the co-op client, without interrupting campaign processing.

## What is the new behavior?

Resolves #2627

Graphical co-op server instances now disable Bannerlord's **Stop Game On Lost Focus** option during startup.

The change uses the existing `/server` role detection, so client instances do not force the option off and retain the user's configured preference. The setting is applied at runtime without explicitly saving it to the global Bannerlord configuration.

## Bot Changelog Entry

- Co-op hosts now continue running when the game window loses focus.

## Other information

N/A