### PR TITLE
[2829] Keep rebel settlement interactions available after rebellion

### DIFF
--- a/source/GameInterface.Tests/Services/Clans/SettlementRebelClanInitializationHandlerTests.cs
+++ b/source/GameInterface.Tests/Services/Clans/SettlementRebelClanInitializationHandlerTests.cs
@@ -6,12 +6,9 @@ using GameInterface.Services.Clans.Handlers;
 using GameInterface.Services.Clans.Messages;
 using GameInterface.Services.Clans.Patches;
 using GameInterface.Services.ObjectManager;
-using GameInterface.Services.Settlements.Patches;
-using HarmonyLib;
 using Moq;
 using System;
 using System.Collections.Generic;
-using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using TaleWorlds.CampaignSystem;
@@ -52,136 +49,6 @@ public class SettlementRebelClanInitializationHandlerTests
             MessageBroker.Instance.Unsubscribe(capture);
         }
 
-        SettlementRebelClanInitialized message = Assert.Single(messages);
-        Assert.Same(clan, message.Clan);
-    }
-
-    [Fact]
-    public void CreateRebelPartyAndClanTranspiler_ReplacesIsNobleSetterWithSnapshotPublisher()
-    {
-        var instructions = new[]
-        {
-            new CodeInstruction(
-                OpCodes.Call,
-                AccessTools.Method(
-                    typeof(Clan),
-                    nameof(Clan.CreateSettlementRebelClan),
-                    new[] { typeof(Settlement), typeof(Hero), typeof(int) })),
-            new CodeInstruction(OpCodes.Nop),
-            new CodeInstruction(OpCodes.Stloc_0),
-            new CodeInstruction(OpCodes.Ldloc_0),
-            new CodeInstruction(OpCodes.Ldc_I4_1),
-            new CodeInstruction(
-                OpCodes.Callvirt,
-                AccessTools.PropertySetter(typeof(Clan), nameof(Clan.IsNoble)))
-        };
-
-        var rewritten = new List<CodeInstruction>(
-            RebellionsCampaignBehaviorPatches.CreateRebelPartyAndClanTranspiler(instructions));
-
-        Assert.Equal(OpCodes.Call, rewritten[5].opcode);
-        Assert.Equal(
-            AccessTools.Method(typeof(RebellionsCampaignBehaviorPatches), nameof(RebellionsCampaignBehaviorPatches.PublishRebelClanIsNoble)),
-            rewritten[5].operand);
-    }
-
-    [Fact]
-    public void CreateRebelPartyAndClanTranspiler_MissingFactorySequence_Throws()
-    {
-        var instructions = new[]
-        {
-            new CodeInstruction(
-                OpCodes.Callvirt,
-                AccessTools.PropertySetter(typeof(Clan), nameof(Clan.IsNoble)))
-        };
-
-        Assert.Throws<InvalidOperationException>(() => new List<CodeInstruction>(
-            RebellionsCampaignBehaviorPatches.CreateRebelPartyAndClanTranspiler(instructions)));
-    }
-
-    [Fact]
-    public void CreateRebelPartyAndClanTranspiler_AmbiguousFactorySequences_Throws()
-    {
-        var instructions = new[]
-        {
-            new CodeInstruction(
-                OpCodes.Call,
-                AccessTools.Method(
-                    typeof(Clan),
-                    nameof(Clan.CreateSettlementRebelClan),
-                    new[] { typeof(Settlement), typeof(Hero), typeof(int) })),
-            new CodeInstruction(OpCodes.Stloc_0),
-            new CodeInstruction(OpCodes.Ldloc_0),
-            new CodeInstruction(OpCodes.Ldc_I4_1),
-            new CodeInstruction(
-                OpCodes.Callvirt,
-                AccessTools.PropertySetter(typeof(Clan), nameof(Clan.IsNoble))),
-            new CodeInstruction(
-                OpCodes.Call,
-                AccessTools.Method(
-                    typeof(Clan),
-                    nameof(Clan.CreateSettlementRebelClan),
-                    new[] { typeof(Settlement), typeof(Hero), typeof(int) })),
-            new CodeInstruction(OpCodes.Stloc_1),
-            new CodeInstruction(OpCodes.Ldloc_1),
-            new CodeInstruction(OpCodes.Ldc_I4_1),
-            new CodeInstruction(
-                OpCodes.Callvirt,
-                AccessTools.PropertySetter(typeof(Clan), nameof(Clan.IsNoble)))
-        };
-
-        Assert.Throws<InvalidOperationException>(() => new List<CodeInstruction>(
-            RebellionsCampaignBehaviorPatches.CreateRebelPartyAndClanTranspiler(instructions)));
-    }
-
-    [Fact]
-    public void CreateRebelPartyAndClanTranspiler_AmbiguousIsNobleSetters_Throws()
-    {
-        var instructions = new[]
-        {
-            new CodeInstruction(
-                OpCodes.Call,
-                AccessTools.Method(
-                    typeof(Clan),
-                    nameof(Clan.CreateSettlementRebelClan),
-                    new[] { typeof(Settlement), typeof(Hero), typeof(int) })),
-            new CodeInstruction(OpCodes.Ldloc_0),
-            new CodeInstruction(OpCodes.Ldc_I4_1),
-            new CodeInstruction(
-                OpCodes.Callvirt,
-                AccessTools.PropertySetter(typeof(Clan), nameof(Clan.IsNoble))),
-            new CodeInstruction(OpCodes.Ldloc_1),
-            new CodeInstruction(OpCodes.Ldc_I4_1),
-            new CodeInstruction(
-                OpCodes.Callvirt,
-                AccessTools.PropertySetter(typeof(Clan), nameof(Clan.IsNoble)))
-        };
-
-        Assert.Throws<InvalidOperationException>(() => new List<CodeInstruction>(
-            RebellionsCampaignBehaviorPatches.CreateRebelPartyAndClanTranspiler(instructions)));
-    }
-
-    [Fact]
-    public void PublishRebelClanIsNoble_Server_SetsAndPublishesCompletedClan()
-    {
-        var clan = ObjectHelper.SkipConstructor<Clan>();
-        var messages = new List<SettlementRebelClanInitialized>();
-        Action<MessagePayload<SettlementRebelClanInitialized>> capture = payload => messages.Add(payload.What);
-        bool wasServer = ModInformation.IsServer;
-
-        MessageBroker.Instance.Subscribe(capture);
-        ModInformation.IsServer = true;
-        try
-        {
-            RebellionsCampaignBehaviorPatches.PublishRebelClanIsNoble(clan, true);
-        }
-        finally
-        {
-            ModInformation.IsServer = wasServer;
-            MessageBroker.Instance.Unsubscribe(capture);
-        }
-
-        Assert.True(clan.IsNoble);
         SettlementRebelClanInitialized message = Assert.Single(messages);
         Assert.Same(clan, message.Clan);
     }

--- a/source/GameInterface.Tests/Services/Clans/SettlementRebelClanInitializationHandlerTests.cs
+++ b/source/GameInterface.Tests/Services/Clans/SettlementRebelClanInitializationHandlerTests.cs
@@ -6,9 +6,12 @@ using GameInterface.Services.Clans.Handlers;
 using GameInterface.Services.Clans.Messages;
 using GameInterface.Services.Clans.Patches;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Settlements.Patches;
+using HarmonyLib;
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using TaleWorlds.CampaignSystem;
@@ -30,7 +33,7 @@ public class SettlementRebelClanInitializationHandlerTests
     }
 
     [Fact]
-    public void CreateSettlementRebelClanPostfix_Server_PublishesCompletedClan()
+    public void CreateSettlementRebelClanPostfix_Server_PublishesFactorySnapshot()
     {
         var clan = ObjectHelper.SkipConstructor<Clan>();
         var messages = new List<SettlementRebelClanInitialized>();
@@ -49,6 +52,108 @@ public class SettlementRebelClanInitializationHandlerTests
             MessageBroker.Instance.Unsubscribe(capture);
         }
 
