### PR TITLE
[2868] Synchronize city claimant selections

### DIFF
--- a/source/Coop.Core/Client/ClientLogic.cs
+++ b/source/Coop.Core/Client/ClientLogic.cs
@@ -80,7 +80,7 @@ public class ClientLogic : IClientLogic
             [typeof(CharacterCreationState)] = () => new CharacterCreationState(this, context.MessageBroker, context.Network, context.HeroInterface, context.RegistryManager, context.ControllerIdProvider, context.LoadingInterface, context.PlayerManager, context.GameStateInterface, context.CoopFinalizer),
             [typeof(ReceivingSavedDataState)] = () => new ReceivingSavedDataState(this, context.MessageBroker, context.LoadingInterface, context.GameStateInterface),
             [typeof(LoadingState)] = () => new LoadingState(this, context.MessageBroker, context.RegistryManager, context.HeroInterface, context.ControllerIdProvider, context.PlayerManager, context.GameStateInterface, context.LoadingInterface),
-            [typeof(CampaignState)] = () => new CampaignState(this, context.MessageBroker, context.Network, context.LoadingInterface, context.GameStateInterface, context.CoopFinalizer, context.MapTimeTrackerInterface),
+            [typeof(CampaignState)] = () => new CampaignState(this, context.MessageBroker, context.Network, context.LoadingInterface, context.GameStateInterface, context.CoopFinalizer, context.MapTimeTrackerInterface, context.SettlementClaimantSnapshotRegistry),
             [typeof(MissionState)] = () => new MissionState(this, context.MessageBroker, context.GameStateInterface, context.CoopFinalizer),
         };
 

--- a/source/Coop.Core/Client/States/CampaignState.cs
+++ b/source/Coop.Core/Client/States/CampaignState.cs
@@ -8,9 +8,12 @@ using Coop.Core.Common;
 using Coop.Core.Server.Connections.Messages;
 using GameInterface.Services.GameState.Interfaces;
 using GameInterface.Services.GameState.Messages;
+using GameInterface.Services.Kingdoms;
+using GameInterface.Services.Kingdoms.Data;
 using GameInterface.Services.Time.Interfaces;
 using GameInterface.Services.UI.Interfaces;
 using GameInterface.Services.UI.Messages;
+using System;
 using System.Globalization;
 
 namespace Coop.Core.Client.States;
@@ -26,6 +29,7 @@ public class CampaignState : ClientStateBase
     private readonly ICoopFinalizer coopFinalizer;
     private readonly INetwork network;
     private readonly IMapTimeTrackerInterface mapTimeTrackerInterface;
+    private readonly ISettlementClaimantSnapshotRegistry settlementClaimantSnapshotRegistry;
     private readonly bool waitingForJoinCatchUp;
     private bool replayAppliedQueued;
     private volatile bool baselineResponseExpected;
@@ -45,7 +49,8 @@ public class CampaignState : ClientStateBase
         ILoadingInterface loadingInterface,
         IGameStateInterface gameStateInterface,
         ICoopFinalizer coopFinalizer,
-        IMapTimeTrackerInterface mapTimeTrackerInterface) : base(logic)
+        IMapTimeTrackerInterface mapTimeTrackerInterface,
+        ISettlementClaimantSnapshotRegistry settlementClaimantSnapshotRegistry) : base(logic)
     {
         this.messageBroker = messageBroker;
         this.loadingInterface = loadingInterface;
@@ -53,6 +58,7 @@ public class CampaignState : ClientStateBase
         this.coopFinalizer = coopFinalizer;
         this.network = network;
         this.mapTimeTrackerInterface = mapTimeTrackerInterface;
+        this.settlementClaimantSnapshotRegistry = settlementClaimantSnapshotRegistry;
         waitingForJoinCatchUp = logic.State is LoadingState;
 
         messageBroker.Subscribe<MainMenuEntered>(Handle_MainMenuEntered);
@@ -99,6 +105,9 @@ public class CampaignState : ClientStateBase
             GameThread.RunSafe(() =>
             {
                 if (ReferenceEquals(Logic.State, this) == false) return;
+                var claimantSnapshots = obj.What.ClaimantSnapshots ??
+                    Array.Empty<SettlementClaimantDecisionSnapshotData>();
+                if (!settlementClaimantSnapshotRegistry.TryApplyJoinSnapshots(claimantSnapshots)) return;
 
                 baselineResponseExpected = true;
                 SendJoinSignal(JoinSyncSignal.ReplayApplied);

--- a/source/Coop.Core/Client/States/ClientContext.cs
+++ b/source/Coop.Core/Client/States/ClientContext.cs
@@ -6,6 +6,7 @@ using GameInterface.Registry;
 using GameInterface.Services.Entity;
 using GameInterface.Services.GameState.Interfaces;
 using GameInterface.Services.Heroes.Interfaces;
+using GameInterface.Services.Kingdoms;
 using GameInterface.Services.Modules;
 using GameInterface.Services.Players;
 using GameInterface.Services.Time.Interfaces;
@@ -32,7 +33,8 @@ public class ClientContext
         IHeroInterface heroInterface,
         IRegistryManager registryManager,
         IPlayerManager playerManager,
-        IMapTimeTrackerInterface mapTimeTrackerInterface)
+        IMapTimeTrackerInterface mapTimeTrackerInterface,
+        ISettlementClaimantSnapshotRegistry settlementClaimantSnapshotRegistry)
     {
         MessageBroker = messageBroker;
         Network = network;
@@ -46,6 +48,7 @@ public class ClientContext
         RegistryManager = registryManager;
         PlayerManager = playerManager;
         MapTimeTrackerInterface = mapTimeTrackerInterface;
+        SettlementClaimantSnapshotRegistry = settlementClaimantSnapshotRegistry;
     }
 
     public IMessageBroker MessageBroker { get; }
@@ -60,4 +63,5 @@ public class ClientContext
     public IRegistryManager RegistryManager { get; }
     public IPlayerManager PlayerManager { get; }
     public IMapTimeTrackerInterface MapTimeTrackerInterface { get; }
+    public ISettlementClaimantSnapshotRegistry SettlementClaimantSnapshotRegistry { get; }
 }

--- a/source/Coop.Core/Server/Connections/ConnectionContext.cs
+++ b/source/Coop.Core/Server/Connections/ConnectionContext.cs
@@ -5,6 +5,7 @@ using Coop.Core.Server.Services.MobileParties;
 using GameInterface.CoopSessionData;
 using GameInterface.Services.CampaignService.Interfaces;
 using GameInterface.Services.Heroes.Interfaces;
+using GameInterface.Services.Kingdoms;
 using GameInterface.Services.Modules;
 using GameInterface.Services.Modules.Validators;
 using GameInterface.Services.ObjectManager;
@@ -35,7 +36,8 @@ public class ConnectionContext
         IAttachmentIdMapper attachmentIdMapper,
         IExistingPlayerSender existingPlayerSender,
         IServerOptionsProvider serverOptionsProvider,
-        IJoinCampaignBaselineSender joinCampaignBaselineSender)
+        IJoinCampaignBaselineSender joinCampaignBaselineSender,
+        ISettlementClaimantSnapshotRegistry settlementClaimantSnapshotRegistry)
     {
         MessageBroker = messageBroker;
         Network = network;
@@ -53,6 +55,7 @@ public class ConnectionContext
         ExistingPlayerSender = existingPlayerSender;
         ServerOptionsProvider = serverOptionsProvider;
         JoinCampaignBaselineSender = joinCampaignBaselineSender;
+        SettlementClaimantSnapshotRegistry = settlementClaimantSnapshotRegistry;
     }
 
     public IMessageBroker MessageBroker { get; }
@@ -71,4 +74,5 @@ public class ConnectionContext
     public IExistingPlayerSender ExistingPlayerSender { get; }
     public IServerOptionsProvider ServerOptionsProvider { get; }
     public IJoinCampaignBaselineSender JoinCampaignBaselineSender { get; }
+    public ISettlementClaimantSnapshotRegistry SettlementClaimantSnapshotRegistry { get; }
 }

--- a/source/Coop.Core/Server/Connections/ConnectionLogic.cs
+++ b/source/Coop.Core/Server/Connections/ConnectionLogic.cs
@@ -83,7 +83,7 @@ public class ConnectionLogic : IConnectionLogic
             [typeof(ResolveCharacterState)] = () => new ResolveCharacterState(this, context.MessageBroker, context.Network, context.ModuleValidator, context.PlayerManager, context.PlayerPartyRestorer, context.ObjectManager, context.ModuleInfoProvider, context.ExistingPlayerSender),
             [typeof(CreateCharacterState)] = () => new CreateCharacterState(this, context.ObjectManager, context.MessageBroker, context.Network, context.HeroInterface, context.PlayerManager, context.ExistingPlayerSender),
             [typeof(TransferSaveState)] = () => new TransferSaveState(this, context.MessageBroker, context.Network, context.CoopSessionProvider, context.SaveInterface, context.ConnectionMessageQueue, context.Coalescer, context.AttachmentIdMapper, context.ServerOptionsProvider),
-            [typeof(LoadingState)] = () => new LoadingState(this, context.MessageBroker, context.Network, context.JoinCampaignBaselineSender, context.ConnectionMessageQueue, context.Coalescer),
+            [typeof(LoadingState)] = () => new LoadingState(this, context.MessageBroker, context.Network, context.JoinCampaignBaselineSender, context.ConnectionMessageQueue, context.Coalescer, context.SettlementClaimantSnapshotRegistry),
             [typeof(CampaignState)] = () => new CampaignState(this, context.MessageBroker),
             [typeof(MissionState)] = () => new MissionState(this, context.MessageBroker),
         };

--- a/source/Coop.Core/Server/Connections/Messages/NetworkJoinSync.cs
+++ b/source/Coop.Core/Server/Connections/Messages/NetworkJoinSync.cs
@@ -1,5 +1,7 @@
 ﻿using Common.Messaging;
+using GameInterface.Services.Kingdoms.Data;
 using ProtoBuf;
+using System;
 
 namespace Coop.Core.Server.Connections.Messages;
 
@@ -23,5 +25,14 @@ public readonly struct NetworkJoinSync : IMessage
     [ProtoMember(1)]
     public readonly JoinSyncSignal Signal;
 
-    public NetworkJoinSync(JoinSyncSignal signal) => Signal = signal;
+    [ProtoMember(2)]
+    public readonly SettlementClaimantDecisionSnapshotData[] ClaimantSnapshots;
+
+    public NetworkJoinSync(
+        JoinSyncSignal signal,
+        SettlementClaimantDecisionSnapshotData[] claimantSnapshots = null)
+    {
+        Signal = signal;
+        ClaimantSnapshots = claimantSnapshots ?? Array.Empty<SettlementClaimantDecisionSnapshotData>();
+    }
 }

--- a/source/Coop.Core/Server/Connections/States/LoadingState.cs
+++ b/source/Coop.Core/Server/Connections/States/LoadingState.cs
@@ -4,6 +4,7 @@ using Common.Network;
 using Common.Network.Coalescing;
 using Coop.Core.Server.Connections.Messages;
 using Coop.Core.Server.Services.MobileParties;
+using GameInterface.Services.Kingdoms;
 using LiteNetLib;
 
 namespace Coop.Core.Server.Connections.States;
@@ -30,6 +31,7 @@ public class LoadingState : ConnectionStateBase
     private readonly IJoinCampaignBaselineSender campaignBaselineSender;
     private readonly IConnectionMessageQueue connectionMessageQueue;
     private readonly ISendCoalescer coalescer;
+    private readonly ISettlementClaimantSnapshotRegistry settlementClaimantSnapshotRegistry;
     private volatile JoinPhase phase;
     private int initialBaselinesSent;
 
@@ -39,7 +41,8 @@ public class LoadingState : ConnectionStateBase
         INetwork network,
         IJoinCampaignBaselineSender campaignBaselineSender,
         IConnectionMessageQueue connectionMessageQueue,
-        ISendCoalescer coalescer)
+        ISendCoalescer coalescer,
+        ISettlementClaimantSnapshotRegistry settlementClaimantSnapshotRegistry)
         : base(connectionLogic)
     {
         this.messageBroker = messageBroker;
@@ -47,6 +50,7 @@ public class LoadingState : ConnectionStateBase
         this.campaignBaselineSender = campaignBaselineSender;
         this.connectionMessageQueue = connectionMessageQueue;
         this.coalescer = coalescer;
+        this.settlementClaimantSnapshotRegistry = settlementClaimantSnapshotRegistry;
 
         messageBroker.Subscribe<NetworkPlayerCampaignEntered>(PlayerCampaignEnteredHandler);
         messageBroker.Subscribe<NetworkJoinSync>(JoinSyncHandler);
@@ -81,8 +85,12 @@ public class LoadingState : ConnectionStateBase
 
             messageBroker.Publish(this, new PlayerCampaignEntered(peer));
             connectionMessageQueue.Flush(peer);
+            if (!settlementClaimantSnapshotRegistry.TryCreateJoinSnapshots(out var claimantSnapshots)) return;
+
             phase = JoinPhase.WaitingForReplayApplied;
-            network.SendImmediate(peer, new NetworkJoinSync(JoinSyncSignal.ReplayComplete));
+            network.SendImmediate(
+                peer,
+                new NetworkJoinSync(JoinSyncSignal.ReplayComplete, claimantSnapshots));
         }, context: nameof(PlayerCampaignEnteredHandler));
     }
 

--- a/source/Coop.Core/Server/Services/Kingdoms/Handlers/ServerKingdomHandler.cs
+++ b/source/Coop.Core/Server/Services/Kingdoms/Handlers/ServerKingdomHandler.cs
@@ -5,6 +5,7 @@ using Common.Util;
 using Coop.Core.Client.Services.MobileParties.Messages;
 using Coop.Core.Server.Services.Kingdoms.Messages;
 using GameInterface.Services.Kingdoms;
+using GameInterface.Services.Kingdoms.Data;
 using GameInterface.Services.Kingdoms.Messages;
 using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Services.ObjectManager;
