### PR TITLE
Prevent missing player parties from blocking synchronization

### DIFF
--- a/source/Coop.Tests/GameInterface/Registry/Auto/AutoRegistryRemapTests.cs
+++ b/source/Coop.Tests/GameInterface/Registry/Auto/AutoRegistryRemapTests.cs
@@ -69,4 +69,44 @@ public class AutoRegistryRemapTests
         Assert.True(objectManager.TryGetObject<object>("Object_lord_1_8", out var found));
         Assert.Same(attachment, found);
     }
+
+    [Fact]
+    public void RegisterAllObjects_RepeatedRefreshRetainsExistingIdsAndAddsNewObjects()
+    {
+        var objectManager = new ObjectManager(Mock.Of<ILogger>());
+        var existing = new object();
+        var added = new object();
+        var registry = new TestRegistry(objectManager);
+        registry.ToRegister.Add(("existing_1", existing));
+        registry.RegisterAllObjects();
+
+        Assert.True(objectManager.TryGetId(existing, out var originalId));
+
+        registry.ToRegister.Add(("added_2", added));
+        registry.RegisterAllObjects();
+
+        Assert.True(objectManager.TryGetId(existing, out var refreshedId));
+        Assert.Equal(originalId, refreshedId);
+        Assert.True(objectManager.TryGetObject<object>("Object_added_2", out var found));
+        Assert.Same(added, found);
+        Assert.True(objectManager.AddNewObject(new object(), out var generatedId));
+        Assert.Equal("Object_5", generatedId);
+    }
+
+    [Fact]
+    public void RegisterAllObjects_DifferentObjectWithDuplicateIdRemainsUnregistered()
+    {
+        var objectManager = new ObjectManager(Mock.Of<ILogger>());
+        var registered = new object();
+        var colliding = new object();
+        var registry = new TestRegistry(objectManager);
+        registry.ToRegister.Add(("shared", registered));
+        registry.ToRegister.Add(("shared", colliding));
+
+        registry.RegisterAllObjects();
+
+        Assert.True(objectManager.TryGetObject<object>("Object_shared", out var found));
+        Assert.Same(registered, found);
+        Assert.False(objectManager.TryGetId(colliding, out _));
+    }
 }

--- a/source/GameInterface.Tests/ContainerTest.cs
+++ b/source/GameInterface.Tests/ContainerTest.cs
@@ -3,6 +3,7 @@ using Common.Messaging;
 using Common.Network;
 using Common.Serialization;
 using GameInterface.AutoSync;
+using GameInterface.Services.Players;
 using HarmonyLib;
 using Moq;
 using System;
@@ -37,6 +38,7 @@ public class ContainerTest
 
             var gameInterface = module.Resolve<IGameInterface>();
             var AutoSyncPatcher = module.Resolve<AutoSyncPatcher>();
+            module.Resolve<IPlayerPartyRestorer>();
 
             gameInterface.PatchAll();
             gameInterface.UnpatchAll();