+        SettlementRebelClanInitialized message = Assert.Single(messages);
+        Assert.Same(clan, message.Clan);
+    }
+
+    [Fact]
+    public void CreateRebelPartyAndClanTranspiler_ReplacesIsNobleSetterWithSnapshotPublisher()
+    {
+        var instructions = new[]
+        {
+            new CodeInstruction(
+                OpCodes.Call,
+                AccessTools.Method(
+                    typeof(Clan),
+                    nameof(Clan.CreateSettlementRebelClan),
+                    new[] { typeof(Settlement), typeof(Hero), typeof(int) })),
+            new CodeInstruction(OpCodes.Stloc_0),
+            new CodeInstruction(OpCodes.Ldloc_0),
+            new CodeInstruction(OpCodes.Ldc_I4_1),
+            new CodeInstruction(
+                OpCodes.Callvirt,
+                AccessTools.PropertySetter(typeof(Clan), nameof(Clan.IsNoble)))
+        };
+
+        var rewritten = new List<CodeInstruction>(
+            RebellionsCampaignBehaviorPatches.CreateRebelPartyAndClanTranspiler(instructions));
+
+        Assert.Equal(OpCodes.Call, rewritten[4].opcode);
+        Assert.Equal(
+            AccessTools.Method(typeof(RebellionsCampaignBehaviorPatches), nameof(RebellionsCampaignBehaviorPatches.PublishRebelClanIsNoble)),
+            rewritten[4].operand);
+    }
+
+    [Fact]
+    public void CreateRebelPartyAndClanTranspiler_MissingFactorySequence_Throws()
+    {
+        var instructions = new[]
+        {
+            new CodeInstruction(
+                OpCodes.Callvirt,
+                AccessTools.PropertySetter(typeof(Clan), nameof(Clan.IsNoble)))
+        };
+
+        Assert.Throws<InvalidOperationException>(() => new List<CodeInstruction>(
+            RebellionsCampaignBehaviorPatches.CreateRebelPartyAndClanTranspiler(instructions)));
+    }
+
+    [Fact]
+    public void CreateRebelPartyAndClanTranspiler_AmbiguousFactorySequences_Throws()
+    {
+        var instructions = new[]
+        {
+            new CodeInstruction(
+                OpCodes.Call,
+                AccessTools.Method(
+                    typeof(Clan),
+                    nameof(Clan.CreateSettlementRebelClan),
+                    new[] { typeof(Settlement), typeof(Hero), typeof(int) })),
+            new CodeInstruction(OpCodes.Stloc_0),
+            new CodeInstruction(OpCodes.Ldloc_0),
+            new CodeInstruction(OpCodes.Ldc_I4_1),
+            new CodeInstruction(
+                OpCodes.Callvirt,
+                AccessTools.PropertySetter(typeof(Clan), nameof(Clan.IsNoble))),
+            new CodeInstruction(
+                OpCodes.Call,
+                AccessTools.Method(
+                    typeof(Clan),
+                    nameof(Clan.CreateSettlementRebelClan),
+                    new[] { typeof(Settlement), typeof(Hero), typeof(int) })),
+            new CodeInstruction(OpCodes.Stloc_1),
+            new CodeInstruction(OpCodes.Ldloc_1),
+            new CodeInstruction(OpCodes.Ldc_I4_1),
+            new CodeInstruction(
+                OpCodes.Callvirt,
+                AccessTools.PropertySetter(typeof(Clan), nameof(Clan.IsNoble)))
+        };
+
+        Assert.Throws<InvalidOperationException>(() => new List<CodeInstruction>(
+            RebellionsCampaignBehaviorPatches.CreateRebelPartyAndClanTranspiler(instructions)));
+    }
+
+    [Fact]
+    public void PublishRebelClanIsNoble_Server_SetsAndPublishesCompletedClan()
+    {
+        var clan = ObjectHelper.SkipConstructor<Clan>();
+        var messages = new List<SettlementRebelClanInitialized>();
+        Action<MessagePayload<SettlementRebelClanInitialized>> capture = payload => messages.Add(payload.What);
+        bool wasServer = ModInformation.IsServer;
+
+        MessageBroker.Instance.Subscribe(capture);
+        ModInformation.IsServer = true;
+        try
+        {
+            RebellionsCampaignBehaviorPatches.PublishRebelClanIsNoble(clan, true);
+        }
+        finally
+        {
+            ModInformation.IsServer = wasServer;
+            MessageBroker.Instance.Unsubscribe(capture);
+        }
+
+        Assert.True(clan.IsNoble);
         SettlementRebelClanInitialized message = Assert.Single(messages);
         Assert.Same(clan, message.Clan);
     }
@@ -74,6 +179,7 @@ public class SettlementRebelClanInitializationHandlerTests
         clan.BannerBackgroundColorSecondary = 14;
         clan.BannerIconColor = 15;
         clan.IsRebelClan = true;
+        clan.IsNoble = true;
 
         var messageBroker = new Mock<IMessageBroker>();
         ServerMessageHandler serverHandler = null!;
@@ -116,6 +222,7 @@ public class SettlementRebelClanInitializationHandlerTests
         Assert.Equal(14u, message.BannerBackgroundColorSecondary);
         Assert.Equal(15u, message.BannerIconColor);
         Assert.True(message.IsRebelClan);
+        Assert.True(message.IsNoble);
     }
 
     [Fact]
@@ -157,6 +264,7 @@ public class SettlementRebelClanInitializationHandlerTests
             13,
             14,
             15,
+            true,
             true);
 
         Assert.NotNull(networkHandler);
@@ -175,6 +283,7 @@ public class SettlementRebelClanInitializationHandlerTests
         Assert.Equal(14u, clan.BannerBackgroundColorSecondary);
         Assert.Equal(15u, clan.BannerIconColor);
         Assert.True(clan.IsRebelClan);
+        Assert.True(clan.IsNoble);
         Assert.True(clan._distanceToClosestNonAllyFortificationCacheDirty);
     }
 