@@ -244,6 +245,7 @@ public class ServerKingdomHandler : IHandler
     private void HandleNetworkAddDecision(MessagePayload<NetworkAddDecision> obj)
     {
         var payload = obj.What;
+        if (payload.Data is SettlementClaimantDecisionData) return;
 
         messageBroker.Publish(
             this,

--- a/source/Coop.IntegrationTests/Kingdoms/KingdomAddDecisionTest.cs
+++ b/source/Coop.IntegrationTests/Kingdoms/KingdomAddDecisionTest.cs
@@ -60,6 +60,36 @@ namespace Coop.IntegrationTests.Kingdoms
             Assert.Equal(0, client1.InternalMessages.GetMessageCount<AddDecision>());
             Assert.Equal(1, TestEnvironment.Clients.Skip(1).First().InternalMessages.GetMessageCount<AddDecision>());
         }
+
+        [Fact]
+        public void ClientKingdom_SettlementClaimantDecision_IsRejected()
+        {
+            var client = TestEnvironment.Clients.First();
+            var server = TestEnvironment.Server;
+            var data = new SettlementClaimantDecisionData(
+                "proposer",
+                "kingdom1",
+                0,
+                false,
+                true,
+                false,
+                "settlement",
+                string.Empty,
+                string.Empty,
+                new List<SettlementClaimantCandidateData>());
+
+            server.SimulateMessage(
+                client.NetPeer,
+                new NetworkAddDecision("kingdom1", data, false, 0.5f));
+
+            Assert.Equal(0, server.InternalMessages.GetMessageCount<AddDecision>());
+            Assert.Equal(0, server.NetworkSentMessages.GetMessageCount<NetworkAddDecision>());
+            foreach (EnvironmentInstance otherClient in TestEnvironment.Clients)
+            {
+                Assert.Equal(0, otherClient.InternalMessages.GetMessageCount<AddDecision>());
+            }
+        }
+
         private static KingdomDecision CreateDecision(EnvironmentInstance instance)
         {
             instance.CreateRegisteredObject<Clan>("clan1");

--- a/source/Coop.IntegrationTests/Kingdoms/KingdomNetworkMessageSerializationTest.cs
+++ b/source/Coop.IntegrationTests/Kingdoms/KingdomNetworkMessageSerializationTest.cs
@@ -112,6 +112,44 @@ public class KingdomNetworkMessageSerializationTest
     }
 
     [Fact]
+    public void NetworkAddDecision_RoundTripsSettlementClaimantCandidates()
+    {
+        var candidates = new List<SettlementClaimantCandidateData>
+        {
+            new SettlementClaimantCandidateData("Clan_Player12", 88.5f),
+            new SettlementClaimantCandidateData("clan_empire_south_4", 41.25f),
+        };
+        var decisionData = new SettlementClaimantDecisionData(
+            "clan_empire_south_1",
+            "Kingdom_empire_s",
+            123,
+            false,
+            true,
+            false,
+            "Settlement_town_ES1",
+            null,
+            null,
+            candidates);
+        var original = new NetworkAddDecision("Kingdom_empire_s", decisionData, false, 0.5f);
+
+        NetworkAddDecision copy = RoundTrip(original);
+
+        var copiedDecision = Assert.IsType<SettlementClaimantDecisionData>(copy.Data);
+        Assert.Collection(
+            copiedDecision.Candidates,
+            candidate =>
+            {
+                Assert.Equal("Clan_Player12", candidate.ClanId);
+                Assert.Equal(88.5f, candidate.InitialMerit);
+            },
+            candidate =>
+            {
+                Assert.Equal("clan_empire_south_4", candidate.ClanId);
+                Assert.Equal(41.25f, candidate.InitialMerit);
+            });
+    }
+
+    [Fact]
     public void NetworkRequestChangeKingdomName_RoundTrips()
     {
         var original = new NetworkRequestChangeKingdomName(

--- a/source/Coop.Tests/Autofac/TestComponentBuildTests.cs
+++ b/source/Coop.Tests/Autofac/TestComponentBuildTests.cs
@@ -1,0 +1,26 @@
+﻿using Autofac;
+using GameInterface.Services.Kingdoms;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Coop.Tests.Autofac;
+
+public class TestComponentBuildTests
+{
+    private readonly ITestOutputHelper output;
+
+    public TestComponentBuildTests(ITestOutputHelper output)
+    {
+        this.output = output;
+    }
+
+    [Fact]
+    public void ClientAndServerTestComponents_ResolveKingdomDecisionConverter()
+    {
+        using IContainer clientContainer = new ClientTestComponent(output).Container;
+        using IContainer serverContainer = new ServerTestComponent(output).Container;
+
+        Assert.NotNull(clientContainer.Resolve<IKingdomDecisionDataConverter>());
+        Assert.NotNull(serverContainer.Resolve<IKingdomDecisionDataConverter>());
+    }
+}

--- a/source/Coop.Tests/Client/States/CampaignStateTests.cs
+++ b/source/Coop.Tests/Client/States/CampaignStateTests.cs
@@ -8,10 +8,13 @@ using Coop.Core.Client.States;
 using Coop.Core.Server.Connections.Messages;
 using GameInterface.Services.GameState.Interfaces;
 using GameInterface.Services.GameState.Messages;
+using GameInterface.Services.Kingdoms;
+using GameInterface.Services.Kingdoms.Data;
 using GameInterface.Services.Time.Interfaces;
 using GameInterface.Services.UI.Interfaces;
 using GameInterface.Services.UI.Messages;
 using Moq;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
@@ -22,6 +25,7 @@ public class CampaignStateTests
 {
     private readonly IClientLogic clientLogic;
     private readonly ClientTestComponent clientComponent;
+    private readonly Mock<ISettlementClaimantSnapshotRegistry> snapshotRegistry;
 
     private TestMessageBroker TestMessageBroker => clientComponent.TestMessageBroker;
     public CampaignStateTests(ITestOutputHelper output)
@@ -29,6 +33,7 @@ public class CampaignStateTests
         clientComponent = new ClientTestComponent(output);
         var container = clientComponent.Container;
         clientLogic = container.Resolve<IClientLogic>()!;
+        snapshotRegistry = container.Resolve<Mock<ISettlementClaimantSnapshotRegistry>>();
     }
 
     [Fact(Skip = "Mission state not implemented and may be removed")]
@@ -199,6 +204,37 @@ public class CampaignStateTests
         loadingInterface.Verify(m => m.SetLoadingMessage(
             "Loading Host Campaign",
             "Finishing synchronization..."), Times.Once);
+    }
+
+    [Fact]
+    public void ReplayComplete_HydrationFailureDoesNotAcknowledgeReplay()
+    {
+        clientComponent.TestNetwork.CreatePeer();
+        _ = clientLogic.SetState<LoadingState>();
+        _ = clientLogic.SetState<CampaignState>();
+        snapshotRegistry
+            .Setup(registry => registry.TryApplyJoinSnapshots(
+                It.IsAny<IReadOnlyList<SettlementClaimantDecisionSnapshotData>>()))
+            .Returns(false);
+        var snapshots = new[]
+        {
+            new SettlementClaimantDecisionSnapshotData(
+                "kingdom",
+                1,
+                new[] { new SettlementClaimantCandidateData("clan", 15f) }),
+        };
+
+        TestMessageBroker.Publish(
+            this,
+            new NetworkJoinSync(JoinSyncSignal.ReplayComplete, snapshots));
+        DrainGameThread();
+
+        Assert.Equal(0, JoinSignalCount(JoinSyncSignal.ReplayApplied));
+        snapshotRegistry.Verify(
+            registry => registry.TryApplyJoinSnapshots(
+                It.Is<IReadOnlyList<SettlementClaimantDecisionSnapshotData>>(
+                    value => value.Count == 1 && value[0].KingdomId == "kingdom")),
+            Times.Once);
     }
 
     [Theory]

--- a/source/Coop.Tests/Server/Connections/States/LoadingStateTests.cs
+++ b/source/Coop.Tests/Server/Connections/States/LoadingStateTests.cs
@@ -11,6 +11,8 @@ using Coop.Core.Server.Services.MobileParties.Messages;
 using Coop.Tests.Extensions;
 using Coop.Tests.Mocks;
 using GameInterface.Services.Heroes.Enum;
+using GameInterface.Services.Kingdoms;
+using GameInterface.Services.Kingdoms.Data;
 using GameInterface.Services.MobileParties.Data;
 using LiteNetLib;
 using Moq;
@@ -29,6 +31,7 @@ namespace Coop.Tests.Server.Connections.States
         private readonly NetPeer differentPeer;
         private readonly ServerTestComponent serverComponent;
         private readonly Mock<IJoinCampaignBaselineSender> baselineSender;
+        private readonly Mock<ISettlementClaimantSnapshotRegistry> snapshotRegistry;
 
         public LoadingStateTests(ITestOutputHelper output)
         {
@@ -42,6 +45,7 @@ namespace Coop.Tests.Server.Connections.States
             differentPeer = network.CreatePeer();
             connectionLogic = container.Resolve<ConnectionLogic>(new TypedParameter(typeof(NetPeer), playerPeer));
             baselineSender = container.Resolve<Mock<IJoinCampaignBaselineSender>>();
+            snapshotRegistry = container.Resolve<Mock<ISettlementClaimantSnapshotRegistry>>();
 
             differentPeer.SetId(playerPeer.Id + 1);
         }
@@ -149,6 +153,33 @@ namespace Coop.Tests.Server.Connections.States
         }
 
         [Fact]
+        public void ReplayComplete_CarriesExportedSettlementClaimantSnapshots()
+        {
+            var snapshots = new[]
+            {
+                new SettlementClaimantDecisionSnapshotData(
+                    "kingdom",
+                    1,
+                    new[] { new SettlementClaimantCandidateData("clan", 15f) }),
+            };
+            snapshotRegistry
+                .Setup(registry => registry.TryCreateJoinSnapshots(out snapshots))
+                .Returns(true);
+            var state = connectionLogic.SetState<LoadingState>();
+
+            StartReplay(state);
+
+            NetworkJoinSync replayComplete = Assert.Single(
+                serverComponent.TestNetwork
+                    .GetPeerMessagesFromType<NetworkJoinSync>(playerPeer),
+                message => message.Signal == JoinSyncSignal.ReplayComplete);
+            SettlementClaimantDecisionSnapshotData snapshot = Assert.Single(replayComplete.ClaimantSnapshots);
+            Assert.Equal("kingdom", snapshot.KingdomId);
+            Assert.Equal(1, snapshot.DecisionIndex);
+            Assert.Equal("clan", Assert.Single(snapshot.Candidates).ClanId);
+        }
+
+        [Fact]
         public void ReplayReplyDuringMarkerSend_IsAccepted()
         {
             var connectionLogicMock = new Mock<IConnectionLogic>();
@@ -162,7 +193,8 @@ namespace Coop.Tests.Server.Connections.States
                 networkMock.Object,
                 baselineSender.Object,
                 new Mock<IConnectionMessageQueue>().Object,
-                new Mock<ISendCoalescer>().Object);
+                new Mock<ISendCoalescer>().Object,
+                snapshotRegistry.Object);
             connectionLogicMock.SetupGet(logic => logic.State).Returns(state);
             networkMock
                 .Setup(network => network.SendImmediate(playerPeer, It.IsAny<IMessage>()))

--- a/source/Coop.Tests/Server/Services/MobileParties/NetworkJoinCampaignBaselineTests.cs
+++ b/source/Coop.Tests/Server/Services/MobileParties/NetworkJoinCampaignBaselineTests.cs
@@ -4,6 +4,7 @@ using Common.Serialization;
 using Coop.Core.Server.Connections.Messages;
 using Coop.Core.Server.Services.MobileParties.Messages;
 using GameInterface.Services.Heroes.Enum;
+using GameInterface.Services.Kingdoms.Data;
 using GameInterface.Services.MobileParties.Data;
 using GameInterface.Surrogates;
 using System;
@@ -96,6 +97,42 @@ public class NetworkJoinCampaignBaselineTests
         {
             Assert.Equal(signal, RoundTrip(new NetworkJoinSync(signal)).Signal);
         }
+    }
+
+    [Fact]
+    public void ReplayComplete_RoundTripsSettlementClaimantSnapshots()
+    {
+        var expected = new NetworkJoinSync(
+            JoinSyncSignal.ReplayComplete,
+            new[]
+            {
+                new SettlementClaimantDecisionSnapshotData(
+                    "kingdom",
+                    2,
+                    new[]
+                    {
+                        new SettlementClaimantCandidateData("second", 22.5f),
+                        new SettlementClaimantCandidateData("first", 11.25f),
+                    }),
+            });
+
+        NetworkJoinSync received = RoundTrip(expected);
+
+        SettlementClaimantDecisionSnapshotData snapshot = Assert.Single(received.ClaimantSnapshots);
+        Assert.Equal("kingdom", snapshot.KingdomId);
+        Assert.Equal(2, snapshot.DecisionIndex);
+        Assert.Collection(
+            snapshot.Candidates,
+            candidate =>
+            {
+                Assert.Equal("second", candidate.ClanId);
+                Assert.Equal(22.5f, candidate.InitialMerit);
+            },
+            candidate =>
+            {
+                Assert.Equal("first", candidate.ClanId);
+                Assert.Equal(11.25f, candidate.InitialMerit);
+            });
     }
 
     private T RoundTrip<T>(T message) where T : IMessage

--- a/source/Coop.Tests/TestComponentBase.cs
+++ b/source/Coop.Tests/TestComponentBase.cs
@@ -14,6 +14,7 @@ using GameInterface.Services.MapEvents.Initialization;
 using GameInterface.Services.Heroes.Interaces;
 using GameInterface.Services.Heroes.Interfaces;
 using GameInterface.Services.Kingdoms;
+using GameInterface.Services.Kingdoms.Data;
 using GameInterface.Services.MapEvents.Interfaces;
 using GameInterface.Services.MapEvents.TroopSupply;
 using GameInterface.Services.MobileParties.Data;