--- a/source/GameInterface.Tests/Registry/RegistryManagerTests.cs
+++ b/source/GameInterface.Tests/Registry/RegistryManagerTests.cs
@@ -1,0 +1,60 @@
+﻿using Common.Messaging;
+using GameInterface.AutoSync;
+using GameInterface.Registry;
+using GameInterface.Registry.Auto;
+using GameInterface.Registry.Messages;
+using GameInterface.Services.ObjectManager;
+using Moq;
+using Xunit;
+
+namespace GameInterface.Tests.Registry;
+
+public class RegistryManagerTests
+{
+    [Fact]
+    public void RegisterUntrackedGameObjects_RegistersWithoutPublishingCompletion()
+    {
+        var autoRegistryFactory = new Mock<IAutoRegistryFactory>();
+        var messageBroker = new Mock<IMessageBroker>();
+        var manager = CreateManager(autoRegistryFactory.Object, messageBroker.Object);
+
+        manager.RegisterUntrackedGameObjects();
+
+        autoRegistryFactory.Verify(factory => factory.RegisterAll(), Times.Once);
+        messageBroker.Verify(
+            broker => broker.Publish(It.IsAny<object>(), It.IsAny<AllGameObjectsRegistered>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void RegisterAllGameObjects_RegistersBeforePublishingCompletion()
+    {
+        var registrationOrder = new MockSequence();
+        var autoRegistryFactory = new Mock<IAutoRegistryFactory>(MockBehavior.Strict);
+        var messageBroker = new Mock<IMessageBroker>(MockBehavior.Strict);
+        autoRegistryFactory
+            .InSequence(registrationOrder)
+            .Setup(factory => factory.RegisterAll());
+        messageBroker
+            .InSequence(registrationOrder)
+            .Setup(broker => broker.Publish(It.IsAny<object>(), It.IsAny<AllGameObjectsRegistered>()));
+        var manager = CreateManager(autoRegistryFactory.Object, messageBroker.Object);
+
+        manager.RegisterAllGameObjects();
+
+        autoRegistryFactory.VerifyAll();
+        messageBroker.VerifyAll();
+    }
+
+    private static RegistryManager CreateManager(
+        IAutoRegistryFactory autoRegistryFactory,
+        IMessageBroker messageBroker)
+    {
+        return new RegistryManager(
+            Mock.Of<IObjectManager>(),
+            Mock.Of<IRegistryCollection>(),
+            messageBroker,
+            autoRegistryFactory,
+            Mock.Of<IAutoSyncPatchCollector>());
+    }
+}

--- a/source/GameInterface.Tests/Registry/RegistryManagerTests.cs
+++ b/source/GameInterface.Tests/Registry/RegistryManagerTests.cs
@@ -12,21 +12,6 @@ namespace GameInterface.Tests.Registry;
 public class RegistryManagerTests
 {
     [Fact]
-    public void RegisterUntrackedGameObjects_RegistersWithoutPublishingCompletion()
-    {
-        var autoRegistryFactory = new Mock<IAutoRegistryFactory>();
-        var messageBroker = new Mock<IMessageBroker>();
-        var manager = CreateManager(autoRegistryFactory.Object, messageBroker.Object);
-
-        manager.RegisterUntrackedGameObjects();
-
-        autoRegistryFactory.Verify(factory => factory.RegisterAll(), Times.Once);
-        messageBroker.Verify(
-            broker => broker.Publish(It.IsAny<object>(), It.IsAny<AllGameObjectsRegistered>()),
-            Times.Never);
-    }
-
-    [Fact]
     public void RegisterAllGameObjects_RegistersBeforePublishingCompletion()
     {
         var registrationOrder = new MockSequence();

--- a/source/GameInterface.Tests/Services/Players/PlayerPartyRestorerTests.cs
+++ b/source/GameInterface.Tests/Services/Players/PlayerPartyRestorerTests.cs
@@ -1,4 +1,4 @@
-﻿using GameInterface.Registry;
+﻿using GameInterface.Registry.Auto;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
 using GameInterface.Services.Players.Data;
@@ -30,7 +30,7 @@ public class PlayerPartyRestorerTests
     public void Restore_MissingPlayerState_AddsMembershipsAndLeader()
     {
         var (hero, party, clan, character) = CreatePlayerGraph();
-        var restorer = new PlayerPartyRestorer(Mock.Of<IObjectManager>(), Mock.Of<IRegistryManager>());
+        var restorer = new PlayerPartyRestorer(Mock.Of<IObjectManager>(), Mock.Of<IAutoRegistryFactory>());
 
         restorer.Restore(hero, party);
 
@@ -46,7 +46,7 @@ public class PlayerPartyRestorerTests
     public void Restore_ExistingPlayerState_DoesNotAddDuplicates()
     {
         var (hero, party, clan, character) = CreatePlayerGraph();
-        var restorer = new PlayerPartyRestorer(Mock.Of<IObjectManager>(), Mock.Of<IRegistryManager>());
+        var restorer = new PlayerPartyRestorer(Mock.Of<IObjectManager>(), Mock.Of<IAutoRegistryFactory>());
 
         restorer.Restore(hero, party);
         restorer.Restore(hero, party);
@@ -62,7 +62,7 @@ public class PlayerPartyRestorerTests
     {
         var (hero, party, _, _) = CreatePlayerGraph();
         var (_, staleParty, _, _) = CreatePlayerGraph();
-        var restorer = new PlayerPartyRestorer(Mock.Of<IObjectManager>(), Mock.Of<IRegistryManager>());
+        var restorer = new PlayerPartyRestorer(Mock.Of<IObjectManager>(), Mock.Of<IAutoRegistryFactory>());
         restorer.Restore(hero, party);
         hero._partyBelongedTo = staleParty;
 
@@ -92,11 +92,11 @@ public class PlayerPartyRestorerTests
         objectManager.Setup(manager => manager.TryGetIdWithLogging(party, out partyId)).Returns(true);
         objectManager.Setup(manager => manager.TryGetIdWithLogging(hero.Clan, out clanId)).Returns(true);
         objectManager.Setup(manager => manager.TryGetIdWithLogging(hero.CharacterObject, out characterId)).Returns(true);
-        var registryManager = new Mock<IRegistryManager>(MockBehavior.Strict);
+        var autoRegistryFactory = new Mock<IAutoRegistryFactory>(MockBehavior.Strict);
 
         var restorer = new PlayerPartyRestorer(
             objectManager.Object,
-            registryManager.Object,
+            autoRegistryFactory.Object,
             () => new[] { party },
             _ => throw new InvalidOperationException("A live owned party should be reused"),
             _ => throw new InvalidOperationException("A reused party should not be removed"));
@@ -113,7 +113,7 @@ public class PlayerPartyRestorerTests
     }
 
     [Fact]
-    public void TryRestore_MissingCaptiveParty_CreatesParkedLeaderlessParty()
+    public void TryRestore_MissingCaptiveParty_CreatesParkedLeaderlessRecoveryParty()
     {
         var (hero, party, _, _) = CreatePlayerGraph();
         var captor = (PartyBase)FormatterServices.GetUninitializedObject(typeof(PartyBase));
@@ -144,11 +144,11 @@ public class PlayerPartyRestorerTests
         objectManager.Setup(manager => manager.TryGetIdWithLogging(party, out partyId)).Returns(true);
         objectManager.Setup(manager => manager.TryGetIdWithLogging(hero.Clan, out clanId)).Returns(true);
         objectManager.Setup(manager => manager.TryGetIdWithLogging(hero.CharacterObject, out characterId)).Returns(true);
-        var registryManager = new Mock<IRegistryManager>();
+        var autoRegistryFactory = new Mock<IAutoRegistryFactory>();
         var registrationOrder = new List<string>();
-        registryManager
-            .Setup(manager => manager.RegisterUntrackedGameObjects())
-            .Callback(() => registrationOrder.Add("refresh"));
+        autoRegistryFactory
+            .Setup(factory => factory.RegisterAll())
+            .Callback(() => registrationOrder.Add("register"));
         objectManager
             .Setup(manager => manager.TryGetIdWithLogging(party, out partyId))
             .Callback(() => registrationOrder.Add("lookup"))
@@ -157,14 +157,14 @@ public class PlayerPartyRestorerTests
 
         var restorer = new PlayerPartyRestorer(
             objectManager.Object,
-            registryManager.Object,
+            autoRegistryFactory.Object,
             () => Array.Empty<MobileParty>(),
-            replacementHero =>
+            recoveryHero =>
             {
-                Assert.Same(hero, replacementHero);
+                Assert.Same(hero, recoveryHero);
                 return party;
             },
-            _ => throw new InvalidOperationException("A registered replacement should not be removed"));
+            _ => throw new InvalidOperationException("A registered recovery party should not be removed"));
 
         Assert.True(restorer.TryRestore(player, out var restored));
 
@@ -176,40 +176,40 @@ public class PlayerPartyRestorerTests
         Assert.Null(hero.PartyBelongedTo);
         Assert.Equal(captivePosition, party.Position);
         Assert.False(party.IsActive);
-        Assert.Equal(new[] { "refresh", "lookup" }, registrationOrder);
+        Assert.Equal(new[] { "register", "lookup" }, registrationOrder);
     }
 
     [Fact]
-    public void TryRestore_ReplacementStillUnregistered_RemovesReplacementAndReturnsFalse()
+    public void TryRestore_RecoveryPartyStillUnregistered_RemovesRecoveryPartyAndReturnsFalse()
     {
         var (hero, party, _, _) = CreatePlayerGraph();
         var player = new Player("Controller", "Hero_Saved", "MobileParty_Missing", "Clan_Saved", "Character_Saved");
         var objectManager = CreateRegisteredPlayerObjectManager(player, hero);
-        var registryManager = new Mock<IRegistryManager>();
+        var autoRegistryFactory = new Mock<IAutoRegistryFactory>();
         var registrationOrder = new List<string>();
-        registryManager
-            .Setup(manager => manager.RegisterUntrackedGameObjects())
+        autoRegistryFactory
+            .Setup(factory => factory.RegisterAll())
             .Callback(() =>
             {
-                registrationOrder.Add("refresh");
+                registrationOrder.Add("register");
                 Assert.True(objectManager.AddExisting("PartyBase_Partial", party.Party));
             });
 
         var restorer = new PlayerPartyRestorer(
             objectManager,
-            registryManager.Object,
+            autoRegistryFactory.Object,
             () => Array.Empty<MobileParty>(),
             _ => party,
-            removedParty =>
+            removedRecoveryParty =>
             {
-                Assert.Same(party, removedParty);
+                Assert.Same(party, removedRecoveryParty);
                 registrationOrder.Add("cleanup");
             });
 
         Assert.False(restorer.TryRestore(player, out var restored));
 
         Assert.Same(player, restored);
-        Assert.Equal(new[] { "refresh", "cleanup" }, registrationOrder);
+        Assert.Equal(new[] { "register", "cleanup" }, registrationOrder);
         Assert.False(objectManager.TryGetId(party.Party, out _));
         Assert.True(objectManager.TryGetId(hero, out _));
         Assert.Equal(0, party.MemberRoster.GetTroopCount(hero.CharacterObject));
@@ -217,18 +217,18 @@ public class PlayerPartyRestorerTests
     }
 
     [Fact]
-    public void TryRestore_ReplacementRegistrationPartiallyFails_RollsBackAndRemovesReplacement()
+    public void TryRestore_RecoveryPartyRegistrationPartiallyFails_RollsBackAndRemovesRecoveryParty()
     {
         var (hero, party, _, _) = CreatePlayerGraph();
         var player = new Player("Controller", "Hero_Saved", "MobileParty_Missing", "Clan_Saved", "Character_Saved");
         var objectManager = CreateRegisteredPlayerObjectManager(player, hero);
-        var registryManager = new Mock<IRegistryManager>();
+        var autoRegistryFactory = new Mock<IAutoRegistryFactory>();
         var registrationOrder = new List<string>();
-        registryManager
-            .Setup(manager => manager.RegisterUntrackedGameObjects())
+        autoRegistryFactory
+            .Setup(factory => factory.RegisterAll())
             .Callback(() =>
             {
-                registrationOrder.Add("refresh");
+                registrationOrder.Add("register");
                 Assert.True(objectManager.AddExisting("MobileParty_Partial", party));
                 Assert.True(objectManager.AddExisting("PartyBase_Partial", party.Party));
                 throw new InvalidOperationException("Registration failed");
@@ -236,19 +236,19 @@ public class PlayerPartyRestorerTests
 
         var restorer = new PlayerPartyRestorer(
             objectManager,
-            registryManager.Object,
+            autoRegistryFactory.Object,
             () => Array.Empty<MobileParty>(),
             _ => party,
-            removedParty =>
+            removedRecoveryParty =>
             {
-                Assert.Same(party, removedParty);
+                Assert.Same(party, removedRecoveryParty);
                 registrationOrder.Add("cleanup");
             });
 
         Assert.False(restorer.TryRestore(player, out var restored));
 
         Assert.Same(player, restored);
-        Assert.Equal(new[] { "refresh", "cleanup" }, registrationOrder);
+        Assert.Equal(new[] { "register", "cleanup" }, registrationOrder);
         Assert.False(objectManager.TryGetId(party, out _));
         Assert.False(objectManager.TryGetId(party.Party, out _));
         Assert.True(objectManager.TryGetId(hero, out _));
@@ -257,7 +257,7 @@ public class PlayerPartyRestorerTests
     }
 
     [Fact]
-    public void TryRestore_ReplacementCleanupThrows_ReturnsOriginalFailure()
+    public void TryRestore_RecoveryPartyCleanupThrows_ReturnsOriginalFailure()
     {
         var (hero, party, _, _) = CreatePlayerGraph();
         var player = new Player("Controller", "Hero_Saved", "MobileParty_Missing", "Clan_Saved", "Character_Saved");
@@ -270,7 +270,7 @@ public class PlayerPartyRestorerTests
 
         var restorer = new PlayerPartyRestorer(
             objectManager.Object,
-            Mock.Of<IRegistryManager>(),
+            Mock.Of<IAutoRegistryFactory>(),
             () => Array.Empty<MobileParty>(),
             _ => party,
             _ =>
@@ -297,7 +297,7 @@ public class PlayerPartyRestorerTests
 
         var restorer = new PlayerPartyRestorer(
             objectManager.Object,
-            Mock.Of<IRegistryManager>(),
+            Mock.Of<IAutoRegistryFactory>(),
             () => Array.Empty<MobileParty>(),
             _ => throw new InvalidOperationException("The saved party should be reused"),
             _ => throw new InvalidOperationException("The saved party should not be removed"));
@@ -317,10 +317,10 @@ public class PlayerPartyRestorerTests
 
         var restorer = new PlayerPartyRestorer(
             objectManager.Object,
-            Mock.Of<IRegistryManager>(),
+            Mock.Of<IAutoRegistryFactory>(),
             () => new[] { party },
             _ => null,
-            _ => throw new InvalidOperationException("No replacement was created"));
+            _ => throw new InvalidOperationException("No recovery party was created"));
 
         Assert.False(restorer.TryRestore(player, out _));
     }
@@ -352,14 +352,14 @@ public class PlayerPartyRestorerTests
         var createCalled = false;
         var restorer = new PlayerPartyRestorer(
             objectManager.Object,
-            Mock.Of<IRegistryManager>(),
+            Mock.Of<IAutoRegistryFactory>(),
             () => new[] { party },
             _ =>
             {
                 createCalled = true;
                 return null;
             },
-            _ => throw new InvalidOperationException("No replacement was created"));
+            _ => throw new InvalidOperationException("No recovery party was created"));
 
         Assert.False(restorer.TryRestore(player, out _));
         Assert.True(createCalled);

--- a/source/GameInterface.Tests/Services/Players/PlayerPartyRestorerTests.cs
+++ b/source/GameInterface.Tests/Services/Players/PlayerPartyRestorerTests.cs
@@ -1,8 +1,10 @@
-﻿using GameInterface.Services.ObjectManager;
+﻿using GameInterface.Registry;
+using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
 using GameInterface.Services.Players.Data;
 using GameInterface.Tests.Bootstrap;
 using Moq;
+using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -28,7 +30,7 @@ public class PlayerPartyRestorerTests
     public void Restore_MissingPlayerState_AddsMembershipsAndLeader()
     {
         var (hero, party, clan, character) = CreatePlayerGraph();
-        var restorer = new PlayerPartyRestorer(Mock.Of<IObjectManager>());
+        var restorer = new PlayerPartyRestorer(Mock.Of<IObjectManager>(), Mock.Of<IRegistryManager>());
 
         restorer.Restore(hero, party);
 
@@ -44,7 +46,7 @@ public class PlayerPartyRestorerTests
     public void Restore_ExistingPlayerState_DoesNotAddDuplicates()
     {
         var (hero, party, clan, character) = CreatePlayerGraph();
-        var restorer = new PlayerPartyRestorer(Mock.Of<IObjectManager>());
+        var restorer = new PlayerPartyRestorer(Mock.Of<IObjectManager>(), Mock.Of<IRegistryManager>());
 
         restorer.Restore(hero, party);
         restorer.Restore(hero, party);
@@ -60,7 +62,7 @@ public class PlayerPartyRestorerTests
     {
         var (hero, party, _, _) = CreatePlayerGraph();
         var (_, staleParty, _, _) = CreatePlayerGraph();
-        var restorer = new PlayerPartyRestorer(Mock.Of<IObjectManager>());
+        var restorer = new PlayerPartyRestorer(Mock.Of<IObjectManager>(), Mock.Of<IRegistryManager>());
         restorer.Restore(hero, party);
         hero._partyBelongedTo = staleParty;
 
@@ -90,11 +92,14 @@ public class PlayerPartyRestorerTests
         objectManager.Setup(manager => manager.TryGetIdWithLogging(party, out partyId)).Returns(true);
         objectManager.Setup(manager => manager.TryGetIdWithLogging(hero.Clan, out clanId)).Returns(true);
         objectManager.Setup(manager => manager.TryGetIdWithLogging(hero.CharacterObject, out characterId)).Returns(true);
+        var registryManager = new Mock<IRegistryManager>(MockBehavior.Strict);
 
         var restorer = new PlayerPartyRestorer(
             objectManager.Object,
+            registryManager.Object,
             () => new[] { party },
-            _ => throw new InvalidOperationException("A live owned party should be reused"));
+            _ => throw new InvalidOperationException("A live owned party should be reused"),
+            _ => throw new InvalidOperationException("A reused party should not be removed"));
 
         Assert.True(restorer.TryRestore(player, out var restored));
 
@@ -139,11 +144,27 @@ public class PlayerPartyRestorerTests
         objectManager.Setup(manager => manager.TryGetIdWithLogging(party, out partyId)).Returns(true);
         objectManager.Setup(manager => manager.TryGetIdWithLogging(hero.Clan, out clanId)).Returns(true);
         objectManager.Setup(manager => manager.TryGetIdWithLogging(hero.CharacterObject, out characterId)).Returns(true);
+        var registryManager = new Mock<IRegistryManager>();
+        var registrationOrder = new List<string>();
+        registryManager
+            .Setup(manager => manager.RegisterUntrackedGameObjects())
+            .Callback(() => registrationOrder.Add("refresh"));
+        objectManager
+            .Setup(manager => manager.TryGetIdWithLogging(party, out partyId))
+            .Callback(() => registrationOrder.Add("lookup"))
+            .Returns(true);
+        EnableRegistrationTransactions(objectManager);
 
         var restorer = new PlayerPartyRestorer(
             objectManager.Object,
+            registryManager.Object,
             () => Array.Empty<MobileParty>(),
-            _ => party);
+            replacementHero =>
+            {
+                Assert.Same(hero, replacementHero);
+                return party;
+            },
+            _ => throw new InvalidOperationException("A registered replacement should not be removed"));
 
         Assert.True(restorer.TryRestore(player, out var restored));
 
@@ -155,6 +176,115 @@ public class PlayerPartyRestorerTests
         Assert.Null(hero.PartyBelongedTo);
         Assert.Equal(captivePosition, party.Position);
         Assert.False(party.IsActive);
+        Assert.Equal(new[] { "refresh", "lookup" }, registrationOrder);
+    }
+
+    [Fact]
+    public void TryRestore_ReplacementStillUnregistered_RemovesReplacementAndReturnsFalse()
+    {
+        var (hero, party, _, _) = CreatePlayerGraph();
+        var player = new Player("Controller", "Hero_Saved", "MobileParty_Missing", "Clan_Saved", "Character_Saved");
+        var objectManager = CreateRegisteredPlayerObjectManager(player, hero);
+        var registryManager = new Mock<IRegistryManager>();
+        var registrationOrder = new List<string>();
+        registryManager
+            .Setup(manager => manager.RegisterUntrackedGameObjects())
+            .Callback(() =>
+            {
+                registrationOrder.Add("refresh");
+                Assert.True(objectManager.AddExisting("PartyBase_Partial", party.Party));
+            });
+
+        var restorer = new PlayerPartyRestorer(
+            objectManager,
+            registryManager.Object,
+            () => Array.Empty<MobileParty>(),
+            _ => party,
+            removedParty =>
+            {
+                Assert.Same(party, removedParty);
+                registrationOrder.Add("cleanup");
+            });
+
+        Assert.False(restorer.TryRestore(player, out var restored));
+
+        Assert.Same(player, restored);
+        Assert.Equal(new[] { "refresh", "cleanup" }, registrationOrder);
+        Assert.False(objectManager.TryGetId(party.Party, out _));
+        Assert.True(objectManager.TryGetId(hero, out _));
+        Assert.Equal(0, party.MemberRoster.GetTroopCount(hero.CharacterObject));
+        Assert.Null(party.LeaderHero);
+    }
+
+    [Fact]
+    public void TryRestore_ReplacementRegistrationPartiallyFails_RollsBackAndRemovesReplacement()
+    {
+        var (hero, party, _, _) = CreatePlayerGraph();
+        var player = new Player("Controller", "Hero_Saved", "MobileParty_Missing", "Clan_Saved", "Character_Saved");
+        var objectManager = CreateRegisteredPlayerObjectManager(player, hero);
+        var registryManager = new Mock<IRegistryManager>();
+        var registrationOrder = new List<string>();
+        registryManager
+            .Setup(manager => manager.RegisterUntrackedGameObjects())
+            .Callback(() =>
+            {
+                registrationOrder.Add("refresh");
+                Assert.True(objectManager.AddExisting("MobileParty_Partial", party));
+                Assert.True(objectManager.AddExisting("PartyBase_Partial", party.Party));
+                throw new InvalidOperationException("Registration failed");
+            });
+
+        var restorer = new PlayerPartyRestorer(
+            objectManager,
+            registryManager.Object,
+            () => Array.Empty<MobileParty>(),
+            _ => party,
+            removedParty =>
+            {
+                Assert.Same(party, removedParty);
+                registrationOrder.Add("cleanup");
+            });
+
+        Assert.False(restorer.TryRestore(player, out var restored));
+
+        Assert.Same(player, restored);
+        Assert.Equal(new[] { "refresh", "cleanup" }, registrationOrder);
+        Assert.False(objectManager.TryGetId(party, out _));
+        Assert.False(objectManager.TryGetId(party.Party, out _));
+        Assert.True(objectManager.TryGetId(hero, out _));
+        Assert.Equal(0, party.MemberRoster.GetTroopCount(hero.CharacterObject));
+        Assert.Null(party.LeaderHero);
+    }
+
+    [Fact]
+    public void TryRestore_ReplacementCleanupThrows_ReturnsOriginalFailure()
+    {
+        var (hero, party, _, _) = CreatePlayerGraph();
+        var player = new Player("Controller", "Hero_Saved", "MobileParty_Missing", "Clan_Saved", "Character_Saved");
+        var objectManager = CreateMissingPartyObjectManager(player, hero);
+        string missingPartyId = string.Empty;
+        objectManager
+            .Setup(manager => manager.TryGetIdWithLogging(party, out missingPartyId))
+            .Returns(false);
+        var cleanupCalled = false;
+
+        var restorer = new PlayerPartyRestorer(
+            objectManager.Object,
+            Mock.Of<IRegistryManager>(),
+            () => Array.Empty<MobileParty>(),
+            _ => party,
+            _ =>
+            {
+                cleanupCalled = true;
+                throw new InvalidOperationException("Cleanup failed");
+            });
+
+        Assert.False(restorer.TryRestore(player, out var restored));
+
+        Assert.Same(player, restored);
+        Assert.True(cleanupCalled);
+        Assert.Equal(0, party.MemberRoster.GetTroopCount(hero.CharacterObject));
+        Assert.Null(party.LeaderHero);
     }
 
     [Fact]
@@ -167,8 +297,10 @@ public class PlayerPartyRestorerTests
 
         var restorer = new PlayerPartyRestorer(
             objectManager.Object,
+            Mock.Of<IRegistryManager>(),
             () => Array.Empty<MobileParty>(),
-            _ => throw new InvalidOperationException("The saved party should be reused"));
+            _ => throw new InvalidOperationException("The saved party should be reused"),
+            _ => throw new InvalidOperationException("The saved party should not be removed"));
 
         Assert.True(restorer.TryRestore(player, out _));
         Assert.Same(party, party.PartyComponent.MobileParty);
@@ -185,8 +317,10 @@ public class PlayerPartyRestorerTests
 
         var restorer = new PlayerPartyRestorer(
             objectManager.Object,
+            Mock.Of<IRegistryManager>(),
             () => new[] { party },
-            _ => null);
+            _ => null,
+            _ => throw new InvalidOperationException("No replacement was created"));
 
         Assert.False(restorer.TryRestore(player, out _));
     }
@@ -218,12 +352,14 @@ public class PlayerPartyRestorerTests
         var createCalled = false;
         var restorer = new PlayerPartyRestorer(
             objectManager.Object,
+            Mock.Of<IRegistryManager>(),
             () => new[] { party },
             _ =>
             {
                 createCalled = true;
                 return null;
-            });
+            },
+            _ => throw new InvalidOperationException("No replacement was created"));
 
         Assert.False(restorer.TryRestore(player, out _));
         Assert.True(createCalled);
@@ -278,5 +414,42 @@ public class PlayerPartyRestorerTests
         objectManager.Setup(manager => manager.TryGetIdWithLogging(hero.Clan, out clanId)).Returns(true);
         objectManager.Setup(manager => manager.TryGetIdWithLogging(hero.CharacterObject, out characterId)).Returns(true);
         return objectManager;
+    }
+
+    private static Mock<IObjectManager> CreateMissingPartyObjectManager(Player player, Hero hero)
+    {
+        var objectManager = new Mock<IObjectManager>();
+        Hero resolvedHero = hero;
+        MobileParty missingParty = null!;
+        string clanId = player.ClanId;
+        string characterId = player.CharacterObjectId;
+        objectManager
+            .Setup(manager => manager.TryGetObjectWithLogging(player.HeroId, out resolvedHero))
+            .Returns(true);
+        objectManager
+            .Setup(manager => manager.TryGetObject(player.MobilePartyId, out missingParty))
+            .Returns(false);
+        objectManager.Setup(manager => manager.TryGetIdWithLogging(hero.Clan, out clanId)).Returns(true);
+        objectManager.Setup(manager => manager.TryGetIdWithLogging(hero.CharacterObject, out characterId)).Returns(true);
+        EnableRegistrationTransactions(objectManager);
+        return objectManager;
+    }
+
+    private static global::GameInterface.Services.ObjectManager.ObjectManager CreateRegisteredPlayerObjectManager(
+        Player player,
+        Hero hero)
+    {
+        var objectManager = new global::GameInterface.Services.ObjectManager.ObjectManager(Mock.Of<ILogger>());
+        Assert.True(objectManager.AddExisting(player.HeroId, hero));
+        Assert.True(objectManager.AddExisting(player.ClanId, hero.Clan));
+        Assert.True(objectManager.AddExisting(player.CharacterObjectId, hero.CharacterObject));
+        return objectManager;
+    }
+
+    private static void EnableRegistrationTransactions(Mock<IObjectManager> objectManager)
+    {
+        objectManager
+            .Setup(manager => manager.RunRegistrationTransaction(It.IsAny<Func<bool>>()))
+            .Returns((Func<bool> registerAndValidate) => registerAndValidate());
     }
 }

