### PR TITLE
[1539] Prevent server deadlocks from trivial AutoSync detours

### DIFF
--- a/source/GameInterface.Tests/DynamicSync/AutoSyncTargetSelectionTests.cs
+++ b/source/GameInterface.Tests/DynamicSync/AutoSyncTargetSelectionTests.cs
@@ -1,0 +1,264 @@
+﻿using GameInterface.Utils;
+using GameInterface.Utils.LocalEvents;
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Party.PartyComponents;
+using TaleWorlds.CampaignSystem.Settlements;
+using Xunit;
+
+namespace GameInterface.Tests.AutoSync;
+
+/// <summary>
+/// Verifies that AutoSync drops dangerous trivial stubs while preserving nontrivial methods whose
+/// existing Harmony detours can be required JIT anti-inlining boundaries.
+/// </summary>
+public class AutoSyncTargetSelectionTests
+{
+    [Fact]
+    public void Keeps_nontrivial_methods_but_drops_empty_and_constant_stubs()
+    {
+        var targets = GenericPatches<SelectionPatch, SelectionSample>
+            .TranspilerTargets(true)
+            .ToArray();
+
+        Assert.Contains(typeof(SelectionSample).GetConstructor(Type.EmptyTypes)!, targets);
+        Assert.Contains(SampleMethod(nameof(SelectionSample.StoreSyncedScalar)), targets);
+        Assert.Contains(SampleMethod(nameof(SelectionSample.MutateSyncedList)), targets);
+        Assert.Contains(SampleMethod(nameof(SelectionSample.MutateSyncedArray)), targets);
+        Assert.Contains(SampleMethod(nameof(SelectionSample.MutateSyncedProperty)), targets);
+        Assert.Contains(SampleMethod(nameof(SelectionSample.AssignSyncedProperty)), targets);
+        Assert.Contains(SampleMethod(nameof(SelectionSample.ReadSyncedList)), targets);
+        Assert.Contains(SampleMethod(nameof(SelectionSample.ReadSyncedProperty)), targets);
+        Assert.Contains(SampleMethod(nameof(SelectionSample.ForwardToScalarStore)), targets);
+        Assert.Contains(SampleMethod(nameof(SelectionSample.ReadSyncedScalar)), targets);
+        Assert.Contains(SampleMethod(nameof(SelectionSample.ReadSyncedArray)), targets);
+        Assert.Contains(SampleMethod(nameof(SelectionSample.StoreOtherScalar)), targets);
+
+        Assert.DoesNotContain(SampleMethod(nameof(SelectionSample.ConstantFalse)), targets);
+        Assert.DoesNotContain(SampleMethod(nameof(SelectionSample.ConstantLong)), targets);
+        Assert.DoesNotContain(SampleMethod(nameof(SelectionSample.ConstantNull)), targets);
+        Assert.DoesNotContain(SampleMethod(nameof(SelectionSample.Empty)), targets);
+    }
+
+    [Fact]
+    public void Drops_the_reported_clan_interface_getter()
+    {
+        var interfaceGetter = typeof(IFaction).GetProperty(nameof(IFaction.IsKingdomFaction))!.GetMethod!;
+        var interfaceMap = typeof(Clan).GetInterfaceMap(typeof(IFaction));
+        var interfaceIndex = Array.IndexOf(interfaceMap.InterfaceMethods, interfaceGetter);
+        Assert.True(interfaceIndex >= 0);
+
+        var reportedGetter = interfaceMap.TargetMethods[interfaceIndex];
+        var targets = GenericPatches<ClanSelectorPatch, Clan>
+            .TranspilerTargets(true)
+            .ToArray();
+
+        Assert.NotEmpty(targets);
+        Assert.DoesNotContain(reportedGetter, targets);
+    }
+
+    [Fact]
+    public void Dead_fief_field_registration_retains_nontrivial_methods()
+    {
+        var targets = GenericPatches<FiefSelectorPatch, Fief>
+            .TranspilerTargets(true)
+            .ToArray();
+
+        Assert.NotEmpty(targets);
+    }
+
+    [Fact]
+    public void Uses_the_composed_instruction_stream_and_retains_replacement_calls()
+    {
+        var introducedWrite = ComposedMethod(nameof(ComposedSelectionSample.IntroducedWrite));
+        var consumedWrite = ComposedMethod(nameof(ComposedSelectionSample.ConsumedWrite));
+        var harmony = new Harmony($"{nameof(AutoSyncTargetSelectionTests)}.{Guid.NewGuid()}");
+
+        try
+        {
+            harmony.Patch(
+                introducedWrite,
+                transpiler: new HarmonyMethod(
+                    typeof(ExistingCompositionTranspilers),
+                    nameof(ExistingCompositionTranspilers.IntroduceWrite)));
+            harmony.Patch(
+                consumedWrite,
+                transpiler: new HarmonyMethod(
+                    typeof(ExistingCompositionTranspilers),
+                    nameof(ExistingCompositionTranspilers.ConsumeWrite)));
+
+            var targets = GenericPatches<ComposedSelectionPatch, ComposedSelectionSample>
+                .TranspilerTargets(false)
+                .ToArray();
+
+            Assert.Contains(introducedWrite, targets);
+            Assert.Contains(consumedWrite, targets);
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmony.Id);
+        }
+    }
+
+    private static MethodInfo SampleMethod(string name) => typeof(SelectionSample).GetMethod(name)!;
+
+    private static MethodInfo ComposedMethod(string name) => typeof(ComposedSelectionSample).GetMethod(name)!;
+
+    /// <summary>
+    /// Provides representative scalar, collection, array, and property IL shapes.
+    /// </summary>
+    private sealed class SelectionSample
+    {
+        public int SyncedScalar;
+        public int OtherScalar;
+        public readonly List<int> SyncedList = new List<int>();
+        public string[] SyncedArray = new string[1];
+        public List<int> SyncedProperty { get; set; } = new List<int>();
+
+        public SelectionSample()
+        {
+            SyncedScalar = 1;
+        }
+
+        public void StoreSyncedScalar(int value) => SyncedScalar = value;
+        public int ReadSyncedScalar() => SyncedScalar;
+        public void StoreOtherScalar(int value) => OtherScalar = value;
+        public bool ConstantFalse() => false;
+        public long ConstantLong() => 4_294_967_296L;
+        public object? ConstantNull() => null;
+        public void Empty() { }
+        public void MutateSyncedList() => SyncedList.Add(1);
+        public int ReadSyncedList() => SyncedList.Count;
+        public void MutateSyncedArray() => SyncedArray[0] = "updated";
+        public string ReadSyncedArray() => SyncedArray[0];
+        public void MutateSyncedProperty() => SyncedProperty.Add(1);
+        public List<int> ReadSyncedProperty() => SyncedProperty;
+        public void AssignSyncedProperty(List<int> values) => SyncedProperty = values;
+        public void ForwardToScalarStore(int value) => StoreSyncedScalar(value);
+    }
+
+    /// <summary>
+    /// Uses the same generic transpilers emitted by AutoSync for the sample members.
+    /// </summary>
+    private sealed class SelectionPatch : GenericPatches<SelectionPatch, SelectionSample>
+    {
+        [HarmonyTranspiler]
+        private static IEnumerable<CodeInstruction> SyncedScalarTranspiler(IEnumerable<CodeInstruction> instructions) =>
+            FieldTranspiler<int, GenericEvent<SelectionSample, int>>(instructions, nameof(SelectionSample.SyncedScalar));
+
+        [HarmonyTranspiler]
+        private static IEnumerable<CodeInstruction> SyncedListTranspiler(IEnumerable<CodeInstruction> instructions) =>
+            ListFieldChangeTranspiler<int, GenericEvent<SelectionSample, int>, GenericEvent<SelectionSample, int>>(
+                instructions,
+                nameof(SelectionSample.SyncedList));
+
+        [HarmonyTranspiler]
+        private static IEnumerable<CodeInstruction> SyncedArrayTranspiler(IEnumerable<CodeInstruction> instructions) =>
+            ArrayFieldChangeTranspiler<string, SelectionArrayChanged>(instructions, nameof(SelectionSample.SyncedArray));
+
+        [HarmonyTranspiler]
+        private static IEnumerable<CodeInstruction> SyncedPropertyTranspiler(IEnumerable<CodeInstruction> instructions) =>
+            ListPropertyChangeTranspiler<int, GenericEvent<SelectionSample, int>, GenericEvent<SelectionSample, int>>(
+                instructions,
+                nameof(SelectionSample.SyncedProperty));
+    }
+
+    /// <summary>
+    /// Supplies the concrete event type required by the array transpiler.
+    /// </summary>
+    private sealed record SelectionArrayChanged : GenericArrayChangedEvent<SelectionSample, string>
+    {
+        public SelectionArrayChanged(SelectionSample instance, string value, int index) : base(instance, value, index)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Represents the registered Clan field while leaving unrelated accessors untouched.
+    /// </summary>
+    private sealed class ClanSelectorPatch : GenericPatches<ClanSelectorPatch, Clan>
+    {
+        [HarmonyTranspiler]
+        private static IEnumerable<CodeInstruction> EliminatedTranspiler(IEnumerable<CodeInstruction> instructions) =>
+            FieldTranspiler<bool, GenericEvent<Clan, bool>>(instructions, nameof(Clan._isEliminated));
+    }
+
+    /// <summary>
+    /// Represents Fief's dead GarrisonPartyComponent field registration.
+    /// </summary>
+    private sealed class FiefSelectorPatch : GenericPatches<FiefSelectorPatch, Fief>
+    {
+        [HarmonyTranspiler]
+        private static IEnumerable<CodeInstruction> GarrisonTranspiler(IEnumerable<CodeInstruction> instructions) =>
+            FieldTranspiler<GarrisonPartyComponent, GenericEvent<Fief, GarrisonPartyComponent>>(
+                instructions,
+                nameof(Fief.GarrisonPartyComponent));
+    }
+
+    private sealed class ComposedSelectionSample
+    {
+        public int SyncedScalar;
+
+        public void IntroducedWrite(int value)
+        {
+        }
+
+        public void ConsumedWrite(int value) => SyncedScalar = value;
+    }
+
+    private sealed class ComposedSelectionPatch : GenericPatches<ComposedSelectionPatch, ComposedSelectionSample>
+    {
+        [HarmonyTranspiler]
+        private static IEnumerable<CodeInstruction> SyncedScalarTranspiler(IEnumerable<CodeInstruction> instructions) =>
+            FieldTranspiler<int, GenericEvent<ComposedSelectionSample, int>>(
+                instructions,
+                nameof(ComposedSelectionSample.SyncedScalar));
+    }
+
+    private static class ExistingCompositionTranspilers
+    {
+        public static IEnumerable<CodeInstruction> IntroduceWrite(IEnumerable<CodeInstruction> instructions)
+        {
+            var field = AccessTools.Field(
+                typeof(ComposedSelectionSample),
+                nameof(ComposedSelectionSample.SyncedScalar));
+
+            foreach (var instruction in instructions)
+            {
+                if (instruction.opcode == OpCodes.Ret)
+                {
+                    yield return new CodeInstruction(OpCodes.Ldarg_0);
+                    yield return new CodeInstruction(OpCodes.Ldarg_1);
+                    yield return new CodeInstruction(OpCodes.Stfld, field);
+                }
+
+                yield return instruction;
+            }
+        }
+
+        public static IEnumerable<CodeInstruction> ConsumeWrite(IEnumerable<CodeInstruction> instructions)
+        {
+            var field = AccessTools.Field(
+                typeof(ComposedSelectionSample),
+                nameof(ComposedSelectionSample.SyncedScalar));
+            var replacement = AccessTools.Method(
+                typeof(ExistingCompositionTranspilers),
+                nameof(StoreWithoutVisibleFieldInstruction));
+
+            foreach (var instruction in instructions)
+            {
+                yield return instruction.StoresField(field)
+                    ? new CodeInstruction(OpCodes.Call, replacement)
+                    : instruction;
+            }
+        }
+
+        private static void StoreWithoutVisibleFieldInstruction(ComposedSelectionSample instance, int value) =>
+            instance.SyncedScalar = value;
+    }
+}