--- a/source/GameInterface.Tests/Services/Clans/SettlementRebelClanInitializationHandlerTests.cs
+++ b/source/GameInterface.Tests/Services/Clans/SettlementRebelClanInitializationHandlerTests.cs
@@ -1,0 +1,199 @@
+﻿using Common;
+using Common.Messaging;
+using Common.Network;
+using Common.Util;
+using GameInterface.Services.Clans.Handlers;
+using GameInterface.Services.Clans.Messages;
+using GameInterface.Services.Clans.Patches;
+using GameInterface.Services.ObjectManager;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
+using Xunit;
+using NetworkMessageHandler = System.Action<Common.Messaging.MessagePayload<GameInterface.Services.Clans.Messages.NetworkInitializeSettlementRebelClan>>;
+using ServerMessageHandler = System.Action<Common.Messaging.MessagePayload<GameInterface.Services.Clans.Messages.SettlementRebelClanInitialized>>;
+
+namespace GameInterface.Tests.Services.Clans;
+
+[Collection(ModInformationRoleCollection.Name)]
+public class SettlementRebelClanInitializationHandlerTests
+{
+    static SettlementRebelClanInitializationHandlerTests()
+    {
+        RuntimeHelpers.RunModuleConstructor(typeof(Coop.Tests.Mocks.TestNetwork).Module.ModuleHandle);
+    }
+
+    [Fact]
+    public void CreateSettlementRebelClanPostfix_Server_PublishesCompletedClan()
+    {
+        var clan = ObjectHelper.SkipConstructor<Clan>();
+        var messages = new List<SettlementRebelClanInitialized>();
+        Action<MessagePayload<SettlementRebelClanInitialized>> capture = payload => messages.Add(payload.What);
+        bool wasServer = ModInformation.IsServer;
+
+        MessageBroker.Instance.Subscribe(capture);
+        ModInformation.IsServer = true;
+        try
+        {
+            ClanPatches.CreateSettlementRebelClanPostfix(clan);
+        }
+        finally
+        {
+            ModInformation.IsServer = wasServer;
+            MessageBroker.Instance.Unsubscribe(capture);
+        }
+
+        SettlementRebelClanInitialized message = Assert.Single(messages);
+        Assert.Same(clan, message.Clan);
+    }
+
+    [Fact]
+    public void CompletedRebelClan_Server_SendsFactoryFieldSnapshot()
+    {
+        var clan = ObjectHelper.SkipConstructor<Clan>();
+        var culture = ObjectHelper.SkipConstructor<CultureObject>();
+        var leader = ObjectHelper.SkipConstructor<Hero>();
+        var settlement = ObjectHelper.SkipConstructor<Settlement>();
+        var banner = CreateBanner();
+
+        clan.Culture = culture;
+        clan._leader = leader;
+        clan._banner = banner;
+        clan._tier = 3;
+        clan.InitialHomeSettlement = settlement;
+        clan._home = settlement;
+        clan.Color = 11;
+        clan.Color2 = 12;
+        clan.BannerBackgroundColorPrimary = 13;
+        clan.BannerBackgroundColorSecondary = 14;
+        clan.BannerIconColor = 15;
+        clan.IsRebelClan = true;
+
+        var messageBroker = new Mock<IMessageBroker>();
+        ServerMessageHandler serverHandler = null!;
+        messageBroker
+            .Setup(b => b.Subscribe(It.IsAny<ServerMessageHandler>()))
+            .Callback<ServerMessageHandler>(handler => serverHandler = handler);
+
+        var objectManager = new Mock<IObjectManager>();
+        SetupId(objectManager, clan, "clan-1");
+        SetupId(objectManager, culture, "culture-1");
+        SetupId(objectManager, leader, "hero-1");
+        SetupId(objectManager, settlement, "settlement-1");
+
+        IMessage sentMessage = null!;
+        var network = new Mock<INetwork>();
+        network.Setup(n => n.SendAll(It.IsAny<IMessage>()))
+            .Callback<IMessage>(message => sentMessage = message);
+
+        using var handler = new SettlementRebelClanInitializationHandler(
+            messageBroker.Object,
+            objectManager.Object,
+            network.Object);
+
+        Assert.NotNull(serverHandler);
+        serverHandler(new MessagePayload<SettlementRebelClanInitialized>(
+            this,
+            new SettlementRebelClanInitialized(clan)));
+
+        var message = Assert.IsType<NetworkInitializeSettlementRebelClan>(sentMessage);
+        Assert.Equal("clan-1", message.ClanId);
+        Assert.Equal("culture-1", message.CultureId);
+        Assert.Equal("hero-1", message.LeaderId);
+        Assert.Equal("settlement-1", message.InitialHomeSettlementId);
+        Assert.Equal("settlement-1", message.HomeSettlementId);
+        Assert.Equal(banner.Serialize(), message.BannerCode);
+        Assert.Equal(3, message.Tier);
+        Assert.Equal(11u, message.Color);
+        Assert.Equal(12u, message.Color2);
+        Assert.Equal(13u, message.BannerBackgroundColorPrimary);
+        Assert.Equal(14u, message.BannerBackgroundColorSecondary);
+        Assert.Equal(15u, message.BannerIconColor);
+        Assert.True(message.IsRebelClan);
+    }
+
+    [Fact]
+    public void RebelClanSnapshot_Client_AppliesCompleteFactoryState()
+    {
+        var clan = (Clan)FormatterServices.GetUninitializedObject(typeof(Clan));
+        var culture = (CultureObject)FormatterServices.GetUninitializedObject(typeof(CultureObject));
+        var leader = (Hero)FormatterServices.GetUninitializedObject(typeof(Hero));
+        var settlement = (Settlement)FormatterServices.GetUninitializedObject(typeof(Settlement));
+        string bannerCode = CreateBanner().Serialize();
+
+        var messageBroker = new Mock<IMessageBroker>();
+        NetworkMessageHandler networkHandler = null!;
+        messageBroker
+            .Setup(b => b.Subscribe(It.IsAny<NetworkMessageHandler>()))
+            .Callback<NetworkMessageHandler>(handler => networkHandler = handler);
+
+        var objectManager = new Mock<IObjectManager>();
+        SetupObject(objectManager, "clan-1", clan);
+        SetupObject(objectManager, "culture-1", culture);
+        SetupObject(objectManager, "hero-1", leader);
+        SetupObject(objectManager, "settlement-1", settlement);
+
+        using var handler = new SettlementRebelClanInitializationHandler(
+            messageBroker.Object,
+            objectManager.Object,
+            new Mock<INetwork>().Object);
+
+        var message = new NetworkInitializeSettlementRebelClan(
+            "clan-1",
+            "culture-1",
+            "hero-1",
+            "settlement-1",
+            "settlement-1",
+            bannerCode,
+            3,
+            11,
+            12,
+            13,
+            14,
+            15,
+            true);
+
+        Assert.NotNull(networkHandler);
+        networkHandler(new MessagePayload<NetworkInitializeSettlementRebelClan>(this, message));
+        GameThread.Run(() => { }, blocking: true);
+
+        Assert.Same(culture, clan.Culture);
+        Assert.Same(leader, clan.Leader);
+        Assert.Equal(bannerCode, clan.Banner.Serialize());
+        Assert.Equal(3, clan.Tier);
+        Assert.Same(settlement, clan.InitialHomeSettlement);
+        Assert.Same(settlement, clan.HomeSettlement);
+        Assert.Equal(11u, clan.Color);
+        Assert.Equal(12u, clan.Color2);
+        Assert.Equal(13u, clan.BannerBackgroundColorPrimary);
+        Assert.Equal(14u, clan.BannerBackgroundColorSecondary);
+        Assert.Equal(15u, clan.BannerIconColor);
+        Assert.True(clan.IsRebelClan);
+        Assert.True(clan._distanceToClosestNonAllyFortificationCacheDirty);
+    }
+
+    private static Banner CreateBanner()
+    {
+        var banner = new Banner();
+        banner.BannerDataList.Add(new BannerData(1, 2, 3, Vec2.One, Vec2.Zero, true, true, 0f));
+        return banner;
+    }
+
+    private static void SetupId<T>(Mock<IObjectManager> objectManager, T instance, string id)
+        where T : class
+    {
+        objectManager.Setup(manager => manager.TryGetIdWithLogging(instance, out id)).Returns(true);
+    }
+
+    private static void SetupObject<T>(Mock<IObjectManager> objectManager, string id, T instance)
+        where T : class
+    {
+        objectManager.Setup(manager => manager.TryGetObjectWithLogging(id, out instance)).Returns(true);
+    }
+}

--- a/source/GameInterface.Tests/Services/Clans/SettlementRebelClanInitializationHandlerTests.cs
+++ b/source/GameInterface.Tests/Services/Clans/SettlementRebelClanInitializationHandlerTests.cs
@@ -67,6 +67,7 @@ public class SettlementRebelClanInitializationHandlerTests
                     typeof(Clan),
                     nameof(Clan.CreateSettlementRebelClan),
                     new[] { typeof(Settlement), typeof(Hero), typeof(int) })),
+            new CodeInstruction(OpCodes.Nop),
             new CodeInstruction(OpCodes.Stloc_0),
             new CodeInstruction(OpCodes.Ldloc_0),
             new CodeInstruction(OpCodes.Ldc_I4_1),
