### PR TITLE
2161 - Disabled tab behavior in tournaments

### DIFF
--- a/source/E2E.Tests/Services/Missions/Tournaments/TournamentSpectatorRulesTests.cs
+++ b/source/E2E.Tests/Services/Missions/Tournaments/TournamentSpectatorRulesTests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Xml.Linq;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
 
 namespace E2E.Tests.Services.Missions.Tournaments;
 
@@ -269,6 +270,31 @@ public class TournamentSpectatorRulesTests
     {
         Assert.Equal(expected, TournamentSpectatorOrange.ShouldDisappearOnCollision(isSpectator, isOrange));
     }
+
+    [Fact]
+    public void SpectatorCombatFlags_WithOrangesAllowThrowsButBlockKicks()
+    {
+        AgentFlag initialFlags = AgentFlag.CanAttack | AgentFlag.CanKick | AgentFlag.CanWieldWeapon;
+
+        AgentFlag combatFlags = TournamentSpectatorOrange.GetCombatFlags(initialFlags, true);
+
+        Assert.True(combatFlags.HasFlag(AgentFlag.CanAttack));
+        Assert.False(combatFlags.HasFlag(AgentFlag.CanKick));
+        Assert.True(combatFlags.HasFlag(AgentFlag.CanWieldWeapon));
+    }
+
+    [Fact]
+    public void SpectatorCombatFlags_WithoutOrangesBlockAllMeleeAttacks()
+    {
+        AgentFlag initialFlags = AgentFlag.CanAttack | AgentFlag.CanKick | AgentFlag.CanWieldWeapon;
+
+        AgentFlag combatFlags = TournamentSpectatorOrange.GetCombatFlags(initialFlags, false);
+
+        Assert.False(combatFlags.HasFlag(AgentFlag.CanAttack));
+        Assert.False(combatFlags.HasFlag(AgentFlag.CanKick));
+        Assert.True(combatFlags.HasFlag(AgentFlag.CanWieldWeapon));
+    }
+
     private static TournamentSessionSnapshot Snapshot(TournamentSessionPhase phase)
     {
         TournamentContestantData[] contestants =

--- a/source/GameInterface.Tests/Services/Tournaments/TournamentTabInputPatchesTests.cs
+++ b/source/GameInterface.Tests/Services/Tournaments/TournamentTabInputPatchesTests.cs
@@ -18,4 +18,16 @@ public class TournamentTabInputPatchesTests
             expected,
             TournamentTabInputPatches.ShouldSuppress(isTab, isCoopTournamentMissionActive));
     }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void ShouldRunScoreboardTick_BlocksEntireScoreboardDuringCoopTournament(
+        bool isCoopTournamentMissionActive,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            TournamentScoreboardInputPatches.ShouldRunScoreboardTick(isCoopTournamentMissionActive));
+    }
 }

--- a/source/GameInterface/Services/Tournaments/Patches/TournamentTabInputPatches.cs
+++ b/source/GameInterface/Services/Tournaments/Patches/TournamentTabInputPatches.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using TaleWorlds.InputSystem;
 using TaleWorlds.MountAndBlade;
+using TaleWorlds.MountAndBlade.GauntletUI.Mission.Singleplayer;
 
 namespace GameInterface.Services.Tournaments.Patches;
 
@@ -29,10 +30,21 @@ internal static class TournamentTabInputPatches
     internal static bool ShouldSuppress(bool isTab, bool isCoopTournamentMissionActive)
         => isTab && isCoopTournamentMissionActive;
 
-    private static bool IsCoopTournamentMissionActive()
+    internal static bool IsCoopTournamentMissionActive()
     {
         return Mission.Current != null &&
             ContainerProvider.TryResolve<TournamentMissionUIContext>(out var context) &&
             context.TryGet(out _);
     }
+}
+
+[HarmonyPatch(typeof(MissionGauntletBattleScore), nameof(MissionGauntletBattleScore.OnMissionScreenTick))]
+internal static class TournamentScoreboardInputPatches
+{
+    [HarmonyPrefix]
+    private static bool SuppressTournamentScoreboard()
+        => ShouldRunScoreboardTick(TournamentTabInputPatches.IsCoopTournamentMissionActive());
+
+    internal static bool ShouldRunScoreboardTick(bool isCoopTournamentMissionActive)
+        => !isCoopTournamentMissionActive;
 }