--- a/source/GameInterface.Tests/DynamicSync/TemplateRenderTests.cs
+++ b/source/GameInterface.Tests/DynamicSync/TemplateRenderTests.cs
@@ -1,5 +1,7 @@
 ﻿using GameInterface.AutoSync.Templates;
+using System;
 using System.Collections.Generic;
+using System.Reflection;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -11,6 +13,31 @@ public class TemplateRenderTests
     public TemplateRenderTests(ITestOutputHelper output)
     {
         this.output = output;
+    }
+
+    [Fact]
+    public void Dynamic_patch_uses_narrowed_automatic_targets_and_preserves_explicit_targets()
+    {
+        var explicitTarget = typeof(string).GetMethod(nameof(string.Trim), Type.EmptyTypes)!;
+        var result = RenderDynamicPatch(true, new[] { explicitTarget });
+
+        Assert.Contains(
+            "GenericPatches<TestType_DynamicPatches, TestType>.TranspilerTargets(true)",
+            result);
+        Assert.Contains("[HarmonyPrepare]", result);
+        Assert.Contains("private static bool Prepare() => TargetMethods().Any();", result);
+        Assert.Contains("yield return AccessTools.Method(typeof(System.String), \"Trim\");", result);
+    }
+
+    [Fact]
+    public void Categorized_dynamic_patch_uses_only_its_explicit_targets()
+    {
+        var explicitTarget = typeof(string).GetMethod(nameof(string.Trim), Type.EmptyTypes)!;
+        var result = RenderDynamicPatch(false, new[] { explicitTarget });
+
+        Assert.DoesNotContain("TranspilerTargets(true)", result);
+        Assert.Contains("yield return AccessTools.Method(typeof(System.String), \"Trim\");", result);
+        Assert.Contains("[HarmonyPrepare]", result);
     }
 
     [Fact(Skip = "Need regeneration")]
