### PR TITLE
[1547] Sync town garrison lifecycle changes

### DIFF
--- a/source/Coop/LiveTesting/LiveTestControlServer.cs
+++ b/source/Coop/LiveTesting/LiveTestControlServer.cs
@@ -33,6 +33,9 @@ namespace Coop.LiveTesting
         private readonly LiveTestProcessInfo processInfo;
         private readonly DateTime processStartedUtc;
         private readonly NamedPipeLiveTestServer pipeServer;
+        private readonly object screenshotGate = new object();
+        private readonly Dictionary<string, ScreenshotCapture> screenshotCaptures =
+            new Dictionary<string, ScreenshotCapture>(StringComparer.Ordinal);
         private int shutdownScheduled;
 
         public LiveTestControlServer(bool isServer, string logFilePath)
@@ -85,10 +88,14 @@ namespace Coop.LiveTesting
                         request,
                         () => CreateStatusResponse(request.Id),
                         false);
+                case "command-catalog":
+                    return HandleCommandCatalog(request);
                 case "command":
                     return HandleCommand(request);
                 case "screenshot":
                     return HandleScreenshot(request);
+                case "screenshot-status":
+                    return HandleScreenshotStatus(request);
                 case "shutdown":
                     return HandleShutdown(request);
                 default:
@@ -143,6 +150,26 @@ namespace Coop.LiveTesting
             }, true);
         }
 
+        private LiveTestResponse HandleCommandCatalog(LiveTestRequest request)
+        {
+            return ExecuteOnGameThread(request, () =>
+            {
+                if (!ContainerProvider.TryResolve<ILiveTestCommandDispatcher>(out var dispatcher))
+                {
+                    return Failure(
+                        request.Id,
+                        "session_not_ready",
+                        "The co-op session command dispatcher is not available yet.",
+                        false);
+                }
+
+                return Success(request.Id, new
+                {
+                    commands = dispatcher.GetCommandNames(),
+                });
+            }, false);
+        }
+
         private LiveTestResponse HandleScreenshot(LiveTestRequest request)
         {
             if (!TryReadString(request.Parameters, "path", out var requestedPath) ||
@@ -166,6 +193,8 @@ namespace Coop.LiveTesting
                 return Failure(request.Id, "invalid_parameters", exception.Message, false);
             }
 
+            string captureId = Guid.NewGuid().ToString("N");
+
             return ExecuteOnGameThread(request, () =>
             {
                 string directory = System.IO.Path.GetDirectoryName(screenshotPath);
@@ -179,13 +208,118 @@ namespace Coop.LiveTesting
                 }
 
                 Directory.CreateDirectory(directory);
-                Utilities.TakeScreenshot(screenshotPath);
+                if (File.Exists(screenshotPath))
+                {
+                    File.Delete(screenshotPath);
+                }
+
+                lock (screenshotGate)
+                {
+                    foreach (string previousCaptureId in screenshotCaptures
+                        .Where(pair => string.Equals(
+                            pair.Value.Path,
+                            screenshotPath,
+                            StringComparison.OrdinalIgnoreCase))
+                        .Select(pair => pair.Key)
+                        .ToArray())
+                    {
+                        screenshotCaptures.Remove(previousCaptureId);
+                    }
+
+                    screenshotCaptures.Add(
+                        captureId,
+                        new ScreenshotCapture(screenshotPath));
+                }
+
+                try
+                {
+                    Utilities.TakeScreenshot(screenshotPath);
+                }
+                catch
+                {
+                    lock (screenshotGate)
+                    {
+                        screenshotCaptures.Remove(captureId);
+                    }
+                    throw;
+                }
+
                 return Success(request.Id, new
                 {
+                    captureId,
                     path = screenshotPath,
                     captureRequested = true,
                 });
             }, true);