--- a/source/GameInterface/Services/Tournaments/UI/CoopTournamentCampaignBehavior.cs
+++ b/source/GameInterface/Services/Tournaments/UI/CoopTournamentCampaignBehavior.cs
@@ -34,7 +34,7 @@ public sealed class CoopTournamentCampaignBehavior : CampaignBehaviorBase
 
         starter.AddGameMenu(
             PreparationMenuId,
-            "{=coop_tournament_preparation_description}Coop tournaments are in BETA. It is recommended to make a save before starting a tournament.\n\nLords in tournament: {TOURNAMENT_LORD_COUNT}\n\nTournament prize: {TOURNAMENT_PRIZE}\n\nEnrolled competitors:\n{TOURNAMENT_PLAYERS}",
+            "{=coop_tournament_preparation_description}Lords in tournament: {TOURNAMENT_LORD_COUNT}\n\nTournament prize: {TOURNAMENT_PRIZE}\n\nEnrolled competitors:\n{TOURNAMENT_PLAYERS}",
             InitializePreparationMenu,
             GameMenu.MenuOverlayType.SettlementWithBoth,
             GameMenu.MenuFlags.None,

--- a/source/Missions/Tournaments/CoopTournamentController.cs
+++ b/source/Missions/Tournaments/CoopTournamentController.cs
@@ -196,8 +196,6 @@ public class CoopTournamentController : CoopMissionController
         snapshot = updated;
         ApplySessionState(updated);
         Mission.AllowAiTicking = session.IsLocalHost;
-        if (missionReadyForManifest)
-            spectatorAgentManager.Reconcile(updated);
         tournamentBehavior.ApplySnapshot(updated);
         KnockOutDepartingContestants(previous, updated);
         if (wasLocalMember && !HasLocalMissionMember(updated))
@@ -214,6 +212,8 @@ public class CoopTournamentController : CoopMissionController
         BeginUpdatedMatch(previous, updated);
         if (updated.CurrentMatchId != previousMatchId)
             ResetMatchRuntimeState();
+        if (missionReadyForManifest)
+            spectatorAgentManager.Reconcile(updated);
         TryStartHostMatch();
         DrainPendingTournamentPackets();
     }
@@ -1005,6 +1005,7 @@ public class CoopTournamentController : CoopMissionController
             ApplyPendingManifest();
             spectatorAgentManager.Reconcile(snapshot);
         }
+        spectatorAgentManager.UpdateCombatPermissions();
         base.OnMissionTick(dt);
         if (snapshot == null || !session.IsLocalHost) return;
 

--- a/source/Missions/Tournaments/Spectators/TournamentSpectatorAgentManager.cs
+++ b/source/Missions/Tournaments/Spectators/TournamentSpectatorAgentManager.cs
@@ -23,6 +23,7 @@ namespace Missions.Tournaments.Spectators;
 public interface ITournamentSpectatorAgentManager
 {
     void Reconcile(TournamentSessionSnapshot snapshot);
+    void UpdateCombatPermissions();
     void HandleJoinInfo(NetworkMissionJoinInfo joinInfo);
     CoopAgentSpawnData[] GetLocalSpawnData();
     string LastLocalSpawnName { get; }
@@ -111,6 +112,12 @@ public class TournamentSpectatorAgentManager : ITournamentSpectatorAgentManager
         }
 
         GameThread.RunSafe(() => ProcessJoinInfo(joinInfo));
+    }
+
+    public void UpdateCombatPermissions()
+    {
+        foreach (SpectatorAgentRecord record in spectators.Values.ToArray())
+            UpdateCombatPermissions(record.Agent);
     }
 
     public CoopAgentSpawnData[] GetLocalSpawnData()
@@ -222,7 +229,7 @@ public class TournamentSpectatorAgentManager : ITournamentSpectatorAgentManager
         if (agent == null) return;
         if (!coopMissionComponent.AgentRegistry.TryRegisterAgent(controllerId, agentId, agent))
         {
-            agent.FadeOut(false, true);
+            agent.FadeOut(true, true);
             return;
         }
 
