### PR TITLE
Preserve family members in troop roster interface

### DIFF
--- a/source/GameInterface/Services/TroopRosters/Interfaces/TroopRosterInterface.cs
+++ b/source/GameInterface/Services/TroopRosters/Interfaces/TroopRosterInterface.cs
@@ -119,12 +119,12 @@ internal class TroopRosterInterface : ITroopRosterInterface
         // Only preserve heroes in a player's troopRoster
         bool preserveHeroes = mainHero != null && mainHero.IsPlayerHero() && targetTroopRoster.OwnerParty?.MemberRoster == targetTroopRoster;
 
-        // If preserving heroes, clear without removing mainHero and player companions
-        // Causes issues if mainHero or player companions are removed from a player's party
+        // If preserving heroes, clear without removing mainHero and heroes in the same clan (companions & family members)
+        // Causes issues if mainHero, player companions or family members are removed from a player's party
         for (int i = targetTroopRoster._count - 1; i >= 0; i--)
         {
             var character = targetTroopRoster.data[i].Character;
-            if (preserveHeroes && (character?.HeroObject == mainHero || character?.HeroObject?.IsPlayerCompanion == true)) continue;
+            if (preserveHeroes && (character?.HeroObject == mainHero || character?.HeroObject?.Clan == mainHero.Clan)) continue;
             targetTroopRoster.AddToCounts(character, -targetTroopRoster.data[i].Number, false, -targetTroopRoster.data[i].WoundedNumber, 0, true);
         }
 


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
TroopRosterInterface is used by the inventory logic. Updating the roster currently only preserves player heroes and companions but not any other player clan members. This means that when having a family member (such as a spouse) assigned to a party role (such as quartermaster), closing the inventory screen resets the family member's role in the party.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #2678
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Fixed a problem where family members would lose their role assignment in player parties.