@@ -35,6 +36,7 @@ using GameInterface.Services.Villages.Interfaces;
 using Moq;
 using Serilog;
 using System;
+using System.Collections.Generic;
 using Xunit.Abstractions;
 using IGameInterface = GameInterface.IGameInterface;
 using GameInterface.Services.CampaignService.Interfaces;
@@ -89,6 +91,7 @@ internal abstract class TestComponentBase
         builder.RegisterType<MobilePartyBehaviorSnapshot>().As<IMobilePartyBehaviorSnapshot>().InstancePerDependency();
         builder.RegisterType<RegistryCollection>().As<IRegistryCollection>().InstancePerLifetimeScope();
         builder.RegisterType<KingdomCreationSettlementTracker>().As<IKingdomCreationSettlementTracker>().InstancePerLifetimeScope();
+        RegisterSettlementClaimantSnapshotRegistryMock(builder);
         builder.RegisterType<KingdomDecisionDataConverter>().As<IKingdomDecisionDataConverter>().InstancePerLifetimeScope();
 
         RegisterMock<ILogger>(builder);
@@ -157,6 +160,17 @@ internal abstract class TestComponentBase
         mock.Setup(m => m.Players).Returns(Array.Empty<Player>());
         builder.RegisterInstance(mock).AsSelf().SingleInstance();
         builder.RegisterInstance(mock.Object).As<IPlayerManager>().SingleInstance();
+    }
+
+    private static void RegisterSettlementClaimantSnapshotRegistryMock(ContainerBuilder builder)
+    {
+        var mock = new Mock<ISettlementClaimantSnapshotRegistry>();
+        var snapshots = Array.Empty<SettlementClaimantDecisionSnapshotData>();
+        mock.Setup(m => m.TryCreateJoinSnapshots(out snapshots)).Returns(true);
+        mock.Setup(m => m.TryApplyJoinSnapshots(
+            It.IsAny<IReadOnlyList<SettlementClaimantDecisionSnapshotData>>())).Returns(true);
+        builder.RegisterInstance(mock).AsSelf().SingleInstance();
+        builder.RegisterInstance(mock.Object).As<ISettlementClaimantSnapshotRegistry>().SingleInstance();
     }
 
     private IContainer SetupContainerProvider(ContainerBuilder builder)

--- a/source/GameInterface.Tests/Services/Kingdoms/KingdomDecision/KingSelectionKingdomDecisionSerializationTest.cs
+++ b/source/GameInterface.Tests/Services/Kingdoms/KingdomDecision/KingSelectionKingdomDecisionSerializationTest.cs
@@ -55,7 +55,8 @@ namespace GameInterface.Tests.Services.Kingdoms.KingdomDecision
             Assert.Null(decision._clanToExclude);
 
             // Serialization: converting back must not throw on the null field and must keep it null.
-            KingdomDecisionData roundTrippedData = new KingdomDecisionDataConverter(objectManager).Convert(decision);
+            var snapshotRegistry = new SettlementClaimantSnapshotRegistry(objectManager);
+            KingdomDecisionData roundTrippedData = new KingdomDecisionDataConverter(objectManager, snapshotRegistry).Convert(decision);
             Assert.True(roundTrippedData is KingSelectionKingdomDecisionData);
             KingSelectionKingdomDecisionData roundTripped = (KingSelectionKingdomDecisionData)roundTrippedData;
             Assert.Null(roundTripped.ClanToExcludeId);

--- a/source/GameInterface.Tests/Services/Kingdoms/KingdomDecision/SettlementClaimantDecisionSerializationTest.cs
+++ b/source/GameInterface.Tests/Services/Kingdoms/KingdomDecision/SettlementClaimantDecisionSerializationTest.cs
@@ -3,6 +3,7 @@ using GameInterface.Services.Kingdoms;
 using GameInterface.Services.ObjectManager;
 using ProtoBuf;
 using Serilog;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using TaleWorlds.CampaignSystem;
@@ -18,7 +19,12 @@ namespace GameInterface.Tests.Services.Kingdoms.KingdomDecision
         [Fact]
         public void SerializeSettlementClaimantDecision()
         {
-            SettlementClaimantDecisionData settlementClaimantDecisionData = new SettlementClaimantDecisionData("ProposerClan", "Kingdom", 10, true, true, true, "Settlement1","Hero1", "Clan1");
+            var candidates = new List<SettlementClaimantCandidateData>
+            {
+                new SettlementClaimantCandidateData("Clan2", 20.5f),
+                new SettlementClaimantCandidateData("Clan3", 10.25f),
+            };
+            SettlementClaimantDecisionData settlementClaimantDecisionData = new SettlementClaimantDecisionData("ProposerClan", "Kingdom", 10, true, true, true, "Settlement1", "Hero1", "Clan1", candidates);
             KingdomDecisionData kingdomDecisionDerivedData = settlementClaimantDecisionData;
             MemoryStream memoryStream = new MemoryStream();
             Serializer.Serialize(memoryStream, kingdomDecisionDerivedData);
@@ -35,6 +41,18 @@ namespace GameInterface.Tests.Services.Kingdoms.KingdomDecision
             Assert.Equal(settlementClaimantDecisionData.SettlementId, deserializedObj.SettlementId);
             Assert.Equal(settlementClaimantDecisionData.CapturerHeroId, deserializedObj.CapturerHeroId);
             Assert.Equal(settlementClaimantDecisionData.ClanToExcludeId, deserializedObj.ClanToExcludeId);
+            Assert.Collection(
+                deserializedObj.Candidates,
+                candidate =>
+                {
+                    Assert.Equal("Clan2", candidate.ClanId);
+                    Assert.Equal(20.5f, candidate.InitialMerit);
+                },
+                candidate =>
+                {
+                    Assert.Equal("Clan3", candidate.ClanId);
+                    Assert.Equal(10.25f, candidate.InitialMerit);
+                });
         }
 
         [Fact]
@@ -66,11 +84,18 @@ namespace GameInterface.Tests.Services.Kingdoms.KingdomDecision
             kingdom.StringId = "Kingdom";
             Settlement settlement = (Settlement)FormatterServices.GetUninitializedObject(typeof(Settlement));
             settlement.StringId = "Settlement";
+            Clan candidateClan = (Clan)FormatterServices.GetUninitializedObject(typeof(Clan));
+            candidateClan.StringId = "CandidateClan";
             objectManager.AddExisting(proposerClan.StringId, proposerClan);
             objectManager.AddExisting(kingdom.StringId, kingdom);
             objectManager.AddExisting(settlement.StringId, settlement);
+            objectManager.AddExisting(candidateClan.StringId, candidateClan);
+            var candidates = new List<SettlementClaimantCandidateData>
+            {
+                new SettlementClaimantCandidateData(candidateClan.StringId, 42f),
+            };
             SettlementClaimantDecisionData data = new SettlementClaimantDecisionData(
-                proposerClan.StringId, kingdom.StringId, 10, true, true, true, settlement.StringId, null, null);
+                proposerClan.StringId, kingdom.StringId, 10, true, true, true, settlement.StringId, null, null, candidates);
 
             // Deserialization: null optional ids must reconstruct the decision, not drop it.
             Assert.True(data.TryGetKingdomDecision(objectManager, out var kingdomDecision));
@@ -81,12 +106,17 @@ namespace GameInterface.Tests.Services.Kingdoms.KingdomDecision
             Assert.Same(settlement, decision.Settlement);
 
             // Serialization: converting back must not throw on the null fields and must keep them null.
-            KingdomDecisionData roundTrippedData = new KingdomDecisionDataConverter(objectManager).Convert(decision);
+            var snapshotRegistry = new SettlementClaimantSnapshotRegistry(objectManager);
+            Assert.True(snapshotRegistry.TryRegister(decision, candidates));
+            KingdomDecisionData roundTrippedData = new KingdomDecisionDataConverter(objectManager, snapshotRegistry).Convert(decision);
             Assert.True(roundTrippedData is SettlementClaimantDecisionData);
             SettlementClaimantDecisionData roundTripped = (SettlementClaimantDecisionData)roundTrippedData;
             Assert.Null(roundTripped.CapturerHeroId);
             Assert.Null(roundTripped.ClanToExcludeId);
             Assert.Equal(settlement.StringId, roundTripped.SettlementId);
+            SettlementClaimantCandidateData candidate = Assert.Single(roundTripped.Candidates);
+            Assert.Equal(candidateClan.StringId, candidate.ClanId);
+            Assert.Equal(42f, candidate.InitialMerit);
         }
     }
 }

--- a/source/GameInterface.Tests/Services/Kingdoms/KingdomDecisionOutcomeResolverTests.cs
+++ b/source/GameInterface.Tests/Services/Kingdoms/KingdomDecisionOutcomeResolverTests.cs
@@ -1,6 +1,8 @@
-using Common.Util;
+﻿using Common.Util;
 using GameInterface.Services.Kingdoms;
 using GameInterface.Services.Kingdoms.Data;
+using GameInterface.Services.ObjectManager;
+using Serilog;
 using System;
 using System.Linq;
 using System.Reflection;
@@ -47,16 +49,92 @@ public class KingdomDecisionOutcomeResolverTests
         Assert.Same(noOutcome, resolvedOutcome);
     }
 
+    [Fact]
+    public void NonemptyOutcomeKey_DoesNotFallBackToOutcomeIndex()
+    {
+        DecisionOutcome yesOutcome = CreateBooleanOutcome(typeof(DeclareWarDecision), "DeclareWarDecisionOutcome", true);
+        var election = ObjectHelper.SkipConstructor<KingdomElection>();
+        election._possibleOutcomes = new MBList<DecisionOutcome> { yesOutcome };
+        var voteData = new KingdomDecisionVoteData(
+            "kingdom",
+            0,
+            0,
+            (int)Supporter.SupportWeights.FullyPush,
+            false,
+            true,
+            "stale-outcome-key");
+
+        var resolver = new KingdomDecisionOutcomeResolver();
+
+        Assert.False(resolver.TryGetOutcome(voteData, election, null, out DecisionOutcome resolvedOutcome));
+        Assert.Null(resolvedOutcome);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void MissingOutcomeKey_UsesOutcomeIndex(string? outcomeKey)
+    {
+        DecisionOutcome yesOutcome = CreateBooleanOutcome(typeof(DeclareWarDecision), "DeclareWarDecisionOutcome", true);
+        DecisionOutcome noOutcome = CreateBooleanOutcome(typeof(DeclareWarDecision), "DeclareWarDecisionOutcome", false);
+        var election = ObjectHelper.SkipConstructor<KingdomElection>();
+        election._possibleOutcomes = new MBList<DecisionOutcome> { yesOutcome, noOutcome };
+        var voteData = new KingdomDecisionVoteData(
+            "kingdom",
+            0,
+            1,
+            (int)Supporter.SupportWeights.FullyPush,
+            false,
+            true,
+            outcomeKey);
+
+        var resolver = new KingdomDecisionOutcomeResolver();
+
+        Assert.True(resolver.TryGetOutcome(voteData, election, null, out DecisionOutcome resolvedOutcome));
+        Assert.Same(noOutcome, resolvedOutcome);
+    }
+
+    [Fact]
+    public void ClaimantOutcomeKey_ResolvesClanWhenLocalIndexDiffers()
+    {
+        var objectManager = new ObjectManager(new LoggerConfiguration().CreateLogger());
+        var firstClan = ObjectHelper.SkipConstructor<TaleWorlds.CampaignSystem.Clan>();
+        firstClan.StringId = "first";
+        var selectedClan = ObjectHelper.SkipConstructor<TaleWorlds.CampaignSystem.Clan>();
+        selectedClan.StringId = "selected";
+        objectManager.AddExisting(firstClan.StringId, firstClan);
+        objectManager.AddExisting(selectedClan.StringId, selectedClan);
+        var firstOutcome = new SettlementClaimantDecision.ClanAsDecisionOutcome(firstClan);
+        var selectedOutcome = new SettlementClaimantDecision.ClanAsDecisionOutcome(selectedClan);
+        var election = ObjectHelper.SkipConstructor<KingdomElection>();
+        election._possibleOutcomes = new MBList<DecisionOutcome> { firstOutcome, selectedOutcome };
+        var resolver = new KingdomDecisionOutcomeResolver();
+
+        Assert.True(resolver.TryGetOutcomeKey(selectedOutcome, objectManager, out string outcomeKey));
+        var voteData = new KingdomDecisionVoteData(
+            "kingdom",
+            0,
+            0,
+            (int)Supporter.SupportWeights.FullyPush,
+            false,
+            true,
+            outcomeKey);
+
+        Assert.True(resolver.TryGetOutcome(voteData, election, objectManager, out DecisionOutcome resolvedOutcome));
+        Assert.Same(selectedOutcome, resolvedOutcome);
+    }
+
     private static DecisionOutcome CreateBooleanOutcome(Type decisionType, string outcomeTypeName, bool value)
     {
         Type outcomeType = decisionType.GetNestedType(
             outcomeTypeName,
-            BindingFlags.Public | BindingFlags.NonPublic);
-        Assert.NotNull(outcomeType);
+            BindingFlags.Public | BindingFlags.NonPublic)
+            ?? throw new NullReferenceException($"{outcomeTypeName} outcome type was not found.");
 
         ConstructorInfo constructor = outcomeType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
             .Single(info => info.GetParameters().Length > 0 && info.GetParameters()[0].ParameterType == typeof(bool));
-        object[] args = constructor.GetParameters()
+        object?[] args = constructor.GetParameters()
             .Select((_, index) => index == 0 ? (object)value : null)
             .ToArray();
 

--- a/source/GameInterface.Tests/Services/Kingdoms/KingdomHandlerTests.cs
+++ b/source/GameInterface.Tests/Services/Kingdoms/KingdomHandlerTests.cs
@@ -1,17 +1,27 @@
-﻿using Common.Messaging;
+﻿using Common;
+using Common.Messaging;
 using Common.Util;
 using GameInterface.Services.Kingdoms;
+using GameInterface.Services.Kingdoms.Data;
 using GameInterface.Services.Kingdoms.Handlers;
+using GameInterface.Services.Kingdoms.Messages;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
 using Moq;
+using Serilog;
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Election;
+using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.Library;
 using Xunit;
+using KingdomDecisionType = TaleWorlds.CampaignSystem.Election.KingdomDecision;
 
 namespace GameInterface.Tests.Services.Kingdoms;
 
+[Collection(ModInformationRoleCollection.Name)]
 public class KingdomHandlerTests
 {
     [Fact]
@@ -128,6 +138,87 @@ public class KingdomHandlerTests
         Assert.Null(reason);
     }
 
+    [Fact]
+    public void ClientSettlementClaimantDecision_RegistersAuthoritativeSnapshotBeforeApplying()
+    {
+        var objectManager = new ObjectManager(new LoggerConfiguration().CreateLogger());
+        Kingdom kingdom = RegisterObject<Kingdom>(objectManager, "kingdom");
+        Clan proposerClan = RegisterObject<Clan>(objectManager, "proposer");
+        Settlement settlement = RegisterObject<Settlement>(objectManager, "settlement");
+        Clan firstClan = RegisterObject<Clan>(objectManager, "first");
+        Clan secondClan = RegisterObject<Clan>(objectManager, "second");
+        var candidates = new List<SettlementClaimantCandidateData>
+        {
+            new SettlementClaimantCandidateData(secondClan.StringId, 15f),
+            new SettlementClaimantCandidateData(firstClan.StringId, 90f),
+        };
+        var data = new SettlementClaimantDecisionData(
+            proposerClan.StringId, kingdom.StringId, 1, false, true, false,
+            settlement.StringId, null, null, candidates);
+        var snapshotRegistry = new SettlementClaimantSnapshotRegistry(objectManager);
+        SettlementClaimantDecision? appliedDecision = null;
+        var kingdomInterface = new Mock<IKingdomInterface>();
+        kingdomInterface
+            .Setup(value => value.RunAddDecision(kingdom, It.IsAny<KingdomDecisionType>(), false, 0.5f))
+            .Callback<Kingdom, KingdomDecisionType, bool, float>((_, decision, _, _) =>
+            {
+                appliedDecision = Assert.IsType<SettlementClaimantDecision>(decision);
+            });
+        KingdomHandler handler = CreateHandler(objectManager, kingdomInterface.Object, snapshotRegistry);
+        bool wasServer = ModInformation.IsServer;
+
+        try
+        {
+            ModInformation.IsServer = false;
+            ApplyAddDecision(handler, new AddDecision(kingdom.StringId, data, false, 0.5f));
+        }
+        finally
+        {
+            ModInformation.IsServer = wasServer;
+        }
+
+        Assert.NotNull(appliedDecision);
+        Assert.True(snapshotRegistry.TryCreateOutcomes(appliedDecision, out MBList<DecisionOutcome> outcomes));
+        Assert.Collection(
+            outcomes,
+            outcome => AssertClaimantOutcome(outcome, secondClan, 15f),
+            outcome => AssertClaimantOutcome(outcome, firstClan, 90f));
+    }
+
+    [Fact]
+    public void ClientSettlementClaimantDecision_WithMissingCandidate_DoesNotApply()
+    {
+        var objectManager = new ObjectManager(new LoggerConfiguration().CreateLogger());
+        Kingdom kingdom = RegisterObject<Kingdom>(objectManager, "kingdom");
+        Clan proposerClan = RegisterObject<Clan>(objectManager, "proposer");
+        Settlement settlement = RegisterObject<Settlement>(objectManager, "settlement");
+        var candidates = new List<SettlementClaimantCandidateData>
+        {
+            new SettlementClaimantCandidateData("missing", 15f),
+        };
+        var data = new SettlementClaimantDecisionData(
+            proposerClan.StringId, kingdom.StringId, 1, false, true, false,
+            settlement.StringId, null, null, candidates);
+        var snapshotRegistry = new SettlementClaimantSnapshotRegistry(objectManager);
+        var kingdomInterface = new Mock<IKingdomInterface>();
+        KingdomHandler handler = CreateHandler(objectManager, kingdomInterface.Object, snapshotRegistry);
+        bool wasServer = ModInformation.IsServer;
+
+        try
+        {
+            ModInformation.IsServer = false;
+            ApplyAddDecision(handler, new AddDecision(kingdom.StringId, data, false, 0.5f));
+        }
+        finally
+        {
+            ModInformation.IsServer = wasServer;
+        }
+
+        kingdomInterface.Verify(
+            value => value.RunAddDecision(It.IsAny<Kingdom>(), It.IsAny<KingdomDecisionType>(), It.IsAny<bool>(), It.IsAny<float>()),
+            Times.Never);
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]
@@ -150,7 +241,10 @@ public class KingdomHandlerTests
         Assert.Equal("kingdom name was empty", reason);
     }
     
