### PR TITLE
Fix companions taking from player garrisons

### DIFF
--- a/source/GameInterface/Services/Settlements/Patches/Disable/DisableGarrisonTroopsCampaignBehavior.cs
+++ b/source/GameInterface/Services/Settlements/Patches/Disable/DisableGarrisonTroopsCampaignBehavior.cs
@@ -1,11 +1,12 @@
 ﻿using Common;
+using GameInterface.Services.Clans.Extensions;
 using GameInterface.Services.MobileParties.Extensions;
 using HarmonyLib;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
 using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Settlements;
 
 namespace GameInterface.Services.Settlements.Patches.Disable;
-
 
 [HarmonyPatch(typeof(GarrisonTroopsCampaignBehavior))]
 internal class DisableGarrisonTroopsCampaignBehavior
@@ -15,11 +16,11 @@ internal class DisableGarrisonTroopsCampaignBehavior
 
     [HarmonyPatch(nameof(GarrisonTroopsCampaignBehavior.OnSettlementEntered))]
     [HarmonyPrefix]
-    public static bool OnSettlementEnteredPrefix(MobileParty mobileParty)
+    public static bool OnSettlementEnteredPrefix(MobileParty mobileParty, Settlement settlement)
     {
         if (mobileParty == null)
             return true;
 
-        return !mobileParty.IsPlayerParty();
+        return !mobileParty.IsPlayerParty() && !settlement.OwnerClan.IsPlayerClan();
     }
 }


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`GarrisonTroopsCampaignBehavior` guards against parties managing parties/armies in settlements that are owned by `Clan.PlayerClan`. The equivalent `IsPlayerClan()` is currently not used in this patch, leading to AI parties being able to take and add to a player controlled garrison.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #2893 
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Fixed a issue where companion parties would take troops from player settlement garrisons.