--- a/source/GameInterface/Registry/Auto/AutoRegistryBase.cs
+++ b/source/GameInterface/Registry/Auto/AutoRegistryBase.cs
@@ -152,6 +152,9 @@ public abstract class AutoRegistryBase<T> : IAutoRegistry<T> where T : class
         if (idRemapOverride != null && idRemapOverride.TryGetValue(id, out var overrideId))
             id = overrideId;
 
+        if (objectManager.TryGetId(obj, out _))
+            return;
+
         EnsureObjectManagerCounter(id, obj);
 
         objectManager.AddExisting(id, obj);

--- a/source/GameInterface/Registry/RegistryManager.cs
+++ b/source/GameInterface/Registry/RegistryManager.cs
@@ -10,6 +10,7 @@ public interface IRegistryManager
 {
     void PatchLifetimes();
     void RegisterAllGameObjects();
+    void RegisterUntrackedGameObjects();
     void ClearAllRegistries();
 }
 
@@ -42,9 +43,14 @@ internal class RegistryManager : IRegistryManager
 
     public void RegisterAllGameObjects()
     {
-        autoRegistryFactory.RegisterAll();
+        RegisterUntrackedGameObjects();
 
         messageBroker.Publish(this, new AllGameObjectsRegistered());
+    }
+
+    public void RegisterUntrackedGameObjects()
+    {
+        autoRegistryFactory.RegisterAll();
     }
 
     public void ClearAllRegistries()