@@ -78,10 +79,10 @@ public class SettlementRebelClanInitializationHandlerTests
         var rewritten = new List<CodeInstruction>(
             RebellionsCampaignBehaviorPatches.CreateRebelPartyAndClanTranspiler(instructions));
 
-        Assert.Equal(OpCodes.Call, rewritten[4].opcode);
+        Assert.Equal(OpCodes.Call, rewritten[5].opcode);
         Assert.Equal(
             AccessTools.Method(typeof(RebellionsCampaignBehaviorPatches), nameof(RebellionsCampaignBehaviorPatches.PublishRebelClanIsNoble)),
-            rewritten[4].operand);
+            rewritten[5].operand);
     }
 
     [Fact]
@@ -122,6 +123,33 @@ public class SettlementRebelClanInitializationHandlerTests
                     nameof(Clan.CreateSettlementRebelClan),
                     new[] { typeof(Settlement), typeof(Hero), typeof(int) })),
             new CodeInstruction(OpCodes.Stloc_1),
+            new CodeInstruction(OpCodes.Ldloc_1),
+            new CodeInstruction(OpCodes.Ldc_I4_1),
+            new CodeInstruction(
+                OpCodes.Callvirt,
+                AccessTools.PropertySetter(typeof(Clan), nameof(Clan.IsNoble)))
+        };
+
+        Assert.Throws<InvalidOperationException>(() => new List<CodeInstruction>(
+            RebellionsCampaignBehaviorPatches.CreateRebelPartyAndClanTranspiler(instructions)));
+    }
+
+    [Fact]
+    public void CreateRebelPartyAndClanTranspiler_AmbiguousIsNobleSetters_Throws()
+    {
+        var instructions = new[]
+        {
+            new CodeInstruction(
+                OpCodes.Call,
+                AccessTools.Method(
+                    typeof(Clan),
+                    nameof(Clan.CreateSettlementRebelClan),
+                    new[] { typeof(Settlement), typeof(Hero), typeof(int) })),
+            new CodeInstruction(OpCodes.Ldloc_0),
+            new CodeInstruction(OpCodes.Ldc_I4_1),
+            new CodeInstruction(
+                OpCodes.Callvirt,
+                AccessTools.PropertySetter(typeof(Clan), nameof(Clan.IsNoble))),
             new CodeInstruction(OpCodes.Ldloc_1),
             new CodeInstruction(OpCodes.Ldc_I4_1),
             new CodeInstruction(

--- a/source/GameInterface.Tests/Services/Settlements/ChangeOwnerOfSettlementPatchTests.cs
+++ b/source/GameInterface.Tests/Services/Settlements/ChangeOwnerOfSettlementPatchTests.cs
@@ -1,0 +1,82 @@
+﻿using Autofac;
+using Common;
+using Common.Messaging;
+using Common.Util;
+using GameInterface.Policies;
+using GameInterface.Services.Clans.Messages;
+using GameInterface.Services.Settlements.Messages;
+using GameInterface.Services.Settlements.Patches;
+using System;
+using System.Collections.Generic;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Actions;
+using TaleWorlds.CampaignSystem.Settlements;
+using Xunit;
+
+namespace GameInterface.Tests.Services.Settlements;
+
+[Collection(ModInformationRoleCollection.Name)]
+public class ChangeOwnerOfSettlementPatchTests
+{
+    [Fact]
+    public void RebellionOwnership_Server_PublishesCompletedClanBeforeOwnershipChange()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterInstance(new TestSyncPolicy()).As<ISyncPolicy>();
+        using var container = builder.Build();
+
+        var clan = ObjectHelper.SkipConstructor<Clan>();
+        var newOwner = ObjectHelper.SkipConstructor<Hero>();
+        newOwner._clan = clan;
+        newOwner.StringId = "hero-1";
+        var settlement = ObjectHelper.SkipConstructor<Settlement>();
+        settlement.StringId = "town-1";
+
+        var publishedTypes = new List<Type>();
+        Action<MessagePayload<SettlementRebelClanInitialized>> clanCapture = payload => publishedTypes.Add(payload.What.GetType());
+        Action<MessagePayload<SettlementOwnershipChanged>> ownershipCapture = payload => publishedTypes.Add(payload.What.GetType());
+        MessageBroker.Instance.Subscribe(clanCapture);
+        MessageBroker.Instance.Subscribe(ownershipCapture);
+
+        bool wasServer = ModInformation.IsServer;
+        bool hadPreviousContainer = ContainerProvider.TryGetContainer(out var previousContainer);
+        try
+        {
+            ModInformation.IsServer = true;
+            using (ContainerProvider.UseContainerThreadSafe(container))
+            {
+                bool runOriginal = ChangeOwnerOfSettlementPatch.Prefix(
+                    settlement,
+                    newOwner,
+                    null,
+                    ChangeOwnerOfSettlementAction.ChangeOwnerOfSettlementDetail.ByRebellion);
+
+                Assert.True(runOriginal);
+            }
+        }
+        finally
+        {
+            ModInformation.IsServer = wasServer;
+            MessageBroker.Instance.Unsubscribe(clanCapture);
+            MessageBroker.Instance.Unsubscribe(ownershipCapture);
+
+            if (hadPreviousContainer)
+            {
+                ContainerProvider.SetContainer(previousContainer);
+            }
+            else
+            {
+                ContainerProvider.Clear();
+            }
+        }
+
+        Assert.Equal(
+            new[] { typeof(SettlementRebelClanInitialized), typeof(SettlementOwnershipChanged) },
+            publishedTypes);
+    }
+
+    private sealed class TestSyncPolicy : ISyncPolicy
+    {
+        public bool AllowOriginal() => false;
+    }
+}

--- a/source/GameInterface.Tests/Services/Settlements/SettlementOwnershipHandlerThreadingTests.cs
+++ b/source/GameInterface.Tests/Services/Settlements/SettlementOwnershipHandlerThreadingTests.cs
@@ -1,0 +1,90 @@
+﻿using Common;
+using Common.Messaging;
+using Common.Network;
+using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Settlements.Handlers;
+using GameInterface.Services.Settlements.Messages;
+using Moq;
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
+using System.Threading;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Settlements;
+using Xunit;
+using SettlementOwnershipMessageHandler = System.Action<Common.Messaging.MessagePayload<GameInterface.Services.Settlements.Messages.NetworkChangeSettlementOwnership>>;
+
+namespace GameInterface.Tests.Services.Settlements;
+
+public class SettlementOwnershipHandlerThreadingTests
+{
+    static SettlementOwnershipHandlerThreadingTests()
+    {
+        RuntimeHelpers.RunModuleConstructor(typeof(Coop.Tests.Mocks.TestNetwork).Module.ModuleHandle);
+    }
+
+    [Fact]
+    public void NetworkOwnershipChange_PublishedWhileOwnerCreationIsQueued_LooksUpOwnerAfterTheQueueDrains()
+    {
+        Assert.True(GameThread.Instance.IsInitialized, "game-loop pump was not initialized");
+
+        var settlement = (Settlement)FormatterServices.GetUninitializedObject(typeof(Settlement));
+        Hero owner = null!;
+        bool ownerRegistered = false;
+        bool lookupSawRegisteredOwner = false;
+        var ownerLookupCompleted = new ManualResetEventSlim(false);
+
+        var objectManager = new Mock<IObjectManager>();
+        objectManager
+            .Setup(o => o.TryGetObjectWithLogging("town-1", out settlement))
+            .Returns(true);
+        objectManager
+            .Setup(o => o.TryGetObjectWithLogging("hero-1", out owner))
+            .Returns(() =>
+            {
+                lookupSawRegisteredOwner = Volatile.Read(ref ownerRegistered);
+                ownerLookupCompleted.Set();
+                return false;
+            });
+
+        SettlementOwnershipMessageHandler subscriber = null!;
+        var messageBroker = new Mock<IMessageBroker>();
+        messageBroker
+            .Setup(b => b.Subscribe(It.IsAny<SettlementOwnershipMessageHandler>()))
+            .Callback<SettlementOwnershipMessageHandler>(s => subscriber = s);
+
+        using var handler = new SettlementOwnershipHandler(
+            messageBroker.Object,
+            objectManager.Object,
+            new Mock<INetwork>().Object);
+        Assert.NotNull(subscriber);
+
+        var releasePump = new ManualResetEventSlim(false);
+        var pumpBlocked = new ManualResetEventSlim(false);
+        try
+        {
+            GameThread.RunSafe(() =>
+            {
+                pumpBlocked.Set();
+                releasePump.Wait(TimeSpan.FromSeconds(30));
+            });
+            Assert.True(pumpBlocked.Wait(TimeSpan.FromSeconds(10)), "the pump never reached the blocker");
+
+            GameThread.EnqueueSafe(() => Volatile.Write(ref ownerRegistered, true));
+            subscriber(new MessagePayload<NetworkChangeSettlementOwnership>(
+                this,
+                new NetworkChangeSettlementOwnership("town-1", "hero-1", null, 0)));
+
+            Assert.False(ownerLookupCompleted.IsSet);
+        }
+        finally
+        {
+            releasePump.Set();
+        }
+
+        Assert.True(ownerLookupCompleted.Wait(TimeSpan.FromSeconds(10)), "the owner lookup was not drained");
+        Assert.True(lookupSawRegisteredOwner, "the owner lookup overtook its queued creation");
+        objectManager.Verify(o => o.TryGetObject(It.IsAny<string>(), out It.Ref<Settlement>.IsAny), Times.Never);
+        objectManager.Verify(o => o.TryGetObject(It.IsAny<string>(), out It.Ref<Hero>.IsAny), Times.Never);
+    }
+}

--- a/source/GameInterface/Services/Clans/Handlers/SettlementRebelClanInitializationHandler.cs
+++ b/source/GameInterface/Services/Clans/Handlers/SettlementRebelClanInitializationHandler.cs
@@ -1,0 +1,94 @@
+﻿using Common;
+using Common.Messaging;
+using Common.Network;
+using Common.Util;
+using GameInterface.Services.Clans.Messages;
+using GameInterface.Services.ObjectManager;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.Core;
+
+namespace GameInterface.Services.Clans.Handlers;
+
+internal sealed class SettlementRebelClanInitializationHandler : IHandler
+{
+    private readonly IMessageBroker messageBroker;
+    private readonly IObjectManager objectManager;
+    private readonly INetwork network;
+
+    public SettlementRebelClanInitializationHandler(
+        IMessageBroker messageBroker,
+        IObjectManager objectManager,
+        INetwork network)
+    {
+        this.messageBroker = messageBroker;
+        this.objectManager = objectManager;
+        this.network = network;
+
+        messageBroker.Subscribe<SettlementRebelClanInitialized>(Handle);
+        messageBroker.Subscribe<NetworkInitializeSettlementRebelClan>(Handle);
+    }
+
+    public void Dispose()
+    {
+        messageBroker.Unsubscribe<SettlementRebelClanInitialized>(Handle);
+        messageBroker.Unsubscribe<NetworkInitializeSettlementRebelClan>(Handle);
+    }
+
+    private void Handle(MessagePayload<SettlementRebelClanInitialized> payload)
+    {
+        Clan clan = payload.What.Clan;
+
+        if (!objectManager.TryGetIdWithLogging(clan, out string clanId)) return;
+        if (!objectManager.TryGetIdWithLogging(clan.Culture, out string cultureId)) return;
+        if (!objectManager.TryGetIdWithLogging(clan.Leader, out string leaderId)) return;
+        if (!objectManager.TryGetIdWithLogging(clan.InitialHomeSettlement, out string initialHomeSettlementId)) return;
+        if (!objectManager.TryGetIdWithLogging(clan.HomeSettlement, out string homeSettlementId)) return;
+
+        network.SendAll(new NetworkInitializeSettlementRebelClan(
+            clanId,
+            cultureId,
+            leaderId,
+            initialHomeSettlementId,
+            homeSettlementId,
+            clan.Banner?.Serialize(),
+            clan.Tier,
+            clan.Color,
+            clan.Color2,
+            clan.BannerBackgroundColorPrimary,
+            clan.BannerBackgroundColorSecondary,
+            clan.BannerIconColor,
+            clan.IsRebelClan));
+    }
+
+    private void Handle(MessagePayload<NetworkInitializeSettlementRebelClan> payload)
+    {
+        NetworkInitializeSettlementRebelClan data = payload.What;
+
+        GameThread.RunSafe(() =>
+        {
+            if (!objectManager.TryGetObjectWithLogging(data.ClanId, out Clan clan)) return;
+            if (!objectManager.TryGetObjectWithLogging(data.CultureId, out CultureObject culture)) return;
+            if (!objectManager.TryGetObjectWithLogging(data.LeaderId, out Hero leader)) return;
+            if (!objectManager.TryGetObjectWithLogging(data.InitialHomeSettlementId, out Settlement initialHomeSettlement)) return;
+            if (!objectManager.TryGetObjectWithLogging(data.HomeSettlementId, out Settlement homeSettlement)) return;
+
+            using (new AllowedThread())
+            {
+                clan.Culture = culture;
+                clan._leader = leader;
+                clan._banner = data.BannerCode == null ? null : new Banner(data.BannerCode);
+                clan._tier = data.Tier;
+                clan.InitialHomeSettlement = initialHomeSettlement;
+                clan._home = homeSettlement;
+                clan.Color = data.Color;
+                clan.Color2 = data.Color2;
+                clan.BannerBackgroundColorPrimary = data.BannerBackgroundColorPrimary;
+                clan.BannerBackgroundColorSecondary = data.BannerBackgroundColorSecondary;
+                clan.BannerIconColor = data.BannerIconColor;
+                clan.IsRebelClan = data.IsRebelClan;
+                clan._distanceToClosestNonAllyFortificationCacheDirty = true;
+            }
+        }, context: nameof(NetworkInitializeSettlementRebelClan));
+    }
+}

--- a/source/GameInterface/Services/Clans/Handlers/SettlementRebelClanInitializationHandler.cs
+++ b/source/GameInterface/Services/Clans/Handlers/SettlementRebelClanInitializationHandler.cs
@@ -58,7 +58,8 @@ internal sealed class SettlementRebelClanInitializationHandler : IHandler
             clan.BannerBackgroundColorPrimary,
             clan.BannerBackgroundColorSecondary,
             clan.BannerIconColor,
-            clan.IsRebelClan));
+            clan.IsRebelClan,
+            clan.IsNoble));
     }
 
     private void Handle(MessagePayload<NetworkInitializeSettlementRebelClan> payload)