+        }
+
+        private LiveTestResponse HandleScreenshotStatus(LiveTestRequest request)
+        {
+            if (!TryReadString(request.Parameters, "captureId", out var captureId) ||
+                captureId.Length != 32 ||
+                !captureId.All(IsLowerHexadecimal))
+            {
+                return Failure(
+                    request.Id,
+                    "invalid_parameters",
+                    "Screenshot status requires a 32-character lowercase hexadecimal capture id.",
+                    false);
+            }
+
+            ScreenshotCapture capture;
+            lock (screenshotGate)
+            {
+                if (!screenshotCaptures.TryGetValue(captureId, out capture))
+                {
+                    return Failure(
+                        request.Id,
+                        "capture_not_found",
+                        $"Screenshot capture '{captureId}' was not found.",
+                        false);
+                }
+            }
+
+            ScreenshotFileObservation observation = ObserveScreenshot(capture.Path);
+            bool stable;
+            bool complete;
+            lock (screenshotGate)
+            {
+                if (!screenshotCaptures.TryGetValue(captureId, out var currentCapture) ||
+                    !ReferenceEquals(capture, currentCapture))
+                {
+                    return Failure(
+                        request.Id,
+                        "capture_not_found",
+                        $"Screenshot capture '{captureId}' was superseded.",
+                        false);
+                }
+
+                stable = observation.Exists &&
+                    observation.IsBmp &&
+                    observation.DeclaredLength == observation.Length &&
+                    observation.Length > 0 &&
+                    capture.HasObservation &&
+                    capture.LastLength == observation.Length &&
+                    capture.LastWriteUtc == observation.LastWriteUtc;
+                capture.HasObservation = observation.Exists;
+                capture.LastLength = observation.Length;
+                capture.LastWriteUtc = observation.LastWriteUtc;
+                capture.Complete |= stable;
+                complete = capture.Complete;
+            }
+
+            return Success(request.Id, new
+            {
+                captureId,
+                path = capture.Path,
+                exists = observation.Exists,
+                isBmp = observation.IsBmp,
+                stable,
+                complete,
+                length = observation.Length,
+                declaredLength = observation.DeclaredLength,
+                lastWriteUtc = observation.LastWriteUtc,
+            });
         }
 
         private LiveTestResponse HandleShutdown(LiveTestRequest request)
@@ -215,6 +349,10 @@ namespace Coop.LiveTesting
             bool coopRunning = false;
             string coopState = null;
             int? registeredPlayers = null;
+            int? registeredPlayerCount = null;
+            int? connectedPlayerCount = null;
+            string[] registeredControllerIds = null;
+            string[] connectedControllerIds = null;
 
             if (campaignLoaded && ContainerProvider.TryResolve<ILogic>(out var logic))
             {
@@ -237,7 +375,22 @@ namespace Coop.LiveTesting
 
                 if (ContainerProvider.TryResolve<IPlayerManager>(out var playerManager))
                 {
-                    registeredPlayers = playerManager.Players.Count;
+                    var players = playerManager.Players
+                        .OrderBy(player => player.ControllerId, StringComparer.Ordinal)
+                        .ToArray();
+                    registeredPlayers = players.Length;
+                    if (ModInformation.IsServer)
+                    {
+                        registeredPlayerCount = players.Length;
+                        registeredControllerIds = players
+                            .Select(player => player.ControllerId)
+                            .ToArray();
+                        connectedControllerIds = players
+                            .Where(playerManager.IsConnected)
+                            .Select(player => player.ControllerId)
+                            .ToArray();
+                        connectedPlayerCount = connectedControllerIds.Length;
+                    }
                 }
             }
 
@@ -294,6 +447,10 @@ namespace Coop.LiveTesting
                 coopRunning,
                 coopState,
                 registeredPlayers,
+                registeredPlayerCount,
+                connectedPlayerCount,
+                registeredControllerIds,
+                connectedControllerIds,
                 readyForCampaignTests,
                 readyForMissionTests = readyForCampaignTests && missionActive,
             });
@@ -379,6 +536,58 @@ namespace Coop.LiveTesting
             };
         }
 
