### PR TITLE
[2843] Prevent dedicated server crash on battle conclusion

### DIFF
--- a/source/E2E.Tests/Services/MapEvents/CoopBattleFinalizeTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/CoopBattleFinalizeTests.cs
@@ -269,64 +269,6 @@ public class CoopBattleFinalizeTests : MapEventTestBase
         Assert.Equal(1, exitToLast.CountFor(Clients.Last()));
     }
 
-    /// <summary>
-    /// The host playing as the aggressor is a player like any other: when the recipient surrenders, the close
-    /// instruction must reach the host's own (server) instance and detach its party from the battle. No menu
-    /// exit is forced on the host — the map-event-destroy fallback is a client-side path, and the host's
-    /// encounter unwind is driven by its own local <c>PlayerEncounter.Update</c> flow.
-    /// </summary>
-    [Fact]
-    public void RecipientSurrenders_PvpBattleClosesHostAggressorEncounter()
-    {
-        var setup = SetupTwoOpposingPlayersInBattle();
-        SetMainPartyInBattle(Server, setup.ctx.AttackerPartyId);
-        EnableHeadlessEncounterFinish(Server);
-
-        string[] closeOnServer = null;
-        Server.Resolve<IMessageBroker>().Subscribe<NetworkClosePvpEncounter>(p => closeOnServer = p.What.PartyIds);
-
-        var recipientClient = Clients.Last();
-        recipientClient.Call(() =>
-        {
-            Assert.True(recipientClient.ObjectManager.TryGetObject<MapEvent>(setup.ctx.MapEventId, out var mapEvent));
-            recipientClient.Resolve<IMessageBroker>().Publish(this, new PlayerSurrendered(mapEvent, MobileParty.MainParty));
-        }, BattleMenuSurrenderDisabledMethods());
-
-        Assert.NotNull(closeOnServer);
-        Assert.Contains(setup.initiatorPartyBaseId, closeOnServer);
-        Assert.Contains(setup.recipientPartyBaseId, closeOnServer);
-        AssertMainPartyLeftBattle(Server);
-    }
-
-    /// <summary>
-    /// The host playing as the aggressor leaves the battle: the finalize runs directly on the server, and the
-    /// close instruction is also published locally so the host's own party detaches through the same path as
-    /// any client's. No menu exit is forced on the host (see
-    /// <see cref="RecipientSurrenders_PvpBattleClosesHostAggressorEncounter"/>).
-    /// </summary>
-    [Fact]
-    public void HostAggressorLeave_PvpBattleClosesHostEncounter()
-    {
-        var setup = SetupTwoOpposingPlayersInBattle();
-        SetMainPartyInBattle(Server, setup.ctx.AttackerPartyId);
-        EnableHeadlessEncounterFinish(Server);
-
-        string[] closeOnServer = null;
-        Server.Resolve<IMessageBroker>().Subscribe<NetworkClosePvpEncounter>(p => closeOnServer = p.What.PartyIds);
-
-        Server.Call(() =>
-        {
-            Assert.True(Server.ObjectManager.TryGetObject<MapEvent>(setup.ctx.MapEventId, out var mapEvent));
-            Server.Resolve<IMessageBroker>().Publish(this, new MapEventFinalizeAttempted(mapEvent));
-        }, MapEventDisabledMethods);
-
-        Assert.NotNull(closeOnServer);
-        Assert.Contains(setup.initiatorPartyBaseId, closeOnServer);
-        Assert.Contains(setup.recipientPartyBaseId, closeOnServer);
-        AssertMapEventRemoved(Server, setup.ctx.MapEventId);
-        AssertMainPartyLeftBattle(Server);
-    }
-
     [Fact]
     public void SpectatorBattleSimulationOpen_ClosesBattleEncounterMenu_WithoutEndingEncounter()
     {

--- a/source/GameInterface/Services/MapEvents/Handlers/BattleFinalizeHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/BattleFinalizeHandler.cs
@@ -158,7 +158,7 @@ internal class BattleFinalizeHandler : IHandler
         // in live p2p hostile battles when player-party collection races teardown.
         if (playerPartyIds.Length > 0)
         {
-            PvpEncounterCloseSender.Send(network, messageBroker, this, playerPartyIds, mapEventId: payload.What.MapEventId);
+            PvpEncounterCloseSender.Send(network, playerPartyIds, mapEventId: payload.What.MapEventId);
             return;
         }
 
@@ -179,7 +179,7 @@ internal class BattleFinalizeHandler : IHandler
         if (!objectManager.TryGetObjectWithLogging(payload.What.MapEventId, out MapEvent mapEvent))
         {
             if (!closeAlreadySent && knownPlayerPartyIds.Length > 0)
-                PvpEncounterCloseSender.Send(network, messageBroker, this, knownPlayerPartyIds, payload.What.SurrenderedPartyId, payload.What.MapEventId);
+                PvpEncounterCloseSender.Send(network, knownPlayerPartyIds, payload.What.SurrenderedPartyId, payload.What.MapEventId);
 
             return;
         }
@@ -194,7 +194,7 @@ internal class BattleFinalizeHandler : IHandler
             var playerPartyIds = FinalizeAndCollectPlayers(mapEvent, knownPlayerPartyIds);
 
             if (!closeAlreadySent && playerPartyIds.Length > 0)
-                PvpEncounterCloseSender.Send(network, messageBroker, this, playerPartyIds, payload.What.SurrenderedPartyId, payload.What.MapEventId);
+                PvpEncounterCloseSender.Send(network, playerPartyIds, payload.What.SurrenderedPartyId, payload.What.MapEventId);
         }
         catch (Exception e)
         {

--- a/source/GameInterface/Services/MapEvents/Handlers/PvPInteractionClientHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/PvPInteractionClientHandler.cs
@@ -1,4 +1,4 @@
-using Common;
+﻿using Common;
 using Common.Logging;
 using Common.Messaging;
 using Common.Network;
@@ -139,6 +139,8 @@ internal class PvPInteractionClientHandler : IHandler
     /// </summary>
     private void Handle_NetworkClosePvpEncounter(MessagePayload<NetworkClosePvpEncounter> payload)
     {
+        if (ModInformation.IsServer) return;
+
         var message = payload.What;
 
         GameThread.RunSafe(() => ClosePvpEncounter(message), context: nameof(Handle_NetworkClosePvpEncounter));

--- a/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyHostileEncounterService.cs
+++ b/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyHostileEncounterService.cs
@@ -1,6 +1,5 @@
 ﻿using Common;
 using Common.Logging;
-using Common.Messaging;
 using Common.Network;
 using Common.Util;
 using GameInterface.Services.MapEvents;
@@ -26,18 +25,15 @@ internal class PlayerPartyHostileEncounterService : IPlayerPartyHostileEncounter
 
     private readonly IObjectManager objectManager;
     private readonly INetwork network;
-    private readonly IMessageBroker messageBroker;
     private readonly IPlayerManager playerManager;
 
     public PlayerPartyHostileEncounterService(
         IObjectManager objectManager,
         INetwork network,
-        IMessageBroker messageBroker,
         IPlayerManager playerManager)
     {
         this.objectManager = objectManager;
         this.network = network;
-        this.messageBroker = messageBroker;
         this.playerManager = playerManager;
     }
 
@@ -139,7 +135,7 @@ internal class PlayerPartyHostileEncounterService : IPlayerPartyHostileEncounter
                 TakePrisonerAction.Apply(initiatorParty, responderHero);
             }
 
-            PvpEncounterCloseSender.Send(network, messageBroker, this, new[] { initiatorPartyId, responderPartyId }, responderPartyId);
+            PvpEncounterCloseSender.Send(network, new[] { initiatorPartyId, responderPartyId }, responderPartyId);
             return true;
         }
         catch (Exception e)