@@ -87,6 +88,7 @@ internal sealed class SettlementRebelClanInitializationHandler : IHandler
                 clan.BannerBackgroundColorSecondary = data.BannerBackgroundColorSecondary;
                 clan.BannerIconColor = data.BannerIconColor;
                 clan.IsRebelClan = data.IsRebelClan;
+                clan.IsNoble = data.IsNoble;
                 clan._distanceToClosestNonAllyFortificationCacheDirty = true;
             }
         }, context: nameof(NetworkInitializeSettlementRebelClan));

--- a/source/GameInterface/Services/Clans/Messages/SettlementRebelClanInitializationMessages.cs
+++ b/source/GameInterface/Services/Clans/Messages/SettlementRebelClanInitializationMessages.cs
@@ -1,0 +1,88 @@
+﻿using Common.Messaging;
+using ProtoBuf;
+using TaleWorlds.CampaignSystem;
+
+namespace GameInterface.Services.Clans.Messages;
+
+internal readonly struct SettlementRebelClanInitialized : IEvent
+{
+    public Clan Clan { get; }
+
+    public SettlementRebelClanInitialized(Clan clan)
+    {
+        Clan = clan;
+    }
+}
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkInitializeSettlementRebelClan : ICommand
+{
+    [ProtoMember(1)]
+    public string ClanId { get; }
+
+    [ProtoMember(2)]
+    public string CultureId { get; }
+
+    [ProtoMember(3)]
+    public string LeaderId { get; }
+
+    [ProtoMember(4)]
+    public string InitialHomeSettlementId { get; }
+
+    [ProtoMember(5)]
+    public string HomeSettlementId { get; }
+
+    [ProtoMember(6)]
+    public string BannerCode { get; }
+
+    [ProtoMember(7)]
+    public int Tier { get; }
+
+    [ProtoMember(8)]
+    public uint Color { get; }
+
+    [ProtoMember(9)]
+    public uint Color2 { get; }
+
+    [ProtoMember(10)]
+    public uint BannerBackgroundColorPrimary { get; }
+
+    [ProtoMember(11)]
+    public uint BannerBackgroundColorSecondary { get; }
+
+    [ProtoMember(12)]
+    public uint BannerIconColor { get; }
+
+    [ProtoMember(13)]
+    public bool IsRebelClan { get; }
+
+    public NetworkInitializeSettlementRebelClan(
+        string clanId,
+        string cultureId,
+        string leaderId,
+        string initialHomeSettlementId,
+        string homeSettlementId,
+        string bannerCode,
+        int tier,
+        uint color,
+        uint color2,
+        uint bannerBackgroundColorPrimary,
+        uint bannerBackgroundColorSecondary,
+        uint bannerIconColor,
+        bool isRebelClan)
+    {
+        ClanId = clanId;
+        CultureId = cultureId;
+        LeaderId = leaderId;
+        InitialHomeSettlementId = initialHomeSettlementId;
+        HomeSettlementId = homeSettlementId;
+        BannerCode = bannerCode;
+        Tier = tier;
+        Color = color;
+        Color2 = color2;
+        BannerBackgroundColorPrimary = bannerBackgroundColorPrimary;
+        BannerBackgroundColorSecondary = bannerBackgroundColorSecondary;
+        BannerIconColor = bannerIconColor;
+        IsRebelClan = isRebelClan;
+    }
+}