+        private static ScreenshotFileObservation ObserveScreenshot(string path)
+        {
+            if (!File.Exists(path)) return ScreenshotFileObservation.Missing;
+
+            try
+            {
+                using (var stream = new FileStream(
+                    path,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.Read))
+                {
+                    long length = stream.Length;
+                    var header = new byte[6];
+                    int headerLength = 0;
+                    while (headerLength < header.Length)
+                    {
+                        int bytesRead = stream.Read(
+                            header,
+                            headerLength,
+                            header.Length - headerLength);
+                        if (bytesRead == 0) break;
+                        headerLength += bytesRead;
+                    }
+                    bool isBmp = headerLength == header.Length &&
+                        header[0] == 'B' &&
+                        header[1] == 'M';
+                    uint declaredLength = isBmp
+                        ? BitConverter.ToUInt32(header, 2)
+                        : 0;
+                    return new ScreenshotFileObservation(
+                        true,
+                        isBmp,
+                        length,
+                        declaredLength,
+                        File.GetLastWriteTimeUtc(path));
+                }
+            }
+            catch (IOException)
+            {
+                return new ScreenshotFileObservation(true, false, 0, 0, null);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return new ScreenshotFileObservation(true, false, 0, 0, null);
+            }
+        }
+
+        private static bool IsLowerHexadecimal(char character) =>
+            (character >= '0' && character <= '9') ||
+            (character >= 'a' && character <= 'f');
+
         private static bool TryReadCommand(
             JsonElement parameters,
             out string command,
@@ -443,6 +652,46 @@ namespace Coop.LiveTesting
                 char.IsLetterOrDigit(character) || character == '-' || character == '_')
                 ? runToken
                 : null;
+        }
+
+        private sealed class ScreenshotCapture
+        {
+            public string Path { get; }
+            public bool HasObservation { get; set; }
+            public long LastLength { get; set; }
+            public DateTime? LastWriteUtc { get; set; }
+            public bool Complete { get; set; }
+
+            public ScreenshotCapture(string path)
+            {
+                Path = path;
+            }
+        }
+
+        private readonly struct ScreenshotFileObservation
+        {
+            public static readonly ScreenshotFileObservation Missing =
+                new ScreenshotFileObservation(false, false, 0, 0, null);
+
+            public bool Exists { get; }
+            public bool IsBmp { get; }
+            public long Length { get; }
+            public uint DeclaredLength { get; }
+            public DateTime? LastWriteUtc { get; }
+
+            public ScreenshotFileObservation(
+                bool exists,
+                bool isBmp,
+                long length,
+                uint declaredLength,
+                DateTime? lastWriteUtc)
+            {
+                Exists = exists;
+                IsBmp = isBmp;
+                Length = length;
+                DeclaredLength = declaredLength;
+                LastWriteUtc = lastWriteUtc;
+            }
         }
     }
 }

--- a/source/E2E.Tests/Services/Fiefs/SyncFiefTests.cs
+++ b/source/E2E.Tests/Services/Fiefs/SyncFiefTests.cs
@@ -1,5 +1,5 @@
-﻿using E2E.Tests.Util;
-using HarmonyLib;
+﻿using E2E.Tests.Environment.Instance;
+using E2E.Tests.Util;
 using TaleWorlds.CampaignSystem.Party.PartyComponents;
 using TaleWorlds.CampaignSystem.Settlements;
 using Xunit.Abstractions;
@@ -7,12 +7,15 @@ using Xunit.Abstractions;
 namespace E2E.Tests.Services.Fiefs;
 public class SyncFiefTests : SyncTestBase
 {
-    private string TownId;
+    private readonly string TownId;
+    private readonly string SettlementId;
+    private readonly string GarrisonComponentId;
 
     public SyncFiefTests(ITestOutputHelper output) : base(output)
     {
         TownId = TestEnvironment.CreateRegisteredObject<Town>();
-        TestEnvironment.CreateRegisteredObject<GarrisonPartyComponent>();
+        SettlementId = TestEnvironment.CreateRegisteredObject<Settlement>();
+        GarrisonComponentId = TestEnvironment.CreateRegisteredObject<GarrisonPartyComponent>();
     }
 
     [Fact]
@@ -22,11 +25,65 @@ public class SyncFiefTests : SyncTestBase
     }
 
     [Fact]