--- a/source/GameInterface/Registry/RegistryManager.cs
+++ b/source/GameInterface/Registry/RegistryManager.cs
@@ -10,7 +10,6 @@ public interface IRegistryManager
 {
     void PatchLifetimes();
     void RegisterAllGameObjects();
-    void RegisterUntrackedGameObjects();
     void ClearAllRegistries();
 }
 
@@ -43,14 +42,9 @@ internal class RegistryManager : IRegistryManager
 
     public void RegisterAllGameObjects()
     {
-        RegisterUntrackedGameObjects();
+        autoRegistryFactory.RegisterAll();
 
         messageBroker.Publish(this, new AllGameObjectsRegistered());
-    }
-
-    public void RegisterUntrackedGameObjects()
-    {
-        autoRegistryFactory.RegisterAll();
     }
 
     public void ClearAllRegistries()

--- a/source/GameInterface/Services/ObjectManager/ObjectManager.cs
+++ b/source/GameInterface/Services/ObjectManager/ObjectManager.cs
@@ -1,6 +1,7 @@
 ﻿using Serilog;
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using TaleWorlds.ObjectSystem;
 
@@ -58,6 +59,12 @@ public interface IObjectManager
     bool AddNewObject(object obj, out string newId);
 
     /// <summary>
+    /// Retains registrations made by <paramref name="registerAndValidate"/> only when it returns true.
+    /// Registrations added before a false result or exception are removed before control returns to the caller.
+    /// </summary>
+    bool RunRegistrationTransaction(Func<bool> registerAndValidate);
+
+    /// <summary>
     /// Removes an object from the <see cref="IObjectManager"/>
     /// </summary>
     /// <param name="obj">Object to remove</param>
