### PR TITLE
Wars non auto-resolve

### DIFF
--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -14,6 +14,7 @@ using GameInterface.Services.GameDebug.Messages;
 using GameInterface.Services.Kingdoms;
 using GameInterface.Services.Kingdoms.Commands;
 using GameInterface.Services.Kingdoms.Data;
+using GameInterface.Services.Kingdoms.Extentions;
 using GameInterface.Services.Kingdoms.Messages;
 using GameInterface.Services.Kingdoms.Patches;
 using GameInterface.Services.MobileParties.Messages.Behavior;
@@ -22,6 +23,7 @@ using GameInterface.Services.Players;
 using GameInterface.Services.Players.Data;
 using GameInterface.Services.Stances.Messages;
 using GameInterface.Services.UI.Notifications.Messages;
+using GameInterface.Services.Villages.Interfaces;
 using HarmonyLib;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -473,6 +475,137 @@ public class PlayerKingdomCreationFlowTests : IDisposable
                            && message.Faction2Id == targetKingdomId
                            && message.Detail == (int)DeclareWarAction.DeclareWarDetail.CausedByKingdomDecision);
         }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void NpcPeaceOffer_TargetingPlayerKingdom_RequiresPlayerVote(bool acceptPeace)
+    {
+        var client = Clients.First();
+        client.Resolve<IControllerIdProvider>().SetControllerId(ControllerId);
+
+        var player = CreateSyncedPlayerContext(ControllerId, client);
+        var playerKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var enemyKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var enemyClanId = CreateSyncedNpcClan();
+
+        ConfigureClanInKingdom(player.ClanId, playerKingdomId);
+        ConfigureClanInKingdom(enemyClanId, enemyKingdomId);
+        EnsureKingdomRegisteredEverywhere(playerKingdomId);
+        EnsureKingdomRegisteredEverywhere(enemyKingdomId);
+        ConfigureWarEverywhere(playerKingdomId, enemyKingdomId);
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(playerKingdomId, out var playerKingdom));
+            Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(enemyKingdomId, out var enemyKingdom));
+            Assert.True(Server.ObjectManager.TryGetObject<Clan>(enemyClanId, out var enemyClan));
+
+            var npcDecision = new MakePeaceKingdomDecision(
+                enemyClan,
+                playerKingdom,
+                dailyTributeToBePaid: 100,
+                dailyTributeDurationInDays: 30);
+            var peaceOutcome = npcDecision.DetermineInitialCandidates()
+                .OfType<MakePeaceKingdomDecision.MakePeaceDecisionOutcome>()
+                .Single(outcome => outcome.ShouldPeaceBeDeclared);
+
+            Assert.True(CoopKingdomElection.TryRedirectPlayerPeaceOffer(npcDecision, peaceOutcome));
+
+            var playerDecision = Assert.IsType<MakePeaceKingdomDecision>(
+                Assert.Single(playerKingdom.UnresolvedDecisions));
+            Assert.Same(enemyKingdom, playerDecision.FactionToMakePeaceWith);
+            Assert.Equal(-100, playerDecision.DailyTributeToBePaid);
+            Assert.Equal(30, playerDecision.DailyTributeDurationInDays);
+            Assert.True(playerDecision._isProposedByOpponent);
+        });
+
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkMakePeace>());
+        Assert.Contains(
+            Server.NetworkSentMessages.GetMessages<NetworkAddDecision>(),
+            message => message.KingdomId == playerKingdomId
+                       && message.Data is MakePeaceKingdomDecisionData peaceData
+                       && peaceData.FactionToMakePeaceWithId == enemyKingdomId
+                       && peaceData.DailyTributeToBePaid == -100
+                       && peaceData.IsProposedByOpponent);
+
+        foreach (var testClient in Clients)
+        {
+            testClient.Call(() =>
+            {
+                Assert.True(testClient.ObjectManager.TryGetObject<Kingdom>(playerKingdomId, out var playerKingdom));
+                var playerDecision = Assert.IsType<MakePeaceKingdomDecision>(
+                    Assert.Single(playerKingdom.UnresolvedDecisions));
+                Assert.Equal(-100, playerDecision.DailyTributeToBePaid);
+                Assert.True(playerDecision._isProposedByOpponent);
+            });
+        }
+
+        client.SimulateMessage(
+            this,
+            new KingdomDecisionVoteRequested(CreateMakePeaceVote(playerKingdomId, acceptPeace)));
+
+        if (acceptPeace)
+        {
+            Assert.Single(
+                Server.NetworkSentMessages.GetMessages<NetworkMakePeace>(),
+                message => message.Faction1Id == playerKingdomId
+                           && message.Faction2Id == enemyKingdomId
+                           && message.DailyTribute == -100
+                           && message.DailyTributeDuration == 30);
+        }
+        else
+        {
+            Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkMakePeace>());
+        }
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(playerKingdomId, out var playerKingdom));
+            Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(enemyKingdomId, out var enemyKingdom));
+            Assert.Empty(playerKingdom.UnresolvedDecisions);
+            Assert.Equal(!acceptPeace, FactionManager.IsAtWarAgainstFaction(playerKingdom, enemyKingdom));
+        });
+    }
+
+    [Fact]
+    public void NpcPeaceOffer_TargetingPlayerKingdom_ExpiresAsDeclined()
+    {
+        var player = CreateSyncedPlayerContext(ControllerId, Clients.First());
+        var playerKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var enemyKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var enemyClanId = CreateSyncedNpcClan();
+
+        ConfigureClanInKingdom(player.ClanId, playerKingdomId);
+        ConfigureClanInKingdom(enemyClanId, enemyKingdomId);
+        EnsureKingdomRegisteredEverywhere(playerKingdomId);
+        EnsureKingdomRegisteredEverywhere(enemyKingdomId);
+        ConfigureWarEverywhere(playerKingdomId, enemyKingdomId);
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(playerKingdomId, out var playerKingdom));
+            Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(enemyKingdomId, out var enemyKingdom));
+            Assert.True(Server.ObjectManager.TryGetObject<Clan>(enemyClanId, out var enemyClan));
+
+            var npcDecision = new MakePeaceKingdomDecision(enemyClan, playerKingdom);
+            var peaceOutcome = npcDecision.DetermineInitialCandidates()
+                .OfType<MakePeaceKingdomDecision.MakePeaceDecisionOutcome>()
+                .Single(outcome => outcome.ShouldPeaceBeDeclared);
+            Assert.True(CoopKingdomElection.TryRedirectPlayerPeaceOffer(npcDecision, peaceOutcome));
+
+            var playerDecision = Assert.IsType<MakePeaceKingdomDecision>(
+                Assert.Single(playerKingdom.UnresolvedDecisions));
+            playerDecision.TriggerTime = CampaignTime.Zero;
+
+            CoopKingdomDecisionProposalBehaviorPatch.HourlyTickPrefix();
+
+            Assert.Empty(playerKingdom.UnresolvedDecisions);
+            Assert.True(FactionManager.IsAtWarAgainstFaction(playerKingdom, enemyKingdom));
+        });
+
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkMakePeace>());
     }
 
     [Fact]