-    public void Server_Fief_Fields()
+    public void Server_GarrisonLifecycle_SyncsFiefField()
     {
-        // GarrisonPartyComponent may be initialized; clear it first so the pre-check passes
-        Server.ObjectManager.TryGetObject<Town>(TownId, out var town);
-        AccessTools.Field(typeof(Fief), nameof(Town.GarrisonPartyComponent)).SetValue(town, null);
-        TestEnvironment.AssertReferenceField<Town, GarrisonPartyComponent>(nameof(Town.GarrisonPartyComponent));
+        ConfigureGarrisonGraph(Server);
+        foreach (var client in TestEnvironment.Clients)
+        {
+            ConfigureGarrisonGraph(client);
+        }
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject(TownId, out Town town));
+            Assert.True(Server.ObjectManager.TryGetObject(GarrisonComponentId, out GarrisonPartyComponent component));
+
+            component.OnInitialize();
+
+            Assert.Same(component, town.GarrisonPartyComponent);
+        });
+
+        foreach (var client in TestEnvironment.Clients)
+        {
+            client.Call(() =>
+            {
+                Assert.True(client.ObjectManager.TryGetObject(TownId, out Town town));
+                Assert.True(client.ObjectManager.TryGetObject(GarrisonComponentId, out GarrisonPartyComponent component));
+                Assert.Same(component, town.GarrisonPartyComponent);
+            });
+        }
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject(TownId, out Town town));
+            Assert.True(Server.ObjectManager.TryGetObject(GarrisonComponentId, out GarrisonPartyComponent component));
+
+            component.OnFinalize();
+
+            Assert.Null(town.GarrisonPartyComponent);
+        });
+
+        foreach (var client in TestEnvironment.Clients)
+        {
+            client.Call(() =>
+            {
+                Assert.True(client.ObjectManager.TryGetObject(TownId, out Town town));
+                Assert.Null(town.GarrisonPartyComponent);
+            });
+        }
+    }
+
+    private void ConfigureGarrisonGraph(EnvironmentInstance instance)
+    {
+        instance.Call(() =>
+        {
+            Assert.True(instance.ObjectManager.TryGetObject(TownId, out Town town));
+            Assert.True(instance.ObjectManager.TryGetObject(SettlementId, out Settlement settlement));
+            Assert.True(instance.ObjectManager.TryGetObject(GarrisonComponentId, out GarrisonPartyComponent component));
+
+            component.Settlement = settlement;
+            settlement.Town = town;
+            town.GarrisonPartyComponent = null;
+        });
     }
 }

--- a/source/GameInterface.Tests/Services/LiveTesting/LiveTestCommandDispatcherTests.cs
+++ b/source/GameInterface.Tests/Services/LiveTesting/LiveTestCommandDispatcherTests.cs
@@ -1,6 +1,8 @@
 ﻿using Common;
 using GameInterface.Services.LiveTesting;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using TaleWorlds.Library;
 using Xunit;
@@ -38,6 +40,18 @@ public class LiveTestCommandDispatcherTests
     public void EnsureReady_CollectsCommandFunctions()
     {
         Assert.True(new LiveTestCommandDispatcher().EnsureReady());
+    }
+
+    [Fact]
+    public void GetCommandNames_ReturnsSortedDebugCommands()
+    {
+        IReadOnlyList<string> commandNames = new LiveTestCommandDispatcher().GetCommandNames();
+
+        Assert.Contains(DebugCommand, commandNames);
+        Assert.DoesNotContain(NonDebugCommand, commandNames);
+        Assert.Equal(
+            commandNames.OrderBy(command => command, StringComparer.Ordinal),
+            commandNames);
     }
 
     [Fact]

--- a/source/GameInterface/Services/Fiefs/FiefSync.cs
+++ b/source/GameInterface/Services/Fiefs/FiefSync.cs
@@ -1,5 +1,6 @@
 ﻿using GameInterface.AutoSync;
 using HarmonyLib;
+using TaleWorlds.CampaignSystem.Party.PartyComponents;
 using TaleWorlds.CampaignSystem.Settlements;
 
 namespace GameInterface.Services.Fiefs;
@@ -11,5 +12,8 @@ class FiefSync : IAutoSync
         autoSyncBuilder.AddField(AccessTools.Field(typeof(Fief), nameof(Fief.GarrisonPartyComponent)));
 
         autoSyncBuilder.AddProperty(AccessTools.Property(typeof(Fief), nameof(Fief.FoodStocks)));