@@ -101,6 +108,29 @@ public class ObjectManager : IObjectManager
     public ObjectManager(ILogger logger)
     {
         this.logger = logger;
+    }
+
+    public bool RunRegistrationTransaction(Func<bool> registerAndValidate)
+    {
+        if (registerAndValidate == null)
+            throw new ArgumentNullException(nameof(registerAndValidate));
+
+        lock (_gate)
+        {
+            var retainedIds = new HashSet<string>(idObjs.Keys, StringComparer.Ordinal);
+            var commit = false;
+
+            try
+            {
+                commit = registerAndValidate();
+                return commit;
+            }
+            finally
+            {
+                if (!commit)
+                    RollBackNewRegistrations(retainedIds);
+            }
+        }
     }
 
     public bool AddExisting(string id, object obj)
@@ -274,6 +304,18 @@ public class ObjectManager : IObjectManager
             if (objsIds.TryGetValue(obj, out var id) == false) return false;
 
             return idObjs.TryRemove(id, out _) && objsIds.Remove(obj);
+        }
+    }
+
+    private void RollBackNewRegistrations(ISet<string> retainedIds)
+    {
+        foreach (var entry in idObjs)
+        {
+            if (retainedIds.Contains(entry.Key))
+                continue;
+
+            if (idObjs.TryRemove(entry.Key, out var registeredObject))
+                objsIds.Remove(registeredObject);
         }
     }
 

