### PR TITLE
Distinguish nightly builds from Workshop installs

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -177,12 +177,15 @@ jobs:
           sed \
             -e "s/<Name value=\"Coop\"\/>/<Name value=\"$nightly_module_name\"\/>/g" \
             -e "s/<Id value=\"Coop\"\/>/<Id value=\"$nightly_module_id\"\/>/" \
+            -e 's/<Module Id="CoopNightly"\/>/<Module Id="Coop"\/>/' \
             -e 's/${main_class}/CoopMod/g' \
             -e "s/\${version}/v$coop_version/g" \
             -e "s/\${game_version}/$game_version/g" \
             deploy/SubModule.xml > "$module/SubModule.xml"
           test "$(grep -Fc "<Name value=\"$nightly_module_name\"/>" "$module/SubModule.xml")" -eq 2
           grep -Fqx "    <Id value=\"$nightly_module_id\"/>" "$module/SubModule.xml"
+          grep -Fqx '        <Module Id="Coop"/>' "$module/SubModule.xml"
+          ! grep -Fq '<Module Id="CoopNightly"/>' "$module/SubModule.xml"
 
           (cd release-stage && 7z a -t7z -m0=LZMA2 -mx=9 -ms=on \
             "../artifact/$FILE_NAME" Coop >/dev/null)

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -169,15 +169,20 @@ jobs:
 
           coop_version=$(sed -n 's/.*<CoopVersion>\([^<]*\)<\/CoopVersion>.*/\1/p' source/Directory.Build.props)
           game_version=$(sed -n 's/.*<GameVersion>\([^<]*\)<\/GameVersion>.*/\1/p' source/Coop/Coop.csproj)
+          nightly_module_id=CoopNightly
+          nightly_module_name="Coop Nightly $RELEASE_DATE"
           test -n "$coop_version"
           test -n "$game_version"
           # shellcheck disable=SC2016
           sed \
-            -e 's/${name}/Coop/g' \
+            -e "s/<Name value=\"Coop\"\/>/<Name value=\"$nightly_module_name\"\/>/g" \
+            -e "s/<Id value=\"Coop\"\/>/<Id value=\"$nightly_module_id\"\/>/" \
             -e 's/${main_class}/CoopMod/g' \
             -e "s/\${version}/v$coop_version/g" \
             -e "s/\${game_version}/$game_version/g" \
             deploy/SubModule.xml > "$module/SubModule.xml"
+          test "$(grep -Fc "<Name value=\"$nightly_module_name\"/>" "$module/SubModule.xml")" -eq 2
+          grep -Fqx "    <Id value=\"$nightly_module_id\"/>" "$module/SubModule.xml"
 
           (cd release-stage && 7z a -t7z -m0=LZMA2 -mx=9 -ms=on \
             "../artifact/$FILE_NAME" Coop >/dev/null)

--- a/deploy/SubModule.xml
+++ b/deploy/SubModule.xml
@@ -12,6 +12,9 @@
         <DependedModule Id="CustomBattle" DependentVersion="${game_version}"/>
         <DependedModule Id="StoryMode" DependentVersion="${game_version}"/>
     </DependedModules>
+    <IncompatibleModules>
+        <Module Id="CoopNightly"/>
+    </IncompatibleModules>
     <SubModules>
         <SubModule>
             <Name value="Coop"/>

--- a/source/GameInterface.Tests/Services/GameDebug/Patches/CharacterCreationIntroPatchTests.cs
+++ b/source/GameInterface.Tests/Services/GameDebug/Patches/CharacterCreationIntroPatchTests.cs
@@ -1,0 +1,25 @@
+﻿using GameInterface.Services.GameDebug.Patches;
+using System;
+using TaleWorlds.CampaignSystem.GameState;
+using TaleWorlds.CampaignSystem.CharacterCreationContent;
+using Xunit;
+using TaleworldGameState = TaleWorlds.Core.GameState;
+
+namespace GameInterface.Tests.Services.GameDebug.Patches;
+
+public class CharacterCreationIntroPatchTests
+{
+    [Fact]
+    public void IsCharacterCreationState_ReturnsTrueForCharacterCreation()
+    {
+        Assert.True(CharacterCreationIntroPatch.IsCharacterCreationState(typeof(CharacterCreationState)));
+    }
+
+    [Theory]
+    [InlineData(typeof(TaleworldGameState))]
+    [InlineData(typeof(MapState))]
+    public void IsCharacterCreationState_ReturnsFalseForOtherGameStates(Type stateType)
+    {
+        Assert.False(CharacterCreationIntroPatch.IsCharacterCreationState(stateType));
+    }
+}

