### PR TITLE
Fix manual build R2 uploader setup

### DIFF
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -252,18 +252,18 @@ jobs:
 
       - name: Install pinned R2 uploader
         env:
-          RCLONE_VERSION: 1.70.3
-          RCLONE_ARCHIVE_SHA256: 7d69057e69385f6514a9684c7eaa424d972096b130284bb34dd967c4ed4f9dad
+          PINNED_RCLONE_VERSION: 1.70.3
+          PINNED_RCLONE_ARCHIVE_SHA256: 7d69057e69385f6514a9684c7eaa424d972096b130284bb34dd967c4ed4f9dad
         run: |
           set -eu
           archive="$RUNNER_TEMP/rclone.zip"
           curl --fail --silent --show-error --location \
-            "https://downloads.rclone.org/v$RCLONE_VERSION/rclone-v$RCLONE_VERSION-linux-amd64.zip" \
+            "https://downloads.rclone.org/v$PINNED_RCLONE_VERSION/rclone-v$PINNED_RCLONE_VERSION-linux-amd64.zip" \
             --output "$archive"
-          echo "$RCLONE_ARCHIVE_SHA256  $archive" | sha256sum -c -
+          echo "$PINNED_RCLONE_ARCHIVE_SHA256  $archive" | sha256sum -c -
           unzip -q "$archive" -d "$RUNNER_TEMP"
           install -m 0755 \
-            "$RUNNER_TEMP/rclone-v$RCLONE_VERSION-linux-amd64/rclone" \
+            "$RUNNER_TEMP/rclone-v$PINNED_RCLONE_VERSION-linux-amd64/rclone" \
             "$RUNNER_TEMP/rclone"
           "$RUNNER_TEMP/rclone" version
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Temporary client builds stop after packaging because the uploader fails to start, so the dedicated-server build never begins.

## What is the new behavior?

Temporary client builds can publish the client package and continue to the dedicated-server build.

## Bot Changelog Entry

- Fixed temporary manual builds failing before the dedicated-server package could be created.