-    private static KingdomHandler CreateHandler(IObjectManager objectManager)
+    private static KingdomHandler CreateHandler(
+        IObjectManager objectManager,
+        IKingdomInterface? kingdomInterface = null,
+        ISettlementClaimantSnapshotRegistry? settlementClaimantSnapshotRegistry = null)
     {
         return new KingdomHandler(
             new Mock<IMessageBroker>().Object,
@@ -158,8 +252,9 @@ public class KingdomHandlerTests
             new Mock<IPlayerManager>().Object,
             new Mock<IKingdomDecisionVoteManager>().Object,
             new Mock<IKingdomMembershipState>().Object,
-            new Mock<IKingdomInterface>().Object,
-            new Mock<IKingdomCreator>().Object);
+            kingdomInterface ?? new Mock<IKingdomInterface>().Object,
+            new Mock<IKingdomCreator>().Object,
+            settlementClaimantSnapshotRegistry ?? new Mock<ISettlementClaimantSnapshotRegistry>().Object);
     }
 
     private static bool TryGetCulture(KingdomHandler handler, string cultureId, out CultureObject culture)
@@ -170,5 +265,29 @@ public class KingdomHandlerTests
         bool result = (bool)(methodInfo.Invoke(handler, args) ?? false);
         culture = (CultureObject)args[1];
         return result;
+    }
+
+    private static void ApplyAddDecision(KingdomHandler handler, AddDecision payload)
+    {
+        MethodInfo methodInfo = typeof(KingdomHandler).GetMethod("ApplyAddDecision", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new NullReferenceException("ApplyAddDecision method was not found.");
+        methodInfo.Invoke(handler, new object[] { payload });
+    }
+
+    private static T RegisterObject<T>(ObjectManager objectManager, string id) where T : class
+    {
+        T value = ObjectHelper.SkipConstructor<T>();
+        PropertyInfo stringIdProperty = typeof(T).GetProperty(nameof(Clan.StringId))
+            ?? throw new NullReferenceException($"{typeof(T).Name}.{nameof(Clan.StringId)} property was not found.");
+        stringIdProperty.SetValue(value, id);
+        objectManager.AddExisting(id, value);
+        return value;
+    }
+
+    private static void AssertClaimantOutcome(DecisionOutcome outcome, Clan clan, float merit)
+    {
+        var claimantOutcome = Assert.IsType<SettlementClaimantDecision.ClanAsDecisionOutcome>(outcome);
+        Assert.Same(clan, claimantOutcome.Clan);
+        Assert.Equal(merit, claimantOutcome.InitialMerit);
     }
 }

--- a/source/GameInterface.Tests/Services/Kingdoms/KingdomInterfaceTests.cs
+++ b/source/GameInterface.Tests/Services/Kingdoms/KingdomInterfaceTests.cs
@@ -1,0 +1,61 @@
+﻿using Autofac;
+using Common;
+using Common.Util;
+using GameInterface.Policies;
+using GameInterface.Services.Kingdoms;
+using Moq;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Election;
+using Xunit;
+using KingdomDecisionType = TaleWorlds.CampaignSystem.Election.KingdomDecision;
+
+namespace GameInterface.Tests.Services.Kingdoms;
+
+[Collection(ModInformationRoleCollection.Name)]
+public class KingdomInterfaceTests
+{
+    [Fact]
+    public void ClientSettlementClaimantDecision_IsNotAppliedLocally()
+    {
+        var voteManager = new Mock<IKingdomDecisionVoteManager>();
+        var kingdomInterface = new KingdomInterface(voteManager.Object);
+        Kingdom kingdom = ObjectHelper.SkipConstructor<Kingdom>();
+        SettlementClaimantDecision decision = ObjectHelper.SkipConstructor<SettlementClaimantDecision>();
+        bool wasServer = ModInformation.IsServer;
+        var builder = new ContainerBuilder();
+        builder.RegisterInstance(new DenyOriginalSyncPolicy()).As<ISyncPolicy>();
+        using var container = builder.Build();
+        bool hadPreviousContainer = ContainerProvider.TryGetContainer(out var previousContainer);
+
+        try
+        {
+            ModInformation.IsServer = false;
+
+            using (ContainerProvider.UseContainerThreadSafe(container))
+            {
+                Assert.False(kingdomInterface.AddDecisionPrefix(kingdom, decision, true));
+            }
+        }
+        finally
+        {
+            ModInformation.IsServer = wasServer;
+            if (hadPreviousContainer)
+            {
+                ContainerProvider.SetContainer(previousContainer);
+            }
+            else
+            {
+                ContainerProvider.Clear();
+            }
+        }
+
+        voteManager.Verify(
+            value => value.HasEligiblePlayerClan(It.IsAny<KingdomDecisionType>()),
+            Times.Never);
+    }
+
+    private sealed class DenyOriginalSyncPolicy : ISyncPolicy
+    {
+        public bool AllowOriginal() => false;
+    }
+}