--- a/source/GameInterface.Tests/Services/Modules/Handlers/UnsupportedModuleWarningHandlerTests.cs
+++ b/source/GameInterface.Tests/Services/Modules/Handlers/UnsupportedModuleWarningHandlerTests.cs
@@ -11,14 +11,16 @@ namespace GameInterface.Tests.Services.Modules.Handlers;
 /// </summary>
 public class UnsupportedModuleWarningHandlerTests
 {
-    [Fact]
-    public void OfficialModulesAndCoop_DoNotShowWarning()
+    [Theory]
+    [InlineData("Coop")]
+    [InlineData("CoopNightly")]
+    public void OfficialModulesAndSingleCoopVariant_DoNotShowWarning(string coopModuleId)
     {
         var provider = new TestModuleInfoProvider(
             Module("Native", isOfficial: true),
             Module("SandBox", isOfficial: true),
             Module("StoryMode", isOfficial: true),
-            Module("Coop", isOfficial: false));
+            Module(coopModuleId, isOfficial: false));
 
         var coordinator = new UnsupportedModuleWarningHandler(provider, new TestOptionsStore(), _ => {});
         var shown = 0;
@@ -27,6 +29,24 @@ public class UnsupportedModuleWarningHandlerTests
 
         Assert.Equal(0, shown);
         Assert.Equal(1, provider.RequestCount);
+    }
+
+    [Fact]
+    public void WorkshopAndNightlyTogether_ShowWarning()
+    {
+        var provider = new TestModuleInfoProvider(
+            Module("Native", isOfficial: true),
+            Module("Coop", isOfficial: false),
+            Module("CoopNightly", isOfficial: false));
+
+        var coordinator = new UnsupportedModuleWarningHandler(provider, new TestOptionsStore(), _ => {});
+        InquiryData inquiry = null;
+
+        coordinator.TryShowPrompt(true, value => inquiry = value);
+
+        Assert.NotNull(inquiry);
+        Assert.Contains("- Coop\n", inquiry.Text);
+        Assert.Contains("- CoopNightly\n", inquiry.Text);
     }
 
     [Fact]

--- a/source/GameInterface/Services/GameDebug/Patches/CharacterCreationIntroPatch.cs
+++ b/source/GameInterface/Services/GameDebug/Patches/CharacterCreationIntroPatch.cs
@@ -4,7 +4,9 @@ using GameInterface.Services.GameDebug.Interfaces;
 using GameInterface.Services.GameDebug.Messages;
 using HarmonyLib;
 using Serilog;
+using System;
 using TaleworldGameState = TaleWorlds.Core.GameState;
+using TaleworldCharacterCreationState = TaleWorlds.CampaignSystem.CharacterCreationContent.CharacterCreationState;
 
 namespace GameInterface.Services.GameDebug.Patches;
 
@@ -20,11 +22,25 @@ internal class CharacterCreationIntroPatch
     {
         Logger.Information("Game State is changing to {state}", __instance.GetType().Name);
 
-        MessageBroker.Instance.Publish(__instance, new CharacterCreationStarted());
+        // GameLoadingState and MapState also activate while an existing player is validating or
+        // loading the transferred save. Publishing for either one moves the client out of
+        // ValidateModuleState before the server's existing-player response can arrive.
+        if (IsCharacterCreationState(__instance.GetType()))
+        {
+            MessageBroker.Instance.Publish(__instance, new CharacterCreationStarted());
+        }
 
 #if DEBUG
         if (DebugCharacterCreationInterface.InCharacterCreationIntro())
         {
+            // The DEBUG fast path previously depended on the lifecycle event above. Keep the
+            // automation behavior without misreporting unrelated game-state transitions as
+            // character creation.
+            if (ContainerProvider.TryResolve<IDebugCharacterCreationInterface>(out var characterCreationInterface))
+            {
+                characterCreationInterface.SkipCharacterCreation();
+            }
+
             if (VideoPlayerViewPatch.CurrentVideoPlayerView != null)
             {
                 VideoPlayerViewPatch.CurrentVideoPlayerView?.StopVideo();
@@ -33,4 +49,7 @@ internal class CharacterCreationIntroPatch
         }
 #endif
     }
+
+    internal static bool IsCharacterCreationState(Type stateType) =>
+        typeof(TaleworldCharacterCreationState).IsAssignableFrom(stateType);
 }