+
+        autoSyncBuilder.AddTargetMethod(typeof(Fief), AccessTools.Method(typeof(GarrisonPartyComponent), nameof(GarrisonPartyComponent.OnInitialize)));
+        autoSyncBuilder.AddTargetMethod(typeof(Fief), AccessTools.Method(typeof(GarrisonPartyComponent), nameof(GarrisonPartyComponent.OnFinalize)));
     }
 }

--- a/source/GameInterface/Services/GameDebug/Commands/UiDebugCommands.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/UiDebugCommands.cs
@@ -55,6 +55,65 @@ Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle 
         return "Called GameMenu.ExitToLast().";
     }
 
+    [CommandLineArgumentFunction("prepare_evidence_map", "coop.debug.ui")]
+    public static string PrepareEvidenceMap(List<string> args)
+    {
+        if (ModInformation.IsServer)
+            return "Run this command on a client.";
+
+        if (args.Count != 0)
+            return "Usage: coop.debug.ui.prepare_evidence_map";
+
+        MapScreen mapScreen = MapScreen.Instance;
+        if (mapScreen == null)
+            return "Campaign map screen is unavailable.";
+
+        try
+        {
+            // Hide only the client presentation; keep the saved encounter and map event unchanged.
+            if (mapScreen.IsInMenu)
+            {
+                mapScreen._latestMenuContext = null;
+                mapScreen.ExitMenuContext();
+            }
+            mapScreen.RemoveEncounterOverlay();
+        }
+        catch (Exception ex)
+        {
+            return CommandHelpers.FormatException("Prepare evidence map", ex);
+        }
+
+        return GetEvidenceMapState(mapScreen);
+    }
+
+    [CommandLineArgumentFunction("evidence_map_state", "coop.debug.ui")]
+    public static string EvidenceMapState(List<string> args)
+    {
+        if (ModInformation.IsServer)
+            return "Run this command on a client.";
+
+        if (args.Count != 0)
+            return "Usage: coop.debug.ui.evidence_map_state";
+
+        MapScreen mapScreen = MapScreen.Instance;
+        return mapScreen == null
+            ? "Campaign map screen is unavailable."
+            : GetEvidenceMapState(mapScreen);
+    }
+
+    private static string GetEvidenceMapState(MapScreen mapScreen)
+    {
+        var cameraView = mapScreen.MapCameraView;
+        string cameraFollowParty = Campaign.Current?.CameraFollowParty?.MobileParty?.StringId ?? "null";
+        return $"menuView={mapScreen.IsInMenu} " +
+               $"pendingMenuView={mapScreen._latestMenuContext != null} " +
+               $"encounterOverlay={mapScreen._encounterOverlay != null} " +
+               $"cameraFollowParty={cameraFollowParty} " +
+               $"animation={cameraView?.CameraAnimationInProgress} " +
+               $"fastMove={cameraView?._doFastCameraMovementToTarget} " +
+               $"loading={LoadingWindow.IsLoadingWindowActive}";
+    }
+
     [CommandLineArgumentFunction("leave_settlement_encounter", "coop.debug.ui")]
     public static string LeaveSettlementEncounter(List<string> args)
     {

--- a/source/GameInterface/Services/GameDebug/Commands/UiDebugCommands.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/UiDebugCommands.cs
@@ -104,11 +104,23 @@ Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle 
     private static string GetEvidenceMapState(MapScreen mapScreen)
     {
         var cameraView = mapScreen.MapCameraView;
-        string cameraFollowParty = Campaign.Current?.CameraFollowParty?.MobileParty?.StringId ?? "null";
+        PartyBase cameraFollowParty = Campaign.Current?.CameraFollowParty;
+        string cameraFollowPartyId = cameraFollowParty?.MobileParty?.StringId ?? "null";
+        string cameraMode = cameraView?.CurrentCameraFollowMode.ToString() ?? "null";
+        bool followTargetReached = false;
+        if (cameraView != null && cameraFollowParty != null)
+        {
+            var followPosition = cameraFollowParty.MapEvent?.Position ?? cameraFollowParty.Position;
+            var targetDelta = followPosition.ToVec2() - cameraView._cameraTarget.AsVec2;
+            followTargetReached = targetDelta.LengthSquared < 0.0001f;
+        }
+
         return $"menuView={mapScreen.IsInMenu} " +
                $"pendingMenuView={mapScreen._latestMenuContext != null} " +
                $"encounterOverlay={mapScreen._encounterOverlay != null} " +
-               $"cameraFollowParty={cameraFollowParty} " +
+               $"cameraFollowParty={cameraFollowPartyId} " +
+               $"cameraMode={cameraMode} " +
+               $"followTargetReached={followTargetReached} " +
                $"animation={cameraView?.CameraAnimationInProgress} " +
                $"fastMove={cameraView?._doFastCameraMovementToTarget} " +
                $"loading={LoadingWindow.IsLoadingWindowActive}";

--- a/source/GameInterface/Services/LiveTesting/LiveTestCommandDispatcher.cs
+++ b/source/GameInterface/Services/LiveTesting/LiveTestCommandDispatcher.cs
@@ -1,6 +1,9 @@
 ﻿using Common;
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using System.Runtime.ExceptionServices;
 using TaleWorlds.Library;
 
@@ -9,6 +12,8 @@ namespace GameInterface.Services.LiveTesting;
 public interface ILiveTestCommandDispatcher
 {
     bool EnsureReady();
+
+    IReadOnlyList<string> GetCommandNames();
 
     LiveTestCommandResult Execute(string command, List<string> arguments);
 }
@@ -37,6 +42,42 @@ public class LiveTestCommandDispatcher : ILiveTestCommandDispatcher
 
         exception?.Throw();
         return true;
+    }
+
+    public IReadOnlyList<string> GetCommandNames()
+    {
+        IReadOnlyList<string> commandNames = null;
+        ExceptionDispatchInfo exception = null;
+
+        GameThread.Run(() =>
+        {
+            try
+            {
+                EnsureFunctionsCollected();
+
+                FieldInfo allFunctionsField = typeof(CommandLineFunctionality).GetField(
+                    "AllFunctions",
+                    BindingFlags.NonPublic | BindingFlags.Static);
+                if (allFunctionsField == null ||
+                    !(allFunctionsField.GetValue(null) is IDictionary allFunctions))
+                {
+                    throw new InvalidOperationException("Unable to read the Bannerlord command registry");
+                }
+
+                commandNames = allFunctions.Keys
+                    .Cast<string>()
+                    .Where(command => command.StartsWith(AllowedCommandPrefix, StringComparison.Ordinal))
+                    .OrderBy(command => command, StringComparer.Ordinal)
+                    .ToArray();
+            }
+            catch (Exception e)
+            {
+                exception = ExceptionDispatchInfo.Capture(e);
+            }
+        }, blocking: true);
+
+        exception?.Throw();
+        return commandNames;
     }
 
     public LiveTestCommandResult Execute(string command, List<string> arguments)

--- a/source/GameInterface/Services/Towns/Commands/TownDebugCommand.cs
+++ b/source/GameInterface/Services/Towns/Commands/TownDebugCommand.cs
@@ -8,6 +8,8 @@ using System.Linq;
 using System.Text;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Party.PartyComponents;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Core;
 using static TaleWorlds.Library.CommandLineFunctionality;
@@ -122,6 +124,108 @@ public class TownDebugCommand
             }
         }
         return sb.ToString();