@@ -1935,6 +2068,30 @@ public class PlayerKingdomCreationFlowTests : IDisposable
         return CreateSyncedPlayerContext(ControllerId, _ => true);
     }
 
+    private string CreateSyncedNpcClan()
+    {
+        const string npcControllerId = "NpcPeaceOfferEnemy";
+        var npc = CreateSyncedPlayerContext(npcControllerId, _ => false);
+
+        RemovePlayerRegistration(Server, npcControllerId);
+        foreach (var client in Clients)
+        {
+            RemovePlayerRegistration(client, npcControllerId);
+        }
+
+        return npc.ClanId;
+    }
+
+    private static void RemovePlayerRegistration(EnvironmentInstance instance, string controllerId)
+    {
+        instance.Call(() =>
+        {
+            var playerManager = instance.Resolve<IPlayerManager>();
+            Assert.True(playerManager.TryGetPlayer(controllerId, out var player));
+            Assert.True(playerManager.RemovePlayer(player));
+        });
+    }
+
     private PlayerContext CreateSyncedPlayerContext(string controllerId, EnvironmentInstance localPlayerClient)
     {
         return CreateSyncedPlayerContext(
@@ -1993,6 +2150,17 @@ public class PlayerKingdomCreationFlowTests : IDisposable
             supportWeight: (int)Supporter.SupportWeights.FullyPush,
             isAbstain: false,
             isFinal: isFinal);
+    }
+
+    private static KingdomDecisionVoteData CreateMakePeaceVote(string kingdomId, bool shouldMakePeace)
+    {
+        return new KingdomDecisionVoteData(
+            kingdomId,
+            decisionIndex: 0,
+            outcomeIndex: shouldMakePeace ? 0 : 1,
+            supportWeight: (int)Supporter.SupportWeights.FullyPush,
+            isAbstain: false,
+            isFinal: true);
     }
 
     private static KingdomDecisionVoteData CreateDeclareWarVoteFromUi(EnvironmentInstance instance, bool shouldWarBeDeclared)