--- a/source/GameInterface.Tests/Services/Kingdoms/SettlementClaimantSnapshotRegistryTests.cs
+++ b/source/GameInterface.Tests/Services/Kingdoms/SettlementClaimantSnapshotRegistryTests.cs
@@ -1,0 +1,258 @@
+﻿using Common.Util;
+using GameInterface.Services.Kingdoms;
+using GameInterface.Services.Kingdoms.Data;
+using GameInterface.Services.ObjectManager;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Election;
+using TaleWorlds.Library;
+using Xunit;
+using KingdomDecisionType = TaleWorlds.CampaignSystem.Election.KingdomDecision;
+
+namespace GameInterface.Tests.Services.Kingdoms;
+
+public class SettlementClaimantSnapshotRegistryTests
+{
+    [Fact]
+    public void RegisteredSnapshot_CreatesOutcomesInAuthoritativeOrderWithMerits()
+    {
+        ObjectManager objectManager = CreateObjectManager();
+        Clan firstClan = RegisterClan(objectManager, "first");
+        Clan secondClan = RegisterClan(objectManager, "second");
+        var decision = ObjectHelper.SkipConstructor<SettlementClaimantDecision>();
+        var registry = new SettlementClaimantSnapshotRegistry(objectManager);
+        var candidates = new List<SettlementClaimantCandidateData>
+        {
+            new SettlementClaimantCandidateData(secondClan.StringId, 22.5f),
+            new SettlementClaimantCandidateData(firstClan.StringId, 11.25f),
+        };
+
+        Assert.True(registry.TryRegister(decision, candidates));
+        Assert.True(registry.TryCreateOutcomes(decision, out MBList<DecisionOutcome> outcomes));
+
+        Assert.Collection(
+            outcomes,
+            outcome => AssertOutcome(outcome, secondClan, 22.5f),
+            outcome => AssertOutcome(outcome, firstClan, 11.25f));
+    }
+
+    [Fact]
+    public void RegisterSnapshot_MissingClan_ReturnsFalseWithoutSnapshot()
+    {
+        ObjectManager objectManager = CreateObjectManager();
+        var decision = ObjectHelper.SkipConstructor<SettlementClaimantDecision>();
+        var registry = new SettlementClaimantSnapshotRegistry(objectManager);
+        var candidates = new List<SettlementClaimantCandidateData>
+        {
+            new SettlementClaimantCandidateData("missing", 10f),
+        };
+
+        Assert.False(registry.TryRegister(decision, candidates));
+        Assert.False(registry.TryCreateOutcomes(decision, out MBList<DecisionOutcome> outcomes));
+        Assert.Null(outcomes);
+    }
+
+    [Fact]
+    public void CapturedNarrowing_IsReusedWithoutRecalculatingMerits()
+    {
+        ObjectManager objectManager = CreateObjectManager();
+        Clan firstClan = RegisterClan(objectManager, "first");
+        Clan secondClan = RegisterClan(objectManager, "second");
+        var decision = ObjectHelper.SkipConstructor<SettlementClaimantDecision>();
+        var registry = new SettlementClaimantSnapshotRegistry(objectManager);
+        var narrowedOutcomes = new MBList<DecisionOutcome>
+        {
+            CreateOutcome(firstClan, 31f),
+            CreateOutcome(secondClan, 17f),
+        };
+
+        registry.Capture(decision, narrowedOutcomes);
+        Assert.True(registry.TryCreateOutcomes(decision, out MBList<DecisionOutcome> reconstructedOutcomes));
+
+        Assert.Collection(
+            reconstructedOutcomes,
+            outcome => AssertOutcome(outcome, firstClan, 31f),
+            outcome => AssertOutcome(outcome, secondClan, 17f));
+        Assert.NotSame(narrowedOutcomes[0], reconstructedOutcomes[0]);
+        Assert.NotSame(narrowedOutcomes[1], reconstructedOutcomes[1]);
+    }
+
+    [Fact]
+    public void RegisterSnapshot_IdenticalRetrySucceedsAndConflictingRetryFails()
+    {
+        ObjectManager objectManager = CreateObjectManager();
+        Clan clan = RegisterClan(objectManager, "claimant");
+        var decision = ObjectHelper.SkipConstructor<SettlementClaimantDecision>();
+        var registry = new SettlementClaimantSnapshotRegistry(objectManager);
+
+        Assert.True(registry.TryRegister(
+            decision,
+            new[] { new SettlementClaimantCandidateData(clan.StringId, 25f) }));
+        Assert.True(registry.TryRegister(
+            decision,
+            new[] { new SettlementClaimantCandidateData(clan.StringId, 25f) }));
+        Assert.False(registry.TryRegister(
+            decision,
+            new[] { new SettlementClaimantCandidateData(clan.StringId, 30f) }));
+
+        Assert.True(registry.TryCreateOutcomes(decision, out MBList<DecisionOutcome> outcomes));
+        Assert.Collection(outcomes, outcome => AssertOutcome(outcome, clan, 25f));
+    }
+
+    [Fact]
+    public void JoinSnapshots_RoundTripByKingdomAndUnresolvedDecisionIndex()
+    {
+        ObjectManager serverObjectManager = CreateObjectManager();
+        Clan serverFirstClan = RegisterClan(serverObjectManager, "first");
+        Clan serverSecondClan = RegisterClan(serverObjectManager, "second");
+        var serverDecision = ObjectHelper.SkipConstructor<SettlementClaimantDecision>();
+        Kingdom serverKingdom = RegisterKingdom(
+            serverObjectManager,
+            "kingdom",
+            ObjectHelper.SkipConstructor<KingSelectionKingdomDecision>(),
+            serverDecision);
+        var serverRegistry = new SettlementClaimantSnapshotRegistry(serverObjectManager);
+        Assert.True(serverRegistry.TryRegister(
+            serverDecision,
+            new[]
+            {
+                new SettlementClaimantCandidateData(serverSecondClan.StringId, 22.5f),
+                new SettlementClaimantCandidateData(serverFirstClan.StringId, 11.25f),
+            }));
+
+        Assert.True(serverRegistry.TryCreateJoinSnapshots(
+            new[] { serverKingdom },
+            out SettlementClaimantDecisionSnapshotData[] snapshots));
+        SettlementClaimantDecisionSnapshotData snapshot = Assert.Single(snapshots);
+        Assert.Equal("kingdom", snapshot.KingdomId);
+        Assert.Equal(1, snapshot.DecisionIndex);
+
+        ObjectManager clientObjectManager = CreateObjectManager();
+        Clan clientFirstClan = RegisterClan(clientObjectManager, "first");
+        Clan clientSecondClan = RegisterClan(clientObjectManager, "second");
+        var clientDecision = ObjectHelper.SkipConstructor<SettlementClaimantDecision>();
+        Kingdom clientKingdom = RegisterKingdom(
+            clientObjectManager,
+            "kingdom",
+            ObjectHelper.SkipConstructor<KingSelectionKingdomDecision>(),
+            clientDecision);
+        var clientRegistry = new SettlementClaimantSnapshotRegistry(clientObjectManager);
+
+        Assert.True(clientRegistry.TryApplyJoinSnapshots(new[] { clientKingdom }, snapshots));
+        Assert.True(clientRegistry.TryCreateOutcomes(clientDecision, out MBList<DecisionOutcome> outcomes));
+        Assert.Collection(
+            outcomes,
+            outcome => AssertOutcome(outcome, clientSecondClan, 22.5f),
+            outcome => AssertOutcome(outcome, clientFirstClan, 11.25f));
+    }
+
+    [Fact]
+    public void ApplyJoinSnapshots_MissingLoadedDecisionSnapshotFails()
+    {
+        ObjectManager objectManager = CreateObjectManager();
+        var decision = ObjectHelper.SkipConstructor<SettlementClaimantDecision>();
+        Kingdom kingdom = RegisterKingdom(objectManager, "kingdom", decision);
+        var registry = new SettlementClaimantSnapshotRegistry(objectManager);
+
+        Assert.False(registry.TryApplyJoinSnapshots(
+            new[] { kingdom },
+            Array.Empty<SettlementClaimantDecisionSnapshotData>()));
+        Assert.False(registry.TryCreateOutcomes(decision, out _));
+    }
+
+    [Fact]
+    public void ApplyJoinSnapshots_ReplacesConflictingProvisionalLocalCapture()
+    {
+        ObjectManager objectManager = CreateObjectManager();
+        Clan localClan = RegisterClan(objectManager, "local");
+        Clan serverClan = RegisterClan(objectManager, "server");
+        var decision = ObjectHelper.SkipConstructor<SettlementClaimantDecision>();
+        Kingdom kingdom = RegisterKingdom(objectManager, "kingdom", decision);
+        var registry = new SettlementClaimantSnapshotRegistry(objectManager);
+        registry.Capture(
+            decision,
+            new MBList<DecisionOutcome> { CreateOutcome(localClan, 30f) });
+        var joinSnapshots = new[]
+        {
+            new SettlementClaimantDecisionSnapshotData(
+                "kingdom",
+                0,
+                new[] { new SettlementClaimantCandidateData(serverClan.StringId, 20f) }),
+        };
+
+        Assert.True(registry.TryApplyJoinSnapshots(new[] { kingdom }, joinSnapshots));
+        Assert.True(registry.TryCreateOutcomes(decision, out MBList<DecisionOutcome> outcomes));
+        Assert.Collection(outcomes, outcome => AssertOutcome(outcome, serverClan, 20f));
+    }
+
+    [Fact]
+    public void ApplyJoinSnapshots_RejectsConflictingSynchronizedSnapshot()
+    {
+        ObjectManager objectManager = CreateObjectManager();
+        Clan firstServerClan = RegisterClan(objectManager, "first-server");
+        Clan secondServerClan = RegisterClan(objectManager, "second-server");
+        var decision = ObjectHelper.SkipConstructor<SettlementClaimantDecision>();
+        Kingdom kingdom = RegisterKingdom(objectManager, "kingdom", decision);
+        var registry = new SettlementClaimantSnapshotRegistry(objectManager);
+        Assert.True(registry.TryRegister(
+            decision,
+            new[] { new SettlementClaimantCandidateData(firstServerClan.StringId, 30f) }));
+        var joinSnapshots = new[]
+        {
+            new SettlementClaimantDecisionSnapshotData(
+                "kingdom",
+                0,
+                new[] { new SettlementClaimantCandidateData(secondServerClan.StringId, 20f) }),
+        };
+
+        Assert.False(registry.TryApplyJoinSnapshots(new[] { kingdom }, joinSnapshots));
+        Assert.True(registry.TryCreateOutcomes(decision, out MBList<DecisionOutcome> outcomes));
+        Assert.Collection(outcomes, outcome => AssertOutcome(outcome, firstServerClan, 30f));
+    }
+
+    private static ObjectManager CreateObjectManager()
+    {
+        return new ObjectManager(new LoggerConfiguration().CreateLogger());
+    }
+
+    private static Clan RegisterClan(ObjectManager objectManager, string clanId)
+    {
+        var clan = ObjectHelper.SkipConstructor<Clan>();
+        clan.StringId = clanId;
+        objectManager.AddExisting(clanId, clan);
+        return clan;
+    }
+
+    private static Kingdom RegisterKingdom(
+        ObjectManager objectManager,
+        string kingdomId,
+        params KingdomDecisionType[] decisions)
+    {
+        var kingdom = ObjectHelper.SkipConstructor<Kingdom>();
+        kingdom.StringId = kingdomId;
+        kingdom._unresolvedDecisions = new MBList<KingdomDecisionType>();
+        foreach (KingdomDecisionType decision in decisions)
+        {
+            kingdom._unresolvedDecisions.Add(decision);
+        }
+        objectManager.AddExisting(kingdomId, kingdom);
+        return kingdom;
+    }
+
+    private static SettlementClaimantDecision.ClanAsDecisionOutcome CreateOutcome(Clan clan, float merit)
+    {
+        return new SettlementClaimantDecision.ClanAsDecisionOutcome(clan)
+        {
+            InitialMerit = merit,
+        };
+    }
+
+    private static void AssertOutcome(DecisionOutcome outcome, Clan expectedClan, float expectedMerit)
+    {
+        var claimantOutcome = Assert.IsType<SettlementClaimantDecision.ClanAsDecisionOutcome>(outcome);
+        Assert.Same(expectedClan, claimantOutcome.Clan);
+        Assert.Equal(expectedMerit, claimantOutcome.InitialMerit);
+    }
+}

--- a/source/GameInterface/GameInterfaceModule.cs
+++ b/source/GameInterface/GameInterfaceModule.cs
@@ -83,6 +83,7 @@ public class GameInterfaceModule : Module
         builder.RegisterType<LiveTestCommandDispatcher>().As<ILiveTestCommandDispatcher>().InstancePerDependency();
         builder.RegisterType<KingdomCreationSettlementTracker>().AsSelf().As<IKingdomCreationSettlementTracker>().InstancePerLifetimeScope();
         builder.RegisterType<KingdomCreator>().AsSelf().As<IKingdomCreator>().InstancePerLifetimeScope();
+        builder.RegisterType<SettlementClaimantSnapshotRegistry>().AsSelf().As<ISettlementClaimantSnapshotRegistry>().InstancePerLifetimeScope();
         builder.RegisterType<KingdomDecisionOutcomeResolver>().AsSelf().As<IKingdomDecisionOutcomeResolver>().InstancePerLifetimeScope();
         builder.RegisterType<KingdomDecisionVoteManager>().AsSelf().As<IKingdomDecisionVoteManager>().InstancePerLifetimeScope();
         builder.RegisterType<KingdomMembershipState>().AsSelf().As<IKingdomMembershipState>().InstancePerLifetimeScope();

--- a/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
+++ b/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
@@ -11,6 +11,8 @@ using GameInterface.Services.Kingdoms.Data;
 using GameInterface.Services.Kingdoms.Messages;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
+using SandBox.GauntletUI;
+using SandBox.View.Map;
 using Serilog;
 using System;
 using System.Collections.Generic;
@@ -22,6 +24,11 @@ using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.Election;
 using TaleWorlds.CampaignSystem.Party.PartyComponents;
 using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.CampaignSystem.ViewModelCollection.KingdomManagement.Decisions;
+using TaleWorlds.CampaignSystem.ViewModelCollection.KingdomManagement.Decisions.ItemTypes;
+using TaleWorlds.CampaignSystem.ViewModelCollection.KingdomManagement.Settlements;
+using TaleWorlds.Library;
+using TaleWorlds.ScreenSystem;
 using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Kingdoms.Commands;
@@ -595,6 +602,360 @@ public class KingdomDebugCommand
 
         return $"Requested vote for {decision.GetType().Name}: outcome={args[2]}, support={supportWeight}.";
     }