+    }
+
+    [CommandLineArgumentFunction("garrison_backlink", "coop.debug.town")]
+    public static string GarrisonBacklink(List<string> args)
+    {
+        if (args.Count != 1)
+        {
+            return "Usage: coop.debug.town.garrison_backlink <townId>";
+        }
+
+        if (!TryGetObjectManager(out var objectManager))
+        {
+            return "Unable to resolve ObjectManager";
+        }
+
+        if (!objectManager.TryGetObject(args[0], out Town town))
+        {
+            return $"ID: '{args[0]}' not found";
+        }
+
+        var activeGarrisons = MobileParty.All
+            .Where(party => party.IsActive &&
+                            party.PartyComponent is GarrisonPartyComponent component &&
+                            component.Settlement?.Town == town)
+            .ToList();
+        var backlink = town.GarrisonPartyComponent;
+        string backlinkId = "null";
+        if (backlink != null)
+        {
+            backlinkId = objectManager.TryGetId(backlink, out string id) ? id : "unregistered";
+        }
+
+        string activeParties = activeGarrisons.Count == 0
+            ? "none"
+            : string.Join(",", activeGarrisons.Select(party => party.StringId));
+        bool backlinkMatchesActive = activeGarrisons.Count == 1 &&
+                                     ReferenceEquals(activeGarrisons[0].PartyComponent, backlink);
+
+        return $"{(ModInformation.IsServer ? "SERVER" : "CLIENT")} " +
+               $"town={args[0]} settlement={town.Settlement.StringId} " +
+               $"backlinkComponent={backlinkId} backlinkParty={backlink?.MobileParty?.StringId ?? "null"} " +
+               $"activeGarrisonCount={activeGarrisons.Count} activeGarrisonParties={activeParties} " +
+               $"backlinkMatchesActive={backlinkMatchesActive}";
+    }
+
+    [CommandLineArgumentFunction("apply_garrison_lifecycle", "coop.debug.town")]
+    public static string ApplyGarrisonLifecycle(List<string> args)
+    {
+        if (ModInformation.IsClient)
+        {
+            return "This function can only be used by the server";
+        }
+
+        if (args.Count != 2)
+        {
+            return "Usage: coop.debug.town.apply_garrison_lifecycle <townId> <initialize|finalize>";
+        }
+
+        if (!TryGetObjectManager(out var objectManager))
+        {
+            return "Unable to resolve ObjectManager";
+        }
+
+        if (!objectManager.TryGetObject(args[0], out Town town))
+        {
+            return $"ID: '{args[0]}' not found";
+        }
+
+        var activeGarrisons = MobileParty.All
+            .Where(party => party.IsActive &&
+                            party.PartyComponent is GarrisonPartyComponent component &&
+                            component.Settlement?.Town == town)
+            .ToList();
+        if (activeGarrisons.Count != 1)
+        {
+            return $"Expected exactly one active garrison for {town.Name}, found {activeGarrisons.Count}";
+        }
+
+        var garrison = (GarrisonPartyComponent)activeGarrisons[0].PartyComponent;
+        switch (args[1].ToLowerInvariant())
+        {
+            case "finalize":
+                if (!ReferenceEquals(town.GarrisonPartyComponent, garrison))
+                {
+                    return $"Refusing to finalize: {town.Name} does not point at its active garrison";
+                }
+                garrison.OnFinalize();
+                break;
+            case "initialize":
+                if (town.GarrisonPartyComponent != null &&
+                    !ReferenceEquals(town.GarrisonPartyComponent, garrison))
+                {
+                    return $"Refusing to initialize: {town.Name} points at a different garrison";
+                }
+                garrison.OnInitialize();
+                break;
+            default:
+                return $"Unknown lifecycle action '{args[1]}'; expected initialize or finalize";
+        }
+
+        return $"Applied {args[1].ToLowerInvariant()} to {activeGarrisons[0].StringId}; " +
+               GarrisonBacklink(new List<string> { args[0] });
     }
 
     // coop.debug.town.list_buildings <townId>

