### PR TITLE
Allow more wanderers

### DIFF
--- a/source/GameInterface/Services/Companions/Patches/Disable/DisableCompanionsCampaignBehavior.cs
+++ b/source/GameInterface/Services/Companions/Patches/Disable/DisableCompanionsCampaignBehavior.cs
@@ -4,6 +4,8 @@ using GameInterface.Extentions;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
 using HarmonyLib;
+using System;
+using System.Collections;
 using System.Collections.Generic;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Actions;
@@ -106,6 +108,40 @@ internal class CompanionsCampaignBehaviorPatches
         }
 
         return false;
+    }
+
+    [HarmonyPatch(nameof(CompanionsCampaignBehavior.GetCompanionTemplateToSpawn))]
+    [HarmonyPostfix]
+    public static void GetCompanionTemplateToSpawnPostfix(CompanionsCampaignBehavior __instance, ref CharacterObject __result)
+    {
+        // Vanilla limit hit for this template, use a random from the pool
+        if (__result == null)
+        {
+            List<CharacterObject> list = __instance._companionsOfTemplates[__instance.GetCompanionTemplateTypeToSpawn()];
+            list.Shuffle<CharacterObject>();
+
+            var random = new Random();
+            var characterObject = list[random.Next(list.Count)];
+
+            __result = characterObject;
+        }
+    }
+
+    [HarmonyPatch(nameof(CompanionsCampaignBehavior.GetCompanionTemplateTypeToSpawn))]
+    [HarmonyPostfix]
+    public static void GetCompanionTemplateTypeToSpawnPostfix(CompanionsCampaignBehavior __instance, ref CompanionsCampaignBehavior.CompanionTemplateType __result)
+    {
+        // Vanilla limit hit for for all templates, use a random type
+        // Combat represents vanilla's default and doesn't have any templates
+        if (__result == CompanionsCampaignBehavior.CompanionTemplateType.Combat)
+        {
+            var random = new Random();
+
+            var values = Enum.GetValues(typeof(CompanionsCampaignBehavior.CompanionTemplateType));
+            var randomTemplateType = (CompanionsCampaignBehavior.CompanionTemplateType)values.GetValue(random.Next(values.Length));
+
+            __result = randomTemplateType;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Vanilla has a hard cap of 67 wanderer templates and when this limit is reached no more will spawn.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #2946
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Check for when the limit is reached and randomly select a template to spawn a new wanderer if under the limit.

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Increased wanderer hard cap from vanilla. You should now see a large number of recruitable companions spawning with the right config.