--- a/source/GameInterface/Services/Clans/Messages/SettlementRebelClanInitializationMessages.cs
+++ b/source/GameInterface/Services/Clans/Messages/SettlementRebelClanInitializationMessages.cs
@@ -56,6 +56,9 @@ internal readonly struct NetworkInitializeSettlementRebelClan : ICommand
     [ProtoMember(13)]
     public bool IsRebelClan { get; }
 
+    [ProtoMember(14)]
+    public bool IsNoble { get; }
+
     public NetworkInitializeSettlementRebelClan(
         string clanId,
         string cultureId,
@@ -69,7 +72,8 @@ internal readonly struct NetworkInitializeSettlementRebelClan : ICommand
         uint bannerBackgroundColorPrimary,
         uint bannerBackgroundColorSecondary,
         uint bannerIconColor,
-        bool isRebelClan)
+        bool isRebelClan,
+        bool isNoble)
     {
         ClanId = clanId;
         CultureId = cultureId;
@@ -84,5 +88,6 @@ internal readonly struct NetworkInitializeSettlementRebelClan : ICommand
         BannerBackgroundColorSecondary = bannerBackgroundColorSecondary;
         BannerIconColor = bannerIconColor;
         IsRebelClan = isRebelClan;
+        IsNoble = isNoble;
     }
 }

--- a/source/GameInterface/Services/Clans/Patches/ClanPatches.cs
+++ b/source/GameInterface/Services/Clans/Patches/ClanPatches.cs
@@ -16,6 +16,16 @@ namespace GameInterface.Services.Clans.Patches;
 [HarmonyPatch(typeof(Clan))]
 internal class ClanPatches
 {
+    [HarmonyPatch(nameof(Clan.CreateSettlementRebelClan))]
+    [HarmonyPostfix]
+    internal static void CreateSettlementRebelClanPostfix(Clan __result)
+    {
+        if (ModInformation.IsServer)
+        {
+            MessageBroker.Instance.Publish(__result, new SettlementRebelClanInitialized(__result));
+        }
+    }
+
     [HarmonyPatch(nameof(Clan.PlayerClan))]
     [HarmonyPatch(MethodType.Getter)]
     [HarmonyPrefix]

--- a/source/GameInterface/Services/Settlements/Handlers/SettlementOwnershipHandler.cs
+++ b/source/GameInterface/Services/Settlements/Handlers/SettlementOwnershipHandler.cs
@@ -1,11 +1,9 @@
 ﻿using Common;
-using Common.Logging;
 using Common.Messaging;
 using Common.Network;
 using Common.Util;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Settlements.Messages;
-using Serilog;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.Settlements;
@@ -20,8 +18,6 @@ namespace GameInterface.Services.Settlements.Handlers
         private readonly IMessageBroker messageBroker;
         private readonly IObjectManager objectManager;
         private readonly INetwork network;
-        private static readonly ILogger Logger = LogManager.GetLogger<SettlementOwnershipHandler>();
-
         public SettlementOwnershipHandler(IMessageBroker messageBroker, IObjectManager objectManager, INetwork network)
         {
             this.messageBroker = messageBroker;
@@ -54,32 +50,22 @@ namespace GameInterface.Services.Settlements.Handlers
         {
             var payload = obj.What;
 
-            if (objectManager.TryGetObject(payload.SettlementId, out Settlement settlement) == false)
+            // Resolve in queue order with deferred ownership-object creation.
+            GameThread.RunSafe(() =>
             {
-                Logger.Verbose("Settlement not found in SettlementHandler with SettlementId: {id}", payload.SettlementId);
-                return;
-            }
+                if (!objectManager.TryGetObjectWithLogging(payload.SettlementId, out Settlement settlement)) return;
+                if (!objectManager.TryGetObjectWithLogging(payload.OwnerId, out Hero owner)) return;
 
-            if (objectManager.TryGetObject(payload.OwnerId, out Hero owner) == false)
-            {
-                Logger.Verbose("Owner not found in SettlementHandler with OwnerId: {id}", payload.OwnerId);
-                return;
-            }
+                Hero capturer = null;
+                if (payload.CapturerId != null &&
+                    !objectManager.TryGetObjectWithLogging(payload.CapturerId, out capturer)) return;
 
-            if (objectManager.TryGetObject(payload.CapturerId, out Hero capturer) == false && payload.CapturerId != null)
-            {
-                Logger.Verbose("Capturer not found in SettlementHandler with CapturerId: {id}", payload.CapturerId);
-                return;
-            }
+                var detail = (ChangeOwnerOfSettlementAction.ChangeOwnerOfSettlementDetail)payload.Detail;
 
-            var detail = (ChangeOwnerOfSettlementAction.ChangeOwnerOfSettlementDetail)payload.Detail;
-
-            // Apply only the direct owner change. The action's other side effects (patrol
-            // culling, garrison destruction and creation, governor removal) run on the server
-            // with patches live and arrive here as their own replicated messages; replaying the
-            // whole action would apply them a second time.
-            GameThread.Run(() =>
-            {
+                // Apply only the direct owner change. The action's other side effects (patrol
+                // culling, garrison destruction and creation, governor removal) run on the server
+                // with patches live and arrive here as their own replicated messages; replaying the
+                // whole action would apply them a second time.
                 using (new AllowedThread())
                 {
                     var oldOwner = settlement.OwnerClan?.Leader;
@@ -112,7 +98,7 @@ namespace GameInterface.Services.Settlements.Handlers
                     CampaignEventDispatcher.Instance.OnSettlementOwnerChanged(
                         settlement, openToClaim, owner, oldOwner, capturer, detail);
                 }
-            });
+            }, context: nameof(NetworkChangeSettlementOwnership));
         }
     }
 }

