### PR TITLE
Fix duplicated companions/troops after forming parties

### DIFF
--- a/source/GameInterface/Services/MobileParties/Patches/MobilePartyHelperPatches.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/MobilePartyHelperPatches.cs
@@ -1,0 +1,26 @@
+﻿using HarmonyLib;
+using Helpers;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Party;
+
+namespace GameInterface.Services.MobileParties.Patches;
+
+[HarmonyPatch(typeof(MobilePartyHelper))]
+internal class MobilePartyHelperPatches
+{
+    [HarmonyPatch(nameof(MobilePartyHelper.CreateNewClanMobileParty))]
+    [HarmonyPrefix]
+    public static bool PrefixCreateNewClanMobileParty(Hero hero, ref MobileParty __result)
+    {
+        var currentSettlement = hero.CurrentSettlement;
+
+        if (currentSettlement == null) return true;
+
+        // Replace hero.CurrentSettlement != null block to not use MainParty
+        hero.PartyBelongedTo?.AddElementToMemberRoster(hero.CharacterObject, -1);
+
+        __result = MobilePartyHelper.SpawnLordParty(hero, currentSettlement);
+
+        return false;
+    }
+}

--- a/source/GameInterface/Services/TroopRosters/Interfaces/TroopRosterInterface.cs
+++ b/source/GameInterface/Services/TroopRosters/Interfaces/TroopRosterInterface.cs
@@ -201,8 +201,7 @@ internal class TroopRosterInterface : ITroopRosterInterface
                     finalWounded < 0 ||
                     finalWounded > finalNumber ||
                     finalXp < 0 ||
-                    finalXp > int.MaxValue ||
-                    (finalNumber == 0 && finalXp != 0))
+                    finalXp > int.MaxValue)
                 {
                     Logger.Warning(
                         "Rejected troop roster delta for {CharacterId}: current=({CurrentNumber},{CurrentWounded},{CurrentXp}) delta=({NumberDelta},{WoundedDelta},{XpDelta})",

--- a/source/GameInterface/Services/TroopRosters/Interfaces/TroopRosterInterface.cs
+++ b/source/GameInterface/Services/TroopRosters/Interfaces/TroopRosterInterface.cs
@@ -156,7 +156,19 @@ internal class TroopRosterInterface : ITroopRosterInterface
 
             int numberDelta = cur.number - init.number;
             int woundedDelta = cur.wounded - init.wounded;
-            int xpDelta = cur.xp - init.xp;
+            int currentXp = cur.xp;
+            if (cur.number == 0)
+            {
+                currentXp = 0;
+            }
+
+            int initialXp = init.xp;
+            if (init.number == 0)
+            {
+                initialXp = 0;
+            }
+
+            int xpDelta = currentXp - initialXp;
             if (numberDelta == 0 && woundedDelta == 0 && xpDelta == 0)
                 continue;
 
@@ -201,7 +213,8 @@ internal class TroopRosterInterface : ITroopRosterInterface
                     finalWounded < 0 ||
                     finalWounded > finalNumber ||
                     finalXp < 0 ||
-                    finalXp > int.MaxValue)
+                    finalXp > int.MaxValue ||
+                    (elementData.Xp != 0 && finalNumber == 0 && finalXp != 0))
                 {
                     Logger.Warning(
                         "Rejected troop roster delta for {CharacterId}: current=({CurrentNumber},{CurrentWounded},{CurrentXp}) delta=({NumberDelta},{WoundedDelta},{XpDelta})",


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- `MobilePartyHelper.CreateNewClanMobileParty` removes the new party leader from `PartyBase.MainParty.MemberRoster` instead of their actual roster. This doesn't work when called on the server, causing the new party leader to become "duplicated".
- `TroopRosterInterface.TryApplyTroopRosterDeltas` currently fails on changes to troop rosters where a troop type with any amount of xp gets removed, causing new clan parties to only receive troops but not remove them from the player's roster.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #2579
Resolves #2614
Resolves #2847
Resolves #2887
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Fixed a problem where a companion could become duplicated when creating a new clan party.
Fixed a problem where troops could duplicate when creating a new clan party.
