### PR TITLE
[2845] Decouple clan banners after kingdom abdication

### DIFF
--- a/source/E2E.Tests/Services/Kingdoms/KingdomRulingClanBannerTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/KingdomRulingClanBannerTests.cs
@@ -1,0 +1,80 @@
+﻿using Common;
+using Common.Util;
+using E2E.Tests.Util;
+using GameInterface.Services.Kingdoms.Messages;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using Xunit.Abstractions;
+
+namespace E2E.Tests.Services.Kingdoms;
+
+public class KingdomRulingClanBannerTests : SyncTestBase
+{
+    private readonly string kingdomId;
+    private readonly string outgoingRulerClanId;
+    private readonly string incomingRulerClanId;
+
+    public KingdomRulingClanBannerTests(ITestOutputHelper output) : base(output)
+    {
+        kingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        outgoingRulerClanId = TestEnvironment.CreateRegisteredObject<Clan>();
+        incomingRulerClanId = TestEnvironment.CreateRegisteredObject<Clan>();
+    }
+
+    [Fact]
+    public void Server_RulingClanChanged_DecouplesOutgoingClanBannerFromKingdomBanner()
+    {
+        const string originalBannerCode = "1.2.3.1528.1528.764.764.0.0.0";
+        const string editedBannerCode = "2.3.4.1528.1528.764.764.0.0.0";
+
+        Server.Call(() =>
+        {
+            var kingdom = Server.GetRegisteredObject<Kingdom>(kingdomId);
+            var outgoingRulerClan = Server.GetRegisteredObject<Clan>(outgoingRulerClanId);
+            var incomingRulerClan = Server.GetRegisteredObject<Clan>(incomingRulerClanId);
+            var sharedBanner = new Banner(originalBannerCode);
+
+            using (new AllowedThread())
+            {
+                outgoingRulerClan._kingdom = kingdom;
+                incomingRulerClan._kingdom = kingdom;
+                outgoingRulerClan._banner = sharedBanner;
+                kingdom.Banner = sharedBanner;
+                kingdom._rulingClan = outgoingRulerClan;
+            }
+
+            Assert.Same(outgoingRulerClan.ClanOriginalBanner, kingdom.Banner);
+        });
+
+        Server.SimulateMessage(
+            this,
+            new NetworkRulingClanChanged(kingdomId, incomingRulerClanId));
+
+        Server.Call(() =>
+        {
+            var kingdom = Server.GetRegisteredObject<Kingdom>(kingdomId);
+            var outgoingRulerClan = Server.GetRegisteredObject<Clan>(outgoingRulerClanId);
+            var incomingRulerClan = Server.GetRegisteredObject<Clan>(incomingRulerClanId);
+
+            Assert.Same(incomingRulerClan, kingdom.RulingClan);
+            Assert.Same(kingdom.Banner, incomingRulerClan.Banner);
+            Assert.NotSame(outgoingRulerClan.ClanOriginalBanner, kingdom.Banner);
+            Assert.Equal(originalBannerCode, kingdom.Banner.Serialize());
+            Assert.Equal(originalBannerCode, outgoingRulerClan.ClanOriginalBanner.Serialize());
+
+            kingdom.Banner.Deserialize(editedBannerCode);
+
+            Assert.Equal(editedBannerCode, incomingRulerClan.Banner.Serialize());
+            Assert.Equal(originalBannerCode, outgoingRulerClan.ClanOriginalBanner.Serialize());
+
+            using (new AllowedThread())
+            {
+                outgoingRulerClan._kingdom = null;
+            }
+
+            Assert.Same(outgoingRulerClan.ClanOriginalBanner, outgoingRulerClan.Banner);
+            Assert.NotSame(outgoingRulerClan.Banner, kingdom.Banner);
+            Assert.Equal(originalBannerCode, outgoingRulerClan.Banner.Serialize());
+        });
+    }
+}

--- a/source/GameInterface/Services/Kingdoms/Handlers/KingdomHandler.cs
+++ b/source/GameInterface/Services/Kingdoms/Handlers/KingdomHandler.cs
@@ -554,6 +554,7 @@ public class KingdomHandler : IHandler
             if (!objectManager.TryGetObjectWithLogging<Kingdom>(payload.What.KingdomId, out var kingdom)) return;
             if (!objectManager.TryGetObjectWithLogging<Clan>(payload.What.ClanId, out var clan)) return;
 
+            kingdom.Banner = new Banner(kingdom.Banner);
             ChangeRulingClanAction.Apply(kingdom, clan);
         });
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Abdicating to another clan can leave the former ruler's clan sharing the kingdom banner, so either ruler's banner changes also change the other clan's banner and the link remains after the former ruler leaves the kingdom.

## What is the new behavior?

Resolves #2845

Abdicating preserves the former ruler's clan banner as an independent copy while the incoming ruler continues to use the kingdom banner, so later banner changes stay with the intended clan even after the former ruler leaves.

## Bot Changelog Entry

- Fixed kingdom abdication linking the former and new rulers' clan banners.