--- a/source/GameInterface/Services/Settlements/Patches/ChangeOwnerOfSettlementPatch.cs
+++ b/source/GameInterface/Services/Settlements/Patches/ChangeOwnerOfSettlementPatch.cs
@@ -2,6 +2,7 @@
 using Common.Logging;
 using Common.Messaging;
 using GameInterface.Policies;
+using GameInterface.Services.Clans.Messages;
 using GameInterface.Services.Settlements.Messages;
 using HarmonyLib;
 using Serilog;
@@ -29,6 +30,12 @@ namespace GameInterface.Services.Settlements.Patches
             {
                 Logger.Error("Client called unmanaged {name}", typeof(ChangeOwnerOfSettlementAction));
                 return false;
+            }
+
+            if (detail == ChangeOwnerOfSettlementDetail.ByRebellion)
+            {
+                var rebelClan = newOwner.Clan;
+                MessageBroker.Instance.Publish(rebelClan, new SettlementRebelClanInitialized(rebelClan));
             }
 
             MessageBroker.Instance.Publish(settlement,

--- a/source/GameInterface/Services/Settlements/Patches/RebellionsCampaignBehaviorPatches.cs
+++ b/source/GameInterface/Services/Settlements/Patches/RebellionsCampaignBehaviorPatches.cs
@@ -1,6 +1,14 @@
 ﻿using Common;
+using Common.Messaging;
+using GameInterface.Services.Clans.Messages;
 using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
+using TaleWorlds.CampaignSystem.Settlements;
 
 namespace GameInterface.Services.Settlements.Patches;
 
@@ -8,6 +16,80 @@ namespace GameInterface.Services.Settlements.Patches;
 [HarmonyPatch(typeof(RebellionsCampaignBehavior))]
 internal class RebellionsCampaignBehaviorPatches
 {
+    private static MethodInfo CreateSettlementRebelClanMethod => AccessTools.Method(
+        typeof(Clan),
+        nameof(Clan.CreateSettlementRebelClan),
+        new[] { typeof(Settlement), typeof(Hero), typeof(int) });
+    private static MethodInfo IsNobleSetter => AccessTools.PropertySetter(typeof(Clan), nameof(Clan.IsNoble));
+    private static MethodInfo PublishRebelClanIsNobleMethod => AccessTools.Method(typeof(RebellionsCampaignBehaviorPatches), nameof(PublishRebelClanIsNoble));
+
     [HarmonyPatch(nameof(RebellionsCampaignBehavior.RegisterEvents))]
     static bool Prefix() => ModInformation.IsServer;
+
+    [HarmonyPatch(nameof(RebellionsCampaignBehavior.CreateRebelPartyAndClan))]
+    [HarmonyTranspiler]
+    internal static IEnumerable<CodeInstruction> CreateRebelPartyAndClanTranspiler(IEnumerable<CodeInstruction> instructions)
+    {
+        var instructionList = new List<CodeInstruction>(instructions);
+        int factoryCalls = 0;
+        int replacements = 0;
+
+        for (int index = 0; index < instructionList.Count; index++)
+        {
+            if (!instructionList[index].Calls(CreateSettlementRebelClanMethod)) continue;
+
+            factoryCalls++;
+            if (index + 4 >= instructionList.Count) continue;
+
+            int storedLocal = GetStoredLocalIndex(instructionList[index + 1]);
+            int loadedLocal = GetLoadedLocalIndex(instructionList[index + 2]);
+            if (storedLocal < 0 || storedLocal != loadedLocal) continue;
+            if (instructionList[index + 3].opcode != OpCodes.Ldc_I4_1) continue;
+            if (!instructionList[index + 4].Calls(IsNobleSetter)) continue;
+
+            instructionList[index + 4].opcode = OpCodes.Call;
+            instructionList[index + 4].operand = PublishRebelClanIsNobleMethod;
+            replacements++;
+        }
+
+        if (factoryCalls != 1 || replacements != 1)
+        {
+            throw new InvalidOperationException(
+                $"Failed to patch rebel clan IsNoble snapshot: found {factoryCalls} factory calls and {replacements} adjacent setters.");
+        }
+
+        return instructionList;
+    }
+
+    private static int GetStoredLocalIndex(CodeInstruction instruction)
+    {
+        if (instruction.opcode == OpCodes.Stloc_0) return 0;
+        if (instruction.opcode == OpCodes.Stloc_1) return 1;
+        if (instruction.opcode == OpCodes.Stloc_2) return 2;
+        if (instruction.opcode == OpCodes.Stloc_3) return 3;
+        if (instruction.opcode != OpCodes.Stloc && instruction.opcode != OpCodes.Stloc_S) return -1;
+
+        return instruction.operand is LocalBuilder local ? local.LocalIndex : -1;
+    }
+
+    private static int GetLoadedLocalIndex(CodeInstruction instruction)
+    {
+        if (instruction.opcode == OpCodes.Ldloc_0) return 0;
+        if (instruction.opcode == OpCodes.Ldloc_1) return 1;
+        if (instruction.opcode == OpCodes.Ldloc_2) return 2;
+        if (instruction.opcode == OpCodes.Ldloc_3) return 3;
+        if (instruction.opcode != OpCodes.Ldloc && instruction.opcode != OpCodes.Ldloc_S) return -1;
+
+        return instruction.operand is LocalBuilder local ? local.LocalIndex : -1;
+    }
+
+    internal static void PublishRebelClanIsNoble(Clan clan, bool isNoble)
+    {
+        clan.IsNoble = isNoble;
+
+        if (ModInformation.IsServer)
+        {
+            MessageBroker.Instance.Publish(clan, new SettlementRebelClanInitialized(clan));
+        }
+    }
 }

--- a/source/GameInterface/Services/Settlements/Patches/RebellionsCampaignBehaviorPatches.cs
+++ b/source/GameInterface/Services/Settlements/Patches/RebellionsCampaignBehaviorPatches.cs
@@ -32,55 +32,34 @@ internal class RebellionsCampaignBehaviorPatches
     {
         var instructionList = new List<CodeInstruction>(instructions);
         int factoryCalls = 0;
-        int replacements = 0;
+        int factoryIndex = -1;
+        int isNobleSetters = 0;
+        int isNobleSetterIndex = -1;
 
         for (int index = 0; index < instructionList.Count; index++)
         {
-            if (!instructionList[index].Calls(CreateSettlementRebelClanMethod)) continue;
+            if (instructionList[index].Calls(CreateSettlementRebelClanMethod))
+            {
+                factoryCalls++;
+                factoryIndex = index;
+            }
 
-            factoryCalls++;
-            if (index + 4 >= instructionList.Count) continue;
-
-            int storedLocal = GetStoredLocalIndex(instructionList[index + 1]);
-            int loadedLocal = GetLoadedLocalIndex(instructionList[index + 2]);
-            if (storedLocal < 0 || storedLocal != loadedLocal) continue;
-            if (instructionList[index + 3].opcode != OpCodes.Ldc_I4_1) continue;
-            if (!instructionList[index + 4].Calls(IsNobleSetter)) continue;
-
-            instructionList[index + 4].opcode = OpCodes.Call;
-            instructionList[index + 4].operand = PublishRebelClanIsNobleMethod;
-            replacements++;
+            if (instructionList[index].Calls(IsNobleSetter))
+            {
+                isNobleSetters++;
+                isNobleSetterIndex = index;
+            }
         }
 
-        if (factoryCalls != 1 || replacements != 1)
+        if (factoryCalls != 1 || isNobleSetters != 1 || isNobleSetterIndex <= factoryIndex)
         {
             throw new InvalidOperationException(
-                $"Failed to patch rebel clan IsNoble snapshot: found {factoryCalls} factory calls and {replacements} adjacent setters.");
+                $"Failed to patch rebel clan IsNoble snapshot: found {factoryCalls} factory calls and {isNobleSetters} later setters.");
         }
 
+        instructionList[isNobleSetterIndex].opcode = OpCodes.Call;
+        instructionList[isNobleSetterIndex].operand = PublishRebelClanIsNobleMethod;
         return instructionList;
-    }
-
-    private static int GetStoredLocalIndex(CodeInstruction instruction)
-    {
-        if (instruction.opcode == OpCodes.Stloc_0) return 0;
-        if (instruction.opcode == OpCodes.Stloc_1) return 1;
-        if (instruction.opcode == OpCodes.Stloc_2) return 2;
-        if (instruction.opcode == OpCodes.Stloc_3) return 3;
-        if (instruction.opcode != OpCodes.Stloc && instruction.opcode != OpCodes.Stloc_S) return -1;
-
-        return instruction.operand is LocalBuilder local ? local.LocalIndex : -1;
-    }
-
-    private static int GetLoadedLocalIndex(CodeInstruction instruction)
-    {
-        if (instruction.opcode == OpCodes.Ldloc_0) return 0;
-        if (instruction.opcode == OpCodes.Ldloc_1) return 1;
-        if (instruction.opcode == OpCodes.Ldloc_2) return 2;
-        if (instruction.opcode == OpCodes.Ldloc_3) return 3;
-        if (instruction.opcode != OpCodes.Ldloc && instruction.opcode != OpCodes.Ldloc_S) return -1;
-
-        return instruction.operand is LocalBuilder local ? local.LocalIndex : -1;
     }
 
     internal static void PublishRebelClanIsNoble(Clan clan, bool isNoble)