+
+#if DEBUG || DEBUGAUTOCONNECT
+    // coop.debug.kingdom.annex_settlement
+    /// <summary>
+    /// Requests a settlement through the real Kingdom settlement view model.
+    /// </summary>
+    /// <param name="args">settlementId</param>
+    /// <returns>result message</returns>
+    [CommandLineArgumentFunction("annex_settlement", "coop.debug.kingdom")]
+    public static string AnnexSettlement(List<string> args)
+    {
+        if (args.Count != 1)
+        {
+            return "Usage: coop.debug.kingdom.annex_settlement <settlementId>";
+        }
+        if (!ModInformation.IsClient)
+        {
+            return "This command can only be run on a client.";
+        }
+        if (!TryGetObjectManager(out var objectManager))
+        {
+            return "Unable to resolve ObjectManager";
+        }
+        if (!objectManager.TryGetObject(args[0], out Settlement settlement))
+        {
+            return $"ID: '{args[0]}' not found";
+        }
+        if (!(ScreenManager.TopScreen is MapScreen mapScreen))
+        {
+            return "The campaign map is not active.";
+        }
+
+        Kingdom playerKingdom = Clan.PlayerClan?.Kingdom;
+        if (playerKingdom == null)
+        {
+            return "The local player is not in a kingdom.";
+        }
+        if (settlement.MapFaction != playerKingdom)
+        {
+            return $"{settlement.Name} is not in the local player's kingdom.";
+        }
+        if (playerKingdom.UnresolvedDecisions.Any(candidate =>
+                candidate is SettlementClaimantPreliminaryDecision preliminaryDecision &&
+                preliminaryDecision.Settlement == settlement))
+        {
+            return $"A preliminary claimant decision already exists for {settlement.Name}.";
+        }
+
+        mapScreen.OpenKingdom();
+        if (!(ScreenManager.TopScreen is GauntletKingdomScreen kingdomScreen))
+        {
+            return "The real Kingdom screen did not open.";
+        }
+
+        KingdomSettlementVM settlementVm = kingdomScreen.DataSource?.Settlement;
+        if (settlementVm == null)
+        {
+            return "The Kingdom settlement view model is unavailable.";
+        }
+
+        settlementVm.SelectSettlement(settlement);
+        if (settlementVm.CurrentSelectedSettlement?.Settlement != settlement)
+        {
+            return $"The real Kingdom settlement UI did not select {settlement.Name}.";
+        }
+        if (!settlementVm.CanAnnexCurrentSettlement)
+        {
+            return $"The real Kingdom settlement UI cannot request {settlement.Name}: " +
+                   $"influence={Clan.PlayerClan.Influence}, annexCost={settlementVm.AnnexCost}.";
+        }
+
+        settlementVm.ExecuteAnnex();
+        SettlementClaimantPreliminaryDecision decision = playerKingdom.UnresolvedDecisions
+            .OfType<SettlementClaimantPreliminaryDecision>()
+            .SingleOrDefault(candidate => candidate.Settlement == settlement);
+        DecisionItemBaseVM decisionItem = kingdomScreen.DataSource?.Decision?.CurrentDecision;
+        if (decision == null || decisionItem?.KingdomDecisionMaker?._decision != decision || !decisionItem.IsActive)
+        {
+            return $"The real request-city action did not activate a preliminary decision for {settlement.Name}.";
+        }
+
+        return $"Requested {settlement.Name} through real KingdomSettlementVM.ExecuteAnnex: " +
+               $"annexCost={settlementVm.AnnexCost}, influence={Clan.PlayerClan.Influence}, " +
+               $"decisionActive={decisionItem.IsActive}, " +
+               $"playerRole={(decisionItem.IsPlayerSupporter ? "Supporter" : "Chooser")}.";
+    }
+
+    // coop.debug.kingdom.open_current_decision
+    /// <summary>
+    /// Accepts the active Kingdom decision inquiry through its real affirmative action.
+    /// </summary>
+    /// <param name="args">kingdomId and 1-based decision index</param>
+    /// <returns>result message</returns>
+    [CommandLineArgumentFunction("open_current_decision", "coop.debug.kingdom")]
+    public static string OpenCurrentDecision(List<string> args)
+    {
+        if (!ModInformation.IsClient)
+        {
+            return "This command can only be run on a client.";
+        }
+        if (!TryGetKingdomDecisionByIndex(args, out Kingdom _, out KingdomDecision decision, out int _, out string message))
+        {
+            return message;
+        }
+        if (ScreenManager.TopScreen is MapScreen mapScreen)
+        {
+            if (InformationManager.IsAnyInquiryActive())
+            {
+                return "Another inquiry is already active on the campaign map.";
+            }
+
+            Kingdom playerKingdom = Clan.PlayerClan?.Kingdom;
+            if (playerKingdom == null)
+            {
+                return "The local player is not in a kingdom.";
+            }
+
+            if (decision.Kingdom != playerKingdom || !decision.IsPlayerParticipant || decision.ShouldBeCancelled())
+            {
+                return $"{decision.GetType().Name} is not an active decision for the local player.";
+            }
+
+            mapScreen.OpenKingdom();
+            if (!(ScreenManager.TopScreen is GauntletKingdomScreen openedKingdomScreen))
+            {
+                return "The real Kingdom screen did not open.";
+            }
+
+            KingdomDecisionsVM openedDecisions = openedKingdomScreen.DataSource?.Decision;
+            if (openedDecisions == null)
+            {
+                return "The Kingdom decision view model is unavailable.";
+            }
+            openedDecisions.HandleDecision(decision);
+            if (openedDecisions._queryData?.AffirmativeAction == null || !InformationManager.IsAnyInquiryActive())
+            {
+                return $"The real Kingdom decision inquiry did not open for {decision.GetType().Name}.";
+            }
+
+            return $"Entered the real Kingdom decision screen for {decision.GetType().Name} " +
+                   "through KingdomDecisionsVM.HandleDecision.";
+        }
+        if (!(ScreenManager.TopScreen is GauntletKingdomScreen kingdomScreen))
+        {
+            return "The Kingdom decision screen is not active.";
+        }
+
+        KingdomDecisionsVM decisions = kingdomScreen.DataSource?.Decision;
+        if (decisions?.CurrentDecision?.KingdomDecisionMaker?._decision == decision)
+        {
+            return $"The real decision UI is already active for {decision.GetType().Name}.";
+        }
+        if (decisions?._queryData?.AffirmativeAction == null)
+        {
+            return $"The decision inquiry is not available for {decision.GetType().Name}.";
+        }
+        if (!InformationManager.IsAnyInquiryActive())
+        {
+            return $"The decision inquiry is not active for {decision.GetType().Name}.";
+        }
+
+        Action affirmativeAction = decisions._queryData.AffirmativeAction;
+        affirmativeAction();
+        InformationManager.HideInquiry();
+        DecisionItemBaseVM decisionItem = decisions.CurrentDecision;
+        if (decisionItem?.KingdomDecisionMaker?._decision != decision || !decisionItem.IsActive)
+        {
+            return $"The real decision UI did not activate for {decision.GetType().Name}.";
+        }
+
+        return $"Opened real decision UI for {decision.GetType().Name}: " +
+               $"decisionActive={decisionItem.IsActive}, playerRole={(decisionItem.IsPlayerSupporter ? "Supporter" : "Chooser")}.";
+    }
+
+    // coop.debug.kingdom.select_current_decision
+    /// <summary>
+    /// Selects an outcome and support weight through the active client decision view model.
+    /// </summary>
+    /// <param name="args">kingdomId, 1-based decision index, 1-based outcome index or abstain, support weight</param>
+    /// <returns>result message</returns>
+    [CommandLineArgumentFunction("select_current_decision", "coop.debug.kingdom")]
+    public static string SelectCurrentDecision(List<string> args)
+    {
+        if (!ModInformation.IsClient)
+        {
+            return "This command can only be run on a client.";
+        }
+        if (!TryGetKingdomDecisionByIndex(args, out Kingdom _, out KingdomDecision decision, out int _, out string message))
+        {
+            return message;
+        }
+        if (args.Count < 4)
+        {
+            return "Usage: coop.debug.kingdom.select_current_decision <kingdomId> <decisionIndex> <outcomeIndex|abstain> <supportWeight>";
+        }
+        if (!(ScreenManager.TopScreen is GauntletKingdomScreen kingdomScreen))
+        {
+            return "The Kingdom decision screen is not active.";
+        }
+
+        DecisionItemBaseVM decisionItem = kingdomScreen.DataSource?.Decision?.CurrentDecision;
+        if (decisionItem?.KingdomDecisionMaker?._decision != decision)
+        {
+            string currentDecision = decisionItem?.KingdomDecisionMaker?._decision?.GetType().Name ?? "none";
+            return $"The active decision is {currentDecision}, expected {decision.GetType().Name}.";
+        }
+        if (!decisionItem.IsActive || !kingdomScreen.DataSource.Decision.IsActive)
+        {
+            return "The active decision UI is not ready for selection.";
+        }
+
+        bool isAbstain = args[2].Equals("abstain", StringComparison.OrdinalIgnoreCase);
+        DecisionOptionVM selectedOption;
+        if (isAbstain)
+        {
+            selectedOption = decisionItem.DecisionOptionsList.FirstOrDefault(option => option.IsOptionForAbstain);
+        }
+        else
+        {
+            if (!int.TryParse(args[2], out int parsedOutcomeIndex))
+            {
+                return $"Outcome index is not a number: {args[2]}";
+            }
+
+            selectedOption = decisionItem.DecisionOptionsList
+                .Where(option => !option.IsOptionForAbstain)
+                .ElementAtOrDefault(parsedOutcomeIndex - 1);
+        }
+        if (selectedOption == null)
+        {
+            return $"The active decision has no outcome at index {args[2]}.";
+        }
+        if (!TryParseSupportWeight(args[3], out Supporter.SupportWeights supportWeight))
+        {
+            return $"Support weight is invalid: {args[3]}. Use Choose, StayNeutral, SlightlyFavor, StronglyFavor, or FullyPush.";
+        }
+
+        int? supportIndex = null;
+        if (decisionItem.IsPlayerSupporter && !selectedOption.IsOptionForAbstain)
+        {
+            switch (supportWeight)
+            {
+                case Supporter.SupportWeights.SlightlyFavor:
+                    supportIndex = 0;
+                    break;
+                case Supporter.SupportWeights.StronglyFavor:
+                    supportIndex = 1;
+                    break;
+                case Supporter.SupportWeights.FullyPush:
+                    supportIndex = 2;
+                    break;
+                default:
+                    return "A supporting player must use SlightlyFavor, StronglyFavor, or FullyPush.";
+            }
+        }
+        else if (!selectedOption.IsOptionForAbstain && supportWeight != Supporter.SupportWeights.Choose)
+        {
+            return "A choosing player must use Choose.";
+        }
+
+        selectedOption.ExecuteSelection();
+        if (supportIndex.HasValue)
+        {
+            selectedOption.OnSupportStrengthChange(supportIndex.Value);
+        }
+        if (decisionItem._currentSelectedOption != selectedOption || !decisionItem.CanEndDecision)
+        {
+            return "The selected decision outcome did not become finalizable.";
+        }
+
+        return $"Selected real outcome for {decision.GetType().Name}: " +
+               $"outcome={args[2]}, support={selectedOption.CurrentSupportWeight}, " +
+               $"playerRole={(decisionItem.IsPlayerSupporter ? "Supporter" : "Chooser")}, " +
+               $"canEnd={decisionItem.CanEndDecision}.";
+    }
+
+    // coop.debug.kingdom.submit_current_decision
+    /// <summary>
+    /// Submits the active finalizable decision through DecisionItemBaseVM.ExecuteFinalSelection.
+    /// </summary>
+    /// <param name="args">kingdomId and 1-based decision index</param>
+    /// <returns>result message</returns>
+    [CommandLineArgumentFunction("submit_current_decision", "coop.debug.kingdom")]
+    public static string SubmitCurrentDecision(List<string> args)
+    {
+        if (!ModInformation.IsClient)
+        {
+            return "This command can only be run on a client.";
+        }
+        if (!TryGetKingdomDecisionByIndex(args, out Kingdom _, out KingdomDecision decision, out int _, out string message))
+        {
+            return message;
+        }
+        if (!(ScreenManager.TopScreen is GauntletKingdomScreen kingdomScreen))
+        {
+            return "The Kingdom decision screen is not active.";
+        }
+
+        DecisionItemBaseVM decisionItem = kingdomScreen.DataSource?.Decision?.CurrentDecision;
+        if (decisionItem?.KingdomDecisionMaker?._decision != decision)
+        {
+            string currentDecision = decisionItem?.KingdomDecisionMaker?._decision?.GetType().Name ?? "none";
+            return $"The active decision is {currentDecision}, expected {decision.GetType().Name}.";
+        }
+        if (!decisionItem.CanEndDecision)
+        {
+            return "The active decision is not finalizable.";
+        }
+
+        decisionItem.ExecuteFinalSelection();
+        string nextDecision = kingdomScreen.DataSource?.Decision?.CurrentDecision?
+            .KingdomDecisionMaker?._decision?.GetType().Name ?? "none";
+        return $"Executed real final selection for {decision.GetType().Name}: " +
+               $"finalSelectionDone={decisionItem._finalSelectionDone}, decisionActive={decisionItem.IsActive}, " +
+               $"decisionPanelActive={kingdomScreen.DataSource.Decision.IsActive}, currentDecision={nextDecision}.";
+    }
+
+    // coop.debug.kingdom.current_decision_ui_state
+    /// <summary>
+    /// Reports the current Kingdom decision view-model state without changing it.
+    /// </summary>
+    /// <param name="args">no arguments</param>
+    /// <returns>result message</returns>
+    [CommandLineArgumentFunction("current_decision_ui_state", "coop.debug.kingdom")]
+    public static string CurrentDecisionUiState(List<string> args)
+    {
+        if (args.Count != 0)
+        {
+            return "Usage: coop.debug.kingdom.current_decision_ui_state";
+        }
+        if (!ModInformation.IsClient)
+        {
+            return "This command can only be run on a client.";
+        }
+        if (!(ScreenManager.TopScreen is GauntletKingdomScreen kingdomScreen))
+        {
+            string topScreen = ScreenManager.TopScreen?.GetType().Name ?? "none";
+            return $"screenActive=False inquiryActive={InformationManager.IsAnyInquiryActive()} " +
+                   $"topScreen={topScreen} currentDecision=none.";
+        }
+
+        DecisionItemBaseVM decisionItem = kingdomScreen.DataSource?.Decision?.CurrentDecision;
+        string currentDecision = decisionItem?.KingdomDecisionMaker?._decision?.GetType().Name ?? "none";
+        string playerRole = decisionItem == null
+            ? "none"
+            : decisionItem.IsPlayerSupporter ? "Supporter" : "Chooser";
+        return $"screenActive=True inquiryActive={InformationManager.IsAnyInquiryActive()} " +
+               $"decisionPanelActive={kingdomScreen.DataSource?.Decision?.IsActive ?? false} " +
+               $"currentDecision={currentDecision} decisionActive={decisionItem?.IsActive ?? false} " +
+               $"playerRole={playerRole} " +
+               $"canEnd={decisionItem?.CanEndDecision ?? false} " +
+               $"finalSelectionDone={decisionItem?._finalSelectionDone ?? false}.";
+    }
+#endif
 
     // coop.debug.kingdom.resolve_decision
     /// <summary>

--- a/source/GameInterface/Services/Kingdoms/Data/SettlementClaimantDecisionData.cs
+++ b/source/GameInterface/Services/Kingdoms/Data/SettlementClaimantDecisionData.cs
@@ -1,5 +1,6 @@
 ﻿using GameInterface.Services.ObjectManager;
 using ProtoBuf;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.Serialization;
 using TaleWorlds.CampaignSystem;