--- a/source/GameInterface/Services/Players/PlayerPartyRestorer.cs
+++ b/source/GameInterface/Services/Players/PlayerPartyRestorer.cs
@@ -1,5 +1,5 @@
 ﻿using Common.Logging;
-using GameInterface.Registry;
+using GameInterface.Registry.Auto;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players.Data;
 using Serilog;
@@ -23,28 +23,28 @@ internal class PlayerPartyRestorer : IPlayerPartyRestorer
     private static readonly ILogger Logger = LogManager.GetLogger<PlayerPartyRestorer>();
 
     private readonly IObjectManager objectManager;
-    private readonly IRegistryManager registryManager;
+    private readonly IAutoRegistryFactory autoRegistryFactory;
     private readonly Func<IEnumerable<MobileParty>> getParties;
-    private readonly Func<Hero, MobileParty> createParty;
-    private readonly Action<MobileParty> removeParty;
+    private readonly Func<Hero, MobileParty> createRecoveryParty;
+    private readonly Action<MobileParty> removeRecoveryParty;
 
-    public PlayerPartyRestorer(IObjectManager objectManager, IRegistryManager registryManager)
-        : this(objectManager, registryManager, () => MobileParty.All, CreateReplacementParty, RemoveParty)
+    public PlayerPartyRestorer(IObjectManager objectManager, IAutoRegistryFactory autoRegistryFactory)
+        : this(objectManager, autoRegistryFactory, () => MobileParty.All, CreateRecoveryParty, RemoveParty)
     {
     }
 
     internal PlayerPartyRestorer(
         IObjectManager objectManager,
-        IRegistryManager registryManager,
+        IAutoRegistryFactory autoRegistryFactory,
         Func<IEnumerable<MobileParty>> getParties,
-        Func<Hero, MobileParty> createParty,
-        Action<MobileParty> removeParty)
+        Func<Hero, MobileParty> createRecoveryParty,
+        Action<MobileParty> removeRecoveryParty)
     {
         this.objectManager = objectManager;
-        this.registryManager = registryManager;
+        this.autoRegistryFactory = autoRegistryFactory;
         this.getParties = getParties;
-        this.createParty = createParty;
-        this.removeParty = removeParty;
+        this.createRecoveryParty = createRecoveryParty;
+        this.removeRecoveryParty = removeRecoveryParty;
     }
 
     public bool TryRestore(Player player, out Player restoredPlayer)
