### PR TITLE
Increase Steam lobby membership slots

### DIFF
--- a/source/Coop.Steam/SteamLobbyAdvertiser.cs
+++ b/source/Coop.Steam/SteamLobbyAdvertiser.cs
@@ -13,7 +13,7 @@ public class SteamLobbyAdvertiser : ISessionAdvertiser, ISteamLobbyOwner
 {
     private static readonly ILogger Logger = LogManager.GetLogger<SteamLobbyAdvertiser>();
 
-    public const int MaxLobbyMembers = 16;
+    public const int MaxLobbyMembers = 128;
     public const string ConnectLobbyArgument = "+connect_lobby";
 
     protected readonly ISteamLobbyApi lobbyApi;


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (not applicable to this constant-only change)

## PR Type

- [x] Other: capacity configuration

## What is the current behavior?

Steam lobby creation uses a maximum member count of 16.

## What is the new behavior?

Steam lobby creation now requests up to 128 members through the existing player-hosted and standalone-server advertiser paths.

## Bot Changelog Entry

- Steam lobbies can now support up to 128 members.