### PR TITLE
Fix inventory duplication on party screen

### DIFF
--- a/source/GameInterface/Services/Party/Patches/PartyScreenDataPatches.cs
+++ b/source/GameInterface/Services/Party/Patches/PartyScreenDataPatches.cs
@@ -1,0 +1,23 @@
+﻿using Common.Util;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem.Party;
+
+namespace GameInterface.Services.Party.Patches;
+
+[HarmonyPatch(typeof(PartyScreenData))]
+internal class PartyScreenDataPatches
+{
+    [HarmonyPatch(nameof(PartyScreenData.ResetUsing))]
+    [HarmonyPrefix]
+    public static void ResetUsingPrefix()
+    {
+        AllowedThread.AllowThisThread();
+    }
+
+    [HarmonyPatch(nameof(PartyScreenData.ResetUsing))]
+    [HarmonyFinalizer]
+    public static void ResetUsingFinalizer()
+    {
+        AllowedThread.RevokeThisThread();
+    }
+}


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When cancelling the upgrade/recruit prisoner popup in the party management screen, `PartyScreenData` attempts to reset the rosters for both troops and items. Because this isn't in an allowed thread, clearing the item roster fails on the client and it adds all items again.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #2611
Resolves #2915
Resolves #2935
Resolves #2965 
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Moved `PartyScreenData.ResetUsing` into an `AllowedThread` so the clear and rebuild happens properly.

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Fixed inventory duplication when cancelling the upgrade troops/recruit prisoners popup on the party screen.