--- a/source/GameInterface/Services/Towns/Commands/TownDebugCommand.cs
+++ b/source/GameInterface/Services/Towns/Commands/TownDebugCommand.cs
@@ -144,11 +144,7 @@ public class TownDebugCommand
             return $"ID: '{args[0]}' not found";
         }
 
-        var activeGarrisons = MobileParty.All
-            .Where(party => party.IsActive &&
-                            party.PartyComponent is GarrisonPartyComponent component &&
-                            component.Settlement?.Town == town)
-            .ToList();
+        var activeGarrisons = GetActiveGarrisons(town);
         var backlink = town.GarrisonPartyComponent;
         string backlinkId = "null";
         if (backlink != null)
@@ -167,6 +163,34 @@ public class TownDebugCommand
                $"backlinkComponent={backlinkId} backlinkParty={backlink?.MobileParty?.StringId ?? "null"} " +
                $"activeGarrisonCount={activeGarrisons.Count} activeGarrisonParties={activeParties} " +
                $"backlinkMatchesActive={backlinkMatchesActive}";
+    }
+
+    [CommandLineArgumentFunction("focus_garrison", "coop.debug.town")]
+    public static string FocusGarrison(List<string> args)
+    {
+        if (args.Count != 1)
+        {
+            return "Usage: coop.debug.town.focus_garrison <townId>";
+        }
+
+        if (!TryGetObjectManager(out var objectManager))
+        {
+            return "Unable to resolve ObjectManager";
+        }
+
+        if (!objectManager.TryGetObject(args[0], out Town town))
+        {
+            return $"ID: '{args[0]}' not found";
+        }
+
+        var activeGarrisons = GetActiveGarrisons(town);
+        if (activeGarrisons.Count != 1)
+        {
+            return $"Expected exactly one active garrison for {town.Name}, found {activeGarrisons.Count}";
+        }
+
+        activeGarrisons[0].Party.SetAsCameraFollowParty();
+        return $"Following {activeGarrisons[0].StringId} at {town.Name} on the campaign map";
     }
 
     [CommandLineArgumentFunction("apply_garrison_lifecycle", "coop.debug.town")]