@@ -2088,6 +2256,26 @@ public class PlayerKingdomCreationFlowTests : IDisposable
         {
             ConfigureClanInKingdom(client, clanId, kingdomId);
         }
+    }
+
+    private void ConfigureWarEverywhere(string faction1Id, string faction2Id)
+    {
+        ConfigureWar(Server, faction1Id, faction2Id);
+        foreach (var client in Clients)
+        {
+            ConfigureWar(client, faction1Id, faction2Id);
+        }
+    }
+
+    private static void ConfigureWar(EnvironmentInstance instance, string faction1Id, string faction2Id)
+    {
+        instance.Call(() =>
+        {
+            Assert.True(instance.ObjectManager.TryGetObject<Kingdom>(faction1Id, out var faction1));
+            Assert.True(instance.ObjectManager.TryGetObject<Kingdom>(faction2Id, out var faction2));
+            VillageHostileFactionStanceHelper.ApplyWarStance(faction1, faction2);
+            Assert.True(FactionManager.IsAtWarAgainstFaction(faction1, faction2));
+        });
     }
 
     /// <summary>

--- a/source/GameInterface/Services/Kingdoms/Extentions/CoopKingdomElection.cs
+++ b/source/GameInterface/Services/Kingdoms/Extentions/CoopKingdomElection.cs
@@ -1,4 +1,6 @@
 ﻿using System.Linq;
+using Common;
+using GameInterface.Services.Clans.Extensions;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Election;
 using TaleWorlds.Core;
