### PR TITLE
[2836] Exclude inactive parties from join baseline

### DIFF
--- a/source/Coop.Core/Client/Services/MobileParties/Handlers/JoinCampaignBaselineHandler.cs
+++ b/source/Coop.Core/Client/Services/MobileParties/Handlers/JoinCampaignBaselineHandler.cs
@@ -2,6 +2,9 @@
 using Common.Messaging;
 using Common.Util;
 using Coop.Core.Client.Messages;
+#if DEBUG
+using Coop.Core.Common.Commands;
+#endif
 using Coop.Core.Server.Services.MobileParties.Messages;
 using GameInterface.Services.Heroes.Interaces;
 using GameInterface.Services.MobileParties.Data;
@@ -43,6 +46,12 @@ public sealed class JoinCampaignBaselineHandler : IHandler
         var baseline = payload.What;
         GameThread.RunSafe(() =>
         {
+#if DEBUG
+            if (baseline.IsComplete)
+            {
+                JoinDebugCommands.ForceArmedInactivePartyDeficit();
+            }
+#endif
             bool success = baseline.IsComplete &&
                 mobilePartyBehaviorSnapshot.TryApplyJoinBaseline(
                     baseline.PartyStates,

--- a/source/Coop.Core/Client/States/CampaignState.cs
+++ b/source/Coop.Core/Client/States/CampaignState.cs
@@ -37,6 +37,20 @@ public class CampaignState : ClientStateBase
     private volatile bool waitingForWorldReady;
     private volatile bool joinCompletionQueued;
     private volatile int lastJoinPacketsRemaining = -1;
+#if DEBUG
+    private int baselineRequestsSent;
+    private int baselineApplicationFailures;
+
+    internal string DebugJoinState =>
+        $"state={nameof(CampaignState)} waitingForJoinCatchUp={waitingForJoinCatchUp} " +
+        $"baselineResponseExpected={baselineResponseExpected} " +
+        $"finalBaselineResponseExpected={finalBaselineResponseExpected} " +
+        $"successfulBaselines={successfulBaselines} baselineRequestsSent={baselineRequestsSent} " +
+        $"baselineApplicationFailures={baselineApplicationFailures} " +
+        $"waitingForTimeCatchUp={waitingForTimeCatchUp} finalTimeCatchUp={finalTimeCatchUp} " +
+        $"waitingForWorldReady={waitingForWorldReady} joinCompletionQueued={joinCompletionQueued} " +
+        $"joinPacketsRemaining={lastJoinPacketsRemaining}";
+#endif
 
     public CampaignState(
         IClientLogic logic,
@@ -130,6 +144,9 @@ public class CampaignState : ClientStateBase
         SetCatchUpLoadingMessage();
         if (!obj.What.Success)
         {
+#if DEBUG
+            baselineApplicationFailures++;
+#endif
             RequestBaseline(isFinalBaseline);
             return;
         }
@@ -154,6 +171,9 @@ public class CampaignState : ClientStateBase
 
     private void RequestBaseline(bool isFinalBaseline)
     {
+#if DEBUG
+        baselineRequestsSent++;
+#endif
         waitingForTimeCatchUp = false;
         finalTimeCatchUp = false;
         mapTimeTrackerInterface.ResetForCampaignJoin();

--- a/source/Coop.Core/Common/Commands/JoinDebugCommands.cs
+++ b/source/Coop.Core/Common/Commands/JoinDebugCommands.cs
@@ -1,0 +1,231 @@
+﻿#if DEBUG
+using Common;
+using Coop.Core.Client;
+using Coop.Core.Client.States;
+using Coop.Core.Server.Connections;
+using GameInterface;
+using GameInterface.Services.MobileParties;
+using GameInterface.Services.MobileParties.Extensions;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Party;
+using static TaleWorlds.Library.CommandLineFunctionality;
+using ServerLoadingState = Coop.Core.Server.Connections.States.LoadingState;
+
+namespace Coop.Core.Common.Commands;
+
+/// <summary>
+/// Stages and observes campaign-join scenarios in DEBUG builds.
+/// </summary>
+internal static class JoinDebugCommands
+{
+    private static int forceNextInactivePartyDeficit;
+    private static string desiredInactivePartyId;
+    private static string lastForcedPartyId = "none";
+    private static MobileParty stagedInactiveParty;
+    private static bool stagedInactivePartyWasActive;
+
+    [CommandLineArgumentFunction("join_state", "coop.debug.connection")]
+    public static string JoinState(List<string> args)
+    {
+        if (args.Count != 0)
+        {
+            return "Usage: coop.debug.connection.join_state";
+        }
+
+        if (ModInformation.IsServer)
+        {
+            if (!ContainerProvider.TryResolve<IConnectionCollection>(out var connections))
+            {
+                return "Failed to get connection collection";
+            }
+
+            string connectionState = string.Join(" | ", connections.Select(connection =>
+            {
+                string state = connection.State?.GetType().Name ?? "none";
+                string details = connection.State is ServerLoadingState loading
+                    ? loading.DebugJoinState
+                    : "joinCatchUpPending=false";
+                return $"peer={connection.Peer.Id} state={state} {details}";
+            }));
+            return $"{GetPartyCounts()} | {connectionState}";
+        }
+
+        if (!ContainerProvider.TryResolve<IClientLogic>(out var clientLogic))
+        {
+            return "Failed to get client logic";
+        }
+
+        return clientLogic.State is CampaignState campaignState
+            ? $"{campaignState.DebugJoinState} {GetPartyCounts()} " +
+              $"forcedInactiveParty={lastForcedPartyId}"
+            : $"state={clientLogic.State?.GetType().Name ?? "none"} {GetPartyCounts()} " +
+              $"forcedInactiveParty={lastForcedPartyId}";
+    }
+
+    [CommandLineArgumentFunction("arm_inactive_party_deficit", "coop.debug.connection")]
+    public static string ArmInactivePartyDeficit(List<string> args)
+    {
+        if (args.Count != 1)
+        {
+            return "Usage: coop.debug.connection.arm_inactive_party_deficit <partyStringId>";
+        }
+        if (ModInformation.IsServer)
+        {
+            return "The inactive-party deficit fixture is client-only.";
+        }
+
+        desiredInactivePartyId = args[0];
+        lastForcedPartyId = "armed";
+        Interlocked.Exchange(ref forceNextInactivePartyDeficit, 1);
+        return $"The next complete join baseline will remove inactive party '{args[0]}' " +
+               "from the client campaign collection before validation.";
+    }
+
+    [CommandLineArgumentFunction("stage_inactive_party", "coop.debug.connection")]
+    public static string StageInactiveParty(List<string> args)
+    {
+        if (args.Count != 0)
+        {
+            return "Usage: coop.debug.connection.stage_inactive_party";
+        }
+        if (!ModInformation.IsServer)
+        {
+            return "stage_inactive_party must be run on the server.";
+        }
+        if (stagedInactiveParty != null)
+        {
+            return GetStagedPartyResult(stagedInactiveParty);
+        }
+
+        var parties = Campaign.Current?.CampaignObjectManager?.MobileParties;
+        stagedInactiveParty = parties?.FirstOrDefault(party =>
+                party?.IsActive == true &&
+                party.Ai != null &&
+                !party.IsPlayerParty() &&
+                party.Army == null &&
+                party.AttachedTo == null &&
+                party.MapEvent == null &&
+                party.CurrentSettlement == null &&
+                party.BesiegedSettlement == null &&
+                party.BesiegerCamp == null &&
+                !party.IsTransitionInProgress &&
+                !party.StartTransitionNextFrameToExitFromPort &&
+                !party.IsInRaftState &&
+                !IsReferencedByActiveParty(party, parties));
+        if (stagedInactiveParty == null)
+        {
+            return "No isolated active non-player field party was available for the fixture.";
+        }
+
+        stagedInactivePartyWasActive = stagedInactiveParty.IsActive;
+        stagedInactiveParty.IsActive = false;
+        return GetStagedPartyResult(stagedInactiveParty);
+    }
+
+    [CommandLineArgumentFunction("restore_inactive_party", "coop.debug.connection")]
+    public static string RestoreInactiveParty(List<string> args)
+    {
+        if (args.Count != 0)
+        {
+            return "Usage: coop.debug.connection.restore_inactive_party";
+        }
+        if (!ModInformation.IsServer)
+        {
+            return "restore_inactive_party must be run on the server.";
+        }
+        if (stagedInactiveParty == null)
+        {
+            return "No inactive-party fixture is staged.";
+        }
+
+        string partyId = stagedInactiveParty.StringId;
+        stagedInactiveParty.IsActive = stagedInactivePartyWasActive;
+        bool restoredActive = stagedInactiveParty.IsActive;
+        stagedInactiveParty = null;
+        stagedInactivePartyWasActive = false;
+        return $"restoredParty={partyId} active={restoredActive}";
+    }
+
+    [CommandLineArgumentFunction("disconnect", "coop.debug.connection")]
+    public static string Disconnect(List<string> args)
+    {
+        if (args.Count != 0)
+        {
+            return "Usage: coop.debug.connection.disconnect";
+        }
+        if (ModInformation.IsServer)
+        {
+            return "disconnect must be run on a client.";
+        }
+        if (!ContainerProvider.TryResolve<IClientLogic>(out var clientLogic))
+        {
+            return "No active client session was found.";
+        }
+
+        clientLogic.Disconnect();
+        return "Client session is returning to the main menu.";
+    }
+
+    internal static void ForceArmedInactivePartyDeficit()
+    {
+        if (Interlocked.Exchange(ref forceNextInactivePartyDeficit, 0) == 0) return;
+
+        var manager = Campaign.Current?.CampaignObjectManager;
+        string partyId = desiredInactivePartyId;
+        desiredInactivePartyId = null;
+        MobileParty candidate = manager?.MobileParties.FirstOrDefault(party =>
+            party?.StringId == partyId &&
+            !party.IsActive &&
+            !ReferenceEquals(party, MobileParty.MainParty));
+        if (candidate == null)
+        {
+            lastForcedPartyId = "missing";
+            throw new System.InvalidOperationException(
+                $"The armed join fixture could not find inactive non-main party '{partyId}'.");
+        }
+
+        lastForcedPartyId = candidate.StringId;
+        JoinBaselineFixture.RemoveFromCampaignCollection(manager, candidate);
+    }
+
+    private static bool IsReferencedByActiveParty(
+        MobileParty candidate,
+        IEnumerable<MobileParty> parties)
+    {
+        foreach (MobileParty party in parties)
+        {
+            if (party?.IsActive != true || ReferenceEquals(party, candidate)) continue;
+
+            object interactable = party.Ai?.AiBehaviorInteractable;
+            if (ReferenceEquals(party.TargetParty, candidate) ||
+                ReferenceEquals(party.MoveTargetParty, candidate) ||
+                ReferenceEquals(interactable, candidate.Party) ||
+                ReferenceEquals(interactable, candidate.Anchor))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string GetPartyCounts()
+    {
+        var parties = Campaign.Current?.CampaignObjectManager?.MobileParties;
+        if (parties == null) return "partyTotal=-1 activeParties=-1 inactiveParties=-1";
+
+        int active = parties.Count(party => party?.IsActive == true);
+        return $"partyTotal={parties.Count} activeParties={active} " +
+               $"inactiveParties={parties.Count - active}";
+    }
+
+    private static string GetStagedPartyResult(MobileParty party)
+    {
+        string active = party.IsActive ? "true" : "false";
+        return $"LIVE_TEST_JSON={{\"partyId\":\"{party.StringId}\",\"active\":{active}}}";
+    }
+}
+#endif

--- a/source/Coop.Core/Server/Connections/States/LoadingState.cs
+++ b/source/Coop.Core/Server/Connections/States/LoadingState.cs
@@ -32,6 +32,13 @@ public class LoadingState : ConnectionStateBase
     private readonly ISendCoalescer coalescer;
     private volatile JoinPhase phase;
     private int initialBaselinesSent;
+#if DEBUG
+    private int totalBaselinesSent;
+
+    internal string DebugJoinState =>
+        $"phase={phase} initialBaselinesSent={initialBaselinesSent} " +
+        $"totalBaselinesSent={totalBaselinesSent} joinCatchUpPending={IsJoinCatchUpPending}";
+#endif
 
     public LoadingState(
         IConnectionLogic connectionLogic,
@@ -128,6 +135,9 @@ public class LoadingState : ConnectionStateBase
             coalescer.Flush(network);
             connectionMessageQueue.Flush(peer);
             if (!isFinal) initialBaselinesSent++;
+#if DEBUG
+            totalBaselinesSent++;
+#endif
             phase = waiting;
             campaignBaselineSender.Send(peer);
         }, context: context);

--- a/source/Coop.Core/Server/Services/MobileParties/JoinCampaignBaselineSender.cs
+++ b/source/Coop.Core/Server/Services/MobileParties/JoinCampaignBaselineSender.cs
@@ -52,13 +52,20 @@ internal sealed class JoinCampaignBaselineSender : IJoinCampaignBaselineSender
             throw new InvalidOperationException("Cannot capture a join baseline without a loaded campaign");
         }
 
-        var liveParties = new HashSet<MobileParty>(parties);
-        var liveSettlements = new HashSet<Settlement>(settlements);
-        var partyStates = new MobilePartyJoinState[parties.Count];
-        bool isComplete = true;
+        var activeParties = new List<MobileParty>(parties.Count);
         for (int i = 0; i < parties.Count; i++)
         {
             MobileParty party = parties[i];
+            if (party?.IsActive == true) activeParties.Add(party);
+        }
+
+        var liveParties = new HashSet<MobileParty>(activeParties);
+        var liveSettlements = new HashSet<Settlement>(settlements);
+        var partyStates = new MobilePartyJoinState[activeParties.Count];
+        bool isComplete = true;
+        for (int i = 0; i < activeParties.Count; i++)
+        {
+            MobileParty party = activeParties[i];
             if (!mobilePartyBehaviorSnapshot.TryCreateJoinState(
                 party,
                 liveParties,

--- a/source/Coop.Tests/Server/Services/MobileParties/JoinCampaignBaselineSenderTests.cs
+++ b/source/Coop.Tests/Server/Services/MobileParties/JoinCampaignBaselineSenderTests.cs
@@ -1,0 +1,104 @@
+﻿using Common.Messaging;
+using Common.Network;
+using Common.Util;
+using Coop.Core.Server.Services.MobileParties;
+using Coop.Core.Server.Services.MobileParties.Messages;
+using GameInterface.Services.Heroes.Enum;
+using GameInterface.Services.Heroes.Interaces;
+using GameInterface.Services.MobileParties.Data;
+using GameInterface.Services.Time.Interfaces;
+using LiteNetLib;
+using Moq;
+using System.Collections.Generic;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.Library;
+using Xunit;
+
+namespace Coop.Tests.Server.Services.MobileParties;
+
+/// <summary>
+/// Serializes tests that replace the global current campaign.
+/// </summary>
+[CollectionDefinition(nameof(CampaignCurrentCollection), DisableParallelization = true)]
+public sealed class CampaignCurrentCollection
+{
+}
+
+/// <summary>
+/// Tests authoritative mobile-party join-baseline capture.
+/// </summary>
+[Collection(nameof(CampaignCurrentCollection))]
+public class JoinCampaignBaselineSenderTests
+{
+    [Fact]
+    public void Send_InactiveParty_CapturesOnlyActiveParty()
+    {
+        Campaign previousCampaign = Campaign.Current;
+        try
+        {
+            var activeParty = ObjectHelper.SkipConstructor<MobileParty>();
+            activeParty.IsActive = true;
+            var inactiveParty = ObjectHelper.SkipConstructor<MobileParty>();
+            inactiveParty.IsActive = false;
+            var campaignObjectManager = new CampaignObjectManager
+            {
+                Settlements = new MBReadOnlyList<Settlement>(new List<Settlement>()),
+            };
+            campaignObjectManager._mobileParties.Add(activeParty);
+            campaignObjectManager._mobileParties.Add(inactiveParty);
+            var campaign = ObjectHelper.SkipConstructor<Campaign>();
+            campaign.CampaignObjectManager = campaignObjectManager;
+            Campaign.Current = campaign;
+
+            var network = new Mock<INetwork>();
+            var mapTimeTracker = new Mock<IMapTimeTrackerInterface>();
+            long serverTicks = 123L;
+            mapTimeTracker
+                .Setup(tracker => tracker.TryGetCurrentTicks(out serverTicks))
+                .Returns(true);
+            var snapshot = new Mock<IMobilePartyBehaviorSnapshot>();
+            var state = new MobilePartyJoinState();
+            string failure = null!;
+            snapshot
+                .Setup(service => service.TryCreateJoinState(
+                    activeParty,
+                    It.Is<ISet<MobileParty>>(parties =>
+                        parties.Count == 1 && parties.Contains(activeParty)),
+                    It.IsAny<ISet<Settlement>>(),
+                    out state,
+                    out failure))
+                .Returns(true);
+            var timeControl = new Mock<ITimeControlInterface>();
+            timeControl.Setup(service => service.GetTimeControl()).Returns(TimeControlEnum.Pause);
+            NetworkJoinCampaignBaseline sent = default;
+            network
+                .Setup(service => service.SendImmediate(
+                    It.IsAny<NetPeer>(),
+                    It.IsAny<IMessage>()))
+                .Callback<NetPeer, IMessage>((_, message) =>
+                    sent = Assert.IsType<NetworkJoinCampaignBaseline>(message));
+            var sender = new JoinCampaignBaselineSender(
+                network.Object,
+                mapTimeTracker.Object,
+                snapshot.Object,
+                timeControl.Object);
+
+            sender.Send(null!);
+
+            Assert.True(sent.IsComplete);
+            Assert.Single(sent.PartyStates!);
+            snapshot.Verify(service => service.TryCreateJoinState(
+                inactiveParty,
+                It.IsAny<ISet<MobileParty>>(),
+                It.IsAny<ISet<Settlement>>(),
+                out It.Ref<MobilePartyJoinState>.IsAny,
+                out It.Ref<string>.IsAny), Times.Never);
+        }
+        finally
+        {
+            Campaign.Current = previousCampaign;
+        }
+    }
+}

--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -23,6 +23,9 @@ using GameInterface.Utils;
 using HarmonyLib;
 using Serilog;
 using System;
+#if DEBUG
+using System.Collections.Generic;
+#endif
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -37,6 +40,9 @@ using TaleWorlds.Localization;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.View;
 using TaleWorlds.ScreenSystem;
+#if DEBUG
+using static TaleWorlds.Library.CommandLineFunctionality;
+#endif
 using Module = TaleWorlds.MountAndBlade.Module;
 
 namespace Coop
@@ -82,6 +88,10 @@ namespace Coop
 
         private bool isServer = false;
         private bool isAutoConnect = false;
+#if DEBUG
+        private bool deferClientAutoConnect;
+        private bool isLiveTestRun;
+#endif
         public override void NoHarmonyInit() 
         {
             AssemblyHellscape.CreateAssemblyBindingRedirects();
@@ -100,6 +110,12 @@ namespace Coop
             }
 
             isAutoConnect = args.Any(a => a.Equals("/autoconnect", StringComparison.OrdinalIgnoreCase));
+#if DEBUG
+            deferClientAutoConnect = args.Any(a =>
+                a.Equals("/cooptestmanualjoin", StringComparison.OrdinalIgnoreCase));
+            isLiveTestRun = args.Any(a =>
+                a.Equals("/cooptestrun", StringComparison.OrdinalIgnoreCase));
+#endif
 
             // GetFullCommandLineString splits on spaces, which would cut a quoted save
             // name apart; the managed-server arguments need real Windows arg parsing.
@@ -573,10 +589,19 @@ namespace Coop
             if (!steamBootAttempted && isAtMainMenu)
             {
                 steamBootAttempted = true;
-                var steamPump = SteamIntegrationBoot.TryStartWithCallbackPump(
-                    isServer, Utilities.GetFullCommandLineString());
-                // The standalone server has no game frame of its own to dispatch its game-server callbacks.
-                if (steamPump != null) Updateables.Add(steamPump);
+#if DEBUG
+                if (isLiveTestRun)
+                {
+                    Logger.Information("[LiveTest] Steam integration disabled for this scoped runtime");
+                }
+                else
+#endif
+                {
+                    var steamPump = SteamIntegrationBoot.TryStartWithCallbackPump(
+                        isServer, Utilities.GetFullCommandLineString());
+                    // The standalone server has no game frame of its own to dispatch its game-server callbacks.
+                    if (steamPump != null) Updateables.Add(steamPump);
+                }
             }
 
             TimeSpan frameTime = TimeSpan.FromSeconds(dt);
@@ -642,7 +667,12 @@ namespace Coop
             // The auto-load-save start path owns this process's startup.
             if (ManagedServerConfig.HasAutoLoadSave) return;
 
-            if (isAutoConnect && !_autoStarted && GameStateManager.Current?.ActiveState is InitialState)
+            if (isAutoConnect &&
+#if DEBUG
+                !deferClientAutoConnect &&
+#endif
+                !_autoStarted &&
+                GameStateManager.Current?.ActiveState is InitialState)
             {
                 _autoStarted = true;
                 try
@@ -686,4 +716,37 @@ namespace Coop
             base.OnAfterGameInitializationFinished(game, starterObject);
         }
     }
+
+#if DEBUG
+    /// <summary>
+    /// Starts a deferred live-test client through the normal connection path.
+    /// </summary>
+    internal static class JoinFixtureCommands
+    {
+        [CommandLineArgumentFunction("start", "coop.debug.connection")]
+        public static string Start(List<string> args)
+        {
+            if (args.Count != 0)
+            {
+                return "Usage: coop.debug.connection.start";
+            }
+
+            if (ModInformation.IsServer)
+            {
+                return "start must be run on a client.";
+            }
+
+            if (ContainerProvider.TryResolve<Common.LogicStates.ILogic>(out _))
+            {
+                return "Client co-op connection is already starting or running.";
+            }
+
+            if (!CoopMod.Coop.StartAsClient())
+            {
+                throw new InvalidOperationException("Client co-op connection start was refused.");
+            }
+            return "Client co-op connection started.";
+        }
+    }
+#endif
 }

--- a/source/Coop/LiveTesting/LiveTestControlServer.cs
+++ b/source/Coop/LiveTesting/LiveTestControlServer.cs
@@ -127,6 +127,25 @@ namespace Coop.LiveTesting
             {
                 if (!ContainerProvider.TryResolve<ILiveTestCommandDispatcher>(out var dispatcher))
                 {
+                    if (string.Equals(command, "coop.debug.connection.start", StringComparison.Ordinal))
+                    {
+                        string output = Coop.JoinFixtureCommands.Start(arguments);
+                        bool hasFallbackStructuredResult = TryGetStructuredResult(
+                            output,
+                            out JsonElement fallbackStructuredResult);
+                        return Success(request.Id, new
+                        {
+                            name = command,
+                            arguments,
+                            found = true,
+                            output,
+                            hasStructuredResult = hasFallbackStructuredResult,
+                            structuredResult = hasFallbackStructuredResult
+                                ? fallbackStructuredResult
+                                : (JsonElement?)null,
+                        });
+                    }
+
                     return Failure(
                         request.Id,
                         "session_not_ready",
@@ -140,12 +159,19 @@ namespace Coop.LiveTesting
                     return Failure(request.Id, "command_not_found", result.Output, false);
                 }
 
+                bool hasStructuredResult = TryGetStructuredResult(
+                    result.Output,
+                    out JsonElement structuredResult);
                 return Success(request.Id, new
                 {
                     name = command,
                     arguments,
                     found = true,
                     output = result.Output,
+                    hasStructuredResult,
+                    structuredResult = hasStructuredResult
+                        ? structuredResult
+                        : (JsonElement?)null,
                 });
             }, true);
         }
@@ -156,11 +182,7 @@ namespace Coop.LiveTesting
             {
                 if (!ContainerProvider.TryResolve<ILiveTestCommandDispatcher>(out var dispatcher))
                 {
-                    return Failure(
-                        request.Id,
-                        "session_not_ready",
-                        "The co-op session command dispatcher is not available yet.",
-                        false);
+                    dispatcher = new LiveTestCommandDispatcher();
                 }
 
                 return Success(request.Id, new
@@ -534,6 +556,34 @@ namespace Coop.LiveTesting
                 PlatformId = processInfo.PlatformId,
                 RunToken = processInfo.RunToken,
             };
+        }
+
+        private static bool TryGetStructuredResult(
+            string output,
+            out JsonElement structuredResult)
+        {
+            const string prefix = "LIVE_TEST_JSON=";
+            structuredResult = default;
+            if (string.IsNullOrEmpty(output)) return false;
+
+            string json = output
+                .Split(new[] { "\r\n", "\n" }, StringSplitOptions.None)
+                .FirstOrDefault(line => line.StartsWith(prefix, StringComparison.Ordinal))?
+                .Substring(prefix.Length);
+            if (string.IsNullOrEmpty(json)) return false;
+
+            try
+            {
+                using (JsonDocument document = JsonDocument.Parse(json))
+                {
+                    structuredResult = document.RootElement.Clone();
+                }
+                return true;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
         }
 
         private static ScreenshotFileObservation ObserveScreenshot(string path)

--- a/source/GameInterface.Tests/Services/MobileParties/MobilePartyBehaviorSnapshotTests.cs
+++ b/source/GameInterface.Tests/Services/MobileParties/MobilePartyBehaviorSnapshotTests.cs
@@ -322,6 +322,72 @@ public class MobilePartyBehaviorSnapshotTests
     }
 
     [Fact]
+    public void TryApplyJoinBaseline_InactiveParty_DoesNotCountTowardCoverage()
+    {
+        Campaign previousCampaign = Campaign.Current;
+        try
+        {
+            var inactiveParty = CreateParty();
+            inactiveParty.IsActive = false;
+            var campaign = ObjectHelper.SkipConstructor<Campaign>();
+            var campaignObjectManager = new CampaignObjectManager
+            {
+                Settlements = new MBReadOnlyList<Settlement>(new List<Settlement>()),
+            };
+            campaignObjectManager._mobileParties.Add(inactiveParty);
+            campaign.CampaignObjectManager = campaignObjectManager;
+            Campaign.Current = campaign;
+            var snapshot = new MobilePartyBehaviorSnapshot(Mock.Of<IObjectManager>());
+
+            bool applied = snapshot.TryApplyJoinBaseline(
+                Array.Empty<MobilePartyJoinState>(),
+                () => { });
+
+            Assert.True(applied);
+            Assert.Null(snapshot.LastJoinBaselineFailure);
+        }
+        finally
+        {
+            Campaign.Current = previousCampaign;
+        }
+    }
+
+    [Fact]
+    public void TryApplyJoinBaseline_MissingActiveParty_ReportsActiveCount()
+    {
+        Campaign previousCampaign = Campaign.Current;
+        try
+        {
+            var campaign = ObjectHelper.SkipConstructor<Campaign>();
+            var campaignObjectManager = new CampaignObjectManager
+            {
+                Settlements = new MBReadOnlyList<Settlement>(new List<Settlement>()),
+            };
+            campaignObjectManager._mobileParties.Add(CreateParty());
+            campaignObjectManager._mobileParties.Add(CreateParty());
+            var inactiveParty = CreateParty();
+            inactiveParty.IsActive = false;
+            campaignObjectManager._mobileParties.Add(inactiveParty);
+            campaign.CampaignObjectManager = campaignObjectManager;
+            Campaign.Current = campaign;
+            var snapshot = new MobilePartyBehaviorSnapshot(Mock.Of<IObjectManager>());
+
+            bool applied = snapshot.TryApplyJoinBaseline(
+                new MobilePartyJoinState[1],
+                () => { });
+
+            Assert.False(applied);
+            Assert.Equal(
+                "party count mismatch (baseline=1, client=2)",
+                snapshot.LastJoinBaselineFailure);
+        }
+        finally
+        {
+            Campaign.Current = previousCampaign;
+        }
+    }
+
+    [Fact]
     public void TryApplyJoinBaseline_MissingPartyId_ReportsStateIndex()
     {
         Campaign previousCampaign = Campaign.Current;
@@ -491,6 +557,7 @@ public class MobilePartyBehaviorSnapshotTests
     {
         var party = ObjectHelper.SkipConstructor<MobileParty>();
         party.Ai = new MobilePartyAi(party);
+        party.IsActive = true;
         party.PartyMoveMode = MoveModeType.Party;
         party.MoveTargetPoint = new CampaignVec2(new Vec2(10f, 20f), isOnLand: true);
         return party;

--- a/source/GameInterface/Services/MobileParties/Data/MobilePartyBehaviorSnapshot.cs
+++ b/source/GameInterface/Services/MobileParties/Data/MobilePartyBehaviorSnapshot.cs
@@ -289,13 +289,19 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
             return RejectJoinBaseline("the client campaign mobile-party collection is unavailable");
         if (settlements == null)
             return RejectJoinBaseline("the client campaign settlement collection is unavailable");
-        if (states.Length != parties.Count)
+        var liveParties = new HashSet<MobileParty>();
+        for (int i = 0; i < parties.Count; i++)
         {
-            return RejectJoinBaseline(
-                $"party count mismatch (baseline={states.Length}, client={parties.Count})");
+            MobileParty party = parties[i];
+            if (party?.IsActive == true) liveParties.Add(party);
         }
 
-        var liveParties = new HashSet<MobileParty>(parties);
+        if (states.Length != liveParties.Count)
+        {
+            return RejectJoinBaseline(
+                $"party count mismatch (baseline={states.Length}, client={liveParties.Count})");
+        }
+
         var liveSettlements = new HashSet<Settlement>(settlements);
         var seenParties = new HashSet<MobileParty>();
         var resolved = new ResolvedBehaviorUpdate[states.Length];

--- a/source/GameInterface/Services/MobileParties/JoinBaselineFixture.cs
+++ b/source/GameInterface/Services/MobileParties/JoinBaselineFixture.cs
@@ -1,0 +1,19 @@
+﻿#if DEBUG
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Party;
+
+namespace GameInterface.Services.MobileParties;
+
+/// <summary>
+/// Provides reversible campaign-collection control for DEBUG join tests.
+/// </summary>
+public static class JoinBaselineFixture
+{
+    public static void RemoveFromCampaignCollection(
+        CampaignObjectManager campaignObjectManager,
+        MobileParty mobileParty)
+    {
+        campaignObjectManager._mobileParties.Remove(mobileParty);
+    }
+}
+#endif


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Joining can remain on "Finishing synchronization..." and repeatedly download the full campaign baseline when the server retains an inactive party that is absent from the client, including while campaign time is paused.

## What is the new behavior?

Resolves #2836

Players now finish joining instead of repeatedly refreshing the campaign baseline when the only server/client party differences are inactive parties. Missing active parties still prevent the join from completing with incomplete campaign state.

## Bot Changelog Entry

- Fixed an issue where clients would get stuck on "Finishing synchronization..." when the server has an inactive party.
