### PR TITLE
Remove old notifications

### DIFF
--- a/source/GameInterface.Tests/Services/GameState/GameStateInterfaceTests.cs
+++ b/source/GameInterface.Tests/Services/GameState/GameStateInterfaceTests.cs
@@ -2,6 +2,9 @@
 using GameInterface.Services.GameState.Interfaces;
 using GameInterface.Services.GameState.Messages;
 using Moq;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using TaleWorlds.Localization;
 using Xunit;
 
 namespace GameInterface.Tests.Services.GameState;
@@ -25,5 +28,33 @@ public class GameStateInterfaceTests
                 It.IsAny<object>(),
                 It.IsAny<MainMenuEntered>()),
             Times.Never);
+    }
+
+    [Fact]
+    public void ClearTransferredMapNotices_DropsHistoryWithoutSuppressingFutureNotices()
+    {
+        var informationManager = new CampaignInformationManager();
+        informationManager._mapNotices.Add(new TestInformationData("Historical"));
+
+        GameStateInterface.ClearTransferredMapNotices(informationManager);
+        informationManager.OnGameLoaded();
+
+        Assert.Empty(informationManager._mapNotices);
+
+        var liveNotice = new TestInformationData("Live");
+        informationManager.NewMapNoticeAdded(liveNotice);
+
+        Assert.Same(liveNotice, Assert.Single(informationManager._mapNotices));
+    }
+
+    private sealed class TestInformationData : InformationData
+    {
+        public TestInformationData(string description) : base(new TextObject(description))
+        {
+        }
+
+        public override TextObject TitleText => DescriptionText;
+
+        public override string SoundEventPath => string.Empty;
     }
 }

--- a/source/GameInterface/Services/GameState/Interfaces/GameStateInterface.cs
+++ b/source/GameInterface/Services/GameState/Interfaces/GameStateInterface.cs
@@ -68,7 +68,17 @@ internal class GameStateInterface : IGameStateInterface
 
         ISaveDriver driver = new CoopInMemSaveDriver(saveData);
         LoadResult loadResult = SaveManager.Load("", driver, loadAsLateInitialize: true);
+        var loadedGame = (Game)loadResult.Root;
+        var loadedCampaign = (Campaign)loadedGame.GameType;
+        ClearTransferredMapNotices(loadedCampaign.CampaignInformationManager);
         MBGameManager.StartNewGame(new SandBoxGameManager(loadResult));
+    }
+
+    internal static void ClearTransferredMapNotices(CampaignInformationManager informationManager)
+    {
+        // A headless server cannot dismiss map notices, so its save contains the campaign's accumulated
+        // UI backlog. Only network-transferred saves use this load path; live notices remain intact.
+        informationManager._mapNotices.Clear();
     }
 
     public void StartNewGame()


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
All old notifications gets shown

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Old notifications gets cleared before load

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Old notifications should no longer show up when joining a server.

## Other information
Easiest to remove it like this as the notifs are a part of the server save.