--- a/source/GameInterface/Services/Settlements/Patches/RebellionsCampaignBehaviorPatches.cs
+++ b/source/GameInterface/Services/Settlements/Patches/RebellionsCampaignBehaviorPatches.cs
@@ -1,14 +1,6 @@
 ﻿using Common;
-using Common.Messaging;
-using GameInterface.Services.Clans.Messages;
 using HarmonyLib;
-using System;
-using System.Collections.Generic;
-using System.Reflection;
-using System.Reflection.Emit;
-using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
-using TaleWorlds.CampaignSystem.Settlements;
 
 namespace GameInterface.Services.Settlements.Patches;
 
@@ -16,59 +8,6 @@ namespace GameInterface.Services.Settlements.Patches;
 [HarmonyPatch(typeof(RebellionsCampaignBehavior))]
 internal class RebellionsCampaignBehaviorPatches
 {
-    private static MethodInfo CreateSettlementRebelClanMethod => AccessTools.Method(
-        typeof(Clan),
-        nameof(Clan.CreateSettlementRebelClan),
-        new[] { typeof(Settlement), typeof(Hero), typeof(int) });
-    private static MethodInfo IsNobleSetter => AccessTools.PropertySetter(typeof(Clan), nameof(Clan.IsNoble));
-    private static MethodInfo PublishRebelClanIsNobleMethod => AccessTools.Method(typeof(RebellionsCampaignBehaviorPatches), nameof(PublishRebelClanIsNoble));
-
     [HarmonyPatch(nameof(RebellionsCampaignBehavior.RegisterEvents))]
     static bool Prefix() => ModInformation.IsServer;
-
-    [HarmonyPatch(nameof(RebellionsCampaignBehavior.CreateRebelPartyAndClan))]
-    [HarmonyTranspiler]
-    internal static IEnumerable<CodeInstruction> CreateRebelPartyAndClanTranspiler(IEnumerable<CodeInstruction> instructions)
-    {
-        var instructionList = new List<CodeInstruction>(instructions);
-        int factoryCalls = 0;
-        int factoryIndex = -1;
-        int isNobleSetters = 0;
-        int isNobleSetterIndex = -1;
-
-        for (int index = 0; index < instructionList.Count; index++)
-        {
-            if (instructionList[index].Calls(CreateSettlementRebelClanMethod))
-            {
-                factoryCalls++;
-                factoryIndex = index;
-            }
-
-            if (instructionList[index].Calls(IsNobleSetter))
-            {
-                isNobleSetters++;
-                isNobleSetterIndex = index;
-            }
-        }
-
-        if (factoryCalls != 1 || isNobleSetters != 1 || isNobleSetterIndex <= factoryIndex)
-        {
-            throw new InvalidOperationException(
-                $"Failed to patch rebel clan IsNoble snapshot: found {factoryCalls} factory calls and {isNobleSetters} later setters.");
-        }
-
-        instructionList[isNobleSetterIndex].opcode = OpCodes.Call;
-        instructionList[isNobleSetterIndex].operand = PublishRebelClanIsNobleMethod;
-        return instructionList;
-    }
-
-    internal static void PublishRebelClanIsNoble(Clan clan, bool isNoble)
-    {
-        clan.IsNoble = isNoble;
-
-        if (ModInformation.IsServer)
-        {
-            MessageBroker.Instance.Publish(clan, new SettlementRebelClanInitialized(clan));
-        }
-    }
 }

--- a/source/GameInterface/Services/Towns/Commands/TownDebugCommand.cs
+++ b/source/GameInterface/Services/Towns/Commands/TownDebugCommand.cs
@@ -1,4 +1,5 @@
 ﻿using Autofac;
+using Common;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Towns.Patches;
 using Helpers;
@@ -6,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.CampaignBehaviors;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Core;
 using static TaleWorlds.Library.CommandLineFunctionality;
@@ -481,6 +483,25 @@ public class TownDebugCommand
 
         RebellionsCampaignBehaviorPatches.PublishTownInRebelliousStateChanged(town, inRebelliousState);
         return $"Town InRebelliousState has changed to: {town.InRebelliousState}.";
+    }
+
+    [CommandLineArgumentFunction("start_rebellion", "coop.debug.town")]
+    public static string StartRebellion(List<string> args)
+    {
+        if (ModInformation.IsClient) return "Run coop.debug.town.start_rebellion on the server.";
+        if (args.Count != 1) return "Usage: coop.debug.town.start_rebellion <townId>";
+        if (TryGetObjectManager(out var objectManager) == false) return "Unable to resolve ObjectManager";
+        if (objectManager.TryGetObject(args[0], out Town town) == false)
+            return $"{nameof(Town)} with ID: '{args[0]}' not found";
+        if (town.OwnerClan.IsRebelClan) return $"{town.Name} is already owned by a rebel clan.";
+        if (town.Settlement.Party.MapEvent != null) return $"{town.Name} is in a map event.";
+        if (town.Settlement.Party.SiegeEvent != null) return $"{town.Name} is under siege.";
+
+        RebellionsCampaignBehavior behavior = Campaign.Current.GetCampaignBehavior<RebellionsCampaignBehavior>();
+        if (behavior == null) return "Unable to resolve RebellionsCampaignBehavior";
+
+        behavior.StartRebellionEvent(town.Settlement);
+        return $"Started the vanilla rebellion in {town.Name}. New owner: {town.OwnerClan.Name} (rebel={town.OwnerClan.IsRebelClan}).";
     }
 
     // coop.debug.town.set_garrison_auto_recruitment town_comp_V1 false


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Rebel-held settlements can lose their interaction sidebar and raid options after ownership changes, while rebel generals may be unapproachable until the client restarts.

## What is the new behavior?

Resolves #2829

Rebel settlements keep their interaction sidebar and raid options after a rebellion, and rebel generals remain approachable without restarting the client.

## Bot Changelog Entry

- Fixed rebel settlements and generals becoming uninteractive after a rebellion.