@@ -109,7 +111,10 @@ namespace GameInterface.Services.Kingdoms.Extentions
 
         public void ApplyChosenOutcomeCoop()
         {
-            if (this._decision.OnShowDecision())
+            // The synchronized kingdom decision is the player-facing prompt. Native's peace
+            // notification checks process-local player singletons and must not run again when
+            // the explicit co-op vote is resolved on the authoritative server.
+            if (IsPendingPlayerPeaceOffer(this._decision) || this._decision.OnShowDecision())
             {
                 this.ApplyChosenOutcome();
             }
@@ -118,10 +123,65 @@ namespace GameInterface.Services.Kingdoms.Extentions
         private void ReadyToAiChooseCoop()
         {
             this._chosenOutcome = this.GetAiChoiceCoop(this._possibleOutcomes);
+            if (TryRedirectPlayerPeaceOffer(this._decision, this._chosenOutcome))
+            {
+                return;
+            }
             if (this._decision.OnShowDecision())
             {
                 this.ApplyChosenOutcome();
             }
+        }
+
+        /// <summary>
+        /// An NPC kingdom deciding that it wants peace is only an offer when the opposing
+        /// kingdom contains a player clan. Mirror that offer into the player's kingdom so
+        /// the existing synchronized kingdom vote decides whether peace is accepted.
+        /// </summary>
+        internal static bool TryRedirectPlayerPeaceOffer(KingdomDecision decision, DecisionOutcome chosenOutcome)
+        {
+            if (decision is not MakePeaceKingdomDecision peaceDecision
+                || peaceDecision._isProposedByOpponent
+                || peaceDecision.FactionToMakePeaceWith is not Kingdom playerKingdom
+                || !playerKingdom.Clans.Any(clan => clan.IsPlayerClan()))
+            {
+                return false;
+            }
+
+            // Consume the original NPC decision on every instance. Only the authoritative
+            // server authors the target-side offer that is then replicated to clients.
+            if (chosenOutcome is not MakePeaceKingdomDecision.MakePeaceDecisionOutcome { ShouldPeaceBeDeclared: true }
+                || !ModInformation.IsServer)
+            {
+                return true;
+            }
+
+            Kingdom proposingKingdom = peaceDecision.Kingdom;
+            bool offerAlreadyPending = playerKingdom.UnresolvedDecisions
+                .OfType<MakePeaceKingdomDecision>()
+                .Any(existing => existing._isProposedByOpponent
+                                 && existing.FactionToMakePeaceWith == proposingKingdom);
+            if (offerAlreadyPending || playerKingdom.RulingClan == null)
+            {
+                return true;
+            }
+
+            var playerDecision = new MakePeaceKingdomDecision(
+                playerKingdom.RulingClan,
+                proposingKingdom,
+                -peaceDecision.DailyTributeToBePaid,
+                peaceDecision.DailyTributeDurationInDays,
+                applyResults: true,
+                isProposedByOpponent: true);
+
+            playerKingdom.AddDecision(playerDecision, ignoreInfluenceCost: true);
+            return true;
+        }
+
+        internal static bool IsPendingPlayerPeaceOffer(KingdomDecision decision)
+        {
+            return decision is MakePeaceKingdomDecision { _isProposedByOpponent: true }
+                   && decision.Kingdom?.Clans.Any(clan => clan.IsPlayerClan()) == true;
         }
 
         public DecisionOutcome GetAiChoiceCoop(MBReadOnlyList<DecisionOutcome> possibleOutcomes)

--- a/source/GameInterface/Services/Kingdoms/Patches/CoopKingdomDecisionProposalBehaviorPatch.cs
+++ b/source/GameInterface/Services/Kingdoms/Patches/CoopKingdomDecisionProposalBehaviorPatch.cs
@@ -2,6 +2,7 @@ using Common;
 using Common.Logging;
 using GameInterface;
 using GameInterface.Services.Clans.Extensions;
+using GameInterface.Services.Kingdoms.Extentions;
 using HarmonyLib;
 using Serilog;
 using System;
@@ -160,6 +161,15 @@ namespace GameInterface.Services.Kingdoms.Patches
                         }
                         else if (decision.TriggerTime.IsPast)
                         {
+                            // An unanswered inbound player peace offer expires as a decline.
+                            // It must never fall through to the forced AI resolution path.
+                            if (CoopKingdomElection.IsPendingPlayerPeaceOffer(decision))
+                            {
+                                kingdom.RemoveDecision(decision);
+                                CampaignEventDispatcher.Instance.OnKingdomDecisionCancelled(decision, true);
+                                continue;
+                            }
+
                             if (ContainerProvider.TryResolve<IKingdomDecisionVoteManager>(out var voteManager) &&
                                 voteManager.TryResolveDecision(decision, force: true))
                             {

--- a/source/GameInterface/Services/Kingdoms/Patches/MakePeaceKingdomDecisionPatches.cs
+++ b/source/GameInterface/Services/Kingdoms/Patches/MakePeaceKingdomDecisionPatches.cs
@@ -1,0 +1,59 @@
+using GameInterface.Services.Kingdoms.Extentions;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Election;
+
+namespace GameInterface.Services.Kingdoms.Patches;
+
+/// <summary>
+/// Keeps a synchronized inbound player peace offer pending until it is voted on or expires.
+/// Native exempts only the process-local <see cref="Clan.PlayerClan"/> from reconsidering its
+/// proposal, which does not identify co-op player clans on the authoritative server.
+/// </summary>
+[HarmonyPatch(typeof(KingdomDecision), nameof(KingdomDecision.ShouldBeCancelled))]
+internal static class PendingPlayerPeaceOfferCancellationPatch
+{
+    [HarmonyPrefix]
+    private static bool ShouldBeCancelledPrefix(KingdomDecision __instance, ref bool __result)
+    {
+        if (!CoopKingdomElection.IsPendingPlayerPeaceOffer(__instance))
+        {
+            return true;
+        }
+
+        var peaceDecision = (MakePeaceKingdomDecision)__instance;
+        __result = __instance.Kingdom.IsEliminated
+                   || __instance.ProposerClan?.Kingdom != __instance.Kingdom
+                   || !__instance.IsAllowed()
+                   || peaceDecision.FactionToMakePeaceWith == null
+                   || peaceDecision.FactionToMakePeaceWith.IsEliminated
+                   || !__instance.Kingdom.IsAtWarWith(peaceDecision.FactionToMakePeaceWith);
+        return false;
+    }
+}
+
+/// <summary>
+/// Reproduces native's ruling-clan support for an inbound player peace offer without relying on
+/// the process-local <see cref="Clan.PlayerClan"/>, which is absent on a dedicated server.
+/// </summary>
+[HarmonyPatch(typeof(MakePeaceKingdomDecision), nameof(MakePeaceKingdomDecision.DetermineSupport))]
+internal static class PendingPlayerPeaceOfferSupportPatch
+{
+    [HarmonyPrefix]
+    private static bool DetermineSupportPrefix(
+        MakePeaceKingdomDecision __instance,
+        Clan clan,
+        DecisionOutcome possibleOutcome,
+        ref float __result)
+    {
+        if (!CoopKingdomElection.IsPendingPlayerPeaceOffer(__instance)
+            || clan != __instance.Kingdom.RulingClan
+            || possibleOutcome is not MakePeaceKingdomDecision.MakePeaceDecisionOutcome peaceOutcome)
+        {
+            return true;
+        }
+
+        __result = peaceOutcome.ShouldPeaceBeDeclared ? 200f : 0f;
+        return false;
+    }
+}


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Wars against player kingdoms get auto resolved as the player is not taken into account

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Players will not be taken into account when AI tries to propose peace.

## Other information