@@ -153,6 +180,24 @@ public class TemplateRenderTests
             ChangeMessageType = "ChangeArrayFieldMessage"
         });
         SnapshotAssert.Equals(result);
+    }
+
+    private static string RenderDynamicPatch(bool includeDeclaredMethods, MethodInfo[] targetMethods)
+    {
+        return TemplateParser.Parse("Patches.DynamicPatchTemplate", new
+        {
+            Libraries = Array.Empty<string>(),
+            DeclaringType = "TestType",
+            PatchClassName = "TestType_DynamicPatches",
+            PatchCategory = includeDeclaredMethods ? null : "TestCategory",
+            IncludeDeclaredMethods = includeDeclaredMethods,
+            TargetMethods = targetMethods,
+            Prefixes = Array.Empty<string>(),
+            Transpilers = new[]
+            {
+                "[HarmonyTranspiler] private static IEnumerable<CodeInstruction> Test(IEnumerable<CodeInstruction> instructions) => instructions;"
+            }
+        });
     }
 
 }

--- a/source/GameInterface/AutoSync/Templates/Patches/DynamicPatchTemplate.txt
+++ b/source/GameInterface/AutoSync/Templates/Patches/DynamicPatchTemplate.txt
@@ -28,15 +28,10 @@ public class {{PatchClassName}} : GenericPatches<{{PatchClassName}}, {{Declaring
 {
     private readonly static ILogger Logger = LogManager.GetLogger<{{PatchClassName}}>();
 
-    private static IEnumerable<MethodBase> TargetMethods()
+    private new static IEnumerable<MethodBase> TargetMethods()
     {
         {{~ if IncludeDeclaredMethods ~}}
-        foreach (var ctor in AccessTools.GetDeclaredConstructors(typeof({{DeclaringType}})))
-        {
-            yield return ctor;
-        }
-
-        foreach (var method in AccessTools.GetDeclaredMethods(typeof({{DeclaringType}})).Where(m => !m.IsAbstract))
+        foreach (var method in GenericPatches<{{PatchClassName}}, {{DeclaringType}}>.TranspilerTargets(true))
         {
             yield return method;
         }
@@ -45,6 +40,10 @@ public class {{PatchClassName}} : GenericPatches<{{PatchClassName}}, {{Declaring
         yield return AccessTools.Method(typeof({{targetMethod.DeclaringType}}), "{{targetMethod.Name}}");
         {{~ end ~}}
     }
+
+    [HarmonyPrepare]
+    private static bool Prepare() => TargetMethods().Any();
+
     {{~ for transpiler in Transpilers ~}}
     {{ transpiler }}
     {{~ end ~}}

--- a/source/GameInterface/Services/Equipments/Patches/EquipmentCollectionPatches.cs
+++ b/source/GameInterface/Services/Equipments/Patches/EquipmentCollectionPatches.cs
@@ -2,6 +2,7 @@
 using GameInterface.Utils;
 using HarmonyLib;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using TaleWorlds.Core;
 
@@ -10,7 +11,10 @@ namespace GameInterface.Services.Equipments.Patches;
 [HarmonyPatch]
 internal class EquipmentCollectionPatches : GenericPatches<EquipmentCollectionPatches, Equipment>
 {
-    static IEnumerable<MethodBase> TargetMethods() => AccessTools.GetDeclaredMethods(typeof(Equipment));
+    new static IEnumerable<MethodBase> TargetMethods() => GenericPatches<EquipmentCollectionPatches, Equipment>.TargetMethods();
+
+    [HarmonyPrepare]
+    private static bool Prepare() => TargetMethods().Any();
     
     [HarmonyTranspiler]
     static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/source/GameInterface/Services/Heroes/Patches/HeroCollectionPatches.cs
+++ b/source/GameInterface/Services/Heroes/Patches/HeroCollectionPatches.cs
@@ -2,6 +2,7 @@
 using GameInterface.Utils;
 using HarmonyLib;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using TaleWorlds.CampaignSystem;
@@ -15,9 +16,9 @@ namespace GameInterface.Services.Heroes.Patches;
 [HarmonyPatch]
 internal class HeroCollectionPatches : GenericPatches<HeroCollectionPatches, Hero>
 {
-    private static IEnumerable<MethodBase> TargetMethods()
+    private new static IEnumerable<MethodBase> TargetMethods()
     {
-        foreach (var method in AccessTools.GetDeclaredMethods(typeof(Hero)))
+        foreach (var method in GenericPatches<HeroCollectionPatches, Hero>.TargetMethods())
         {
             yield return method;
         }
@@ -32,6 +33,9 @@ internal class HeroCollectionPatches : GenericPatches<HeroCollectionPatches, Her
         // (see AlleyPatches / AlleyHandler), so it is not collection-synced here.
         //yield return AccessTools.Method(typeof(TroopRosterHandler), nameof(TroopRosterHandler.HandleOnRecruitmentDone));
     }
+
+    [HarmonyPrepare]
+    private static bool Prepare() => TargetMethods().Any();
 
     [HarmonyTranspiler]
     static IEnumerable<CodeInstruction> VolunteerTranspiler(IEnumerable<CodeInstruction> instructions)

--- a/source/GameInterface/Services/MobileParties/Patches/MobilePartyCollectionPatches.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/MobilePartyCollectionPatches.cs
@@ -2,6 +2,7 @@
 using GameInterface.Utils;
 using HarmonyLib;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using TaleWorlds.CampaignSystem.Party;
 
@@ -10,10 +11,13 @@ namespace GameInterface.Services.MobileParties.Patches;
 [HarmonyPatch]
 internal class MobilePartyCollectionPatches : GenericPatches<MobilePartyCollectionPatches, MobileParty>
 {
-    static IEnumerable<MethodBase> TargetMethods()
+    new static IEnumerable<MethodBase> TargetMethods()
     {
-        return AccessTools.GetDeclaredMethods(typeof(MobileParty));
+        return GenericPatches<MobilePartyCollectionPatches, MobileParty>.TargetMethods();
     }
+
+    [HarmonyPrepare]
+    private static bool Prepare() => TargetMethods().Any();
 
     [HarmonyTranspiler]
     static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/source/GameInterface/Utils/GenericPatches.cs
+++ b/source/GameInterface/Utils/GenericPatches.cs
@@ -28,10 +28,33 @@ namespace GameInterface.Utils
 
         private static Dictionary<Type, Dictionary<string, FieldInfo>> fieldInfoCache = new Dictionary<Type, Dictionary<string, FieldInfo>>();
         private static Dictionary<Type, Dictionary<string, PropertyInfo>> propertyInfoCache = new Dictionary<Type, Dictionary<string, PropertyInfo>>();
+        private static readonly Lazy<MethodBase[]> declaredMethodTargets = new Lazy<MethodBase[]>(() => SelectTargetMethods(false));
+        private static readonly Lazy<MethodBase[]> declaredMemberTargets = new Lazy<MethodBase[]>(() => SelectTargetMethods(true));
 
         public static IEnumerable<MethodBase> TargetMethods()
         {
-            return AccessTools.GetDeclaredMethods(typeof(TInstance));
+            return declaredMethodTargets.Value;
+        }
+
+        public static IEnumerable<MethodBase> TranspilerTargets(bool includeConstructors)
+        {
+            return includeConstructors ? declaredMemberTargets.Value : declaredMethodTargets.Value;
+        }
+
+        private static MethodBase[] SelectTargetMethods(bool includeConstructors)
+        {
+            IEnumerable<MethodBase> candidates = AccessTools.GetDeclaredMethods(typeof(TInstance))
+                .Where(method => !method.IsAbstract)
+                .Cast<MethodBase>();
+
+            if (includeConstructors)
+            {
+                candidates = AccessTools.GetDeclaredConstructors(typeof(TInstance))
+                    .Cast<MethodBase>()
+                    .Concat(candidates);
+            }
+
+            return GenericPatchHelpers.SelectTranspilerTargets(candidates, typeof(TPatch)).ToArray();
         }
 
         #region ListTranspiler
@@ -1438,6 +1461,110 @@ namespace GameInterface.Utils
 
     public class GenericPatchHelpers
     {
+        /// <summary>
+        /// Drops only empty, null-return, and numeric constant-return stubs unless a declared transpiler changes their composed
+        /// instruction stream. Other methods remain targets because the existing detour can be a required
+        /// JIT anti-inlining boundary even when this patch class does not rewrite that method's own IL.
+        /// </summary>
+        public static IEnumerable<MethodBase> SelectTranspilerTargets(IEnumerable<MethodBase> candidates, Type patchType)
+        {
+            if (candidates == null) throw new ArgumentNullException(nameof(candidates));
+            if (patchType == null) throw new ArgumentNullException(nameof(patchType));
+
+            var transpilers = AccessTools.GetDeclaredMethods(patchType)
+                .Where(method => method.GetCustomAttributes(typeof(HarmonyTranspiler), false).Any())
+                .ToArray();
+
+            foreach (var candidate in candidates.Where(candidate => candidate != null && !candidate.IsAbstract).Distinct())
+            {
+                if (!IsTrivialStub(candidate) ||
+                    transpilers.Any(transpiler => ChangesInstructions(candidate, transpiler)))
+                {
+                    yield return candidate;
+                }
+            }
+        }
+
+        private static bool IsTrivialStub(MethodBase candidate)
+        {
+            try
+            {
+                var instructions = PatchProcessor.GetCurrentInstructions(candidate)
+                    .Where(instruction => instruction.opcode != OpCodes.Nop)
+                    .ToArray();
+
+                if (instructions.Length == 1)
+                    return instructions[0].opcode == OpCodes.Ret;
+
+                if (instructions.Length != 2 || instructions[1].opcode != OpCodes.Ret)
+                    return false;
+
+                var opcode = instructions[0].opcode;
+                return opcode == OpCodes.Ldnull ||
+                    opcode == OpCodes.Ldc_I4_M1 ||
+                    opcode == OpCodes.Ldc_I4_0 ||
+                    opcode == OpCodes.Ldc_I4_1 ||
+                    opcode == OpCodes.Ldc_I4_2 ||
+                    opcode == OpCodes.Ldc_I4_3 ||
+                    opcode == OpCodes.Ldc_I4_4 ||
+                    opcode == OpCodes.Ldc_I4_5 ||
+                    opcode == OpCodes.Ldc_I4_6 ||
+                    opcode == OpCodes.Ldc_I4_7 ||
+                    opcode == OpCodes.Ldc_I4_8 ||
+                    opcode == OpCodes.Ldc_I4_S ||
+                    opcode == OpCodes.Ldc_I4 ||
+                    opcode == OpCodes.Ldc_I8 ||
+                    opcode == OpCodes.Ldc_R4 ||
+                    opcode == OpCodes.Ldc_R8;
+            }
+            catch
+            {
+                // Inspection failures preserve the existing target.
+                return false;
+            }
+        }
+
+        private static bool ChangesInstructions(MethodBase candidate, MethodInfo transpiler)
+        {
+            try
+            {
+                var parameters = transpiler.GetParameters();
+                if (!transpiler.IsStatic || parameters.Length != 1 ||
+                    !parameters[0].ParameterType.IsAssignableFrom(typeof(List<CodeInstruction>)))
+                {
+                    return true;
+                }
+
+                // AutoSync is installed after the static GameInterface patches, so classify the
+                // same composed instruction stream that Harmony will pass to this transpiler.
+                var instructions = PatchProcessor.GetCurrentInstructions(candidate);
+                var originalOpcodes = instructions.Select(instruction => instruction.opcode).ToArray();
+                var originalOperands = instructions.Select(instruction => instruction.operand).ToArray();
+
+                var result = transpiler.Invoke(null, new object[] { instructions }) as IEnumerable<CodeInstruction>;
+                if (result == null) return true;
+
+                var transpiled = result.ToArray();
+                if (transpiled.Length != originalOpcodes.Length) return true;
+
+                for (var i = 0; i < transpiled.Length; i++)
+                {
+                    if (transpiled[i].opcode != originalOpcodes[i] ||
+                        !Equals(transpiled[i].operand, originalOperands[i]))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+            catch
+            {
+                // Preserve the existing target when its IL cannot be inspected safely.
+                return true;
+            }
+        }
+
         public static ConcurrentDictionary<FieldInfo, MethodInfo> FieldInterceptCache = new ConcurrentDictionary<FieldInfo, MethodInfo>();
         public static ConcurrentDictionary<MemberInfo, MethodInfo> CollectionAddInterceptCache = new ConcurrentDictionary<MemberInfo, MethodInfo>();
         public static ConcurrentDictionary<MemberInfo, MethodInfo> CollectionRemoveInterceptCache = new ConcurrentDictionary<MemberInfo, MethodInfo>();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Dedicated servers still install unnecessary synchronization hooks on empty or constant-only game routines, leaving the original large-battle freeze path dependent on a separate safety guard.

## What is the new behavior?

Resolves #1539

Dedicated servers skip those unnecessary hooks while keeping existing campaign synchronization working normally.

## Bot Changelog Entry

- Stopped dedicated servers from applying unnecessary synchronization hooks to empty or constant-only game routines.