--- a/source/GameInterface/Services/Modules/Handlers/UnsupportedModuleWarningHandler.cs
+++ b/source/GameInterface/Services/Modules/Handlers/UnsupportedModuleWarningHandler.cs
@@ -19,6 +19,7 @@ public class UnsupportedModuleWarningHandler
     public const string SectionId = "UnsupportedModules";
 
     private const string CoopModuleId = "Coop";
+    private const string CoopNightlyModuleId = "CoopNightly";
     private const string DedicatedServerModulePrefix = "DedicatedServer.";
     
     private readonly IModuleInfoProvider moduleInfoProvider;
@@ -126,8 +127,12 @@ public class UnsupportedModuleWarningHandler
         }
 
         modulesEvaluated = true;
-        unsupportedModuleIds = moduleInfoProvider.GetModuleInfos()
-            .Where(IsUnsupported)
+        var modules = moduleInfoProvider.GetModuleInfos().ToArray();
+        var hasConflictingCoopVariants = modules.Any(module => IsCoopVariant(module, CoopModuleId)) &&
+                                         modules.Any(module => IsCoopVariant(module, CoopNightlyModuleId));
+        unsupportedModuleIds = modules
+            .Where(module => IsUnsupported(module) ||
+                             hasConflictingCoopVariants && IsCoopVariant(module))
             .Select(module => module.Id)
             .Where(id => !string.IsNullOrWhiteSpace(id))
             .Distinct(StringComparer.OrdinalIgnoreCase)
@@ -137,7 +142,7 @@ public class UnsupportedModuleWarningHandler
 
     private static bool IsUnsupported(ModuleInfo module)
     {
-        if (string.Equals(module.Id, CoopModuleId, StringComparison.OrdinalIgnoreCase))
+        if (IsCoopVariant(module))
         {
             return false;
         }
@@ -150,6 +155,14 @@ public class UnsupportedModuleWarningHandler
         }
 
         return !module.IsOfficial || module.IsDlc;
+    }
+
+    private static bool IsCoopVariant(ModuleInfo module, string moduleId = null)
+    {
+        return moduleId == null
+            ? string.Equals(module.Id, CoopModuleId, StringComparison.OrdinalIgnoreCase) ||
+              string.Equals(module.Id, CoopNightlyModuleId, StringComparison.OrdinalIgnoreCase)
+            : string.Equals(module.Id, moduleId, StringComparison.OrdinalIgnoreCase);
     }
 
     private static string BuildPromptText(string[] moduleIds)

--- a/source/GameInterface/Services/Modules/Handlers/UnsupportedModuleWarningHandler.cs
+++ b/source/GameInterface/Services/Modules/Handlers/UnsupportedModuleWarningHandler.cs
@@ -132,7 +132,7 @@ public class UnsupportedModuleWarningHandler
                                          modules.Any(module => IsCoopVariant(module, CoopNightlyModuleId));
         unsupportedModuleIds = modules
             .Where(module => IsUnsupported(module) ||
-                             hasConflictingCoopVariants && IsCoopVariant(module))
+                             (hasConflictingCoopVariants && IsCoopVariant(module)))
             .Select(module => module.Id)
             .Where(id => !string.IsNullOrWhiteSpace(id))
             .Distinct(StringComparer.OrdinalIgnoreCase)


### PR DESCRIPTION
> [!WARNING]
> **Coordinated merge required:** This PR must be merged together with [BannerlordCoop.DedicatedServer #24](https://github.com/Bannerlord-Coop-Team/BannerlordCoop.DedicatedServer/pull/24). Do not merge either PR independently.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Nightly downloads identify themselves as Coop, the same as the Steam Workshop version, so the Bannerlord launcher can confuse the two when both are installed.

## What is the new behavior?

Nightly downloads use the separate CoopNightly identity and display a dated name such as Coop Nightly 2026-08-09, while Workshop and manual builds remain Coop.

## Bot Changelog Entry

- Nightly builds now have a dated Coop Nightly name and a separate identity from the Workshop version.