@@ -90,7 +90,7 @@ internal class PlayerPartyRestorer : IPlayerPartyRestorer
         string partyId;
         if (party == null)
         {
-            party = createParty(hero);
+            party = createRecoveryParty(hero);
             if (party == null)
             {
                 Logger.Error(
@@ -101,12 +101,12 @@ internal class PlayerPartyRestorer : IPlayerPartyRestorer
             }
 
             Logger.Warning(
-                "Created replacement party {PartyId} for controller {ControllerId} hero {HeroId}",
+                "Created recovery party {PartyId} for controller {ControllerId} hero {HeroId}",
                 party.StringId,
                 player.ControllerId,
                 player.HeroId);
 
-            if (!TryRegisterReplacementParty(player, party, out partyId))
+            if (!TryRegisterRecoveryParty(player, party, out partyId))
                 return false;
         }
         else if (!objectManager.TryGetIdWithLogging(party, out partyId))
@@ -131,7 +131,7 @@ internal class PlayerPartyRestorer : IPlayerPartyRestorer
         return true;
     }
 
-    private bool TryRegisterReplacementParty(Player player, MobileParty party, out string partyId)
+    private bool TryRegisterRecoveryParty(Player player, MobileParty party, out string partyId)
     {
         partyId = null;
 
@@ -140,7 +140,7 @@ internal class PlayerPartyRestorer : IPlayerPartyRestorer
             var registeredPartyId = string.Empty;
             var registered = objectManager.RunRegistrationTransaction(() =>
             {
-                registryManager.RegisterUntrackedGameObjects();
+                autoRegistryFactory.RegisterAll();
                 return objectManager.TryGetIdWithLogging(party, out registeredPartyId);
             });
 
@@ -152,34 +152,34 @@ internal class PlayerPartyRestorer : IPlayerPartyRestorer
         {
             Logger.Error(
                 exception,
-                "Cannot restore player {ControllerId} hero {HeroId}: failed to register replacement party {PartyId}",
+                "Cannot restore player {ControllerId} hero {HeroId}: failed to register recovery party {PartyId}",
                 player.ControllerId,
                 player.HeroId,
                 party.StringId);
-            RemoveFailedReplacement(player, party);
+            RemoveFailedRecoveryParty(player, party);
             return false;
         }
 
         Logger.Error(
-            "Cannot restore player {ControllerId} hero {HeroId}: replacement party {PartyId} was not registered",
+            "Cannot restore player {ControllerId} hero {HeroId}: recovery party {PartyId} was not registered",
             player.ControllerId,
             player.HeroId,
             party.StringId);
-        RemoveFailedReplacement(player, party);
+        RemoveFailedRecoveryParty(player, party);
         return false;
     }
 