@@ -8,6 +9,22 @@ using TaleWorlds.CampaignSystem.Settlements;
 
 namespace GameInterface.Services.Kingdoms.Data
 {
+    [ProtoContract(SkipConstructor = true)]
+    public class SettlementClaimantCandidateData
+    {
+        [ProtoMember(1)]
+        public string ClanId { get; }
+
+        [ProtoMember(2)]
+        public float InitialMerit { get; }
+
+        public SettlementClaimantCandidateData(string clanId, float initialMerit)
+        {
+            ClanId = clanId;
+            InitialMerit = initialMerit;
+        }
+    }
+
     /// <summary>
     /// Class for serializing <see cref="SettlementClaimantDecision"> class.
     /// </summary>
@@ -24,12 +41,26 @@ namespace GameInterface.Services.Kingdoms.Data
         public string CapturerHeroId { get; }
         [ProtoMember(3)]
         public string ClanToExcludeId { get; }
+        [ProtoMember(4)]
+        public List<SettlementClaimantCandidateData> Candidates { get; }
 
-        public SettlementClaimantDecisionData(string proposedClanId, string kingdomId, long triggerTime, bool isEnforced, bool notifyPlayer, bool playerExamined, string settlementId, string capturerHeroId, string clanToExcludeId) : base(proposedClanId, kingdomId, triggerTime, isEnforced, notifyPlayer, playerExamined)
+        public SettlementClaimantDecisionData(
+            string proposedClanId,
+            string kingdomId,
+            long triggerTime,
+            bool isEnforced,
+            bool notifyPlayer,
+            bool playerExamined,
+            string settlementId,
+            string capturerHeroId,
+            string clanToExcludeId,
+            List<SettlementClaimantCandidateData> candidates)
+            : base(proposedClanId, kingdomId, triggerTime, isEnforced, notifyPlayer, playerExamined)
         {
             SettlementId = settlementId;
             CapturerHeroId = capturerHeroId;
             ClanToExcludeId = clanToExcludeId;
+            Candidates = candidates;
         }
 
         /// <inheritdoc/>

--- a/source/GameInterface/Services/Kingdoms/Data/SettlementClaimantDecisionSnapshotData.cs
+++ b/source/GameInterface/Services/Kingdoms/Data/SettlementClaimantDecisionSnapshotData.cs
@@ -1,0 +1,26 @@
+﻿using ProtoBuf;
+
+namespace GameInterface.Services.Kingdoms.Data;
+
+[ProtoContract(SkipConstructor = true)]
+public class SettlementClaimantDecisionSnapshotData
+{
+    [ProtoMember(1)]
+    public string KingdomId { get; }
+
+    [ProtoMember(2)]
+    public int DecisionIndex { get; }
+
+    [ProtoMember(3)]
+    public SettlementClaimantCandidateData[] Candidates { get; }
+
+    public SettlementClaimantDecisionSnapshotData(
+        string kingdomId,
+        int decisionIndex,
+        SettlementClaimantCandidateData[] candidates)
+    {
+        KingdomId = kingdomId;
+        DecisionIndex = decisionIndex;
+        Candidates = candidates;
+    }
+}

--- a/source/GameInterface/Services/Kingdoms/Handlers/KingdomHandler.cs
+++ b/source/GameInterface/Services/Kingdoms/Handlers/KingdomHandler.cs
@@ -5,10 +5,10 @@ using Common.Messaging;
 using Common.Util;
 using GameInterface.Registry.Auto;
 using GameInterface.Services.Kingdoms;
+using GameInterface.Services.Kingdoms.Data;
 using GameInterface.Services.Kingdoms.Messages;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
-using GameInterface.Registry.Auto;
 using Helpers;
 using Serilog;
 using System;
@@ -36,6 +36,7 @@ public class KingdomHandler : IHandler
     private readonly IKingdomMembershipState kingdomMembershipState;
     private readonly IKingdomInterface kingdomInterface;
     private readonly IKingdomCreator kingdomCreator;
+    private readonly ISettlementClaimantSnapshotRegistry settlementClaimantSnapshotRegistry;
 
     public KingdomHandler(
         IMessageBroker messageBroker,
@@ -44,7 +45,8 @@ public class KingdomHandler : IHandler
         IKingdomDecisionVoteManager decisionVoteManager,
         IKingdomMembershipState kingdomMembershipState,
         IKingdomInterface kingdomInterface,
-        IKingdomCreator kingdomCreator)
+        IKingdomCreator kingdomCreator,
+        ISettlementClaimantSnapshotRegistry settlementClaimantSnapshotRegistry)
     {
         this.messageBroker = messageBroker;
         this.objectManager = objectManager;
@@ -53,6 +55,7 @@ public class KingdomHandler : IHandler
         this.kingdomMembershipState = kingdomMembershipState;
         this.kingdomInterface = kingdomInterface;
         this.kingdomCreator = kingdomCreator;
+        this.settlementClaimantSnapshotRegistry = settlementClaimantSnapshotRegistry;
         messageBroker.Subscribe<AddDecision>(HandleAddDecision);
         messageBroker.Subscribe<RemoveDecision>(HandleRemoveDecision);
         messageBroker.Subscribe<ChangeKingdomPolicy>(HandleChangeKingdomPolicy);
@@ -493,6 +496,11 @@ public class KingdomHandler : IHandler
     {
         var payload = obj.What;
 
+        RunKingdomMutation(() => ApplyAddDecision(payload));
+    }
+
+    private void ApplyAddDecision(AddDecision payload)
+    {
         if (!objectManager.TryGetObject(payload.KingdomId, out Kingdom kingdom))
         {
             Logger.Debug("Kingdom not found in KingdomDecisionHandler with KingdomId: {id}", payload.KingdomId);
@@ -502,6 +510,15 @@ public class KingdomHandler : IHandler
         if (!payload.Data.TryGetKingdomDecision(objectManager, out KingdomDecision kingdomDecision))
         {
             Logger.Warning("KingdomDecision could not be deserialized in KingdomDecisionHandler.");
+            return;
+        }
+
+        if (ModInformation.IsClient &&
+            kingdomDecision is SettlementClaimantDecision claimantDecision &&
+            payload.Data is SettlementClaimantDecisionData claimantData &&
+            !settlementClaimantSnapshotRegistry.TryRegister(claimantDecision, claimantData.Candidates))
+        {
+            Logger.Warning("Settlement claimant decision snapshot could not be registered.");
             return;
         }
 

--- a/source/GameInterface/Services/Kingdoms/KingdomDecisionDataConverter.cs
+++ b/source/GameInterface/Services/Kingdoms/KingdomDecisionDataConverter.cs
@@ -13,10 +13,14 @@ namespace GameInterface.Services.Kingdoms
     internal class KingdomDecisionDataConverter : IKingdomDecisionDataConverter
     {
         private readonly IObjectManager objectManager;
+        private readonly ISettlementClaimantSnapshotRegistry settlementClaimantSnapshotRegistry;
         private readonly Dictionary<Type, Func<KingdomDecision, KingdomDecisionData>> supportedConversions;
-        public KingdomDecisionDataConverter(IObjectManager objectManager)
+        public KingdomDecisionDataConverter(
+            IObjectManager objectManager,
+            ISettlementClaimantSnapshotRegistry settlementClaimantSnapshotRegistry)
         {
             this.objectManager = objectManager;
+            this.settlementClaimantSnapshotRegistry = settlementClaimantSnapshotRegistry;
             supportedConversions = new Dictionary<Type, Func<KingdomDecision, KingdomDecisionData>>()
             {
                 { typeof(DeclareWarDecision), ConvertDeclareWarDecision },
@@ -110,8 +114,25 @@ namespace GameInterface.Services.Kingdoms
             SettlementClaimantDecision settlementClaimantDecision = decision as SettlementClaimantDecision;
             if (settlementClaimantDecision != null)
             {
+                if (!settlementClaimantSnapshotRegistry.TryGetSnapshot(settlementClaimantDecision, out var candidates))
+                {
+                    throw new InvalidOperationException("Settlement claimant candidates were not captured before serialization.");
+                }
+
+                var candidateData = new List<SettlementClaimantCandidateData>(candidates.Count);
+                foreach (SettlementClaimantCandidate candidate in candidates)
+                {
+                    string clanId = GetId(candidate.Clan);
+                    if (string.IsNullOrWhiteSpace(clanId))
+                    {
+                        throw new InvalidOperationException("Settlement claimant candidate clan was not registered.");
+                    }
+
+                    candidateData.Add(new SettlementClaimantCandidateData(clanId, candidate.InitialMerit));
+                }
+
                 return new SettlementClaimantDecisionData(GetId(settlementClaimantDecision.ProposerClan), GetId(settlementClaimantDecision.Kingdom),
-                    settlementClaimantDecision.TriggerTime._numTicks, settlementClaimantDecision.IsEnforced, settlementClaimantDecision.NotifyPlayer, settlementClaimantDecision.PlayerExamined, GetId(settlementClaimantDecision.Settlement), GetOptionalId(settlementClaimantDecision._capturerHero), GetOptionalId(settlementClaimantDecision.ClanToExclude));
+                    settlementClaimantDecision.TriggerTime._numTicks, settlementClaimantDecision.IsEnforced, settlementClaimantDecision.NotifyPlayer, settlementClaimantDecision.PlayerExamined, GetId(settlementClaimantDecision.Settlement), GetOptionalId(settlementClaimantDecision._capturerHero), GetOptionalId(settlementClaimantDecision.ClanToExclude), candidateData);
             }
             else
             {

--- a/source/GameInterface/Services/Kingdoms/KingdomDecisionOutcomeResolver.cs
+++ b/source/GameInterface/Services/Kingdoms/KingdomDecisionOutcomeResolver.cs
@@ -1,4 +1,4 @@
-using GameInterface.Services.Kingdoms.Data;
+﻿using GameInterface.Services.Kingdoms.Data;
 using GameInterface.Services.ObjectManager;
 using System;
 using System.Reflection;
@@ -70,6 +70,8 @@ namespace GameInterface.Services.Kingdoms
                     outcome = possibleOutcome;
                     return true;
                 }
+
+                return false;
             }
 
             if (voteData.OutcomeIndex < 0 || voteData.OutcomeIndex >= election._possibleOutcomes.Count) return false;

--- a/source/GameInterface/Services/Kingdoms/KingdomInterface.cs
+++ b/source/GameInterface/Services/Kingdoms/KingdomInterface.cs
@@ -32,6 +32,8 @@ internal class KingdomInterface : IKingdomInterface
         if (CallOriginalPolicy.IsOriginalAllowed()) return true;
         if (ModInformation.IsClient)
         {
+            if (kingdomDecision is SettlementClaimantDecision) return false;
+
             float clientRandomNumber = AddDecision(kingdom, kingdomDecision, ignoreInfluenceCost, applyInfluenceCost: false);
             MessageBroker.Instance.Publish(kingdom,
                 new DecisionAdded(kingdom, kingdomDecision, ignoreInfluenceCost, clientRandomNumber));

--- a/source/GameInterface/Services/Kingdoms/Patches/KingdomElectionPatches.cs
+++ b/source/GameInterface/Services/Kingdoms/Patches/KingdomElectionPatches.cs
@@ -2,12 +2,35 @@
 using HarmonyLib;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Election;
+using TaleWorlds.Library;
 
 namespace GameInterface.Services.Kingdoms.Patches;
 
 [HarmonyPatch]
 internal class KingdomElectionPatches
 {
+    [HarmonyPatch(typeof(KingdomDecision), nameof(KingdomDecision.NarrowDownCandidates))]
+    [HarmonyPrefix]
+    private static bool NarrowDownCandidatesPrefix(KingdomDecision __instance, ref MBList<DecisionOutcome> __result)
+    {
+        if (__instance is not SettlementClaimantDecision claimantDecision) return true;
+        if (!ContainerProvider.TryResolve<ISettlementClaimantSnapshotRegistry>(out var snapshotRegistry)) return true;
+        if (!snapshotRegistry.TryCreateOutcomes(claimantDecision, out MBList<DecisionOutcome> outcomes)) return true;
+
+        __result = outcomes;
+        return false;
+    }
+
+    [HarmonyPatch(typeof(KingdomDecision), nameof(KingdomDecision.NarrowDownCandidates))]
+    [HarmonyPostfix]
+    private static void NarrowDownCandidatesPostfix(KingdomDecision __instance, MBList<DecisionOutcome> __result)
+    {
+        if (__instance is not SettlementClaimantDecision claimantDecision) return;
+        if (!ContainerProvider.TryResolve<ISettlementClaimantSnapshotRegistry>(out var snapshotRegistry)) return;
+
+        snapshotRegistry.Capture(claimantDecision, __result);
+    }
+
     [HarmonyPatch(typeof(KingdomElection), nameof(KingdomElection.OnPlayerSupport))]
     [HarmonyPrefix]
     private static bool Prefix(KingdomElection __instance, DecisionOutcome decisionOutcome, Supporter.SupportWeights supportWeight)

--- a/source/GameInterface/Services/Kingdoms/SettlementClaimantSnapshotRegistry.cs
+++ b/source/GameInterface/Services/Kingdoms/SettlementClaimantSnapshotRegistry.cs
@@ -1,0 +1,423 @@
+﻿using Common.Logging;
+using GameInterface.Services.Kingdoms.Data;
+using GameInterface.Services.ObjectManager;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Election;
+using TaleWorlds.Library;
+
+namespace GameInterface.Services.Kingdoms;
+
+public interface ISettlementClaimantSnapshotRegistry
+{
+    bool TryRegister(
+        SettlementClaimantDecision decision,
+        IReadOnlyList<SettlementClaimantCandidateData> candidates);
+    bool TryGetSnapshot(
+        SettlementClaimantDecision decision,
+        out IReadOnlyList<SettlementClaimantCandidate> candidates);
+    bool TryCreateOutcomes(
+        SettlementClaimantDecision decision,
+        out MBList<DecisionOutcome> outcomes);
+    void Capture(SettlementClaimantDecision decision, MBList<DecisionOutcome> outcomes);
+    bool TryCreateJoinSnapshots(out SettlementClaimantDecisionSnapshotData[] snapshots);
+    bool TryApplyJoinSnapshots(IReadOnlyList<SettlementClaimantDecisionSnapshotData> snapshots);
+}
+
+public sealed class SettlementClaimantCandidate
+{
+    public Clan Clan { get; }
+    public float InitialMerit { get; }
+
+    public SettlementClaimantCandidate(Clan clan, float initialMerit)
+    {
+        Clan = clan;
+        InitialMerit = initialMerit;
+    }
+}
+
+internal sealed class SettlementClaimantSnapshotRegistry : ISettlementClaimantSnapshotRegistry
+{
+    private static readonly ILogger Logger = LogManager.GetLogger<SettlementClaimantSnapshotRegistry>();
+
+    private readonly IObjectManager objectManager;
+    private readonly ConditionalWeakTable<SettlementClaimantDecision, Snapshot> snapshots = new();
+    private readonly object syncRoot = new();
+
+    public SettlementClaimantSnapshotRegistry(IObjectManager objectManager)
+    {
+        this.objectManager = objectManager;
+    }
+
+    public bool TryRegister(
+        SettlementClaimantDecision decision,
+        IReadOnlyList<SettlementClaimantCandidateData> candidates)
+    {
+        if (decision == null || candidates == null)
+        {
+            Logger.Error("Cannot register a settlement claimant snapshot without a decision and candidates.");
+            return false;
+        }
+
+        if (!TryResolveCandidates(candidates, out var resolvedCandidates)) return false;
+        return TryRegisterResolved(decision, resolvedCandidates);
+    }
+
+    public bool TryGetSnapshot(
+        SettlementClaimantDecision decision,
+        out IReadOnlyList<SettlementClaimantCandidate> candidates)
+    {
+        if (decision != null && snapshots.TryGetValue(decision, out Snapshot snapshot))
+        {
+            candidates = snapshot.Candidates;
+            return true;
+        }
+
+        candidates = null;
+        return false;
+    }
+
+    public bool TryCreateOutcomes(
+        SettlementClaimantDecision decision,
+        out MBList<DecisionOutcome> outcomes)
+    {
+        outcomes = null;
+        if (!TryGetSnapshot(decision, out IReadOnlyList<SettlementClaimantCandidate> candidates)) return false;
+
+        outcomes = new MBList<DecisionOutcome>();
+        foreach (SettlementClaimantCandidate candidate in candidates)
+        {
+            outcomes.Add(new SettlementClaimantDecision.ClanAsDecisionOutcome(candidate.Clan)
+            {
+                InitialMerit = candidate.InitialMerit,
+            });
+        }
+
+        return true;
+    }
+
+    public void Capture(SettlementClaimantDecision decision, MBList<DecisionOutcome> outcomes)
+    {
+        if (decision == null || outcomes == null) return;
+
+        var candidates = new List<SettlementClaimantCandidate>(outcomes.Count);
+        foreach (DecisionOutcome outcome in outcomes)
+        {
+            if (outcome is not SettlementClaimantDecision.ClanAsDecisionOutcome claimantOutcome)
+            {
+                Logger.Error("Settlement claimant narrowing returned an unexpected outcome type {OutcomeType}.", outcome?.GetType().FullName);
+                return;
+            }
+
+            candidates.Add(new SettlementClaimantCandidate(claimantOutcome.Clan, claimantOutcome.InitialMerit));
+        }
+
+        lock (syncRoot)
+        {
+            if (snapshots.TryGetValue(decision, out _)) return;
+            snapshots.Add(decision, new Snapshot(candidates, isSynchronized: false));
+        }
+    }
+
+    public bool TryCreateJoinSnapshots(out SettlementClaimantDecisionSnapshotData[] snapshots)
+    {
+        var kingdoms = Campaign.Current?.CampaignObjectManager?.Kingdoms;
+        if (kingdoms == null)
+        {
+            snapshots = Array.Empty<SettlementClaimantDecisionSnapshotData>();
+            Logger.Error("Cannot create settlement claimant join snapshots without a loaded campaign.");
+            return false;
+        }
+
+        return TryCreateJoinSnapshots(kingdoms, out snapshots);
+    }
+
+    internal bool TryCreateJoinSnapshots(
+        IEnumerable<Kingdom> kingdoms,
+        out SettlementClaimantDecisionSnapshotData[] snapshots)
+    {
+        snapshots = Array.Empty<SettlementClaimantDecisionSnapshotData>();
+        if (kingdoms == null) return false;
+
+        var snapshotData = new List<SettlementClaimantDecisionSnapshotData>();
+        foreach (Kingdom kingdom in kingdoms)
+        {
+            if (kingdom == null) return false;
+
+            MBList<KingdomDecision> decisions = kingdom._unresolvedDecisions;
+            if (decisions == null) continue;
+
+            string kingdomId = null;
+            for (int decisionIndex = 0; decisionIndex < decisions.Count; decisionIndex++)
+            {
+                if (decisions[decisionIndex] is not SettlementClaimantDecision decision) continue;
+                if (kingdomId == null && !objectManager.TryGetIdWithLogging(kingdom, out kingdomId)) return false;
+                if (!TryCaptureMissingSnapshot(decision)) return false;
+                if (!TryGetSnapshot(decision, out var candidates)) return false;
+
+                var candidateData = new SettlementClaimantCandidateData[candidates.Count];
+                for (int candidateIndex = 0; candidateIndex < candidates.Count; candidateIndex++)
+                {
+                    SettlementClaimantCandidate candidate = candidates[candidateIndex];
+                    if (!objectManager.TryGetIdWithLogging(candidate.Clan, out string clanId)) return false;
+
+                    candidateData[candidateIndex] = new SettlementClaimantCandidateData(
+                        clanId,
+                        candidate.InitialMerit);
+                }
+
+                snapshotData.Add(new SettlementClaimantDecisionSnapshotData(
+                    kingdomId,
+                    decisionIndex,
+                    candidateData));
+            }
+        }
+
+        snapshots = snapshotData.ToArray();
+        return true;
+    }
+
+    public bool TryApplyJoinSnapshots(IReadOnlyList<SettlementClaimantDecisionSnapshotData> snapshots)
+    {
+        var kingdoms = Campaign.Current?.CampaignObjectManager?.Kingdoms;
+        if (kingdoms == null)
+        {
+            Logger.Error("Cannot apply settlement claimant join snapshots without a loaded campaign.");
+            return false;
+        }
+
+        return TryApplyJoinSnapshots(
+            kingdoms,
+            snapshots ?? Array.Empty<SettlementClaimantDecisionSnapshotData>());
+    }
+
+    internal bool TryApplyJoinSnapshots(
+        IEnumerable<Kingdom> kingdoms,
+        IReadOnlyList<SettlementClaimantDecisionSnapshotData> snapshots)
+    {
+        if (kingdoms == null || snapshots == null) return false;
+
+        var expectedDecisions = new Dictionary<string, SettlementClaimantDecision>();
+        foreach (Kingdom kingdom in kingdoms)
+        {
+            if (kingdom == null) return false;
+
+            MBList<KingdomDecision> decisions = kingdom._unresolvedDecisions;
+            if (decisions == null) continue;
+
+            string kingdomId = null;
+            for (int decisionIndex = 0; decisionIndex < decisions.Count; decisionIndex++)
+            {
+                if (decisions[decisionIndex] is not SettlementClaimantDecision decision) continue;
+                if (kingdomId == null && !objectManager.TryGetIdWithLogging(kingdom, out kingdomId)) return false;
+
+                string identity = CreateDecisionIdentity(kingdomId, decisionIndex);
+                if (expectedDecisions.ContainsKey(identity))
+                {
+                    Logger.Error("Loaded campaign contains duplicate settlement claimant decision identities.");
+                    return false;
+                }
+                expectedDecisions.Add(identity, decision);
+            }
+        }
+
+        if (expectedDecisions.Count != snapshots.Count)
+        {
+            Logger.Error(
+                "Settlement claimant join snapshot count {SnapshotCount} does not match loaded decision count {DecisionCount}.",
+                snapshots.Count,
+                expectedDecisions.Count);
+            return false;
+        }
+
+        var identities = new HashSet<string>();
+        var registrations = new List<SnapshotRegistration>(snapshots.Count);
+        foreach (SettlementClaimantDecisionSnapshotData snapshot in snapshots)
+        {
+            if (snapshot == null ||
+                string.IsNullOrWhiteSpace(snapshot.KingdomId) ||
+                snapshot.DecisionIndex < 0 ||
+                snapshot.Candidates == null)
+            {
+                Logger.Error("Settlement claimant join snapshot contains invalid decision data.");
+                return false;
+            }
+
+            string identity = CreateDecisionIdentity(snapshot.KingdomId, snapshot.DecisionIndex);
+            if (!identities.Add(identity))
+            {
+                Logger.Error("Settlement claimant join snapshot contains a duplicate decision identity.");
+                return false;
+            }
+
+            if (!expectedDecisions.TryGetValue(identity, out SettlementClaimantDecision decision))
+            {
+                Logger.Error(
+                    "Settlement claimant join snapshot decision index {DecisionIndex} was unavailable for kingdom {KingdomId}.",
+                    snapshot.DecisionIndex,
+                    snapshot.KingdomId);
+                return false;
+            }
+
+            if (!TryResolveCandidates(snapshot.Candidates, out var resolvedCandidates)) return false;
+            registrations.Add(new SnapshotRegistration(decision, resolvedCandidates));
+        }
+
+        return TryRegisterResolved(registrations);
+    }
+
+    private bool TryCaptureMissingSnapshot(SettlementClaimantDecision decision)
+    {
+        if (TryGetSnapshot(decision, out _)) return true;
+
+        MBList<DecisionOutcome> initialCandidates = decision.DetermineInitialCandidates().ToMBList();
+        MBList<DecisionOutcome> outcomes = decision.NarrowDownCandidates(initialCandidates, 3);
+        Capture(decision, outcomes);
+        return TryGetSnapshot(decision, out _);
+    }
+
+    private static bool SnapshotsMatch(
+        IReadOnlyList<SettlementClaimantCandidate> first,
+        IReadOnlyList<SettlementClaimantCandidate> second)
+    {
+        if (first.Count != second.Count) return false;
+
+        for (int i = 0; i < first.Count; i++)
+        {
+            if (first[i].Clan != second[i].Clan || first[i].InitialMerit != second[i].InitialMerit)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private bool TryResolveCandidates(
+        IReadOnlyList<SettlementClaimantCandidateData> candidates,
+        out IReadOnlyList<SettlementClaimantCandidate> resolvedCandidates)
+    {
+        var resolved = new List<SettlementClaimantCandidate>(candidates.Count);
+        var candidateIds = new HashSet<string>();
+        foreach (SettlementClaimantCandidateData candidate in candidates)
+        {
+            if (candidate == null ||
+                string.IsNullOrWhiteSpace(candidate.ClanId) ||
+                !candidateIds.Add(candidate.ClanId))
+            {
+                resolvedCandidates = null;
+                Logger.Error("Settlement claimant snapshot contains an invalid or duplicate clan id.");
+                return false;
+            }
+            if (!objectManager.TryGetObjectWithLogging(candidate.ClanId, out Clan clan))
+            {
+                resolvedCandidates = null;
+                return false;
+            }
+
+            resolved.Add(new SettlementClaimantCandidate(clan, candidate.InitialMerit));
+        }
+
+        resolvedCandidates = resolved;
+        return true;
+    }
+
+    private bool TryRegisterResolved(
+        SettlementClaimantDecision decision,
+        IReadOnlyList<SettlementClaimantCandidate> candidates)
+    {
+        lock (syncRoot)
+        {
+            if (snapshots.TryGetValue(decision, out Snapshot existingSnapshot))
+            {
+                if (SnapshotsMatch(existingSnapshot.Candidates, candidates))
+                {
+                    existingSnapshot.IsSynchronized = true;
+                    return true;
+                }
+
+                Logger.Error("A different settlement claimant snapshot is already registered for this decision.");
+                return false;
+            }
+
+            snapshots.Add(decision, new Snapshot(candidates, isSynchronized: true));
+            return true;
+        }
+    }
+
+    private bool TryRegisterResolved(IReadOnlyList<SnapshotRegistration> registrations)
+    {
+        lock (syncRoot)
+        {
+            foreach (SnapshotRegistration registration in registrations)
+            {
+                if (snapshots.TryGetValue(registration.Decision, out Snapshot existingSnapshot) &&
+                    existingSnapshot.IsSynchronized &&
+                    !SnapshotsMatch(existingSnapshot.Candidates, registration.Candidates))
+                {
+                    Logger.Error("A different settlement claimant snapshot is already registered for this decision.");
+                    return false;
+                }
+            }
+
+            foreach (SnapshotRegistration registration in registrations)
+            {
+                if (!snapshots.TryGetValue(registration.Decision, out Snapshot existingSnapshot))
+                {
+                    snapshots.Add(
+                        registration.Decision,
+                        new Snapshot(registration.Candidates, isSynchronized: true));
+                    continue;
+                }
+
+                if (SnapshotsMatch(existingSnapshot.Candidates, registration.Candidates))
+                {
+                    existingSnapshot.IsSynchronized = true;
+                    continue;
+                }
+
+                snapshots.Remove(registration.Decision);
+                snapshots.Add(
+                    registration.Decision,
+                    new Snapshot(registration.Candidates, isSynchronized: true));
+            }
+        }
+
+        return true;
+    }
+
+    private static string CreateDecisionIdentity(string kingdomId, int decisionIndex) =>
+        kingdomId + "\n" + decisionIndex;
+
+    private readonly struct SnapshotRegistration
+    {
+        public SettlementClaimantDecision Decision { get; }
+        public IReadOnlyList<SettlementClaimantCandidate> Candidates { get; }
+
+        public SnapshotRegistration(
+            SettlementClaimantDecision decision,
+            IReadOnlyList<SettlementClaimantCandidate> candidates)
+        {
+            Decision = decision;
+            Candidates = candidates;
+        }
+    }
+
+    private sealed class Snapshot
+    {
+        public IReadOnlyList<SettlementClaimantCandidate> Candidates { get; }
+        public bool IsSynchronized { get; set; }
+
+        public Snapshot(
+            IReadOnlyList<SettlementClaimantCandidate> candidates,
+            bool isSynchronized)
+        {
+            Candidates = candidates;
+            IsSynchronized = isSynchronized;
+        }
+    }
+}

--- a/source/GameInterface/Services/Settlements/Commands/SettlementCommands.cs
+++ b/source/GameInterface/Services/Settlements/Commands/SettlementCommands.cs
@@ -399,6 +399,7 @@ internal class SettlementCommands
         sb.AppendLine($"LastThreatTime:  '{settlement.LastThreatTime}'");
         sb.AppendLine($"CurrentSiegeState:   '{settlement.CurrentSiegeState}'");
         sb.AppendLine($"Militia :   '{settlement.Militia}'");
+        sb.AppendLine($"OwnerClanId: '{settlement.OwnerClan?.StringId ?? "none"}'");
         sb.AppendLine($"LastVisitTimeOfOwner  :   '{settlement.LastVisitTimeOfOwner}'");
         //sb.AppendLine($"ClaimedBy   :   '{settlement.ClaimedBy}'");
         //sb.AppendLine($"ClaimValue    :   '{settlement.ClaimValue}'");


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Requesting a city and finalizing its ownership vote can show different claimant choices to each player and the server. A player's selection can be applied to another clan, after which affected sessions may terminate or repeatedly reopen the Kingdom screen on reconnect.

## What is the new behavior?

Resolves #2868

City ownership votes now use the server's claimant choices for every player. Each selection resolves to the intended clan, reconnecting players receive the same unresolved vote, and an unavailable claimant is rejected instead of being replaced by a different clan.

## Bot Changelog Entry

- Fixed city ownership votes showing different claimant choices or awarding the city to the wrong clan.