@@ -192,11 +216,7 @@ public class TownDebugCommand
             return $"ID: '{args[0]}' not found";
         }
 
-        var activeGarrisons = MobileParty.All
-            .Where(party => party.IsActive &&
-                            party.PartyComponent is GarrisonPartyComponent component &&
-                            component.Settlement?.Town == town)
-            .ToList();
+        var activeGarrisons = GetActiveGarrisons(town);
         if (activeGarrisons.Count != 1)
         {
             return $"Expected exactly one active garrison for {town.Name}, found {activeGarrisons.Count}";
@@ -226,6 +246,15 @@ public class TownDebugCommand
 
         return $"Applied {args[1].ToLowerInvariant()} to {activeGarrisons[0].StringId}; " +
                GarrisonBacklink(new List<string> { args[0] });
+    }
+
+    private static List<MobileParty> GetActiveGarrisons(Town town)
+    {
+        return MobileParty.All
+            .Where(party => party.IsActive &&
+                            party.PartyComponent is GarrisonPartyComponent component &&
+                            component.Settlement?.Town == town)
+            .ToList();
     }
 
     // coop.debug.town.list_buildings <townId>

--- a/source/GameInterface/Services/Towns/Commands/TownDebugCommand.cs
+++ b/source/GameInterface/Services/Towns/Commands/TownDebugCommand.cs
@@ -3,6 +3,7 @@ using Common;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Towns.Patches;
 using Helpers;
+using SandBox.View.Map;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -189,8 +190,18 @@ public class TownDebugCommand
             return $"Expected exactly one active garrison for {town.Name}, found {activeGarrisons.Count}";
         }
 
-        activeGarrisons[0].Party.SetAsCameraFollowParty();
-        return $"Following {activeGarrisons[0].StringId} at {town.Name} on the campaign map";
+        MapScreen mapScreen = MapScreen.Instance;
+        if (mapScreen?.MapCameraView == null)
+        {
+            return "Campaign map camera is unavailable";
+        }
+
+        MobileParty garrison = activeGarrisons[0];
+        var targetPosition = garrison.MapEvent?.Position ?? garrison.Position;
+        garrison.Party.SetAsCameraFollowParty();
+        mapScreen.MapCameraView.FastMoveCameraToPosition(targetPosition, mapScreen.IsInMenu);
+        mapScreen.MapCameraView.SetCameraMode(MapCameraView.CameraFollowMode.FollowParty);
+        return $"Following {garrison.StringId} at {town.Name} on the campaign map";
     }
 
     [CommandLineArgumentFunction("apply_garrison_lifecycle", "coop.debug.town")]


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Initializing or finalizing a town garrison on the server can leave clients with a missing or stale town-to-garrison link.

## What is the new behavior?

Resolves #1547

Town garrison initialization and finalization now update every connected client's town state, so all peers agree on the active garrison.

## Bot Changelog Entry

- Fixed town garrison creation and removal leaving clients with stale garrison state.