--- a/source/GameInterface/Services/MapEvents/PvpEncounterCloseSender.cs
+++ b/source/GameInterface/Services/MapEvents/PvpEncounterCloseSender.cs
@@ -1,6 +1,4 @@
-using Common;
-using Common.Messaging;
-using Common.Network;
+﻿using Common.Network;
 using GameInterface.Services.MapEvents.Messages;
 
 namespace GameInterface.Services.MapEvents;
@@ -9,8 +7,6 @@ internal static class PvpEncounterCloseSender
 {
     public static void Send(
         INetwork network,
-        IMessageBroker messageBroker,
-        object source,
         string[] playerPartyIds,
         string surrenderedPartyId = null,
         string mapEventId = null)
@@ -20,8 +16,5 @@ internal static class PvpEncounterCloseSender
 
         var message = new NetworkClosePvpEncounter(playerPartyIds, surrenderedPartyId, mapEventId);
         network.SendAll(message);
-
-        if (ModInformation.IsServer)
-            messageBroker.Publish(source, message);
     }
 }

--- a/source/GameInterface/Services/PlayerCaptivityService/Handlers/PlayerCaptivityServerHandler.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Handlers/PlayerCaptivityServerHandler.cs
@@ -327,7 +327,7 @@ internal class PlayerCaptivityServerHandler : IHandler
                 string.Join(",", playerPartyIds),
                 surrenderedPartyId ?? "<none>",
                 payload.What.MapEventId ?? "<none>");
-            PvpEncounterCloseSender.Send(network, messageBroker, this, playerPartyIds, surrenderedPartyId, payload.What.MapEventId);
+            PvpEncounterCloseSender.Send(network, playerPartyIds, surrenderedPartyId, payload.What.MapEventId);
             mapEvent.DoSurrender(playerParty.Party.Side);
             messageBroker.Publish(this, new MapEventConcluded(payload.What.MapEventId, playerPartyIds, surrenderedPartyId));
         }, blocking: true, context: nameof(Handle_NetworkPlayerSurrendered));


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Completing a co-op battle can abort the native Linux dedicated server, disconnecting players and leaving time control unavailable while the container restarts.

## What is the new behavior?

Resolves #2843

Completing a co-op battle now closes the encounter on connected clients without running client encounter and UI teardown on the dedicated server, so the server stays online and time control remains available.

## Bot Changelog Entry

- Fixed native Linux dedicated servers crashing when a co-op battle concludes.