@@ -258,7 +265,7 @@ public class TournamentSpectatorAgentManager : ITournamentSpectatorAgentManager
         if (agent == null) return;
         if (!coopMissionComponent.AgentRegistry.TryRegisterAgent(joinInfo.ControllerId, data.AgentId, agent))
         {
-            agent.FadeOut(false, true);
+            agent.FadeOut(true, true);
             return;
         }
 
@@ -407,6 +414,7 @@ public class TournamentSpectatorAgentManager : ITournamentSpectatorAgentManager
                     equippedOrange.Item?.StringId,
                     equippedOrange.Amount);
             }
+            UpdateCombatPermissions(agent);
             agent.FadeIn();
             return agent;
         }
@@ -436,7 +444,19 @@ public class TournamentSpectatorAgentManager : ITournamentSpectatorAgentManager
         if (agent == null || !agent.IsActive()) return;
 
         agent.Controller = AgentControllerType.None;
-        agent.FadeOut(false, true);
+        agent.FadeOut(true, true);
+    }
+
+    private void UpdateCombatPermissions(Agent agent)
+    {
+        if (agent == null || !agent.IsActive()) return;
+
+        MissionWeapon weapon = agent.Equipment[TournamentSpectatorOrange.EquipmentSlot];
+        bool hasUsableOrange = weapon.Amount > 0 && IsOrange(weapon.Item);
+        AgentFlag currentFlags = agent.GetAgentFlags();
+        AgentFlag combatFlags = TournamentSpectatorOrange.GetCombatFlags(currentFlags, hasUsableOrange);
+        if (combatFlags != currentFlags)
+            agent.SetAgentFlags(combatFlags);
     }
 
     private sealed class SpectatorAgentRecord

--- a/source/Missions/Tournaments/Spectators/TournamentSpectatorAgentManager.cs
+++ b/source/Missions/Tournaments/Spectators/TournamentSpectatorAgentManager.cs
@@ -116,7 +116,7 @@ public class TournamentSpectatorAgentManager : ITournamentSpectatorAgentManager
 
     public void UpdateCombatPermissions()
     {
-        foreach (SpectatorAgentRecord record in spectators.Values.ToArray())
+        foreach (SpectatorAgentRecord record in spectators.Values)
             UpdateCombatPermissions(record.Agent);
     }
 

--- a/source/Missions/Tournaments/Spectators/TournamentSpectatorOrange.cs
+++ b/source/Missions/Tournaments/Spectators/TournamentSpectatorOrange.cs
@@ -1,4 +1,5 @@
 using TaleWorlds.Core;
+using TaleWorlds.MountAndBlade;
 
 namespace Missions.Tournaments.Spectators;
 
@@ -33,4 +34,12 @@ public static class TournamentSpectatorOrange
 
     public static bool ShouldDisappearOnCollision(bool isSpectator, bool isOrange)
         => isSpectator && isOrange;
+
+    public static AgentFlag GetCombatFlags(AgentFlag currentFlags, bool hasUsableOrange)
+    {
+        AgentFlag combatFlags = currentFlags & ~AgentFlag.CanKick;
+        if (!hasUsableOrange)
+            combatFlags &= ~AgentFlag.CanAttack;
+        return combatFlags;
+    }
 }

--- a/source/Missions/Tournaments/TournamentMatchLifecycle.cs
+++ b/source/Missions/Tournaments/TournamentMatchLifecycle.cs
@@ -84,7 +84,7 @@ public class TournamentMatchLifecycle : IDisposable
             foreach (Agent agent in mission.Agents?.ToArray() ?? Array.Empty<Agent>())
             {
                 if (agent == null || agent.Mission != mission || !agent.IsActive()) continue;
-                if (agent.Team == Team.Invalid) continue;
+                if (agent.Team == Team.Invalid && !registry.TryGetAgentInfo(agent, out _)) continue;
 
                 // This is a withdrawal from the finished arena set, never a campaign casualty.
                 agent.FadeOut(true, true);


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Disabled tab behavior in tournaments until it can be properly addressed; it was causing some freezing issues and race conditions. 
Spectators can no longer throw hands when they run out of oranges. 
Fixed some spectator puppet cleanup
Removed beta text in tournaments

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #2161 
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->


## Other information
