### PR TITLE
Fix MapEvent AI freeze: repopulate fallback TroopUpgradeTracker on load

### DIFF
--- a/source/E2E.Tests/Services/MapEvents/MapEventRobustnessPatchesTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/MapEventRobustnessPatchesTests.cs
@@ -1,0 +1,45 @@
+using HarmonyLib;
+using System.Collections;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.MapEvents;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace E2E.Tests.Services.MapEvents;
+
+public class MapEventRobustnessPatchesTests : MapEventTestBase
+{
+    public MapEventRobustnessPatchesTests(ITestOutputHelper output) : base(output) { }
+
+    [Fact]
+    public void TroopUpgradeTracker_WhenNullAfterLoad_IsRepopulatedWithEveryInvolvedParty()
+    {
+        var context = CreateServerMapEvent();
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<MapEvent>(context.MapEventId, out var mapEvent));
+
+            var trackerField = AccessTools.Field(typeof(MapEvent), "<TroopUpgradeTracker>k__BackingField");
+            Assert.NotNull(trackerField);
+            trackerField.SetValue(mapEvent, null);
+
+            var restored = mapEvent.TroopUpgradeTracker;
+            Assert.NotNull(restored);
+
+            var mapEventPartiesField = AccessTools.Field(typeof(TroopUpgradeTracker), "_mapEventParties");
+            Assert.NotNull(mapEventPartiesField);
+            var mapEventParties = (IList)mapEventPartiesField.GetValue(restored)!;
+
+            var involvedParties = new List<MapEventParty>();
+            involvedParties.AddRange(mapEvent.AttackerSide.Parties);
+            involvedParties.AddRange(mapEvent.DefenderSide.Parties);
+
+            Assert.Equal(involvedParties.Count, mapEventParties.Count);
+            foreach (var party in involvedParties)
+            {
+                Assert.Contains(party, mapEventParties.Cast<MapEventParty>());
+            }
+        }, MapEventDisabledMethods);
+    }
+}

--- a/source/GameInterface/Services/MapEvents/Patches/MapEventRobustnessPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/MapEventRobustnessPatches.cs
@@ -22,12 +22,8 @@ internal class MapEventRobustnessPatches
     {
         if (__result is null)
         {
-            // The assignment below runs the generated AutoSync setter prefix, which reads this getter
-            // to compare values. Let that nested read observe null instead of recursively restoring again.
             if (restoringTroopUpgradeTracker) return;
 
-            // Pending graphs are incomplete by design. A fallback here would replace the registered
-            // tracker before its queued reference apply reaches the game thread.
             if (ContainerProvider.TryResolve<IMapEventInitializationBarrier>(out var barrier) &&
                 barrier.IsPending(__instance))
             {
@@ -38,7 +34,17 @@ internal class MapEventRobustnessPatches
             restoringTroopUpgradeTracker = true;
             try
             {
-                __result = new TroopUpgradeTracker();
+                var restoredTracker = new TroopUpgradeTracker();
+                foreach (var party in __instance.AttackerSide.Parties)
+                {
+                    restoredTracker.AddParty(party);
+                }
+                foreach (var party in __instance.DefenderSide.Parties)
+                {
+                    restoredTracker.AddParty(party);
+                }
+
+                __result = restoredTracker;
                 __instance.TroopUpgradeTracker = __result;
             }
             finally


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
`MapEvent.TroopUpgradeTracker` is not saved, so after loading a save it comes back `null` for any battle that was still in progress at save time — this is normal, expected vanilla behavior. Coop's own fallback (a Harmony postfix on the `TroopUpgradeTracker` getter, in `MapEventRobustnessPatches.cs`) replaces that `null` with a brand-new, empty `TroopUpgradeTracker` — but unlike vanilla's own `MapEvent.OnAfterLoad()` self-heal, it never actually populates the new tracker with the battle's parties

Any later call into `TroopUpgradeTracker.CalculateReadyToUpgradeSafe` (reached via `CheckUpgradedCount`, called every `MapEvent.Update()`) looks up the owning party in the tracker's internal party list and dereferences the result without a null check. Against the empty fallback tracker that lookup always misses, so it throws a `NullReferenceException` on every tick for that MapEvent. Since the exception fires before `Update()` can ever progress the battle to completion, the MapEvent can never resolve — leaving whichever parties were actually fighting in it stuck in that battle indefinitely (observed in-game as AI lords going permanently immobile after loading a save with in-progress battles, while unrelated AI/villages/caravans kept working normally).

## What is the new behavior?
The fallback in `MapEventRobustnessPatches.cs` now repopulates the replacement `TroopUpgradeTracker` the same way vanilla's `OnAfterLoad()` does: it calls `AddParty` for every party on both the attacker and defender sides before assigning it back to the `MapEvent`. This keeps the crash from ever happening in the first place, so affected battles can resolve normally instead of freezing forever.

Added `MapEventRobustnessPatchesTests.cs` with a regression test that forces `TroopUpgradeTracker` to `null` on a live `MapEvent`, triggers the fallback through the real getter, and asserts every involved party was re-registered in the restored tracker.


## Bot Changelog Entry
Fixed a bug where some AI lords could get stuck frozen in battle after loading a save, because their fight could never resolve.


## Other information
decided to patch this after running into it in a live game with my friend preventing me and my friend from playing that save until this is patched