-    private void RemoveFailedReplacement(Player player, MobileParty party)
+    private void RemoveFailedRecoveryParty(Player player, MobileParty party)
     {
         try
         {
-            removeParty(party);
+            removeRecoveryParty(party);
         }
         catch (Exception exception)
         {
             Logger.Error(
                 exception,
-                "Failed to remove replacement party {PartyId} after restoration failed for controller {ControllerId} hero {HeroId}",
+                "Failed to remove recovery party {PartyId} after restoration failed for controller {ControllerId} hero {HeroId}",
                 party.StringId,
                 player.ControllerId,
                 player.HeroId);
@@ -239,7 +239,7 @@ internal class PlayerPartyRestorer : IPlayerPartyRestorer
         return party.PartyComponent.MobileParty == party;
     }
 
-    private static MobileParty CreateReplacementParty(Hero hero)
+    private static MobileParty CreateRecoveryParty(Hero hero)
     {
         var position = hero.GetCampaignPosition();
         if (!position.IsValid() && hero.LastKnownClosestSettlement != null)

--- a/source/GameInterface/Services/Players/PlayerPartyRestorer.cs
+++ b/source/GameInterface/Services/Players/PlayerPartyRestorer.cs
@@ -1,4 +1,5 @@
 ﻿using Common.Logging;
+using GameInterface.Registry;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players.Data;
 using Serilog;
@@ -22,22 +23,28 @@ internal class PlayerPartyRestorer : IPlayerPartyRestorer
     private static readonly ILogger Logger = LogManager.GetLogger<PlayerPartyRestorer>();
 
     private readonly IObjectManager objectManager;
+    private readonly IRegistryManager registryManager;
     private readonly Func<IEnumerable<MobileParty>> getParties;
     private readonly Func<Hero, MobileParty> createParty;
+    private readonly Action<MobileParty> removeParty;
 
-    public PlayerPartyRestorer(IObjectManager objectManager)
-        : this(objectManager, () => MobileParty.All, CreateReplacementParty)
+    public PlayerPartyRestorer(IObjectManager objectManager, IRegistryManager registryManager)
+        : this(objectManager, registryManager, () => MobileParty.All, CreateReplacementParty, RemoveParty)
     {
     }
 
     internal PlayerPartyRestorer(
         IObjectManager objectManager,
+        IRegistryManager registryManager,
         Func<IEnumerable<MobileParty>> getParties,
-        Func<Hero, MobileParty> createParty)
+        Func<Hero, MobileParty> createParty,
+        Action<MobileParty> removeParty)
     {
         this.objectManager = objectManager;
+        this.registryManager = registryManager;
         this.getParties = getParties;
         this.createParty = createParty;
+        this.removeParty = removeParty;
     }
 
     public bool TryRestore(Player player, out Player restoredPlayer)
@@ -80,6 +87,7 @@ internal class PlayerPartyRestorer : IPlayerPartyRestorer
             }
         }
 
+        string partyId;
         if (party == null)
         {
             party = createParty(hero);
@@ -97,9 +105,14 @@ internal class PlayerPartyRestorer : IPlayerPartyRestorer
                 party.StringId,
                 player.ControllerId,
                 player.HeroId);
-        }
 
-        if (!objectManager.TryGetIdWithLogging(party, out var partyId)) return false;
+            if (!TryRegisterReplacementParty(player, party, out partyId))
+                return false;
+        }
+        else if (!objectManager.TryGetIdWithLogging(party, out partyId))
+        {
+            return false;
+        }
 
         Restore(hero, party);
 
@@ -116,6 +129,61 @@ internal class PlayerPartyRestorer : IPlayerPartyRestorer
         }
 
         return true;
+    }
+
+    private bool TryRegisterReplacementParty(Player player, MobileParty party, out string partyId)
+    {
+        partyId = null;
+
+        try
+        {
+            var registeredPartyId = string.Empty;
+            var registered = objectManager.RunRegistrationTransaction(() =>
+            {
+                registryManager.RegisterUntrackedGameObjects();
+                return objectManager.TryGetIdWithLogging(party, out registeredPartyId);
+            });
+
+            partyId = registeredPartyId;
+            if (registered)
+                return true;
+        }
+        catch (Exception exception)
+        {
+            Logger.Error(
+                exception,
+                "Cannot restore player {ControllerId} hero {HeroId}: failed to register replacement party {PartyId}",
+                player.ControllerId,
+                player.HeroId,
+                party.StringId);
+            RemoveFailedReplacement(player, party);
+            return false;
+        }
+
+        Logger.Error(
+            "Cannot restore player {ControllerId} hero {HeroId}: replacement party {PartyId} was not registered",
+            player.ControllerId,
+            player.HeroId,
+            party.StringId);
+        RemoveFailedReplacement(player, party);
+        return false;
+    }
+
+    private void RemoveFailedReplacement(Player player, MobileParty party)
+    {
+        try
+        {
+            removeParty(party);
+        }
+        catch (Exception exception)
+        {
+            Logger.Error(
+                exception,
+                "Failed to remove replacement party {PartyId} after restoration failed for controller {ControllerId} hero {HeroId}",
+                party.StringId,
+                player.ControllerId,
+                player.HeroId);
+        }
     }
 
     public void Restore(Hero hero, MobileParty party)
@@ -182,5 +250,10 @@ internal class PlayerPartyRestorer : IPlayerPartyRestorer
         var party = MobileParty.CreateParty($"{hero.StringId}_recovered_{Guid.NewGuid():N}", component);
         party.InitializeMobilePartyAtPosition(position);
         return party;
+    }
+
+    private static void RemoveParty(MobileParty party)
+    {
+        party.RemoveParty();
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

A player reconnecting after their saved party has disappeared can remain stuck on “Finishing synchronization,” and the unusable recovery party left behind can block every later join.

## What is the new behavior?

Reconnecting players now receive a valid recovery party before their state is restored, so synchronization completes; failed recovery removes the incomplete party instead of leaving future joins blocked.

## Bot Changelog Entry

- Fixed reconnecting players getting stuck on “Finishing synchronization” when their saved party no longer exists.
