### PR TITLE
Harden late joins and authoritative campaign actions

### DIFF
--- a/deploy/mod-config.default.json
+++ b/deploy/mod-config.default.json
@@ -58,10 +58,10 @@
     // true: Disconnected players have gold and food change.
     "goldFoodInfluenceChangeForDisconnectedPlayers": false,
 
-    // Set grace period (hours) for AI parties to be able to join battles involving players.
-    // Default is 24, meaning AI parties can only join a player battle within a day of it starting.
-    // If set to 0, AI parties will not join in player battles.
-    "playerBattleAiJoinWindowHours": 24,
+    // Set the campaign-hour grace period for any AI or player reinforcement.
+    // Default and hard maximum are 10 hours from the battle's native start time.
+    // If set to 0, reinforcements are allowed only at the instant the battle starts.
+    "playerBattleAiJoinWindowHours": 10,
 
     // Toggle speed limit when players are in a battle.
     // Default is true, meaning the game will be locked at 1x speed when any player is in a battle.

--- a/source/Coop.Core/Client/Services/TroopRosters/Handlers/ClientTroopRosterHandler.cs
+++ b/source/Coop.Core/Client/Services/TroopRosters/Handlers/ClientTroopRosterHandler.cs
@@ -3,6 +3,7 @@ using Common.Messaging;
 using Common.Network;
 using Coop.Core.Client.Services.TroopRosters.Messages;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.GameDebug.Messages;
 using GameInterface.Services.TroopRosters.Messages;
 using Serilog;
 using System.Collections.Generic;
@@ -34,13 +35,21 @@ public class ClientTroopRosterHandler : IHandler
     {
         var obj = payload.What;
 
-        if (!objectManager.TryGetIdWithLogging(obj.MobileParty, out var mobilePartyId)) return;
+        if (!objectManager.TryGetIdWithLogging(obj.MobileParty, out var mobilePartyId))
+        {
+            AbortCart("Recruitment could not be sent because your party is still synchronizing. Please reopen the recruitment screen.");
+            return;
+        }
 
         List<TroopInfo> troops = new();
         foreach (var (hero, character, index) in obj.TroopsInCart)
         {
-            if (!objectManager.TryGetIdWithLogging(hero, out var heroId)) continue;
-            if (!objectManager.TryGetIdWithLogging(character, out var characterId)) continue;
+            if (!objectManager.TryGetIdWithLogging(hero, out var heroId) ||
+                !objectManager.TryGetIdWithLogging(character, out var characterId))
+            {
+                AbortCart("Recruitment changed while the screen was open. No troops were recruited; please reopen the recruitment screen.");
+                return;
+            }
 
             troops.Add(new TroopInfo(heroId, characterId, index));
         }
@@ -54,5 +63,11 @@ public class ClientTroopRosterHandler : IHandler
         var message = new ClientRequestRecruitment(mobilePartyId, troops.ToArray());
 
         network.SendAll(message);
+    }
+
+    private void AbortCart(string reason)
+    {
+        Logger.Warning(reason);
+        messageBroker.Publish(this, new SendInformationMessage(reason));
     }
 }

--- a/source/Coop.Core/Server/Connections/ConnectionCollection.cs
+++ b/source/Coop.Core/Server/Connections/ConnectionCollection.cs
@@ -31,6 +31,7 @@ public class ConnectionCollection : IConnectionCollection
 
     private readonly IMessageBroker messageBroker;
     private readonly ConnectionContext connectionContext;
+    private readonly object connectionGate = new object();
 
     private int lastBroadcastLoadingCount;
 
@@ -55,21 +56,37 @@ public class ConnectionCollection : IConnectionCollection
     internal void PlayerJoiningHandler(MessagePayload<PlayerConnected> obj)
     {
         var playerPeer = obj.What.PlayerPeer;
-        if (ConnectionStates.TryAdd(playerPeer, new ConnectionLogic(playerPeer, connectionContext)))
+        bool added = false;
+        lock (connectionGate)
         {
-            BroadcastConnectedPlayersChanged();
+            if (ConnectionStates.ContainsKey(playerPeer)) return;
+
+            var logic = new ConnectionLogic(playerPeer, connectionContext);
+            if (!ConnectionStates.TryAdd(playerPeer, logic))
+            {
+                logic.Dispose();
+                return;
+            }
+            added = true;
         }
+
+        if (added)
+            BroadcastConnectedPlayersChanged();
     }
 
     internal void PlayerDisconnectedHandler(MessagePayload<PlayerDisconnected> obj)
     {
         var playerId = obj.What.PlayerId;
 
-        if (ConnectionStates.TryRemove(playerId, out IConnectionLogic logic))
+        IConnectionLogic logic;
+        lock (connectionGate)
         {
-            logic.Dispose();
-            BroadcastConnectedPlayersChanged();
+            ConnectionStates.TryRemove(playerId, out logic);
         }
+        logic?.Dispose();
+
+        if (logic != null)
+            BroadcastConnectedPlayersChanged();
 
         BroadcastLoadingStateIfChanged();
     }

--- a/source/Coop.Core/Server/Connections/ConnectionLogic.cs
+++ b/source/Coop.Core/Server/Connections/ConnectionLogic.cs
@@ -81,8 +81,8 @@ public class ConnectionLogic : IConnectionLogic
         new Dictionary<Type, Func<IConnectionState>>
         {
             [typeof(ResolveCharacterState)] = () => new ResolveCharacterState(this, context.MessageBroker, context.Network, context.ModuleValidator, context.PlayerManager, context.PlayerPartyRestorer, context.ObjectManager, context.ModuleInfoProvider, context.ExistingPlayerSender),
-            [typeof(CreateCharacterState)] = () => new CreateCharacterState(this, context.ObjectManager, context.MessageBroker, context.Network, context.HeroInterface, context.PlayerManager, context.ExistingPlayerSender),
-            [typeof(TransferSaveState)] = () => new TransferSaveState(this, context.MessageBroker, context.Network, context.CoopSessionProvider, context.SaveInterface, context.ConnectionMessageQueue, context.Coalescer, context.AttachmentIdMapper, context.ServerOptionsProvider),
+            [typeof(CreateCharacterState)] = () => new CreateCharacterState(this, context.ObjectManager, context.MessageBroker, context.Network, context.HeroInterface, context.PlayerManager, context.ExistingPlayerSender, context.ConnectionMessageQueue),
+            [typeof(TransferSaveState)] = () => new TransferSaveState(this, context.Network, context.CoopSessionProvider, context.SaveInterface, context.ConnectionMessageQueue, context.Coalescer, context.AttachmentIdMapper, context.ServerOptionsProvider),
             [typeof(LoadingState)] = () => new LoadingState(this, context.MessageBroker, context.Network, context.JoinCampaignBaselineSender, context.ConnectionMessageQueue, context.Coalescer),
             [typeof(CampaignState)] = () => new CampaignState(this, context.MessageBroker),
             [typeof(MissionState)] = () => new MissionState(this, context.MessageBroker),

--- a/source/Coop.Core/Server/Connections/ConnectionMessageQueue.cs
+++ b/source/Coop.Core/Server/Connections/ConnectionMessageQueue.cs
@@ -3,13 +3,16 @@ using Common.Messaging;
 using Common.Network;
 using Common.Network.Messages;
 using Common.PacketHandlers;
+using Coop.Core.Common.Network.Packets;
 using Coop.Core.Common.Session.Messages;
 using Coop.Core.Server.Connections.Messages;
+using Coop.Core.Server.Services.MobileParties.Messages;
 using LiteNetLib;
 using Serilog;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 
 namespace Coop.Core.Server.Connections;
@@ -43,6 +46,24 @@ public interface IConnectionMessageQueue
     /// </summary>
     bool TryHandleBroadcast(NetPeer peer, IPacket packet);
 
+    void ExecuteWorldSend(IPacket packet, Action send);
+
+    void ExecuteCacheNeutralWorldSend(Action send);
+
+    bool TryUseCachedJoinSnapshot(NetPeer peer, out CachedJoinSnapshot snapshot);
+
+    long CaptureFreshJoinSnapshot(
+        NetPeer peer,
+        Func<GameSaveDataPacket> capture,
+        out GameSaveDataPacket snapshot);
+
+    void CompleteJoinSnapshot(
+        long generation,
+        GameSaveDataPacket snapshot,
+        byte[] compressedData);
+
+    void InvalidateJoinSnapshot();
+
     /// <summary>
     /// Moves a peer from <c>Dropping</c> to <c>Queueing</c>. Call on the main thread immediately after
     /// the transfer-save snapshot is taken. Because that save runs under a blocking GameThread.Run
@@ -54,8 +75,18 @@ public interface IConnectionMessageQueue
     /// <summary>Replays held packets while keeping later broadcasts queued.</summary>
     void Flush(NetPeer peer);
 
+    /// <summary>
+    /// Ends the period where party-behavior broadcasts are covered by the final authoritative party
+    /// baseline. Call after flushing the behavior coalescer and immediately before that baseline is
+    /// captured; later behavior changes must remain queued behind it.
+    /// </summary>
+    void EndPartyBehaviorBaselineCoverage(NetPeer peer);
+
     /// <summary>Gets the gate and reliable-channel backlog while catch-up is active.</summary>
     bool TryGetCatchUpPacketsRemaining(NetPeer peer, out int packetsRemaining);
+
+    /// <summary>Returns a compact queue breakdown for join diagnostics.</summary>
+    string DescribeCatchUp(NetPeer peer);
 
     /// <summary>Replays held packets, appends a reliable marker, and opens the peer atomically.</summary>
     void OpenWithTail(NetPeer peer, IMessage tailMarker);
@@ -64,9 +95,35 @@ public interface IConnectionMessageQueue
     void CompleteCatchUp(NetPeer peer);
 }
 
+public readonly struct CachedJoinSnapshot
+{
+    public readonly GameSaveDataPacket Metadata;
+    public readonly byte[] CompressedData;
+    public readonly int UncompressedSize;
+
+    public CachedJoinSnapshot(
+        GameSaveDataPacket metadata,
+        byte[] compressedData,
+        int uncompressedSize)
+    {
+        Metadata = metadata;
+        CompressedData = compressedData;
+        UncompressedSize = uncompressedSize;
+    }
+}
+
 /// <inheritdoc cref="IConnectionMessageQueue"/>
 internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposable
 {
+    private sealed class JoinSnapshotCacheEntry
+    {
+        public long Generation;
+        public DateTime CutUtc;
+        public GameSaveDataPacket Metadata;
+        public byte[] CompressedData;
+        public int UncompressedSize;
+    }
+
     private enum Phase
     {
         Dropping,
@@ -79,10 +136,19 @@ internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposa
         public readonly object Gate = new object();
         public volatile Phase Phase = Phase.Dropping;
         public readonly Queue<IPacket> Pending = new Queue<IPacket>();
+        public readonly Dictionary<string, int> PendingByType = new Dictionary<string, int>();
         public int PendingCount;
+        public long EnqueuedTotal;
+        public long DrainedTotal;
+        public int DrainCount;
+        public string LastDrain = "none";
+        public bool PartyBehaviorCoveredByFinalBaseline = true;
+        public long CoveredPartyBehaviorTotal;
     }
 
     private static readonly ILogger Logger = LogManager.GetLogger<ConnectionMessageQueue>();
+    private static readonly TimeSpan JoinSnapshotLifetime = TimeSpan.FromSeconds(5);
+    [ThreadStatic] private static int cacheNeutralSendDepth;
 
     // Lazy breaks the construction cycle: CoopServer (the INetwork) depends on this queue, and the
     // queue only needs INetwork later, at flush time, to replay held packets.
@@ -90,6 +156,9 @@ internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposa
     private readonly IMessageBroker messageBroker;
 
     private readonly ConcurrentDictionary<NetPeer, PeerChannel> channels = new ConcurrentDictionary<NetPeer, PeerChannel>();
+    private readonly object snapshotGate = new object();
+    private JoinSnapshotCacheEntry joinSnapshot;
+    private long joinSnapshotGeneration;
 
     public ConnectionMessageQueue(Lazy<INetwork> network, IMessageBroker messageBroker)
     {
@@ -113,25 +182,163 @@ internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposa
         // No channel means a fully-joined (or unknown) peer: send live.
         if (channels.TryGetValue(peer, out var channel) == false) return false;
 
+        bool handled;
         lock (channel.Gate)
         {
             switch (channel.Phase)
             {
                 case Phase.Queueing:
+                    // The final join baseline is a complete authoritative snapshot of every mobile
+                    // party's behavior. Sending the thousands of movement snapshots produced while
+                    // the client loads is redundant. Once that final baseline is about to be captured,
+                    // coverage ends and later changes stay in the ordered tail as normal.
+                    if (channel.PartyBehaviorCoveredByFinalBaseline &&
+                        IsPartyBehaviorSnapshot(packet))
+                    {
+                        channel.CoveredPartyBehaviorTotal++;
+                        handled = true;
+                        break;
+                    }
+
                     channel.Pending.Enqueue(packet);
+                    Increment(channel.PendingByType, GetPacketTypeName(packet));
+                    channel.EnqueuedTotal++;
                     Interlocked.Increment(ref channel.PendingCount);
-                    return true;
+                    handled = true;
+                    break;
                 case Phase.Dropping:
                     // Already in the save the peer is about to load; discard.
-                    return true;
+                    handled = true;
+                    break;
                 default:
                     // Open: this peer has already caught up and is a normal live player now, so just
                     // send the packet. (We only land here for a split second, right after the catch-up
                     // finishes and before its channel is tidied away.)
-                    return false;
+                    handled = false;
+                    break;
+            }
+        }
+
+        return handled;
+    }
+
+    public void ExecuteWorldSend(IPacket packet, Action send)
+    {
+        if (send == null) throw new ArgumentNullException(nameof(send));
+
+        lock (snapshotGate)
+        {
+            if (cacheNeutralSendDepth == 0 && !ShouldBypassLoadingQueue(packet))
+                joinSnapshot = null;
+            send();
+        }
+    }
+
+    public void ExecuteCacheNeutralWorldSend(Action send)
+    {
+        if (send == null) throw new ArgumentNullException(nameof(send));
+
+        lock (snapshotGate)
+        {
+            cacheNeutralSendDepth++;
+            try
+            {
+                send();
+            }
+            finally
+            {
+                cacheNeutralSendDepth--;
             }
         }
     }
+
+    public bool TryUseCachedJoinSnapshot(NetPeer peer, out CachedJoinSnapshot snapshot)
+    {
+        lock (snapshotGate)
+        {
+            var cached = joinSnapshot;
+            if (cached == null ||
+                cached.CompressedData == null ||
+                DateTime.UtcNow - cached.CutUtc > JoinSnapshotLifetime)
+            {
+                joinSnapshot = null;
+                snapshot = default;
+                return false;
+            }
+
+            BeginQueueing(peer);
+            snapshot = new CachedJoinSnapshot(
+                cached.Metadata,
+                cached.CompressedData,
+                cached.UncompressedSize);
+            return true;
+        }
+    }
+
+    public long CaptureFreshJoinSnapshot(
+        NetPeer peer,
+        Func<GameSaveDataPacket> capture,
+        out GameSaveDataPacket snapshot)
+    {
+        if (capture == null) throw new ArgumentNullException(nameof(capture));
+
+        lock (snapshotGate)
+        {
+            snapshot = capture();
+            long generation = ++joinSnapshotGeneration;
+            joinSnapshot = new JoinSnapshotCacheEntry
+            {
+                Generation = generation,
+                CutUtc = DateTime.UtcNow,
+            };
+            BeginQueueing(peer);
+            return generation;
+        }
+    }
+
+    public void CompleteJoinSnapshot(
+        long generation,
+        GameSaveDataPacket snapshot,
+        byte[] compressedData)
+    {
+        if (compressedData == null) throw new ArgumentNullException(nameof(compressedData));
+
+        lock (snapshotGate)
+        {
+            if (joinSnapshot == null ||
+                joinSnapshot.Generation != generation ||
+                DateTime.UtcNow - joinSnapshot.CutUtc > JoinSnapshotLifetime)
+            {
+                return;
+            }
+
+            joinSnapshot.Metadata = WithoutRawSave(snapshot);
+            joinSnapshot.CompressedData = compressedData;
+            joinSnapshot.UncompressedSize = snapshot.GameSaveData?.Length ?? 0;
+        }
+    }
+
+    public void InvalidateJoinSnapshot()
+    {
+        lock (snapshotGate)
+        {
+            joinSnapshot = null;
+        }
+    }
+
+    private static GameSaveDataPacket WithoutRawSave(GameSaveDataPacket snapshot) =>
+        new GameSaveDataPacket(
+            null,
+            snapshot.CampaignID,
+            snapshot.CraftingPlayerData,
+            snapshot.WorkshopPlayerData,
+            snapshot.CaravansPlayerData,
+            snapshot.AlleyPlayerData,
+            snapshot.InteractionsPlayerData,
+            snapshot.TradePlayerData,
+            snapshot.InventoryPlayerData,
+            snapshot.AttachmentIdMap,
+            snapshot.ServerOptions);
 
     private static bool ShouldBypassLoadingQueue(IPacket packet)
     {
@@ -143,6 +350,10 @@ internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposa
                messagePacket.MessageType == typeof(NetworkSessionLobbyChanged);
     }
 
+    private static bool IsPartyBehaviorSnapshot(IPacket packet) =>
+        packet is MessagePacket messagePacket &&
+        messagePacket.MessageType == typeof(NetworkUpdatePartyBehavior);
+
     public void BeginQueueing(NetPeer peer)
     {
         // GetOrAdd guards the (not expected) case where BeginQueueing runs before PlayerConnected was
@@ -152,6 +363,7 @@ internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposa
         lock (channel.Gate)
         {
             channel.Phase = Phase.Queueing;
+            channel.PartyBehaviorCoveredByFinalBaseline = true;
         }
     }
 
@@ -180,6 +392,17 @@ internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposa
         Logger.Debug("Flushed {Count} queued packets to peer {Peer} while joining", replayed, peer.Id);
     }
 
+    public void EndPartyBehaviorBaselineCoverage(NetPeer peer)
+    {
+        if (channels.TryGetValue(peer, out var channel) == false) return;
+
+        lock (channel.Gate)
+        {
+            if (channel.Phase == Phase.Queueing)
+                channel.PartyBehaviorCoveredByFinalBaseline = false;
+        }
+    }
+
     public bool TryGetCatchUpPacketsRemaining(NetPeer peer, out int packetsRemaining)
     {
         packetsRemaining = 0;
@@ -191,6 +414,24 @@ internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposa
                            peer.GetPacketsCountInReliableQueue(0, true) +
                            peer.GetPacketsCountInReliableQueue(0, false);
         return true;
+    }
+
+    public string DescribeCatchUp(NetPeer peer)
+    {
+        if (channels.TryGetValue(peer, out var channel) == false)
+        {
+            return $"gate=none reliable={ReliableQueueDescription(peer)}";
+        }
+
+        lock (channel.Gate)
+        {
+            return $"gate={channel.Phase} pending={channel.PendingCount} " +
+                   $"reliable={ReliableQueueDescription(peer)} enqueued={channel.EnqueuedTotal} " +
+                   $"coveredBehavior={channel.CoveredPartyBehaviorTotal} " +
+                   $"drained={channel.DrainedTotal} drains={channel.DrainCount} " +
+                   $"pendingTypes={DescribeTypes(channel.PendingByType)} " +
+                   $"lastDrain={channel.LastDrain}";
+        }
     }
 
     public void OpenWithTail(NetPeer peer, IMessage tailMarker)
@@ -207,7 +448,7 @@ internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposa
         lock (channel.Gate)
         {
             replayed = channel.Pending.Count;
-            Drain(peer, channel);
+            Drain(peer, channel, "open");
 
             // A racing broadcast is either drained before this marker or observes Open and is sent
             // after it. The client can therefore use the marker as the reliable world-stream barrier.
@@ -229,13 +470,59 @@ internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposa
         }
     }
 
-    private void Drain(NetPeer peer, PeerChannel channel)
+    private void Drain(NetPeer peer, PeerChannel channel, string reason = "flush")
     {
+        var drainedByType = new Dictionary<string, int>();
+        int drained = 0;
         while (channel.Pending.Count > 0)
         {
             var packet = channel.Pending.Dequeue();
+            string packetType = GetPacketTypeName(packet);
+            Decrement(channel.PendingByType, packetType);
+            Increment(drainedByType, packetType);
+            drained++;
             Interlocked.Decrement(ref channel.PendingCount);
             network.Value.SendImmediate(peer, packet);
         }
+
+        channel.DrainedTotal += drained;
+        channel.DrainCount++;
+        channel.LastDrain = $"{reason}:{drained}[{DescribeTypes(drainedByType)}]";
+    }
+
+    private static string ReliableQueueDescription(NetPeer peer) =>
+        $"{peer.GetPacketsCountInReliableQueue(0, true)}/" +
+        $"{peer.GetPacketsCountInReliableQueue(0, false)}";
+
+    private static string GetPacketTypeName(IPacket packet)
+    {
+        if (packet is MessagePacket messagePacket)
+            return messagePacket.MessageType?.Name ?? nameof(MessagePacket);
+
+        return packet?.GetType().Name ?? "null";
+    }
+
+    private static void Increment(Dictionary<string, int> counts, string key)
+    {
+        counts.TryGetValue(key, out int count);
+        counts[key] = count + 1;
+    }
+
+    private static void Decrement(Dictionary<string, int> counts, string key)
+    {
+        if (!counts.TryGetValue(key, out int count)) return;
+        if (count <= 1) counts.Remove(key);
+        else counts[key] = count - 1;
+    }
+
+    private static string DescribeTypes(Dictionary<string, int> counts)
+    {
+        if (counts.Count == 0) return "none";
+        return string.Join(
+            ",",
+            counts.OrderByDescending(pair => pair.Value)
+                .ThenBy(pair => pair.Key)
+                .Take(6)
+                .Select(pair => $"{pair.Key}:{pair.Value}"));
     }
 }

--- a/source/Coop.Core/Server/Connections/ExistingPlayerSender.cs
+++ b/source/Coop.Core/Server/Connections/ExistingPlayerSender.cs
@@ -27,23 +27,33 @@ public class ExistingPlayerSender : IExistingPlayerSender
 {
     private readonly IPlayerManager playerManager;
     private readonly INetwork network;
+    private readonly IConnectionMessageQueue connectionMessageQueue;
 
-    public ExistingPlayerSender(IPlayerManager playerManager, INetwork network)
+    public ExistingPlayerSender(
+        IPlayerManager playerManager,
+        INetwork network,
+        IConnectionMessageQueue connectionMessageQueue)
     {
         this.playerManager = playerManager;
         this.network = network;
+        this.connectionMessageQueue = connectionMessageQueue;
     }
 
     public void SendExistingPlayers(NetPeer joiner, string joinerControllerId)
     {
-        foreach (var player in playerManager.Players)
+        // These empty-data messages only restore controller markers for heroes already present in
+        // the save. They still enter the joiner's queue, but do not dirty the snapshot itself.
+        connectionMessageQueue.ExecuteCacheNeutralWorldSend(() =>
         {
-            // Skip the joiner's own player (it registers itself on load) and the host (the server is not a
-            // controlled player on clients).
-            if (player.ControllerId == joinerControllerId) continue;
-            if (player.ControllerId == CoopServer.ServerControllerId) continue;
+            foreach (var player in playerManager.Players)
+            {
+                // Skip the joiner's own player (it registers itself on load) and the host (the server is not a
+                // controlled player on clients).
+                if (player.ControllerId == joinerControllerId) continue;
+                if (player.ControllerId == CoopServer.ServerControllerId) continue;
 
-            network.Send(joiner, new NetworkNewPlayerHeroCreated(player.ControllerId, player, Array.Empty<byte>()));
-        }
+                network.Send(joiner, new NetworkNewPlayerHeroCreated(player.ControllerId, player, Array.Empty<byte>()));
+            }
+        });
     }
 }

--- a/source/Coop.Core/Server/Connections/States/CreateCharacterState.cs
+++ b/source/Coop.Core/Server/Connections/States/CreateCharacterState.cs
@@ -10,6 +10,7 @@ using GameInterface.Services.Players;
 using GameInterface.Services.Players.Data;
 using LiteNetLib;
 using Serilog;
+using System;
 using TaleWorlds.CampaignSystem;
 
 namespace Coop.Core.Server.Connections.States;
@@ -26,6 +27,8 @@ public class CreateCharacterState : ConnectionStateBase
     private readonly IHeroInterface heroInterface;
     private readonly IPlayerManager playerManager;
     private readonly IExistingPlayerSender existingPlayerSender;
+    private readonly IConnectionMessageQueue connectionMessageQueue;
+    private bool playerCommitted;
 
     public CreateCharacterState(
         IConnectionLogic connectionLogic,
@@ -34,7 +37,8 @@ public class CreateCharacterState : ConnectionStateBase
         INetwork network,
         IHeroInterface heroInterface,
         IPlayerManager playerManager,
-        IExistingPlayerSender existingPlayerSender)
+        IExistingPlayerSender existingPlayerSender,
+        IConnectionMessageQueue connectionMessageQueue)
         : base(connectionLogic)
     {
         this.objectManager = objectManager;
@@ -43,12 +47,15 @@ public class CreateCharacterState : ConnectionStateBase
         this.heroInterface = heroInterface;
         this.playerManager = playerManager;
         this.existingPlayerSender = existingPlayerSender;
+        this.connectionMessageQueue = connectionMessageQueue;
         messageBroker.Subscribe<NetworkTransferNewHero>(Handle_NetworkTransferNewHero);
     }
 
     public override void Dispose()
     {
         messageBroker.Unsubscribe<NetworkTransferNewHero>(Handle_NetworkTransferNewHero);
+        if (!playerCommitted)
+            playerManager.ReleaseNewControllerReservation(ConnectionLogic.Peer);
     }
 
     internal void Handle_NetworkTransferNewHero(MessagePayload<NetworkTransferNewHero> obj)
@@ -56,40 +63,78 @@ public class CreateCharacterState : ConnectionStateBase
         var netPeer = obj.Who as NetPeer;
 
         if (netPeer != ConnectionLogic.Peer) return;
+        if (netPeer.ConnectionState != ConnectionState.Connected)
+        {
+            playerManager.ReleaseNewControllerReservation(netPeer);
+            return;
+        }
 
         var controllerId = obj.What.PlayerId;
         var data = obj.What.PlayerHero;
 
+        if (!playerManager.TryReserveNewController(
+                controllerId, netPeer, out NetPeer existingPeer))
+        {
+            Logger.Warning(
+                "Rejected character payload for unreserved controller {ControllerId} from peer {PeerId}; " +
+                "reservation belongs to peer {ExistingPeerId}",
+                controllerId,
+                netPeer.Id,
+                existingPeer?.Id);
+            netPeer.Disconnect();
+            return;
+        }
+
+        connectionMessageQueue.InvalidateJoinSnapshot();
+
         Logger.Debug("Unpacking hero for {ControllerId}", controllerId);
 
-        var hero = heroInterface.ServerUnpackHero(data);
+        Hero hero;
+        try
+        {
+            hero = heroInterface.ServerUnpackHero(data);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Character creation failed for {ControllerId}; disconnecting", controllerId);
+            netPeer.Disconnect();
+            return;
+        }
+
+        if (netPeer.ConnectionState != ConnectionState.Connected)
+        {
+            heroInterface.DiscardUncommittedServerHero(hero);
+            playerManager.ReleaseNewControllerReservation(netPeer);
+            return;
+        }
 
         if (!TryCreatePlayer(controllerId, hero, out var player))
         {
             Logger.Error("Failed to create player; disconnecting the joining peer");
-            ConnectionLogic.Peer.Disconnect();
+            heroInterface.DiscardUncommittedServerHero(hero);
+            netPeer.Disconnect();
             return;
         }
 
-        if (!playerManager.AddPlayer(player))
+        if (!playerManager.TryCommitReservedPlayer(controllerId, netPeer, player))
         {
-            // The controller already holds a registration — two joins for it raced into character
-            // creation before either finished. Everything below assumes this peer owns the player
-            // it just created, so continuing would bind the peer to the *other* registration and
-            // announce this refused one to the joiner and every other client. Drop the connection
-            // instead, exactly as a failed create does above.
             Logger.Error(
-                "Controller {ControllerId} is already registered; disconnecting the joining peer",
+                "Character creation reservation was lost for {ControllerId}; disconnecting",
                 controllerId);
-            ConnectionLogic.Peer.Disconnect();
+            heroInterface.DiscardUncommittedServerHero(hero);
+            netPeer.Disconnect();
             return;
         }
+        playerCommitted = true;
+        connectionMessageQueue.InvalidateJoinSnapshot();
 
-        // First join: associate this peer with the player it just created.
-        playerManager.SetPeer(controllerId, netPeer);
-        // Send created to all other clients
+        // Once committed, every live client must learn about the authoritative hero even if the
+        // creator disconnects immediately afterwards.
         var message = new NetworkNewPlayerHeroCreated(controllerId, player, data);
         network.SendAllBut(netPeer, message);
+
+        if (netPeer.ConnectionState != ConnectionState.Connected)
+            return;
 
         // Respond with ids for the creating client
         network.SendImmediate(netPeer, new NetworkHeroRecieved(player));
@@ -136,10 +181,8 @@ public class CreateCharacterState : ConnectionStateBase
 
     public override void TransferSave()
     {
-        // SetState packages and sends the save synchronously; then move to LoadingState to await the
-        // client reporting it has entered the campaign. Load() must run here (not inside the
-        // TransferSaveState ctor) so it resolves against TransferSaveState, not this state.
-        ConnectionLogic.SetState<TransferSaveState>();
-        ConnectionLogic.Load();
+        var transfer = ConnectionLogic.SetState<TransferSaveState>();
+        if (transfer.StartTransfer())
+            ConnectionLogic.Load();
     }
 }

--- a/source/Coop.Core/Server/Connections/States/LoadingState.cs
+++ b/source/Coop.Core/Server/Connections/States/LoadingState.cs
@@ -55,13 +55,15 @@ public class LoadingState : ConnectionStateBase
     public override bool IsLoading => true;
 
     internal bool IsJoinCatchUpPending =>
-        phase == JoinPhase.WaitingForReplayApplied ||
-        phase == JoinPhase.InitialBaselineQueued ||
-        phase == JoinPhase.WaitingForInitialBaseline ||
-        phase == JoinPhase.FinalBaselineQueued ||
-        phase == JoinPhase.WaitingForFinalBaseline ||
-        phase == JoinPhase.WorldReadyQueued ||
-        phase == JoinPhase.WaitingForCatchUpApplied;
+        phase >= JoinPhase.WaitingForReplayApplied &&
+        phase != JoinPhase.CatchUpAppliedQueued;
+
+    // Loading a save is not catch-up and must not freeze the campaign. Emergency join pausing begins
+    // only once replay is underway.
+    internal bool IsJoinCatchUpPauseEligible =>
+        phase >= JoinPhase.WaitingForReplayApplied;
+
+    internal string JoinPhaseName => phase.ToString();
 
     public override void Dispose()
     {
@@ -126,6 +128,8 @@ public class LoadingState : ConnectionStateBase
             if (!IsCurrent(queued)) return;
 
             coalescer.Flush(network);
+            if (isFinal)
+                connectionMessageQueue.EndPartyBehaviorBaselineCoverage(peer);
             connectionMessageQueue.Flush(peer);
             if (!isFinal) initialBaselinesSent++;
             phase = waiting;

--- a/source/Coop.Core/Server/Connections/States/ResolveCharacterState.cs
+++ b/source/Coop.Core/Server/Connections/States/ResolveCharacterState.cs
@@ -128,6 +128,9 @@ public class ResolveCharacterState : ConnectionStateBase
 
     private void ResolveCharacter(NetPeer peer, string controllerId)
     {
+        if (peer?.ConnectionState != ConnectionState.Connected)
+            return;
+
         if (playerManager.TryGetPlayer(controllerId, out var player))
         {
             var heroExists = false;
@@ -140,6 +143,12 @@ public class ResolveCharacterState : ConnectionStateBase
             // validation has already arrived.
             GameThread.Run(() =>
             {
+                // A timed-out blocking call remains queued in GameThread. Never let that late
+                // action mutate registration after this socket/state has gone away.
+                if (peer.ConnectionState != ConnectionState.Connected ||
+                    !ReferenceEquals(ConnectionLogic.State, this))
+                    return;
+
                 heroExists = objectManager.TryGetObjectWithLogging(player.HeroId, out Hero _);
                 if (!heroExists) return;
 
@@ -147,7 +156,16 @@ public class ResolveCharacterState : ConnectionStateBase
                 if (!partyRestored || ReferenceEquals(restoredPlayer, player)) return;
 
                 registrationReplaced = playerManager.ReplacePlayer(player, restoredPlayer);
+                if (registrationReplaced)
+                {
+                    // Replacement is authoritative once committed. Existing clients must receive
+                    // it even if the reconnecting socket dies immediately afterwards.
+                    network.SendAllBut(peer, new NetworkPlayerRegistrationUpdated(restoredPlayer));
+                }
             }, blocking: true);
+
+            if (peer.ConnectionState != ConnectionState.Connected)
+                return;
 
             if (heroExists)
             {
@@ -161,12 +179,20 @@ public class ResolveCharacterState : ConnectionStateBase
                     return;
                 }
 
-                if (registrationReplaced)
-                    network.SendAllBut(peer, new NetworkPlayerRegistrationUpdated(restoredPlayer));
-
                 // This peer is a new NetPeer for an already registered player, so the
                 // peer-Player link must be established here
-                playerManager.SetPeer(controllerId, peer);
+                if (!playerManager.TrySetPeerIfAvailable(
+                        controllerId, peer, out NetPeer existingPeer))
+                {
+                    Logger.Warning(
+                        "Refusing overlapping reconnect for controller {ControllerId}: " +
+                        "peer {PeerId} is still connected as peer {ExistingPeerId}",
+                        controllerId,
+                        peer.Id,
+                        existingPeer?.Id);
+                    peer.Disconnect();
+                    return;
+                }
                 network.SendImmediate(peer, new NetworkClientValidated(true, restoredPlayer));
                 ConnectionLogic.TransferSave();
 
@@ -174,16 +200,27 @@ public class ResolveCharacterState : ConnectionStateBase
                 return;
             }
 
-            // Registered, but the hero it names is not in the campaign — a registration that
-            // outlived its objects. Deregister it before routing to character creation: the
-            // character created next registers this same controller id, and leaving the dead
-            // entry behind would make the controller ambiguous for the rest of the session.
-            Logger.Warning(
-                "Controller {ControllerId} is registered to hero {HeroId}, which no longer exists; " +
-                "dropping the stale registration and creating a new character",
+            // Never turn a transient/missing campaign object into character deletion. The
+            // authoritative registration stays intact for repair or an explicit admin reset.
+            Logger.Error(
+                "Controller {ControllerId} is registered to hero {HeroId}, but that hero is not " +
+                "available in the loaded campaign; refusing reconnect without changing the character",
                 controllerId, player.HeroId);
+            peer.Disconnect();
+            return;
+        }
 
-            playerManager.RemovePlayer(player);
+        if (!playerManager.TryReserveNewController(
+                controllerId, peer, out NetPeer reservedPeer))
+        {
+            Logger.Warning(
+                "Refusing duplicate character creation for controller {ControllerId}: " +
+                "peer {PeerId} conflicts with peer {ExistingPeerId}",
+                controllerId,
+                peer.Id,
+                reservedPeer?.Id);
+            peer.Disconnect();
+            return;
         }
 
         network.SendImmediate(peer, new NetworkClientValidated(false, null));
@@ -197,11 +234,11 @@ public class ResolveCharacterState : ConnectionStateBase
 
     public override void TransferSave()
     {
-        // SetState packages and sends the save synchronously; then move to LoadingState to await the
-        // client reporting it has entered the campaign. Load() must run here (not inside the
-        // TransferSaveState ctor) so it resolves against TransferSaveState, not this state.
-        ConnectionLogic.SetState<TransferSaveState>();
-        ConnectionLogic.Load();
+        // Assign the state before blocking game-thread work starts. A disconnect can then cancel a
+        // queued save before it serializes an abandoned join later.
+        var transfer = ConnectionLogic.SetState<TransferSaveState>();
+        if (transfer.StartTransfer())
+            ConnectionLogic.Load();
     }
 
     public override void Load()

--- a/source/Coop.Core/Server/Connections/States/TransferSaveState.cs
+++ b/source/Coop.Core/Server/Connections/States/TransferSaveState.cs
@@ -1,10 +1,8 @@
 ﻿using Common;
 using Common.Logging;
-using Common.Messaging;
 using Common.Network;
 using Common.Network.Coalescing;
 using Coop.Core.Common.Network.Packets;
-using GameInterface.Services.Save.Messages;
 using GameInterface.CoopSessionData;
 using GameInterface.Services.CampaignService.Interfaces;
 using GameInterface.Services.Heroes.Interfaces;
@@ -25,9 +23,18 @@ public class TransferSaveState : ConnectionStateBase
     private static readonly ILogger Logger = LogManager.GetLogger<TransferSaveState>();
     private static int nextSaveTransferId;
 
+    private readonly INetwork network;
+    private readonly ICoopSessionProvider coopSessionProvider;
+    private readonly ISaveInterface saveInterface;
+    private readonly IConnectionMessageQueue connectionMessageQueue;
+    private readonly ISendCoalescer coalescer;
+    private readonly IAttachmentIdMapper attachmentIdMapper;
+    private readonly IServerOptionsProvider serverOptionsProvider;
+    private int cancelled;
+    private int started;
+
     public TransferSaveState(
         IConnectionLogic connectionLogic,
-        IMessageBroker messageBroker,
         INetwork network,
         ICoopSessionProvider coopSessionProvider,
         ISaveInterface saveInterface,
@@ -37,89 +44,157 @@ public class TransferSaveState : ConnectionStateBase
         IServerOptionsProvider serverOptionsProvider)
         : base(connectionLogic)
     {
-        GameSaveDataPacket snapshot = default;
-        bool snapshotCreated = false;
+        this.network = network;
+        this.coopSessionProvider = coopSessionProvider;
+        this.saveInterface = saveInterface;
+        this.connectionMessageQueue = connectionMessageQueue;
+        this.coalescer = coalescer;
+        this.attachmentIdMapper = attachmentIdMapper;
+        this.serverOptionsProvider = serverOptionsProvider;
+    }
 
-        GameThread.Run(() =>
+    /// <summary>
+    /// Captures and sends the transient join snapshot after this state has become current.
+    /// A timed-out queued action checks the current state before touching the campaign, so an
+    /// abandoned join cannot perform a phantom serialization minutes later.
+    /// </summary>
+    internal bool StartTransfer()
+    {
+        if (Interlocked.Exchange(ref started, 1) != 0 || !IsCurrent())
+            return false;
+
+        if (connectionMessageQueue.TryUseCachedJoinSnapshot(
+                ConnectionLogic.Peer, out CachedJoinSnapshot cached))
         {
-            // Flush pending coalesced sends before the snapshot, while this peer is still Dropping: a deferred
-            // delta would otherwise be both captured in the snapshot and replayed to this peer after BeginQueueing
-            // (double-apply). Guarded so a throwing send can't strand this blocking GameThread.Run.
             try
             {
-                coalescer.Flush(network);
+                Logger.Information(
+                    "Reusing unchanged join snapshot for peer {PeerId}: {CompressedSize:N0} compressed bytes",
+                    ConnectionLogic.Peer.Id,
+                    cached.CompressedData.Length);
+                SendSaveChunks(
+                    network,
+                    cached.Metadata,
+                    cached.CompressedData,
+                    cached.UncompressedSize);
+                return IsCurrent();
             }
             catch (Exception ex)
             {
-                Logger.Error(ex, "Failed to flush coalesced sends before the join save snapshot");
+                Interlocked.Exchange(ref cancelled, 1);
+                Logger.Error(ex, "Failed to send cached join save to peer {PeerId}; disconnecting", ConnectionLogic.Peer.Id);
+                ConnectionLogic.Peer.Disconnect();
+                return false;
             }
+        }
 
-            try
+        GameSaveDataPacket snapshot = default;
+        bool snapshotCreated = false;
+        Exception captureError = null;
+        long snapshotGeneration = 0;
+
+        try
+        {
+            GameThread.Run(() =>
             {
+                if (!IsCurrent()) return;
+
                 try
                 {
-                    messageBroker.Publish(this, new GameSaveStateChanged(true));
-                    // The poll thread is blocked on this action, so flush before the save starts.
-                    network.FlushPendingMessages();
+                    snapshotGeneration = connectionMessageQueue.CaptureFreshJoinSnapshot(
+                        ConnectionLogic.Peer,
+                        () =>
+                        {
+                            // A deferred delta could otherwise exist both in the save and in the replay tail.
+                            // CaptureFreshJoinSnapshot excludes every normal world send for this exact cut.
+                            coalescer.Flush(network);
+
+                            if (!IsCurrent())
+                                throw new OperationCanceledException("The joining peer left before its save cut.");
+
+                            var saveResults = saveInterface.SaveCurrentGame();
+                            if (!saveResults.Success)
+                                throw new InvalidOperationException("The in-memory join save failed.");
+
+                            if (!IsCurrent())
+                                throw new OperationCanceledException("The joining peer left during its save cut.");
+
+                            return new GameSaveDataPacket(
+                                saveResults.Data,
+                                saveResults.CampaignId,
+                                Clone(coopSessionProvider.CoopSession?.CraftingPlayerData),
+                                Clone(coopSessionProvider.CoopSession?.WorkshopPlayerData),
+                                Clone(coopSessionProvider.CoopSession?.CaravansPlayerData),
+                                Clone(coopSessionProvider.CoopSession?.AlleyPlayerData),
+                                Clone(coopSessionProvider.CoopSession?.InteractionsPlayerData),
+                                Clone(coopSessionProvider.CoopSession?.TradePlayerData),
+                                Clone(coopSessionProvider.CoopSession?.InventoryPlayerData),
+                                attachmentIdMapper.BuildServerMap(),
+                                serverOptionsProvider.GetServerOptions());
+                        },
+                        out snapshot);
+
+                    if (!IsCurrent())
+                    {
+                        connectionMessageQueue.InvalidateJoinSnapshot();
+                        return;
+                    }
+                    snapshotCreated = true;
                 }
                 catch (Exception ex)
                 {
-                    Logger.Error(ex, "Failed to broadcast the join save start");
+                    captureError = ex;
                 }
+            }, blocking: true, label: "Join save snapshot");
+        }
+        catch (Exception ex) when (ex is TimeoutException || ex is OperationCanceledException)
+        {
+            captureError = ex;
+        }
 
-                var saveResults = saveInterface.SaveCurrentGame();
+        if (!snapshotCreated || captureError != null || !IsCurrent())
+        {
+            Interlocked.Exchange(ref cancelled, 1);
+            if (captureError != null)
+                Logger.Error(captureError, "Join save snapshot failed for peer {PeerId}; disconnecting", ConnectionLogic.Peer.Id);
+            ConnectionLogic.Peer.Disconnect();
+            return false;
+        }
 
-                // Disconnect peer on failure — before touching Data, which a failed snapshot may leave null.
-                if (!saveResults.Success)
-                {
-                    Logger.Error("Join save snapshot failed for peer {PeerId}; disconnecting", connectionLogic.Peer.Id);
-                    connectionLogic.Peer.Disconnect();
-                    return;
-                }
-
-                // Clone the mutable session DTOs at the same boundary as the campaign save. Compression and
-                // packet serialization run after the game-thread action returns, while campaign ticks resume.
-                snapshot = new GameSaveDataPacket(
-                    saveResults.Data,
-                    saveResults.CampaignId,
-                    Clone(coopSessionProvider.CoopSession?.CraftingPlayerData),
-                    Clone(coopSessionProvider.CoopSession?.WorkshopPlayerData),
-                    Clone(coopSessionProvider.CoopSession?.CaravansPlayerData),
-                    Clone(coopSessionProvider.CoopSession?.AlleyPlayerData),
-                    Clone(coopSessionProvider.CoopSession?.InteractionsPlayerData),
-                    Clone(coopSessionProvider.CoopSession?.TradePlayerData),
-                    Clone(coopSessionProvider.CoopSession?.InventoryPlayerData),
-                    attachmentIdMapper.BuildServerMap(),
-                    serverOptionsProvider.GetServerOptions());
-
-                // Start holding this peer's broadcasts now that the snapshot has been taken. The whole save
-                // runs in a blocking GameThread.Run call issued from the network thread, so the poller is
-                // parked for its duration and cannot broadcast a received delta that races the snapshot;
-                // taking the cut right after the snapshot cleanly separates "in the save" (dropped while
-                // Dropping) from "after the save" (queued for replay).
-                connectionMessageQueue.BeginQueueing(ConnectionLogic.Peer);
-                snapshotCreated = true;
-            }
-            finally
-            {
-                try
-                {
-                    messageBroker.Publish(this, new GameSaveStateChanged(false));
-                }
-                catch (Exception ex)
-                {
-                    Logger.Error(ex, "Failed to broadcast the join save end");
-                }
-            }
-        }, blocking: true);
-
-        if (!snapshotCreated) return;
-
-        byte[] compressedSave = SaveDataCompression.Compress(snapshot.GameSaveData);
-        SendSaveChunks(network, snapshot, compressedSave);
+        try
+        {
+            byte[] compressedSave = SaveDataCompression.Compress(snapshot.GameSaveData);
+            if (!IsCurrent()) return false;
+            connectionMessageQueue.CompleteJoinSnapshot(
+                snapshotGeneration,
+                snapshot,
+                compressedSave);
+            SendSaveChunks(
+                network,
+                snapshot,
+                compressedSave,
+                snapshot.GameSaveData?.Length ?? 0);
+            return IsCurrent();
+        }
+        catch (Exception ex)
+        {
+            Interlocked.Exchange(ref cancelled, 1);
+            Logger.Error(ex, "Failed to compress or send join save to peer {PeerId}; disconnecting", ConnectionLogic.Peer.Id);
+            ConnectionLogic.Peer.Disconnect();
+            return false;
+        }
     }
 
-    private void SendSaveChunks(INetwork network, GameSaveDataPacket snapshot, byte[] compressedSave)
+    private bool IsCurrent() =>
+        Volatile.Read(ref cancelled) == 0 &&
+        ConnectionLogic.Peer.ConnectionState == LiteNetLib.ConnectionState.Connected &&
+        ReferenceEquals(ConnectionLogic.State, this);
+
+    private void SendSaveChunks(
+        INetwork network,
+        GameSaveDataPacket snapshot,
+        byte[] compressedSave,
+        int uncompressedSize)
     {
         int transferId = Interlocked.Increment(ref nextSaveTransferId);
         int chunkCount = Math.Max(1, (compressedSave.Length + GameSaveDataChunkPacket.ChunkSize - 1) / GameSaveDataChunkPacket.ChunkSize);
@@ -130,7 +205,7 @@ public class TransferSaveState : ConnectionStateBase
             ConnectionLogic.Peer.Id,
             chunkCount,
             compressedSave.Length,
-            snapshot.GameSaveData?.Length ?? 0);
+            uncompressedSize);
 
         for (int chunkIndex = 0; chunkIndex < chunkCount; chunkIndex++)
         {
@@ -147,7 +222,7 @@ public class TransferSaveState : ConnectionStateBase
                 chunkIndex,
                 chunkCount,
                 compressedSave.Length,
-                snapshot.GameSaveData?.Length ?? 0,
+                uncompressedSize,
                 chunkData,
                 chunkIndex == 0 ? snapshot.CampaignID : null,
                 chunkIndex == 0 ? snapshot.CraftingPlayerData : null,
@@ -171,6 +246,7 @@ public class TransferSaveState : ConnectionStateBase
 
     public override void Dispose()
     {
+        Interlocked.Exchange(ref cancelled, 1);
     }
 
     public override void CreateCharacter()

--- a/source/Coop.Core/Server/CoopServer.cs
+++ b/source/Coop.Core/Server/CoopServer.cs
@@ -205,12 +205,12 @@ public class CoopServer : CoopNetworkBase, ICoopServer
 
     public override void SendAll(IPacket packet)
     {
-        SendAll(netManager, packet);
+        connectionMessageQueue.ExecuteWorldSend(packet, () => SendAll(netManager, packet));
     }
 
     public override void SendAllBut(NetPeer ignoredPeer, IPacket packet)
     {
-        SendAllBut(netManager, ignoredPeer, packet);
+        connectionMessageQueue.ExecuteWorldSend(packet, () => SendAllBut(netManager, ignoredPeer, packet));
     }
 
     // Every per-peer send funnels through here, so a still-loading peer's world deltas are dropped
@@ -219,7 +219,10 @@ public class CoopServer : CoopNetworkBase, ICoopServer
     // mid-join peer (the save, the join handshake) uses SendImmediate to bypass this.
     public override void Send(NetPeer netPeer, IPacket packet)
     {
-        if (connectionMessageQueue.TryHandleBroadcast(netPeer, packet)) return;
-        base.Send(netPeer, packet);
+        connectionMessageQueue.ExecuteWorldSend(packet, () =>
+        {
+            if (connectionMessageQueue.TryHandleBroadcast(netPeer, packet)) return;
+            base.Send(netPeer, packet);
+        });
     }
 }

--- a/source/Coop.Core/Server/ServerLogic.cs
+++ b/source/Coop.Core/Server/ServerLogic.cs
@@ -77,6 +77,6 @@ public class ServerLogic : IServerLogic
         new Dictionary<Type, Func<IServerState>>
         {
             [typeof(InitialServerState)] = () => new InitialServerState(this, context.MessageBroker, context.RegistryManager, context.ModuleInfoProvider, context.ModuleValidator, context.GameStateInterface, context.LoadingInterface),
-            [typeof(ServerRunningState)] = () => new ServerRunningState(this, context.MessageBroker, context.Network, context.GameStateInterface, context.LoadingInterface),
+            [typeof(ServerRunningState)] = () => new ServerRunningState(this, context.MessageBroker, context.Network, context.GameStateInterface, context.LoadingInterface, context.TimeControlInterface),
         };
 }

--- a/source/Coop.Core/Server/Services/Players/Handlers/DisconnectedPlayersServerHandler.cs
+++ b/source/Coop.Core/Server/Services/Players/Handlers/DisconnectedPlayersServerHandler.cs
@@ -30,7 +30,6 @@ internal sealed class DisconnectedPlayersServerHandler : IHandler
         this.timeControlInterface = timeControlInterface;
 
         messageBroker.Subscribe<PlayerDisconnected>(HandlePlayerDisconnected);
-        timeControlInterface.AddUnpausePolicy(PlayersConnectedPolicy);
     }
 
     private void HandlePlayerDisconnected(MessagePayload<PlayerDisconnected> _)
@@ -48,14 +47,8 @@ internal sealed class DisconnectedPlayersServerHandler : IHandler
         }
     }
 
-    private bool PlayersConnectedPolicy()
-    {
-        return playerManager.Players.Any(playerManager.IsConnected);
-    }
-
     public void Dispose()
     {
         messageBroker.Unsubscribe<PlayerDisconnected>(HandlePlayerDisconnected);
-        timeControlInterface.RemoveUnpausePolicy(PlayersConnectedPolicy);
     }
 }

--- a/source/Coop.Core/Server/Services/Players/Handlers/PlayerPartyVisibilityHandler.cs
+++ b/source/Coop.Core/Server/Services/Players/Handlers/PlayerPartyVisibilityHandler.cs
@@ -16,6 +16,7 @@ using GameInterface.Services.PartyVisuals.Messages;
 using GameInterface.Services.Players;
 using GameInterface.Services.Players.Data;
 using GameInterface.Services.SiegeEvents.Interfaces;
+using GameInterface.Services.Settlements.Interfaces;
 using HarmonyLib;
 using LiteNetLib;
 using SandBox.View.Map.Managers;
@@ -47,6 +48,7 @@ internal class PlayerPartyVisibilityHandler : IHandler
     private readonly IObjectManager objectManager;
     private readonly INetwork network;
     private readonly ISiegeEventInterface siegeEventInterface;
+    private readonly ISettlementInterface settlementInterface;
     private readonly Dictionary<MobileParty, MapEvent> deferredMapEventParking = new();
 
     public PlayerPartyVisibilityHandler(
@@ -54,13 +56,15 @@ internal class PlayerPartyVisibilityHandler : IHandler
         IPlayerManager playerManager,
         IObjectManager objectManager,
         INetwork network,
-        ISiegeEventInterface siegeEventInterface)
+        ISiegeEventInterface siegeEventInterface,
+        ISettlementInterface settlementInterface)
     {
         this.messageBroker = messageBroker;
         this.playerManager = playerManager;
         this.objectManager = objectManager;
         this.network = network;
         this.siegeEventInterface = siegeEventInterface;
+        this.settlementInterface = settlementInterface;
 
         messageBroker.Subscribe<PlayerDisconnected>(Handle_PlayerDisconnected);
         messageBroker.Subscribe<PlayerCampaignEntered>(Handle_PlayerCampaignEntered);
@@ -118,12 +122,14 @@ internal class PlayerPartyVisibilityHandler : IHandler
     private void ParkParty(Player player, MobileParty party, string reason)
     {
         var mapEvent = party.MapEvent;
-        if (mapEvent != null)
+        if (mapEvent != null && !mapEvent.IsFinalized)
         {
             deferredMapEventParking[party] = mapEvent;
+            party.IgnoreByOtherPartiesTill(CampaignTime.Never);
+            RemoveVisual(party);
             messageBroker.Publish(this, new PlayerDisconnectedFromMapEvent(player.ControllerId, mapEvent));
             Logger.Information(
-                "Keeping party {PartyId} active in MapEvent {MapEventId} because {Reason}",
+                "Hid and ignored party {PartyId} in MapEvent {MapEventId} because {Reason}",
                 party.StringId,
                 mapEvent.StringId,
                 reason);
@@ -132,6 +138,7 @@ internal class PlayerPartyVisibilityHandler : IHandler
 
         LeaveSiegeBeforeParking(party);
 
+        party.IgnoreByOtherPartiesTill(CampaignTime.Never);
         var wasActive = party.IsActive;
         party.IsActive = false;
         party.IsVisible = false;
@@ -166,26 +173,41 @@ internal class PlayerPartyVisibilityHandler : IHandler
             if (party.MapEvent != null)
                 messageBroker.Publish(this, new PlayerReconnectedToMapEvent());
 
-            if (party.IsActive)
-            {
-                return; // fresh join, never parked, nothing to restore
-            }
-
             // Retrieves the player and outs it to the Hero Object
             // Checks if the player is prisoner or if they belong there
             // If they do, the Debug message appears.
             if (objectManager.TryGetObject(player.HeroId, out Hero hero) &&
                 (hero.IsPrisoner || hero.PartyBelongedToAsPrisoner != null))
             {
+                party.IgnoreByOtherPartiesTill(CampaignTime.Never);
+                party.IsActive = false;
+                party.IsVisible = false;
+                RemoveVisual(party);
                 Logger.Debug("Keeping captive party {PartyId} parked for peer {Peer}",
                     party.StringId,
                     peer.Id);
                 return;
             }
 
+            party.IgnoreByOtherPartiesTill(CampaignTime.Now);
             party.IsActive = true;
-            CreateVisual(party, player.MobilePartyId);
+            party.IsVisible = true;
+            var existingVisual = party.Party.GetPartyVisual();
+            if (existingVisual == null || !objectManager.TryGetId(existingVisual, out _))
+                CreateVisual(party, player.MobilePartyId);
             party.Party.UpdateVisibilityAndInspected(party.Position);
+
+            // A newly created or reconnecting player can already be inside a
+            // settlement, so no enter-settlement command is emitted. Populate and
+            // broadcast its authoritative location roster here; otherwise tavern
+            // heroes exist in the campaign but never appear in the settlement UI
+            // or scene until a later leave-and-reenter round trip.
+            if (party.CurrentSettlement != null)
+            {
+                settlementInterface.OnPartyEnteredSettlement(
+                    party.CurrentSettlement,
+                    party);
+            }
             Logger.Information("Restored party {PartyId} for reconnected peer {Peer}", party.StringId, peer.Id);
         });
     }
@@ -194,18 +216,36 @@ internal class PlayerPartyVisibilityHandler : IHandler
     {
         if (ModInformation.IsClient) return;
 
+        var finalizedMapEvent = payload.What.MapEvent;
+        GameThread.EnqueueSafe(
+            () => FinishDeferredMapEventParking(finalizedMapEvent),
+            nameof(PlayerPartyVisibilityHandler));
+    }
+
+    private void FinishDeferredMapEventParking(MapEvent finalizedMapEvent)
+    {
         foreach (var party in deferredMapEventParking
-            .Where(entry => ReferenceEquals(entry.Value, payload.What.MapEvent))
+            .Where(entry => ReferenceEquals(entry.Value, finalizedMapEvent))
             .Select(entry => entry.Key)
             .ToArray())
         {
-            if (party.MapEvent != null) continue;
+            if (party.MapEvent != null && !party.MapEvent.IsFinalized)
+            {
+                deferredMapEventParking[party] = party.MapEvent;
+                continue;
+            }
 
             deferredMapEventParking.Remove(party);
-            if (!party.IsActive || !playerManager.IsOwnerOfPartyDisconnected(party)) continue;
+            if (!playerManager.IsOwnerOfPartyDisconnected(party))
+            {
+                party.IgnoreByOtherPartiesTill(CampaignTime.Now);
+                continue;
+            }
 
             LeaveSiegeBeforeParking(party);
-            party.IsActive = false;
+            party.IgnoreByOtherPartiesTill(CampaignTime.Never);
+            if (party.IsActive)
+                party.IsActive = false;
             party.IsVisible = false;
             RemoveVisual(party);
             Logger.Information(
@@ -233,18 +273,22 @@ internal class PlayerPartyVisibilityHandler : IHandler
     {
         var partyVisual = party.Party.GetPartyVisual();
         if (partyVisual == null) return;
-        if (!objectManager.TryGetIdWithLogging(partyVisual, out string partyVisualId))
-            return;
-        if (!objectManager.TryGetIdWithLogging(party, out string mobilePartyId))
-            return;
-        objectManager.Remove(partyVisual);
+        bool hasPartyVisualId = objectManager.TryGetId(partyVisual, out string partyVisualId);
+        bool hasMobilePartyId = objectManager.TryGetId(party, out string mobilePartyId);
+        if (hasPartyVisualId)
+            objectManager.Remove(partyVisual);
 
-        using (new AllowedThread())
+        if (MobilePartyVisualManager.Current != null)
         {
-            AccessTools.Method(typeof(MobilePartyVisualManager), "RemovePartyVisualForParty").Invoke(MobilePartyVisualManager.Current, new object[] { party });
+            using (new AllowedThread())
+            {
+                AccessTools.Method(typeof(MobilePartyVisualManager), "RemovePartyVisualForParty")
+                    .Invoke(MobilePartyVisualManager.Current, new object[] { party });
+            }
         }
 
-        network.SendAll(new NetworkDestroyPartyVisual(partyVisualId, mobilePartyId));
+        if (hasPartyVisualId && hasMobilePartyId)
+            network.SendAll(new NetworkDestroyPartyVisual(partyVisualId, mobilePartyId));
     }
 
     /// <summary>
@@ -254,12 +298,16 @@ internal class PlayerPartyVisibilityHandler : IHandler
     /// </summary>
     private void CreateVisual(MobileParty party, string mobilePartyId)
     {
-        using (new AllowedThread())
+        var partyVisual = party.Party.GetPartyVisual();
+        if (partyVisual == null)
         {
-            party.CreateNewPartyVisual();
+            using (new AllowedThread())
+            {
+                party.CreateNewPartyVisual();
+            }
+            partyVisual = party.Party.GetPartyVisual();
         }
 
-        var partyVisual = party.Party.GetPartyVisual();
         if (partyVisual == null)
         {
             Logger.Error("CreateNewPartyVisual did not produce a visual for party {PartyId}", party.StringId);

--- a/source/Coop.Core/Server/Services/Time/OverloadedPeerManager.cs
+++ b/source/Coop.Core/Server/Services/Time/OverloadedPeerManager.cs
@@ -34,12 +34,14 @@ internal class OverloadedPeerManager : IOverloadedPeerManager
     private TimeControlEnum? originalSpeed;
     private volatile NetPeer[] cachedOverloadedPeers = Array.Empty<NetPeer>();
     private readonly Dictionary<NetPeer, DateTime> joinCatchUpStartedUtc = new Dictionary<NetPeer, DateTime>();
+    private readonly HashSet<NetPeer> idleJoinPeers = new HashSet<NetPeer>();
+    private bool resumeAtPlayAfterIdleJoin;
 
     // Diagnostics for the catch-up pause: when it started and when depths were last logged, so a
     // long pause leaves periodic evidence in the log instead of only an in-game message.
     private DateTime pauseStartedUtc;
     private DateTime lastPauseDepthLogUtc;
-    private static readonly TimeSpan PauseDepthLogInterval = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan PauseDepthLogInterval = TimeSpan.FromSeconds(30);
     internal static readonly TimeSpan JoinCatchUpPauseDelay = TimeSpan.FromSeconds(20);
 
     public OverloadedPeerManager(
@@ -67,6 +69,7 @@ internal class OverloadedPeerManager : IOverloadedPeerManager
         // Removes pause policy from time handler
         timeControlInterface.RemoveUnpausePolicy(PlayersOverloadedPolicy);
         joinCatchUpStartedUtc.Clear();
+        idleJoinPeers.Clear();
     }
 
     private static int GetQueueDepth(NetPeer peer)
@@ -90,14 +93,19 @@ internal class OverloadedPeerManager : IOverloadedPeerManager
     private List<NetPeer> UpdateJoinCatchUpPeers(DateTime utcNow)
     {
         var peers = connectionCollection
-            .Where(logic => logic.State is LoadingState { IsJoinCatchUpPending: true })
+            .Where(logic => logic.State is LoadingState { IsJoinCatchUpPauseEligible: true })
             .Select(logic => logic.Peer)
             .ToList();
         var activePeers = new HashSet<NetPeer>(peers);
 
         foreach (var peer in joinCatchUpStartedUtc.Keys.Where(peer => !activePeers.Contains(peer)).ToArray())
         {
+            var connection = connectionCollection.FirstOrDefault(logic => logic.Peer == peer);
             joinCatchUpStartedUtc.Remove(peer);
+            if (idleJoinPeers.Remove(peer) && connection?.IsLoading == false)
+            {
+                resumeAtPlayAfterIdleJoin = true;
+            }
         }
 
         foreach (var peer in peers)
@@ -105,15 +113,25 @@ internal class OverloadedPeerManager : IOverloadedPeerManager
             if (!joinCatchUpStartedUtc.ContainsKey(peer))
             {
                 joinCatchUpStartedUtc.Add(peer, utcNow);
+                bool hasCampaignPeer = connectionCollection.Any(logic => logic.IsLoading == false);
+                if (!hasCampaignPeer &&
+                    timeControlInterface.GetTimeControl() == TimeControlEnum.Pause)
+                {
+                    idleJoinPeers.Add(peer);
+                }
             }
         }
 
         return peers;
     }
 
-    private List<NetPeer> GetStalledJoiningPeers(IEnumerable<NetPeer> joinCatchUpPeers, DateTime utcNow) =>
+    private List<NetPeer> GetStalledJoiningPeers(
+        IEnumerable<NetPeer> joinCatchUpPeers,
+        DateTime utcNow,
+        int queueThreshold) =>
         joinCatchUpPeers
-            .Where(peer => utcNow - joinCatchUpStartedUtc[peer] >= JoinCatchUpPauseDelay)
+            .Where(peer => utcNow - joinCatchUpStartedUtc[peer] >= JoinCatchUpPauseDelay &&
+                GetReportedQueueDepth(peer) > queueThreshold)
             .ToList();
 
     private int GetReportedQueueDepth(NetPeer peer) =>
@@ -126,7 +144,15 @@ internal class OverloadedPeerManager : IOverloadedPeerManager
     private string DescribePeerQueues(IEnumerable<NetPeer> peers)
     {
         return string.Join(", ", peers.Select(peer =>
-            $"{peer.Id}@{peer.Address} queue={GetReportedQueueDepth(peer)} ping={peer.Ping}ms"));
+        {
+            string phase = connectionCollection
+                .FirstOrDefault(logic => logic.Peer == peer)?.State is LoadingState loading
+                ? loading.JoinPhaseName
+                : "Campaign";
+            return $"{peer.Id}@{peer.Address} phase={phase} " +
+                   $"queue={GetReportedQueueDepth(peer)} ping={peer.Ping}ms " +
+                   connectionMessageQueue.DescribeCatchUp(peer);
+        }));
     }
 
     public void CheckForOverloadedPeers() => CheckForOverloadedPeers(DateTime.UtcNow);
@@ -134,7 +160,10 @@ internal class OverloadedPeerManager : IOverloadedPeerManager
     internal void CheckForOverloadedPeers(DateTime utcNow)
     {
         var joinCatchUpPeers = UpdateJoinCatchUpPeers(utcNow);
-        var stalledJoiningPeers = GetStalledJoiningPeers(joinCatchUpPeers, utcNow);
+        var stalledJoiningPeers = GetStalledJoiningPeers(
+            joinCatchUpPeers,
+            utcNow,
+            config.MaxPacketsInQueue);
 
         // While paused for overload, hold until every peer has drained below the (lower) resume
         // threshold, not just back under the pause threshold. The gap between the two thresholds is
@@ -142,7 +171,10 @@ internal class OverloadedPeerManager : IOverloadedPeerManager
         if (originalSpeed.HasValue)
         {
             var stillDraining = GetLivePeersAboveThreshold(config.ResumePacketsInQueue)
-                .Concat(stalledJoiningPeers)
+                .Concat(GetStalledJoiningPeers(
+                    joinCatchUpPeers,
+                    utcNow,
+                    config.ResumePacketsInQueue))
                 .Distinct()
                 .ToArray();
             cachedOverloadedPeers = stillDraining;
@@ -151,10 +183,11 @@ internal class OverloadedPeerManager : IOverloadedPeerManager
                 if (utcNow - lastPauseDepthLogUtc >= PauseDepthLogInterval)
                 {
                     lastPauseDepthLogUtc = utcNow;
+                    string queueDescription = DescribePeerQueues(stillDraining);
                     Logger.Information(
                         "Catch-up pause ongoing for {Seconds:0}s: {PeerQueues}",
                         (utcNow - pauseStartedUtc).TotalSeconds,
-                        DescribePeerQueues(stillDraining));
+                        queueDescription);
                 }
                 return;
             }
@@ -173,12 +206,19 @@ internal class OverloadedPeerManager : IOverloadedPeerManager
             return;
         }
 
-        if (overloadedPeers.Count == 0) return;
+        if (overloadedPeers.Count > 0)
+        {
+            PauseTime(
+                overloadedPeers.ToArray(),
+                utcNow,
+                $"{overloadedPeers.Count} clients are catching up. Pausing...");
+            return;
+        }
 
-        PauseTime(
-            overloadedPeers.ToArray(),
-            utcNow,
-            $"{overloadedPeers.Count} clients are catching up. Pausing...");
+        if (resumeAtPlayAfterIdleJoin && !originalSpeed.HasValue)
+        {
+            ResumeIdleServerAfterJoin();
+        }
     }
 
     private void PauseTime(NetPeer[] overloadedPeers, DateTime utcNow, string notification)
@@ -188,10 +228,11 @@ internal class OverloadedPeerManager : IOverloadedPeerManager
         pauseStartedUtc = utcNow;
         lastPauseDepthLogUtc = utcNow;
 
+        string queueDescription = DescribePeerQueues(overloadedPeers);
         Logger.Information(
             "Pausing campaign time for {PeerCount} peer(s): {PeerQueues}",
             overloadedPeers.Length,
-            DescribePeerQueues(overloadedPeers));
+            queueDescription);
 
         timeControlInterface.ServerSetTimeControl(TimeControlEnum.Pause);
         NotifyAll(notification);
@@ -201,8 +242,13 @@ internal class OverloadedPeerManager : IOverloadedPeerManager
     {
         if (!originalSpeed.HasValue) return;
 
-        var resumeSpeed = originalSpeed.Value;
+        bool joinedIdleServer = resumeAtPlayAfterIdleJoin &&
+            connectionCollection.Any(logic => logic.IsLoading == false);
+        var resumeSpeed = joinedIdleServer
+            ? TimeControlEnum.Play_1x
+            : originalSpeed.Value;
         originalSpeed = null;
+        resumeAtPlayAfterIdleJoin = false;
         cachedOverloadedPeers = Array.Empty<NetPeer>();   // clear first so the policy allows it
 
         Logger.Information(
@@ -213,19 +259,27 @@ internal class OverloadedPeerManager : IOverloadedPeerManager
         NotifyAll("All clients synchronized. Resuming...");
     }
 
+    private void ResumeIdleServerAfterJoin()
+    {
+        resumeAtPlayAfterIdleJoin = false;
+        cachedOverloadedPeers = Array.Empty<NetPeer>();
+        Logger.Information("First player finished loading; resuming idle campaign at 1x");
+        timeControlInterface.ServerSetTimeControl(TimeControlEnum.Play_1x);
+        NotifyAll("All clients synchronized. Resuming...");
+    }
+
     /// <summary>
     /// Policy to prevent unpausing when a client queue is overloaded
     /// </summary>
     /// <returns>True if unpausing is allowed, otherwise false</returns>
     private bool PlayersOverloadedPolicy()
     {
-        if (cachedOverloadedPeers.Any())
-        {
-            NotifyAll($"{cachedOverloadedPeers.Length} clients are catching up. Unable to change time.");
-            return false;
-        }
-
-        return true;
+        // Policies are evaluated repeatedly while a time-control request is blocked.
+        // Broadcasting here fed a new reliable message into the same joining peer's
+        // gated queue on every evaluation, so the catch-up barrier could sustain its
+        // own backlog indefinitely. Pause/resume notifications are emitted once by
+        // PauseTime and ResumeTime instead.
+        return !cachedOverloadedPeers.Any();
     }
 
     private void NotifyAll(string message)

--- a/source/Coop.Core/Server/Services/TroopRosters/Handlers/ServerTroopRosterHandler.cs
+++ b/source/Coop.Core/Server/Services/TroopRosters/Handlers/ServerTroopRosterHandler.cs
@@ -4,11 +4,18 @@ using Common.Messaging;
 using Common.Network;
 using Coop.Core.Client.Services.TroopRosters.Messages;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.MobileParties.Messages;
+using GameInterface.Services.Players;
 using GameInterface.Services.TroopRosters.Interfaces;
+using GameInterface.Services.Transactions;
 using GameInterface.Services.UI.Notifications.Messages;
 using LiteNetLib;
 using Serilog;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Party;
 
 namespace Coop.Core.Server.Services.TroopRosters.Handlers;
 internal class ServerTroopRosterHandler : IHandler
@@ -18,13 +25,20 @@ internal class ServerTroopRosterHandler : IHandler
     private readonly INetwork network;
     private readonly IObjectManager objectManager;
     private readonly ITroopRosterInterface troopRosterInterface;
+    private readonly IPlayerManager playerManager;
 
-    public ServerTroopRosterHandler(IMessageBroker messageBroker, INetwork network, IObjectManager objectManager, ITroopRosterInterface troopRosterInterface)
+    public ServerTroopRosterHandler(
+        IMessageBroker messageBroker,
+        INetwork network,
+        IObjectManager objectManager,
+        ITroopRosterInterface troopRosterInterface,
+        IPlayerManager playerManager)
     {
         this.messageBroker = messageBroker;
         this.network = network;
         this.objectManager = objectManager;
         this.troopRosterInterface = troopRosterInterface;
+        this.playerManager = playerManager;
 
         messageBroker.Subscribe<ClientRequestRecruitment>(HandleOnRecruitmentDone);
     }
@@ -37,17 +51,81 @@ internal class ServerTroopRosterHandler : IHandler
     private void HandleOnRecruitmentDone(MessagePayload<ClientRequestRecruitment> payload)
     {
         var data = payload.What;
+        var peer = payload.Who as NetPeer;
 
-        GameThread.Run(() =>
+        GameThread.Run(() => ServerTransactionOutcome.Execute(
+            peer, ServerTransactionOutcome.Recruit, () =>
         {
             try
             {
-                troopRosterInterface.HandleOnRecruitmentDone(data.MobilePartyId, data.TroopsInCart);
+                string authenticationReason =
+                    "The server could not authenticate this player.";
+                if (!playerManager.TryGetPlayer(peer, out var player) ||
+                    !ServerTransactionOutcome.TryResolvePlayer(
+                        peer,
+                        playerManager,
+                        objectManager,
+                        player?.HeroId,
+                        data.MobilePartyId,
+                        out _,
+                        out _,
+                        out _,
+                        out authenticationReason))
+                {
+                    ServerTransactionOutcome.Reject(
+                        peer,
+                        ServerTransactionOutcome.Recruit,
+                        authenticationReason);
+                    return;
+                }
+                if (troopRosterInterface.TryHandleOnRecruitmentDone(
+                        data.MobilePartyId,
+                        data.TroopsInCart,
+                        out string reason))
+                    ServerTransactionOutcome.Accept(
+                        peer, ServerTransactionOutcome.Recruit);
+                else
+                {
+                    ServerTransactionOutcome.Reject(
+                        peer, ServerTransactionOutcome.Recruit, reason);
+                    TryPublishCurrentVolunteerSnapshot(data.MobilePartyId);
+                }
             }
             catch (Exception e)
             {
                 Logger.Error(e, "Failed to apply {Message}", nameof(ClientRequestRecruitment));
+                ServerTransactionOutcome.Reject(
+                    peer,
+                    ServerTransactionOutcome.Recruit,
+                    "Recruitment could not be completed.");
             }
-        });
+        }));
+    }
+
+    private void TryPublishCurrentVolunteerSnapshot(string mobilePartyId)
+    {
+        try
+        {
+            if (!objectManager.TryGetObject<MobileParty>(
+                    mobilePartyId, out var mobileParty) ||
+                mobileParty?.CurrentSettlement?.Notables == null)
+                return;
+
+            var snapshots = new Dictionary<Hero, CharacterObject[]>();
+            foreach (Hero notable in mobileParty.CurrentSettlement.Notables)
+            {
+                if (notable?.VolunteerTypes != null)
+                    snapshots[notable] = notable.VolunteerTypes.ToArray();
+            }
+
+            if (snapshots.Count > 0)
+                messageBroker.Publish(this, new VolunteersUpdated(snapshots));
+        }
+        catch (Exception exception)
+        {
+            Logger.Warning(
+                exception,
+                "Recruitment was rejected but the volunteer snapshot could not be refreshed");
+        }
     }
 }

--- a/source/Coop.Core/Server/States/ServerContext.cs
+++ b/source/Coop.Core/Server/States/ServerContext.cs
@@ -2,6 +2,7 @@ using Common.Messaging;
 using Common.Network;
 using GameInterface.Registry;
 using GameInterface.Services.GameState.Interfaces;
+using GameInterface.Services.Heroes.Interaces;
 using GameInterface.Services.Modules;
 using GameInterface.Services.Modules.Validators;
 using GameInterface.Services.UI.Interfaces;
@@ -22,7 +23,8 @@ public class ServerContext
         IModuleValidator moduleValidator,
         IModuleInfoProvider moduleInfoProvider,
         IGameStateInterface gameStateInterface,
-        ILoadingInterface loadingInterface)
+        ILoadingInterface loadingInterface,
+        ITimeControlInterface timeControlInterface)
     {
         MessageBroker = messageBroker;
         Network = network;
@@ -31,6 +33,7 @@ public class ServerContext
         ModuleInfoProvider = moduleInfoProvider;
         GameStateInterface = gameStateInterface;
         LoadingInterface = loadingInterface;
+        TimeControlInterface = timeControlInterface;
     }
 
     public IMessageBroker MessageBroker { get; }
@@ -40,4 +43,5 @@ public class ServerContext
     public IModuleInfoProvider ModuleInfoProvider { get; }
     public IGameStateInterface GameStateInterface { get; }
     public ILoadingInterface LoadingInterface { get; }
+    public ITimeControlInterface TimeControlInterface { get; }
 }

--- a/source/Coop.Core/Server/States/ServerRunningState.cs
+++ b/source/Coop.Core/Server/States/ServerRunningState.cs
@@ -4,6 +4,8 @@ using Coop.Core.Common.Services.Connection.Messages;
 using GameInterface.Services.GameDebug.Messages;
 using GameInterface.Services.GameState.Interfaces;
 using GameInterface.Services.GameState.Messages;
+using GameInterface.Services.Heroes.Enum;
+using GameInterface.Services.Heroes.Interaces;
 using GameInterface.Services.UI.Interfaces;
 
 namespace Coop.Core.Server.States;
@@ -22,13 +24,18 @@ public class ServerRunningState : ServerStateBase
         IMessageBroker messageBroker,
         INetwork network,
         IGameStateInterface gameStateInterface,
-        ILoadingInterface loadingInterface) : base(logic)    {
+        ILoadingInterface loadingInterface,
+        ITimeControlInterface timeControlInterface) : base(logic)    {
         this.messageBroker = messageBroker;
         this.network = network;
         this.gameStateInterface = gameStateInterface;
 
         // Start server
         network.Start();
+
+        // A loaded dedicated campaign starts paused. Advancing it at 1x immediately lets Bannerlord
+        // finish its first campaign tick and materialize the map before any player begins joining.
+        timeControlInterface.ServerSetTimeControl(TimeControlEnum.Play_1x);
 
         loadingInterface.HideLoadingScreen();
 

--- a/source/Coop.Tests/Server/Connections/States/CreateCharacterStateTests.cs
+++ b/source/Coop.Tests/Server/Connections/States/CreateCharacterStateTests.cs
@@ -176,7 +176,8 @@ namespace Coop.Tests.Server.Connections.States
             SetupUnpackedHero();
             var playerRegistryMock = serverComponent.Container.Resolve<Mock<IPlayerManager>>();
             playerRegistryMock
-                .Setup(p => p.AddPlayer(It.IsAny<Player>()))
+                .Setup(p => p.TryCommitReservedPlayer(
+                    It.IsAny<string>(), It.IsAny<NetPeer>(), It.IsAny<Player>()))
                 .Returns(false);
             var currentState = connectionLogic.SetState<CreateCharacterState>();
 
@@ -191,7 +192,8 @@ namespace Coop.Tests.Server.Connections.States
             // only this peer is ejected and nothing is sent.
             Assert.Equal(ConnectionState.ShutdownRequested, playerPeer.ConnectionState);
             Assert.NotEqual(ConnectionState.ShutdownRequested, differentPeer.ConnectionState);
-            playerRegistryMock.Verify(p => p.SetPeer(It.IsAny<string>(), It.IsAny<NetPeer>()), Times.Never);
+            playerRegistryMock.Verify(p => p.TryCommitReservedPlayer(
+                It.IsAny<string>(), It.IsAny<NetPeer>(), It.IsAny<Player>()), Times.Once);
             Assert.Empty(serverComponent.TestNetwork.SentNetworkMessages);
             Assert.IsType<CreateCharacterState>(connectionLogic.State);
         }

--- a/source/Coop.Tests/Server/Connections/States/ResolveCharacterStateTests.cs
+++ b/source/Coop.Tests/Server/Connections/States/ResolveCharacterStateTests.cs
@@ -278,7 +278,7 @@ namespace Coop.Tests.Server.Connections.States
         }
 
         [Fact]
-        public void NetworkClientValidate_RegisteredPlayerWithMissingHero_DropsStaleRegistration()
+        public void NetworkClientValidate_RegisteredPlayerWithMissingHero_RefusesWithoutDeletingRegistration()
         {
             // Arrange
             var currentState = connectionLogic.SetState<ResolveCharacterState>();
@@ -301,17 +301,13 @@ namespace Coop.Tests.Server.Connections.States
                 playerPeer, new NetworkClientValidate(player.ControllerId));
             currentState.Handle_ClientValidate(payload);
 
-            // Assert — the dead registration must be dropped before character creation, otherwise
-            // the character created next registers this controller a second time and every later
-            // lookup for it is ambiguous.
-            playerManagerMock.Verify(i => i.RemovePlayer(player), Times.Once);
+            // A missing campaign object may be transient during restoration. Keep the authoritative
+            // registration and fail closed instead of creating a duplicate character.
+            playerManagerMock.Verify(i => i.RemovePlayer(player), Times.Never);
             playerManagerMock.Verify(i => i.SetPeer(It.IsAny<string>(), It.IsAny<NetPeer>()), Times.Never);
-
-            var message = Assert.Single(
-                serverComponent.TestNetwork.GetPeerMessages(playerPeer).OfType<NetworkClientValidated>());
-            Assert.False(message.HeroExists);
-
-            Assert.IsType<CreateCharacterState>(connectionLogic.State);
+            Assert.Equal(ConnectionState.ShutdownRequested, playerPeer.ConnectionState);
+            Assert.False(serverComponent.TestNetwork.SentNetworkMessages.ContainsKey(playerPeer.Id));
+            Assert.IsType<ResolveCharacterState>(connectionLogic.State);
         }
 
         [Fact]

--- a/source/Coop.Tests/Server/Connections/States/TransferCharacterStateTests.cs
+++ b/source/Coop.Tests/Server/Connections/States/TransferCharacterStateTests.cs
@@ -74,8 +74,9 @@ namespace Coop.Tests.Server.Connections.States
             var saveMock = serverComponent.Container.Resolve<Mock<ISaveInterface>>();
             saveMock.Setup(m => m.SaveCurrentGame()).Returns(new SaveResults(true, data, campaignId));
 
-            // Act — entering the state packages the save and sends it to the joining peer.
-            connectionLogic.SetState<TransferSaveState>();
+            // Act — install the cancellable state before starting its blocking snapshot.
+            var state = connectionLogic.SetState<TransferSaveState>();
+            Assert.True(state.StartTransfer());
 
             // Assert — exactly one save chunk for this tiny save, carrying the deflate-compressed
             // save data to the joining peer.
@@ -95,42 +96,35 @@ namespace Coop.Tests.Server.Connections.States
         }
 
         [Fact]
-        public void EnteringState_BroadcastsSavingStateAroundSnapshot()
+        public void JoinSnapshot_DoesNotBroadcastDiskAutosaveState()
         {
             var saveMock = serverComponent.Container.Resolve<Mock<ISaveInterface>>();
             saveMock
                 .Setup(value => value.SaveCurrentGame())
-                .Callback(() =>
-                {
-                    var messages = serverComponent.TestNetwork
-                        .GetPeerMessagesFromType<NetworkGameSaveStateChanged>(differentPeer)
-                        .ToArray();
-                    Assert.Single(messages);
-                    Assert.True(messages[0].IsSaving);
-                    Assert.Equal(1, serverComponent.TestNetwork.FlushPendingMessagesCalls);
-                })
                 .Returns(new SaveResults(true, new byte[] { 1, 2, 3 }, "12345"));
 
-            connectionLogic.SetState<TransferSaveState>();
+            var state = connectionLogic.SetState<TransferSaveState>();
+            Assert.True(state.StartTransfer());
 
-            var messages = serverComponent.TestNetwork
-                .GetPeerMessagesFromType<NetworkGameSaveStateChanged>(differentPeer)
-                .ToArray();
-            Assert.Equal(new[] { true, false }, messages.Select(message => message.IsSaving));
+            Assert.False(
+                serverComponent.TestNetwork.SentNetworkMessages.TryGetValue(
+                    differentPeer.Id, out var messages) &&
+                messages.OfType<NetworkGameSaveStateChanged>().Any());
         }
 
         [Fact]
-        public void EnteringState_FlushFailureStillClearsSavingState()
+        public void JoinSnapshot_DoesNotUseGlobalNetworkFlush()
         {
             serverComponent.TestNetwork.FlushPendingMessagesException =
                 new InvalidOperationException("Flush failed.");
 
-            connectionLogic.SetState<TransferSaveState>();
+            var state = connectionLogic.SetState<TransferSaveState>();
+            Assert.True(state.StartTransfer());
 
-            var messages = serverComponent.TestNetwork
-                .GetPeerMessagesFromType<NetworkGameSaveStateChanged>(differentPeer)
-                .ToArray();
-            Assert.Equal(new[] { true, false }, messages.Select(message => message.IsSaving));
+            Assert.False(
+                serverComponent.TestNetwork.SentNetworkMessages.TryGetValue(
+                    differentPeer.Id, out var messages) &&
+                messages.OfType<NetworkGameSaveStateChanged>().Any());
             Assert.Single(
                 serverComponent.TestNetwork.GetPeerPacketsFromType<GameSaveDataChunkPacket>(playerPeer));
         }
@@ -145,7 +139,8 @@ namespace Coop.Tests.Server.Connections.States
             saveMock.Setup(m => m.SaveCurrentGame()).Returns(new SaveResults(true, data, "12345"));
 
             // Act
-            connectionLogic.SetState<TransferSaveState>();
+            var state = connectionLogic.SetState<TransferSaveState>();
+            Assert.True(state.StartTransfer());
 
             // Assert
             var packets = serverComponent.TestNetwork.GetPeerPacketsFromType<GameSaveDataChunkPacket>(playerPeer).ToArray();

--- a/source/Coop.Tests/Server/Services/Players/PlayerPartyVisibilityHandlerTests.cs
+++ b/source/Coop.Tests/Server/Services/Players/PlayerPartyVisibilityHandlerTests.cs
@@ -7,6 +7,7 @@ using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
 using GameInterface.Services.Players.Data;
 using GameInterface.Services.SiegeEvents.Interfaces;
+using GameInterface.Services.Settlements.Interfaces;
 using HarmonyLib;
 using Moq;
 using System;
@@ -80,7 +81,8 @@ public class PlayerPartyVisibilityHandlerTests : IDisposable
             playerManager.Object,
             objectManager.Object,
             Mock.Of<INetwork>(),
-            Mock.Of<ISiegeEventInterface>());
+            Mock.Of<ISiegeEventInterface>(),
+            Mock.Of<ISettlementInterface>());
 
         broker.Publish(this, new SavedPlayerRegistrationsRestored());
 
@@ -104,7 +106,8 @@ public class PlayerPartyVisibilityHandlerTests : IDisposable
             playerManager.Object,
             objectManager.Object,
             Mock.Of<INetwork>(),
-            Mock.Of<ISiegeEventInterface>());
+            Mock.Of<ISiegeEventInterface>(),
+            Mock.Of<ISettlementInterface>());
 
         broker.Publish(this, new SavedPlayerRegistrationsRestored());
 
@@ -135,7 +138,8 @@ public class PlayerPartyVisibilityHandlerTests : IDisposable
             playerManager.Object,
             objectManager.Object,
             Mock.Of<INetwork>(),
-            siegeEventInterface.Object);
+            siegeEventInterface.Object,
+            Mock.Of<ISettlementInterface>());
 
         broker.Publish(this, new SavedPlayerRegistrationsRestored());
 

--- a/source/Coop.Tests/Server/Services/Time/OverloadedPeerManagerTests.cs
+++ b/source/Coop.Tests/Server/Services/Time/OverloadedPeerManagerTests.cs
@@ -104,7 +104,7 @@ public class OverloadedPeerManagerTests
     }
 
     [Fact]
-    public void InitialJoinCatchUp_PausesAfterTwentySecondsRegardlessOfPacketCount()
+    public void InitialJoinCatchUp_PausesAfterTwentySecondsWhenQueueIsOverloaded()
     {
         var timeControlMock = serverComponent.Container.Resolve<Mock<ITimeControlInterface>>();
         timeControlMock.Setup(t => t.GetTimeControl()).Returns(TimeControlEnum.Play_1x);
@@ -112,7 +112,7 @@ public class OverloadedPeerManagerTests
         var manager = (OverloadedPeerManager)serverComponent.Container.Resolve<IOverloadedPeerManager>();
         var peer = AddConnectedPeer(connections);
         StartInitialCatchUp(connections, peer);
-        peer.SetQueueLength(100);
+        peer.SetQueueLength(AbovePauseThreshold);
         DateTime startedUtc = DateTime.UtcNow;
 
         manager.CheckForOverloadedPeers(startedUtc);
@@ -130,7 +130,7 @@ public class OverloadedPeerManagerTests
     }
 
     [Fact]
-    public void FinalJoinCatchUp_RemainsPausedUntilCatchUpCompletes()
+    public void FinalJoinCatchUp_ResumesWhenQueueDrainsBelowThreshold()
     {
         var timeControlMock = serverComponent.Container.Resolve<Mock<ITimeControlInterface>>();
         timeControlMock.Setup(t => t.GetTimeControl()).Returns(TimeControlEnum.Play_1x);
@@ -140,7 +140,7 @@ public class OverloadedPeerManagerTests
         StartFinalCatchUp(connections, peer);
         DateTime startedUtc = DateTime.UtcNow;
 
-        peer.SetQueueLength(100);
+        peer.SetQueueLength(AbovePauseThreshold);
         manager.CheckForOverloadedPeers(startedUtc);
         manager.CheckForOverloadedPeers(startedUtc + OverloadedPeerManager.JoinCatchUpPauseDelay);
 
@@ -148,7 +148,7 @@ public class OverloadedPeerManagerTests
         manager.CheckForOverloadedPeers(
             startedUtc + OverloadedPeerManager.JoinCatchUpPauseDelay + TimeSpan.FromSeconds(1));
 
-        timeControlMock.Verify(t => t.ServerSetTimeControl(TimeControlEnum.Play_1x), Times.Never());
+        timeControlMock.Verify(t => t.ServerSetTimeControl(TimeControlEnum.Play_1x), Times.Once());
 
         var state = Assert.IsType<LoadingState>(connections.ConnectionStates[peer].State);
         SendAndDrain(state, peer, JoinSyncSignal.FinalBaselineApplied);
@@ -168,7 +168,7 @@ public class OverloadedPeerManagerTests
         var manager = (OverloadedPeerManager)serverComponent.Container.Resolve<IOverloadedPeerManager>();
         var peer = AddConnectedPeer(connections);
         StartFinalCatchUp(connections, peer);
-        peer.SetQueueLength(NetworkJoinSync.CompletionPacketThreshold + 1);
+        peer.SetQueueLength(AbovePauseThreshold);
         DateTime startedUtc = DateTime.UtcNow;
         manager.CheckForOverloadedPeers(startedUtc);
         manager.CheckForOverloadedPeers(startedUtc + OverloadedPeerManager.JoinCatchUpPauseDelay);

--- a/source/Coop.Tests/TestComponentBase.cs
+++ b/source/Coop.Tests/TestComponentBase.cs
@@ -23,6 +23,7 @@ using GameInterface.Services.Modules.Validators;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
 using GameInterface.Services.Settlements.Interfaces;
+using LiteNetLib;
 using GameInterface.Services.SiegeEvents.Interfaces;
 using GameInterface.Services.Save.Interfaces;
 using GameInterface.Services.Players.Data;
@@ -155,6 +156,15 @@ internal abstract class TestComponentBase
     {
         var mock = new Mock<IPlayerManager>();
         mock.Setup(m => m.Players).Returns(Array.Empty<Player>());
+        mock.Setup(m => m.TryReserveNewController(
+                It.IsAny<string>(), It.IsAny<NetPeer>(), out It.Ref<NetPeer>.IsAny))
+            .Returns(true);
+        mock.Setup(m => m.TryCommitReservedPlayer(
+                It.IsAny<string>(), It.IsAny<NetPeer>(), It.IsAny<Player>()))
+            .Returns(true);
+        mock.Setup(m => m.TrySetPeerIfAvailable(
+                It.IsAny<string>(), It.IsAny<NetPeer>(), out It.Ref<NetPeer>.IsAny))
+            .Returns(true);
         builder.RegisterInstance(mock).AsSelf().SingleInstance();
         builder.RegisterInstance(mock.Object).As<IPlayerManager>().SingleInstance();
     }

--- a/source/GameInterface.Tests/Configuration/ModConfigTests.cs
+++ b/source/GameInterface.Tests/Configuration/ModConfigTests.cs
@@ -274,7 +274,7 @@ public class ModConfigTests : IDisposable
         Assert.True(options.GoldFoodInfluenceChangeInSettlements);
         Assert.Equal(GoldFoodChangeMode.OneDayMax, options.GoldFoodInfluenceChangeInBattles);
         Assert.False(options.GoldFoodInfluenceChangeForDisconnectedPlayers);
-        Assert.Equal(24, options.PlayerBattleAiJoinWindowHours);
+        Assert.Equal(10, options.PlayerBattleAiJoinWindowHours);
         Assert.True(options.SpeedLimitWhilePlayersInBattle);
         Assert.Equal(32, options.WandererLimit);
         Assert.False(options.WandererLimitScalesWithPlayers);

--- a/source/GameInterface.Tests/Services/MapEvents/BattleLootGrantRegistryTests.cs
+++ b/source/GameInterface.Tests/Services/MapEvents/BattleLootGrantRegistryTests.cs
@@ -1,0 +1,199 @@
+using GameInterface.Services.MapEvents;
+using System.Linq;
+using TaleWorlds.Core;
+using Xunit;
+
+namespace GameInterface.Tests.Services.MapEvents;
+
+public class BattleLootGrantRegistryTests
+{
+    [Fact]
+    public void PartialClaim_UsesServerAwardForDiscardedRemainder()
+    {
+        var awarded = new ItemObject("awarded");
+        var owned = new ItemObject("owned");
+        var registry = new BattleLootGrantRegistry();
+        registry.Stage(
+            "controller",
+            "hero",
+            "party",
+            "battle",
+            new[] { Row(awarded, 3) });
+
+        BattleLootClaimStatus status = registry.TryBeginClaim(
+            "controller",
+            "hero",
+            "party",
+            new[] { Row(awarded, 2) },
+            new[] { Row(awarded, 1), Row(owned, 1), default },
+            out BattleLootClaim claim,
+            out string reason);
+
+        Assert.Equal(BattleLootClaimStatus.Accepted, status);
+        Assert.Null(reason);
+        ItemRosterElement discarded = Assert.Single(claim.DiscardedItems);
+        Assert.Same(awarded, discarded.EquipmentElement.Item);
+        Assert.Equal(1, discarded.Amount);
+        Assert.Empty(claim.ReturnedOwnedItems);
+        Assert.True(registry.Consume(claim));
+        Assert.Equal(
+            BattleLootClaimStatus.NoGrant,
+            registry.TryBeginClaim(
+                "controller",
+                "hero",
+                "party",
+                new[] { Row(awarded, 1) },
+                new[] { Row(awarded, 2) },
+                out _,
+                out _));
+    }
+
+    [Fact]
+    public void Claim_DoesNotTrustTemporaryClientLootRemainder()
+    {
+        var awarded = new ItemObject("awarded");
+        var registry = new BattleLootGrantRegistry();
+        registry.Stage(
+            "controller",
+            "hero",
+            "party",
+            "battle",
+            new[] { Row(awarded, 3) });
+
+        BattleLootClaimStatus status = registry.TryBeginClaim(
+            "controller",
+            "hero",
+            "party",
+            new[] { Row(awarded, 1) },
+            new[] { Row(awarded, 1) },
+            out _,
+            out string reason);
+
+        Assert.Equal(BattleLootClaimStatus.Accepted, status);
+        Assert.Null(reason);
+    }
+
+    [Fact]
+    public void Claim_CannotTakeMoreThanTheServerAwarded()
+    {
+        var awarded = new ItemObject("awarded");
+        var registry = new BattleLootGrantRegistry();
+        registry.Stage(
+            "controller",
+            "hero",
+            "party",
+            "battle",
+            new[] { Row(awarded, 2) });
+
+        BattleLootClaimStatus status = registry.TryBeginClaim(
+            "controller",
+            "hero",
+            "party",
+            new[] { Row(awarded, 3) },
+            Enumerable.Empty<ItemRosterElement>(),
+            out _,
+            out string reason);
+
+        Assert.Equal(BattleLootClaimStatus.Rejected, status);
+        Assert.Contains("not present", reason);
+    }
+
+    [Fact]
+    public void ConsumedGrant_CannotBeRestagedForTheSameMapEvent()
+    {
+        var awarded = new ItemObject("awarded");
+        var registry = new BattleLootGrantRegistry();
+        registry.Stage("controller", "hero", "party", "battle", new[] { Row(awarded, 1) });
+        Assert.Equal(
+            BattleLootClaimStatus.Accepted,
+            registry.TryBeginClaim(
+                "controller", "hero", "party",
+                new[] { Row(awarded, 1) },
+                Enumerable.Empty<ItemRosterElement>(),
+                out BattleLootClaim claim,
+                out _));
+        Assert.True(registry.Consume(claim));
+
+        registry.Stage("controller", "hero", "party", "battle", new[] { Row(awarded, 1) });
+
+        Assert.Equal(
+            BattleLootClaimStatus.NoGrant,
+            registry.TryBeginClaim(
+                "controller", "hero", "party",
+                new[] { Row(awarded, 1) },
+                Enumerable.Empty<ItemRosterElement>(),
+                out _,
+                out _));
+    }
+
+    [Fact]
+    public void ForfeitedGrant_CannotBeRestagedAndWrongIdentityCannotClaim()
+    {
+        var awarded = new ItemObject("awarded");
+        var registry = new BattleLootGrantRegistry();
+        registry.Stage("controller", "hero", "party", "battle", new[] { Row(awarded, 1) });
+
+        Assert.Equal(
+            BattleLootClaimStatus.NoGrant,
+            registry.TryBeginClaim(
+                "controller", "other-hero", "party",
+                new[] { Row(awarded, 1) },
+                Enumerable.Empty<ItemRosterElement>(),
+                out _,
+                out _));
+
+        registry.Forfeit("controller");
+        registry.Stage("controller", "hero", "party", "battle", new[] { Row(awarded, 1) });
+
+        Assert.Equal(
+            BattleLootClaimStatus.NoGrant,
+            registry.TryBeginClaim(
+                "controller", "hero", "party",
+                new[] { Row(awarded, 1) },
+                Enumerable.Empty<ItemRosterElement>(),
+                out _,
+                out _));
+    }
+
+    [Fact]
+    public void EmptyAward_DoesNotCreateAClaimableGrant()
+    {
+        var registry = new BattleLootGrantRegistry();
+        registry.Stage(
+            "controller", "hero", "party", "battle",
+            new[] { default(ItemRosterElement) });
+
+        Assert.Equal(
+            BattleLootClaimStatus.NoGrant,
+            registry.TryBeginClaim(
+                "controller", "hero", "party",
+                Enumerable.Empty<ItemRosterElement>(),
+                Enumerable.Empty<ItemRosterElement>(),
+                out _,
+                out _));
+    }
+
+    [Fact]
+    public void SameEventEmptyReplay_DoesNotDestroyPendingGrant()
+    {
+        var awarded = new ItemObject("awarded");
+        var registry = new BattleLootGrantRegistry();
+        registry.Stage("controller", "hero", "party", "battle", new[] { Row(awarded, 1) });
+
+        registry.Stage(
+            "controller", "hero", "party", "battle",
+            new[] { default(ItemRosterElement) });
+
+        Assert.Equal(
+            BattleLootClaimStatus.Accepted,
+            registry.TryBeginClaim(
+                "controller", "hero", "party",
+                new[] { Row(awarded, 1) },
+                Enumerable.Empty<ItemRosterElement>(),
+                out _,
+                out _));
+    }
+
+    private static ItemRosterElement Row(ItemObject item, int amount) =>
+        new(new EquipmentElement(item), amount);
+}

--- a/source/GameInterface.Tests/Services/MobileParties/MobilePartyBehaviorSnapshotTests.cs
+++ b/source/GameInterface.Tests/Services/MobileParties/MobilePartyBehaviorSnapshotTests.cs
@@ -491,6 +491,7 @@ public class MobilePartyBehaviorSnapshotTests
     {
         var party = ObjectHelper.SkipConstructor<MobileParty>();
         party.Ai = new MobilePartyAi(party);
+        party._position = new CampaignVec2(new Vec2(5f, 5f), isOnLand: true);
         party.PartyMoveMode = MoveModeType.Party;
         party.MoveTargetPoint = new CampaignVec2(new Vec2(10f, 20f), isOnLand: true);
         return party;

--- a/source/GameInterface.Tests/Services/Party/PlayerCaptivityReleasePositionTests.cs
+++ b/source/GameInterface.Tests/Services/Party/PlayerCaptivityReleasePositionTests.cs
@@ -2,6 +2,7 @@
 using Common.Network;
 using Common.Util;
 using GameInterface.Services.Entity;
+using GameInterface.Services.MapEvents;
 using GameInterface.Services.MapEventParties;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Party.Data;
@@ -44,7 +45,9 @@ public class PlayerCaptivityReleasePositionTests
             messageBroker.Object,
             objectManager.Object,
             network.Object,
-            troopRosterInterface.Object);
+            troopRosterInterface.Object,
+            Mock.Of<IPlayerManager>(),
+            new BattlePartyGrantRegistry(objectManager.Object));
     }
 
     [Fact]

--- a/source/GameInterface.Tests/Services/Players/PlayerPartyRestorerTests.cs
+++ b/source/GameInterface.Tests/Services/Players/PlayerPartyRestorerTests.cs
@@ -72,6 +72,38 @@ public class PlayerPartyRestorerTests
     }
 
     [Fact]
+    public void Restore_DeserializedComponentWithoutPartyBackReference_RestoresBeforeLeaderChange()
+    {
+        var (hero, party, _, _) = CreatePlayerGraph();
+        party.PartyComponent.MobileParty = null;
+        var restorer = new PlayerPartyRestorer(Mock.Of<IObjectManager>(), Mock.Of<IAutoRegistryFactory>());
+
+        restorer.Restore(hero, party);
+
+        Assert.Same(party, party.PartyComponent.MobileParty);
+        Assert.Same(hero, party.LeaderHero);
+        Assert.Same(hero, party.LordPartyComponent.Owner);
+    }
+
+    [Fact]
+    public void RestoreMemberships_DoesNotRaiseLeaderChangeBeforeCallerCommitsParty()
+    {
+        var (hero, party, clan, character) = CreatePlayerGraph();
+        var restorer = new PlayerPartyRestorer(Mock.Of<IObjectManager>(), Mock.Of<IAutoRegistryFactory>());
+
+        restorer.RestoreMemberships(hero, party);
+
+        Assert.Contains(hero, clan.Heroes);
+        Assert.Equal(1, party.MemberRoster.GetTroopCount(character));
+        Assert.Null(party.LeaderHero);
+
+        restorer.RestorePartyLeader(hero, party);
+
+        Assert.Same(hero, party.LeaderHero);
+        Assert.Same(hero, party.LordPartyComponent.Owner);
+    }
+
+    [Fact]
     public void TryRestore_StalePartyId_ReassociatesOwnedPartyWithoutReplacingHero()
     {
         var (hero, party, _, _) = CreatePlayerGraph();

--- a/source/GameInterface.Tests/Services/Time/Patches/MapCameraViewPatchesTests.cs
+++ b/source/GameInterface.Tests/Services/Time/Patches/MapCameraViewPatchesTests.cs
@@ -23,8 +23,35 @@ public class MapCameraViewPatchesTests
     }
 
     [Fact]
-    public void ShouldTickMapCamera_WhenMenuStateIsActive_ReturnsTrue()
+    public void ShouldTickMapCamera_WhenMapMenuIsActive_ReturnsFalse()
     {
-        Assert.True(MapCameraViewPatches.ShouldTickMapCamera(new InventoryState()));
+        Assert.False(MapCameraViewPatches.ShouldTickMapCamera(
+            new MapState(), isInMenu: true));
+    }
+
+    [Fact]
+    public void ShouldTickMapCamera_WhenMapConversationIsActive_ReturnsFalse()
+    {
+        Assert.False(MapCameraViewPatches.ShouldTickMapCamera(
+            new MapState(), isConversationActive: true));
+    }
+
+    [Fact]
+    public void ShouldTickMapCamera_WhenEncounterTransitionIsActive_ReturnsFalse()
+    {
+        Assert.False(MapCameraViewPatches.ShouldTickMapCamera(
+            new MapState(), isEncounterActive: true));
+    }
+
+    [Fact]
+    public void ShouldTickMapCamera_WhenMenuStateIsActive_ReturnsFalse()
+    {
+        Assert.False(MapCameraViewPatches.ShouldTickMapCamera(new InventoryState()));
+    }
+
+    [Fact]
+    public void ShouldTickMapCamera_WhenNoStateIsActive_ReturnsFalse()
+    {
+        Assert.False(MapCameraViewPatches.ShouldTickMapCamera(null));
     }
 }

--- a/source/GameInterface.Tests/Services/Transactions/ServerTransactionOutcomeTests.cs
+++ b/source/GameInterface.Tests/Services/Transactions/ServerTransactionOutcomeTests.cs
@@ -1,0 +1,71 @@
+using GameInterface.Services.Transactions;
+using LiteNetLib;
+using System;
+using Xunit;
+
+namespace GameInterface.Tests.Services.Transactions;
+
+public class ServerTransactionOutcomeTests
+{
+    [Fact]
+    public void Execute_WithoutExternalAuthorizationBridge_RunsAuthoritativeAction()
+    {
+        bool actionRan = false;
+        bool completed = false;
+        Action<NetPeer, int, bool, string> listener = (_, kind, success, reason) =>
+        {
+            Assert.Equal(ServerTransactionOutcome.Trade, kind);
+            Assert.True(success);
+            Assert.Empty(reason);
+            completed = true;
+        };
+
+        ServerTransactionOutcome.Completed += listener;
+        try
+        {
+            ServerTransactionOutcome.Execute(null, ServerTransactionOutcome.Trade, () =>
+            {
+                actionRan = true;
+                ServerTransactionOutcome.Accept(null, ServerTransactionOutcome.Trade);
+            });
+        }
+        finally
+        {
+            ServerTransactionOutcome.Completed -= listener;
+        }
+
+        Assert.True(actionRan);
+        Assert.True(completed);
+    }
+
+    [Fact]
+    public void Execute_WhenHandlerDoesNotReportResult_RejectsTransaction()
+    {
+        bool? success = null;
+        string rejection = null;
+        Action<NetPeer, int, bool, string> listener = (_, kind, accepted, reason) =>
+        {
+            if (kind != ServerTransactionOutcome.Party) return;
+            success = accepted;
+            rejection = reason;
+        };
+
+        ServerTransactionOutcome.Completed += listener;
+        try
+        {
+            ServerTransactionOutcome.Execute(
+                null,
+                ServerTransactionOutcome.Party,
+                () => { });
+        }
+        finally
+        {
+            ServerTransactionOutcome.Completed -= listener;
+        }
+
+        Assert.False(success);
+        Assert.Equal(
+            "The authoritative handler did not report a result.",
+            rejection);
+    }
+}

--- a/source/GameInterface/AutoSync/AutoSyncRegistry.cs
+++ b/source/GameInterface/AutoSync/AutoSyncRegistry.cs
@@ -19,11 +19,12 @@ public class AutoSyncRegistry
     
     public readonly List<Action<object, object>> ReadonlySetters = new List<Action<object, object>>();
 
-    public void AddField(FieldInfo field, bool debug = false, bool coalesce = false)
+    public void AddField(FieldInfo field, bool debug = false, bool coalesce = false,
+        bool skipUnregisteredReference = false)
     {
         if (field == null) throw new ArgumentNullException(nameof(field));
 
-        if (!AddMember(field.DeclaringType, field, debug, coalesce)) throw new ArgumentException($"{nameof(AutoSyncBuilder)} Field: {field.Name} has already been registered as a synced field");
+        if (!AddMember(field.DeclaringType, field, debug, coalesce, skipUnregisteredReference)) throw new ArgumentException($"{nameof(AutoSyncBuilder)} Field: {field.Name} has already been registered as a synced field");
     }
 
     public void AddProperty(PropertyInfo property, bool debug = false, bool coalesce = false)
@@ -33,7 +34,7 @@ public class AutoSyncRegistry
         // only prevent properties from being added if they are no collection like type
         if (property.CanWrite == false) throw new ArgumentException($"{nameof(AutoSyncBuilder)} Property: {property.Name} does not have a set method");
 
-        if (!AddMember(property.DeclaringType, property, debug, coalesce)) throw new ArgumentException($"{nameof(AutoSyncBuilder)} Property: {property.Name} has already been registered as a synced property");
+        if (!AddMember(property.DeclaringType, property, debug, coalesce, false)) throw new ArgumentException($"{nameof(AutoSyncBuilder)} Property: {property.Name} has already been registered as a synced property");
     }
 
     public bool AddTargetMethod(Type type, MethodInfo methodInfo, string patchCategory = null)
@@ -75,7 +76,8 @@ public class AutoSyncRegistry
         return ReadonlySetters.Count - 1;
     }
 
-    private bool AddMember(Type type, MemberInfo memberInfo, bool debug, bool coalesce)
+    private bool AddMember(Type type, MemberInfo memberInfo, bool debug, bool coalesce,
+        bool skipUnregisteredReference)
     {
         if (memberInfo is not FieldInfo && memberInfo is not PropertyInfo)
             return false;
@@ -89,7 +91,7 @@ public class AutoSyncRegistry
             if (Registrations[type].Contains(fieldInfo))
                 return false;
 
-            Registrations[type].AddField(fieldInfo, debug, coalesce);
+            Registrations[type].AddField(fieldInfo, debug, coalesce, skipUnregisteredReference);
         }
         else if (memberInfo is PropertyInfo propertyInfo)
         {

--- a/source/GameInterface/AutoSync/AutoSyncRegistryItem.cs
+++ b/source/GameInterface/AutoSync/AutoSyncRegistryItem.cs
@@ -24,9 +24,9 @@ public class AutoSyncRegistryItem
             || Properties.Contains(new Debuggable<PropertyInfo>(property, false));
     }
 
-    public void AddField(FieldInfo field, bool debug, bool coalesce)
+    public void AddField(FieldInfo field, bool debug, bool coalesce, bool skipUnregisteredReference)
     {
-        Fields.Add(new Debuggable<FieldInfo>(field, debug, coalesce));
+        Fields.Add(new Debuggable<FieldInfo>(field, debug, coalesce, skipUnregisteredReference));
     }
 
     public void AddProperty(PropertyInfo property, bool debug, bool coalesce)
@@ -64,11 +64,14 @@ public class Debuggable<T>
     public bool Debug;
     // Route this member's per-change sends through the per-tick coalescer instead of SendAll.
     public bool Coalesce;
+    // Preserve the local assignment but do not publish a reference that has no network identity.
+    public bool SkipUnregisteredReference;
 
-    public Debuggable(T value, bool debug, bool coalesce = false)
+    public Debuggable(T value, bool debug, bool coalesce = false, bool skipUnregisteredReference = false)
     {
         Value = value;
         Debug = debug;
         Coalesce = coalesce;
+        SkipUnregisteredReference = skipUnregisteredReference;
     }
 }

--- a/source/GameInterface/AutoSync/Builders/AutoSyncFieldBuilder.cs
+++ b/source/GameInterface/AutoSync/Builders/AutoSyncFieldBuilder.cs
@@ -22,7 +22,7 @@ public class AutoSyncFieldBuilder : AutoSyncBuilderBase
     {
         var fieldInfo = fieldItem.Value;
 
-        var templateData = GetTemplateData(fieldInfo, fieldItem.Debug, fieldItem.Coalesce);
+        var templateData = GetTemplateData(fieldItem);
         string localMessage = AutoSyncUtils.GetLocalSetMessage(fieldInfo);
         string networkMessage;
         if (SyncByValue(fieldInfo.FieldType))
@@ -45,15 +45,16 @@ public class AutoSyncFieldBuilder : AutoSyncBuilderBase
     {
         var fieldInfo = fieldItem.Value;
 
-        var templateData = GetTemplateData(fieldInfo, fieldItem.Debug, fieldItem.Coalesce);
+        var templateData = GetTemplateData(fieldItem);
         if (SyncByValue(fieldInfo.FieldType))
             return TemplateParser.Parse("Handlers.SubscribeSetValueTemplate", templateData);
         else
             return TemplateParser.Parse("Handlers.SubscribeSetReferenceTemplate", templateData);
     }
 
-    private object GetTemplateData(FieldInfo fieldInfo, bool debug, bool coalesce)
+    private object GetTemplateData(Debuggable<FieldInfo> fieldItem)
     {
+        var fieldInfo = fieldItem.Value;
         var serializerNames = GetSerializerMethodNames(fieldInfo.FieldType);
         return new
         {
@@ -66,8 +67,9 @@ public class AutoSyncFieldBuilder : AutoSyncBuilderBase
             DeserializeMethod = serializerNames.deserialize,
             ReadOnly = fieldInfo.IsInitOnly,
             ReadOnlySetterIndex = fieldInfo.IsInitOnly ? GetReadOnlyFieldSetter(fieldInfo) : (int?)null,
-            Debug = debug,
-            Coalesce = coalesce
+            Debug = fieldItem.Debug,
+            Coalesce = fieldItem.Coalesce,
+            SkipUnregisteredReference = fieldItem.SkipUnregisteredReference
         };
     }
 }

--- a/source/GameInterface/AutoSync/Templates/Patches/FieldSetTranspilerTemplate.txt
+++ b/source/GameInterface/AutoSync/Templates/Patches/FieldSetTranspilerTemplate.txt
@@ -59,6 +59,22 @@ public static void {{MemberName}}_Intercept({{MemberDeclaringType}} instance, {{
         return;
     }
 
+{{~ if SkipUnregisteredReference ~}}
+    // Dedicated/headless implementations can satisfy a native interface without having a client-side
+    // network identity. Keep the authoritative field assignment, but do not publish an unusable reference.
+    if (newValue != null &&
+        (!GameInterface.ContainerProvider.TryResolve<GameInterface.Services.ObjectManager.IObjectManager>(out var objectManager) ||
+         !objectManager.TryGetId(newValue, out _)))
+    {
+{{~ if ReadOnly ~}}
+	    {{MemberName}}FieldInfo.SetValue(instance, newValue);
+{{~ else ~}}
+	    instance.{{MemberName}} = newValue;
+{{~ end ~}}
+        return;
+    }
+{{~ end ~}}
+
 {{~ if Debug ~}}
     Logger.Debug("[Server] Publishing local set message for {type}", "{{MemberName}}");
 {{~ end ~}}

--- a/source/GameInterface/Configuration/ModConfigProvider.cs
+++ b/source/GameInterface/Configuration/ModConfigProvider.cs
@@ -33,7 +33,7 @@ public readonly struct ModOptions
     [ProtoMember(6)]
     public readonly bool GoldFoodInfluenceChangeForDisconnectedPlayers { get; } = false;
     [ProtoMember(7)]
-    public readonly int PlayerBattleAiJoinWindowHours { get; } = 24;
+    public readonly int PlayerBattleAiJoinWindowHours { get; } = 10;
     [ProtoMember(8)]
     public readonly bool SpeedLimitWhilePlayersInBattle { get; } = true;
     [ProtoMember(9)]
@@ -63,7 +63,12 @@ public readonly struct ModOptions
         GoldFoodInfluenceChangeInSettlements = modOptionsData.GoldFoodInfluenceChangeInSettlements ?? GoldFoodInfluenceChangeInSettlements;
         GoldFoodInfluenceChangeInBattles = modOptionsData.GoldFoodInfluenceChangeInBattles ?? GoldFoodInfluenceChangeInBattles;
         GoldFoodInfluenceChangeForDisconnectedPlayers = modOptionsData.GoldFoodInfluenceChangeForDisconnectedPlayers ?? GoldFoodInfluenceChangeForDisconnectedPlayers;
-        PlayerBattleAiJoinWindowHours = modOptionsData.PlayerBattleAiJoinWindowHours ?? PlayerBattleAiJoinWindowHours;
+        PlayerBattleAiJoinWindowHours = System.Math.Max(
+            0,
+            System.Math.Min(
+                10,
+                modOptionsData.PlayerBattleAiJoinWindowHours ??
+                PlayerBattleAiJoinWindowHours));
         SpeedLimitWhilePlayersInBattle = modOptionsData.SpeedLimitWhilePlayersInBattle ?? SpeedLimitWhilePlayersInBattle;
         WandererLimit = modOptionsData.WandererLimit ?? WandererLimit;
         WandererLimitScalesWithPlayers = modOptionsData.WandererLimitScalesWithPlayers ?? WandererLimitScalesWithPlayers;

--- a/source/GameInterface/GameInterfaceModule.cs
+++ b/source/GameInterface/GameInterfaceModule.cs
@@ -65,6 +65,8 @@ public class GameInterfaceModule : Module
         builder.RegisterType<PartyVisibilitySweep>().As<IPartyVisibilitySweep>().InstancePerDependency();
         builder.RegisterType<ConversationRestartContextTracker>().As<IConversationRestartContextTracker>().InstancePerLifetimeScope();
         builder.RegisterType<BattleHostRegistry>().As<IBattleHostRegistry>().InstancePerLifetimeScope();
+        builder.RegisterType<BattleLootGrantRegistry>().As<IBattleLootGrantRegistry>().InstancePerLifetimeScope();
+        builder.RegisterType<BattlePartyGrantRegistry>().As<IBattlePartyGrantRegistry>().InstancePerLifetimeScope();
         builder.RegisterType<BattleAgentBudget>().As<IBattleAgentBudget>().InstancePerDependency();
         builder.RegisterType<MapEventContributionBarrier>().As<IMapEventContributionBarrier>().InstancePerDependency();
         builder.RegisterType<EncounterMenuConditionRefresher>().As<IEncounterMenuConditionRefresher>().InstancePerDependency();

--- a/source/GameInterface/Services/Clans/Handlers/ClanPartiesVMHandler.cs
+++ b/source/GameInterface/Services/Clans/Handlers/ClanPartiesVMHandler.cs
@@ -4,9 +4,12 @@ using Common.Messaging;
 using Common.Network;
 using GameInterface.Services.Clans.Messages;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Players;
+using GameInterface.Services.Transactions;
 using Helpers;
 using LiteNetLib;
 using Serilog;
+using System;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.Party;
@@ -20,15 +23,18 @@ internal class ClanPartiesVMHandler : IHandler
     private readonly IMessageBroker messageBroker;
     private readonly IObjectManager objectManager;
     private readonly INetwork network;
+    private readonly IPlayerManager playerManager;
 
     public ClanPartiesVMHandler(
         IMessageBroker messageBroker,
         IObjectManager objectManager,
-        INetwork network)
+        INetwork network,
+        IPlayerManager playerManager)
     {
         this.messageBroker = messageBroker;
         this.objectManager = objectManager;
         this.network = network;
+        this.playerManager = playerManager;
 
         messageBroker.Subscribe<NewClanPartyCreated>(Handle_NewClanPartyCreated);
         messageBroker.Subscribe<CreateNewClanParty>(Handle_CreateNewClanParty);
@@ -59,21 +65,89 @@ internal class ClanPartiesVMHandler : IHandler
 
     private void Handle_CreateNewClanParty(MessagePayload<CreateNewClanParty> obj)
     {
-        if (!objectManager.TryGetObjectWithLogging<Hero>(obj.What.MainHeroId, out var mainHero)) return;
-        if (!objectManager.TryGetObjectWithLogging<Hero>(obj.What.NewLeaderId, out var newLeader)) return;
-        if (!objectManager.TryGetObjectWithLogging<Clan>(obj.What.TargetClanId, out var targetClan)) return;
-
-        GameThread.RunSafe(() =>
+        NetPeer peer = obj.Who as NetPeer;
+        GameThread.RunSafe(() => ServerTransactionOutcome.Execute(
+            peer, ServerTransactionOutcome.ClanParty, () =>
         {
-            MobileParty mobileParty = MobilePartyHelper.CreateNewClanMobileParty(newLeader, targetClan);
-            if (newLeader.Gold < obj.What.PartyGoldLowerThreshold)
+            if (!TryResolveAuthenticatedPlayer(
+                    peer,
+                    obj.What.MainHeroId,
+                    null,
+                    out Hero mainHero,
+                    out MobileParty sourceParty,
+                    out string reason) ||
+                !objectManager.TryGetObjectWithLogging(
+                    obj.What.NewLeaderId, out Hero newLeader) ||
+                !objectManager.TryGetObjectWithLogging(
+                    obj.What.TargetClanId, out Clan targetClan) ||
+                targetClan != mainHero.Clan ||
+                newLeader == mainHero ||
+                newLeader.Clan != targetClan ||
+                newLeader.PartyBelongedTo != null ||
+                newLeader.PartyBelongedToAsPrisoner != null ||
+                newLeader.IsChild ||
+                !newLeader.CanLeadParty() ||
+                !newLeader.CanBeGovernorOrHavePartyRole() ||
+                newLeader.GovernorOf != null ||
+                newLeader.HeroState != Hero.CharacterStates.Active ||
+                sourceParty.MapEvent != null ||
+                sourceParty.IsCurrentlyAtSea ||
+                sourceParty.IsInRaftState ||
+                targetClan.WarPartyComponents.Count >= targetClan.WarPartyLimit)
             {
-                GiveGoldAction.ApplyBetweenCharacters(mainHero, newLeader, obj.What.PartyGoldLowerThreshold - newLeader.Gold, false);
+                ServerTransactionOutcome.Reject(
+                    peer, ServerTransactionOutcome.ClanParty,
+                    reason ?? "The selected clan-party leader is no longer available.");
+                return;
             }
-            mobileParty.SetMoveModeHold();
 
-            network.Send(obj.Who as NetPeer, new RefreshPartiesList());
-        });
+            int mainGoldBefore = mainHero.Gold;
+            int leaderGoldBefore = newLeader.Gold;
+            int threshold = Campaign.Current.Models.ClanFinanceModel
+                .PartyGoldLowerThreshold;
+            int requiredGold = Math.Max(0, threshold - newLeader.Gold);
+            if (mainHero.Gold < requiredGold)
+            {
+                ServerTransactionOutcome.Reject(
+                    peer, ServerTransactionOutcome.ClanParty,
+                    "You no longer have enough denars to create that party.");
+                return;
+            }
+
+            MobileParty mobileParty = null;
+            try
+            {
+                mobileParty = MobilePartyHelper.CreateNewClanMobileParty(
+                    newLeader, targetClan);
+                if (mobileParty == null)
+                    throw new InvalidOperationException(
+                        "The clan party was not created.");
+
+                if (requiredGold > 0)
+                    GiveGoldAction.ApplyBetweenCharacters(
+                        mainHero, newLeader, requiredGold, false);
+                mobileParty.SetMoveModeHold();
+            }
+            catch (Exception exception)
+            {
+                Logger.Error(
+                    exception,
+                    "Rolling back failed clan-party creation for {LeaderId}",
+                    obj.What.NewLeaderId);
+                mainHero.Gold = mainGoldBefore;
+                newLeader.Gold = leaderGoldBefore;
+                if (mobileParty?.IsActive == true)
+                    DestroyPartyAction.Apply(null, mobileParty);
+                ServerTransactionOutcome.Reject(
+                    peer, ServerTransactionOutcome.ClanParty,
+                    "The clan party could not be created safely.");
+                return;
+            }
+
+            TryRefreshParties(peer);
+            ServerTransactionOutcome.Accept(
+                peer, ServerTransactionOutcome.ClanParty);
+        }));
     }
 
     private void Handle_ClanPartyLeaderChanged(MessagePayload<ClanPartyLeaderChanged> obj)
@@ -93,47 +167,153 @@ internal class ClanPartiesVMHandler : IHandler
 
     private void Handle_ChangeClanPartyLeader(MessagePayload<ChangeClanPartyLeader> obj)
     {
-        if (!objectManager.TryGetObjectWithLogging<Hero>(obj.What.MainHeroId, out var mainHero)) return;
-
-        Hero newLeader = null;
-        if (obj.What.NewLeaderId != null && !objectManager.TryGetObjectWithLogging<Hero>(obj.What.NewLeaderId, out newLeader)) return;
-
-        if (!objectManager.TryGetObjectWithLogging<Hero>(obj.What.OldLeaderId, out var oldLeader)) return;
-
-        MobileParty selectedParty = null;
-        if (obj.What.SelectedPartyId != null && !objectManager.TryGetObjectWithLogging<MobileParty>(obj.What.SelectedPartyId, out selectedParty)) return;
-        
-        if (!objectManager.TryGetObjectWithLogging<MobileParty>(obj.What.MainPartyId, out var mainParty)) return;
-
-        GameThread.RunSafe(() =>
+        NetPeer peer = obj.Who as NetPeer;
+        GameThread.RunSafe(() => ServerTransactionOutcome.Execute(
+            peer, ServerTransactionOutcome.ClanParty, () =>
         {
-            var isDisbanding = newLeader == null;
-            var existingOldLeader = selectedParty?.Party?.LeaderHero != null;
-            if (existingOldLeader)
+            if (!TryResolveAuthenticatedPlayer(
+                    peer,
+                    obj.What.MainHeroId,
+                    obj.What.MainPartyId,
+                    out Hero mainHero,
+                    out MobileParty mainParty,
+                    out string reason) ||
+                !objectManager.TryGetObjectWithLogging(
+                    obj.What.OldLeaderId, out Hero oldLeader) ||
+                string.IsNullOrEmpty(obj.What.SelectedPartyId) ||
+                !objectManager.TryGetObjectWithLogging(
+                    obj.What.SelectedPartyId,
+                    out MobileParty selectedParty) ||
+                selectedParty == mainParty ||
+                selectedParty?.IsActive != true ||
+                selectedParty.ActualClan != mainHero.Clan ||
+                selectedParty.LeaderHero != oldLeader ||
+                selectedParty.MapEvent != null ||
+                selectedParty.SiegeEvent != null ||
+                selectedParty.Army != null ||
+                selectedParty.IsCurrentlyAtSea ||
+                selectedParty.IsInRaftState)
             {
-                if (isDisbanding) // Disbanding party
+                ServerTransactionOutcome.Reject(
+                    peer, ServerTransactionOutcome.ClanParty,
+                    reason ?? "The selected clan party no longer matches the server state.");
+                return;
+            }
+
+            Hero newLeader = null;
+            if (!string.IsNullOrEmpty(obj.What.NewLeaderId) &&
+                (!objectManager.TryGetObjectWithLogging(
+                    obj.What.NewLeaderId, out newLeader) ||
+                 newLeader == mainHero ||
+                 newLeader.Clan != mainHero.Clan ||
+                 newLeader.PartyBelongedToAsPrisoner != null ||
+                 newLeader.IsChild ||
+                 !newLeader.CanLeadParty() ||
+                 !newLeader.CanBeGovernorOrHavePartyRole() ||
+                 newLeader.GovernorOf != null ||
+                 newLeader.HeroState != Hero.CharacterStates.Active ||
+                 newLeader.IsReleased ||
+                 newLeader.IsFugitive ||
+                 newLeader.IsTraveling ||
+                 newLeader.Age < Campaign.Current.Models.AgeModel
+                     .HeroComesOfAge ||
+                 newLeader.CurrentSettlement?.IsUnderSiege == true ||
+                 newLeader.CurrentSettlement?.IsUnderRaid == true ||
+                 newLeader.PartyBelongedTo?.LeaderHero == newLeader ||
+                 newLeader.PartyBelongedTo?.MapEvent != null ||
+                 newLeader.PartyBelongedTo?.IsCurrentlyAtSea == true ||
+                 newLeader.PartyBelongedTo?.IsInRaftState == true))
+            {
+                ServerTransactionOutcome.Reject(
+                    peer, ServerTransactionOutcome.ClanParty,
+                    "The new clan-party leader is no longer available.");
+                return;
+            }
+
+            var isDisbanding = newLeader == null;
+            int threshold = Campaign.Current.Models.ClanFinanceModel
+                .PartyGoldLowerThreshold;
+            int requiredGold = isDisbanding
+                ? 0
+                : Math.Max(0, threshold - newLeader.Gold);
+            if (mainHero.Gold < requiredGold)
+            {
+                ServerTransactionOutcome.Reject(
+                    peer, ServerTransactionOutcome.ClanParty,
+                    "You no longer have enough denars to change that party leader.");
+                return;
+            }
+
+            int mainGoldBefore = mainHero.Gold;
+            int newLeaderGoldBefore = newLeader?.Gold ?? 0;
+            MobileParty newLeaderSourceParty = newLeader?.PartyBelongedTo;
+            var newLeaderSourceSettlement = newLeader?.CurrentSettlement;
+            bool oldLeaderDetached = false;
+            bool oldLeaderMoved = false;
+            bool newLeaderMoved = false;
+            try
+            {
+                if (isDisbanding)
                 {
                     selectedParty.RemovePartyLeader();
+                    oldLeaderDetached = true;
                     MakeHeroFugitiveAction.Apply(oldLeader, false);
                 }
-                else // Swapping with new leader
+                else
                 {
+                    if (requiredGold > 0)
+                        GiveGoldAction.ApplyBetweenCharacters(
+                            mainHero, newLeader, requiredGold, false);
                     TeleportHeroAction.ApplyDelayedTeleportToParty(oldLeader, mainParty);
+                    oldLeaderMoved = true;
+                    TeleportHeroAction.ApplyDelayedTeleportToPartyAsPartyLeader(
+                        newLeader, selectedParty);
+                    newLeaderMoved = true;
                 }
             }
-            if (newLeader != null) // Teleport new leader to party
+            catch (Exception exception)
             {
-                TeleportHeroAction.ApplyDelayedTeleportToPartyAsPartyLeader(newLeader, selectedParty);
+                Logger.Error(
+                    exception,
+                    "Clan-party leader change failed for {PartyId}",
+                    obj.What.SelectedPartyId);
+                mainHero.Gold = mainGoldBefore;
+                if (newLeader != null)
+                    newLeader.Gold = newLeaderGoldBefore;
+                try
+                {
+                    if (newLeaderMoved)
+                    {
+                        if (newLeaderSourceParty != null)
+                            TeleportHeroAction.ApplyDelayedTeleportToParty(
+                                newLeader, newLeaderSourceParty);
+                        else if (newLeaderSourceSettlement != null)
+                            TeleportHeroAction.ApplyDelayedTeleportToSettlement(
+                                newLeader, newLeaderSourceSettlement);
+                    }
+                    if (oldLeaderMoved || oldLeaderDetached)
+                    {
+                        oldLeader.ChangeState(Hero.CharacterStates.Active);
+                        TeleportHeroAction.ApplyDelayedTeleportToPartyAsPartyLeader(
+                            oldLeader, selectedParty);
+                    }
+                }
+                catch (Exception rollbackException)
+                {
+                    Logger.Error(
+                        rollbackException,
+                        "Clan-party leader rollback failed for {PartyId}",
+                        obj.What.SelectedPartyId);
+                }
+                ServerTransactionOutcome.Reject(
+                    peer, ServerTransactionOutcome.ClanParty,
+                    "The clan-party leader could not be changed safely.");
+                return;
             }
 
-            // Sync GiveGoldAction.ApplyBetweenCharacters in ClanPartiesVM.OnChangeLeaderOver here instead to avoid patching the huge client side function
-            // GiveGoldAction.ApplyInternal blocked on the client so OnChangeLeaderOver shouldn't manage the gold change clientside
-            var partyGoldLowerThreshold = Campaign.Current.Models.ClanFinanceModel.PartyGoldLowerThreshold;
-            if (!isDisbanding && newLeader.Gold < partyGoldLowerThreshold)
-            {
-                GiveGoldAction.ApplyBetweenCharacters(mainHero, newLeader, partyGoldLowerThreshold - newLeader.Gold, false);
-            }
-        });
+            ServerTransactionOutcome.Accept(
+                peer, ServerTransactionOutcome.ClanParty);
+        }));
     }
 
     private void Handle_ClanPartyDisbanded(MessagePayload<ClanPartyDisbanded> obj)
@@ -145,13 +325,94 @@ internal class ClanPartiesVMHandler : IHandler
 
     private void Handle_DisbandClanParty(MessagePayload<DisbandClanParty> obj)
     {
-        if (!objectManager.TryGetObjectWithLogging<MobileParty>(obj.What.SelectedPartyId, out var selectedParty)) return;
-
-        GameThread.RunSafe(() =>
+        NetPeer peer = obj.Who as NetPeer;
+        GameThread.RunSafe(() => ServerTransactionOutcome.Execute(
+            peer, ServerTransactionOutcome.ClanParty, () =>
         {
-            DisbandPartyAction.StartDisband(selectedParty);
+            if (!TryResolveAuthenticatedPlayer(
+                    peer,
+                    null,
+                    null,
+                    out Hero mainHero,
+                    out MobileParty mainParty,
+                    out string reason) ||
+                !objectManager.TryGetObjectWithLogging(
+                    obj.What.SelectedPartyId,
+                    out MobileParty selectedParty) ||
+                selectedParty == mainParty ||
+                selectedParty?.IsActive != true ||
+                selectedParty.ActualClan != mainHero.Clan ||
+                selectedParty.IsMilitia ||
+                selectedParty.IsGarrison ||
+                selectedParty.IsDisbanding ||
+                selectedParty.MapEvent != null ||
+                selectedParty.SiegeEvent != null)
+            {
+                ServerTransactionOutcome.Reject(
+                    peer, ServerTransactionOutcome.ClanParty,
+                    reason ?? "The selected clan party is not yours to disband.");
+                return;
+            }
 
-            network.Send(obj.Who as NetPeer, new RefreshPartiesList());
-        });
+            try
+            {
+                DisbandPartyAction.StartDisband(selectedParty);
+            }
+            catch (Exception exception)
+            {
+                Logger.Error(
+                    exception,
+                    "Clan-party disband failed for {PartyId}",
+                    obj.What.SelectedPartyId);
+                ServerTransactionOutcome.Reject(
+                    peer, ServerTransactionOutcome.ClanParty,
+                    "The clan party could not be disbanded safely.");
+                return;
+            }
+
+            TryRefreshParties(peer);
+            ServerTransactionOutcome.Accept(
+                peer, ServerTransactionOutcome.ClanParty);
+        }));
     }
+
+    private bool TryResolveAuthenticatedPlayer(
+        NetPeer peer,
+        string requestedHeroId,
+        string requestedPartyId,
+        out Hero mainHero,
+        out MobileParty mainParty,
+        out string reason)
+    {
+        mainHero = null;
+        mainParty = null;
+        reason = "The server could not authenticate this player.";
+        if (!playerManager.TryGetPlayer(peer, out var player))
+            return false;
+        return ServerTransactionOutcome.TryResolvePlayer(
+            peer,
+            playerManager,
+            objectManager,
+            requestedHeroId ?? player.HeroId,
+            requestedPartyId ?? player.MobilePartyId,
+            out _,
+            out mainHero,
+            out mainParty,
+            out reason);
+    }
+
+    private void TryRefreshParties(NetPeer peer)
+    {
+        try
+        {
+            network.Send(peer, new RefreshPartiesList());
+        }
+        catch (Exception exception)
+        {
+            Logger.Warning(
+                exception,
+                "Clan-party action committed, but the party list could not refresh");
+        }
+    }
+
 }

--- a/source/GameInterface/Services/Clans/Patches/ClanPartyItemVMPatches.cs
+++ b/source/GameInterface/Services/Clans/Patches/ClanPartyItemVMPatches.cs
@@ -1,6 +1,12 @@
 ﻿using Common.Messaging;
 using GameInterface.Services.Clans.Messages;
 using HarmonyLib;
+using Common;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.CampaignBehaviors;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Party.PartyComponents;
 using TaleWorlds.CampaignSystem.Settlements;
@@ -12,6 +18,87 @@ namespace GameInterface.Services.Clans.Patches;
 [HarmonyPatch(typeof(ClanPartyItemVM))]
 internal class ClanPartyItemVMPatches
 {
+    private sealed class CaravanViewModels
+    {
+        internal readonly List<WeakReference<ClanPartyItemVM>> Items = new();
+    }
+
+    private static readonly ConditionalWeakTable<MobileParty, CaravanViewModels>
+        CaravanViews = new();
+
+    [HarmonyPatch(MethodType.Constructor, new Type[]
+    {
+        typeof(PartyBase),
+        typeof(Action<ClanPartyItemVM>),
+        typeof(Action),
+        typeof(Action),
+        typeof(ClanPartyItemVM.ClanPartyType),
+        typeof(IDisbandPartyCampaignBehavior),
+        typeof(ITeleportationCampaignBehavior),
+    })]
+    [HarmonyPostfix]
+    public static void ConstructorPostfix(ClanPartyItemVM __instance)
+    {
+        MobileParty party = __instance?.Party?.MobileParty;
+        if (!ModInformation.IsClient || party?.IsCaravan != true)
+            return;
+
+        CaravanViewModels views = CaravanViews.GetOrCreateValue(party);
+        lock (views.Items)
+            views.Items.Add(new WeakReference<ClanPartyItemVM>(__instance));
+        RefreshIncome(__instance, notifyParent: false);
+    }
+
+    [HarmonyPatch(nameof(ClanPartyItemVM.UpdateProperties))]
+    [HarmonyPostfix]
+    public static void UpdatePropertiesPostfix(ClanPartyItemVM __instance)
+    {
+        if (ModInformation.IsClient &&
+            __instance?.Party?.MobileParty?.IsCaravan == true)
+            RefreshIncome(__instance, notifyParent: true);
+    }
+
+    internal static void RefreshCaravanIncome(MobileParty caravan)
+    {
+        if (!ModInformation.IsClient || caravan == null ||
+            !CaravanViews.TryGetValue(caravan, out CaravanViewModels views))
+            return;
+
+        lock (views.Items)
+        {
+            for (int i = views.Items.Count - 1; i >= 0; i--)
+            {
+                if (!views.Items[i].TryGetTarget(out ClanPartyItemVM viewModel))
+                {
+                    views.Items.RemoveAt(i);
+                    continue;
+                }
+                RefreshIncome(viewModel, notifyParent: true);
+            }
+        }
+    }
+
+    private static void RefreshIncome(
+        ClanPartyItemVM viewModel,
+        bool notifyParent)
+    {
+        MobileParty caravan = viewModel?.Party?.MobileParty;
+        if (Campaign.Current?.Models?.ClanFinanceModel == null ||
+            caravan?.IsCaravan != true)
+            return;
+
+        int income = Campaign.Current.Models.ClanFinanceModel
+            .CalculateOwnerIncomeFromCaravan(caravan);
+        if (viewModel.Income == income)
+            return;
+
+        viewModel.Income = income;
+        viewModel.OnPropertyChangedWithValue(
+            income, nameof(ClanPartyItemVM.Income));
+        if (notifyParent)
+            viewModel._onExpenseChange?.Invoke();
+    }
+
     [HarmonyPatch(nameof(ClanPartyItemVM.UpdatePartyBehaviorSelectionUpdate))]
     [HarmonyPrefix]
     public static bool UpdatePartyBehaviorSelectionUpdatePrefix(ref ClanPartyItemVM __instance, SelectorVM<SelectorItemVM> s)

--- a/source/GameInterface/Services/Heroes/Interfaces/HeroInterface.cs
+++ b/source/GameInterface/Services/Heroes/Interfaces/HeroInterface.cs
@@ -17,6 +17,7 @@ using SandBox.View.Map.Managers;
 using SandBox.View.Map.Visuals;
 using Serilog;
 using System;
+using System.Threading;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.CharacterDevelopment;
@@ -32,6 +33,7 @@ public interface IHeroInterface : IGameAbstraction
     byte[] PackageMainHero();
     void SwitchToPlayer(Player player);
     Hero ServerUnpackHero(byte[] bytes);
+    void DiscardUncommittedServerHero(Hero hero);
     Hero ClientUnpackHero(byte[] bytes, Player player);
 }
 
@@ -87,8 +89,9 @@ internal class HeroInterface : IHeroInterface
     private Hero UnpackHero(byte[] bytes, Action<Hero> assignNetworkIds)
     {
         Hero hero = null;
+        Exception unpackError = null;
 
-        GameThread.Run(() => {
+        RunGameThreadWithoutAbandoning(() => {
             try
             {
                 using (new AllowedThread())
@@ -102,12 +105,127 @@ internal class HeroInterface : IHeroInterface
             }
             catch (Exception ex)
             {
-                Logger.Error(ex, "Failed to unpack hero");
+                unpackError = ex;
             }
-        },
-        blocking: true);
+        });
+
+        if (unpackError != null)
+        {
+            try
+            {
+                DiscardUncommittedServerHero(hero);
+            }
+            catch (Exception cleanupError)
+            {
+                Logger.Error(cleanupError, "Failed to roll back a partially unpacked hero");
+            }
+
+            throw new InvalidOperationException("Failed to unpack and register the player hero.", unpackError);
+        }
 
         return hero;
+    }
+
+    public void DiscardUncommittedServerHero(Hero hero)
+    {
+        if (hero == null) return;
+
+        RunGameThreadWithoutAbandoning(() =>
+        {
+            using (new AllowedThread())
+            {
+                var party = hero.PartyBelongedTo;
+                var clan = hero.Clan;
+                var character = hero.CharacterObject;
+                var campaign = Campaign.Current;
+                var campaignObjects = campaign?.CampaignObjectManager;
+
+                TryCleanup("remove party locator", () =>
+                    campaign?.MobilePartyLocator?.RemoveLocatable(party));
+                TryCleanup("remove party tracking", () =>
+                    campaign?.VisualTrackerManager?.RemoveTrackedObject(party, true));
+                TryCleanup("remove mobile party", () =>
+                    campaignObjects?.RemoveMobileParty(party));
+                TryCleanup("remove hero from clan", () =>
+                    clan?.OnLordRemoved(hero));
+                TryCleanup("remove clan", () =>
+                    campaignObjects?.RemoveClan(clan));
+                TryCleanup("remove alive hero", () =>
+                    campaignObjects?._aliveHeroes?.Remove(hero));
+                TryCleanup("remove disabled hero", () =>
+                    campaignObjects?._deadOrDisabledHeroes?.Remove(hero));
+
+                if (party != null)
+                {
+                    objectManager.Remove(party.Party?.GetPartyVisual());
+                    objectManager.Remove(party.ItemRoster);
+                    objectManager.Remove(party.Party);
+                    objectManager.Remove(party.MemberRoster);
+                    objectManager.Remove(party.PrisonRoster);
+                    objectManager.Remove(party);
+                }
+
+                objectManager.Remove(hero.HeroDeveloper);
+                objectManager.Remove(character);
+                objectManager.Remove(clan);
+                objectManager.Remove(hero);
+
+                TryCleanup("unregister character", () =>
+                {
+                    if (character?.IsRegistered == true)
+                        MBObjectManager.Instance?.UnregisterObject(character);
+                });
+            }
+        });
+    }
+
+    private static void TryCleanup(string step, Action action)
+    {
+        try
+        {
+            action();
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Failed to {Step} while rolling back an uncommitted player hero", step);
+        }
+    }
+
+    /// <summary>
+    /// Cancels a hero-unpack action only while it is still waiting in the game-thread queue. Once
+    /// native object creation has started, the caller waits for it to finish instead of timing out
+    /// and leaving an orphan hero graph to appear later.
+    /// </summary>
+    private static void RunGameThreadWithoutAbandoning(Action action)
+    {
+        using var completed = new ManualResetEventSlim(false);
+        int state = 0; // 0=pending, 1=running, 2=cancelled, 3=complete
+
+        GameThread.Run(() =>
+        {
+            if (Interlocked.CompareExchange(ref state, 1, 0) != 0)
+                return;
+
+            try
+            {
+                action();
+            }
+            finally
+            {
+                Volatile.Write(ref state, 3);
+                completed.Set();
+            }
+        });
+
+        if (completed.Wait(GameThread.BlockingTimeout)) return;
+
+        // If it has not started, cancel it so a failed join cannot create a hero later. If native
+        // creation is already running, it is safer to finish the one operation than abandon it.
+        if (Interlocked.CompareExchange(ref state, 2, 0) == 0)
+            throw new TimeoutException(
+                $"Hero unpack did not start within {GameThread.BlockingTimeout.TotalSeconds:0} seconds.");
+
+        completed.Wait();
     }
 
     public void SwitchToPlayer(Player player)

--- a/source/GameInterface/Services/Inventory/Handlers/TradeHandler.cs
+++ b/source/GameInterface/Services/Inventory/Handlers/TradeHandler.cs
@@ -6,15 +6,22 @@ using Common.Util;
 using GameInterface.Services.Inventory.Data;
 using GameInterface.Services.Inventory.Interfaces;
 using GameInterface.Services.Inventory.Messages;
+using GameInterface.Services.MapEvents;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Players;
 using GameInterface.Services.TroopRosters.Interfaces;
+using GameInterface.Services.Transactions;
+using GameInterface.Services.Workshops.Interfaces;
 using GameInterface.Services.Workshops.Messages;
 using HarmonyLib;
 using Helpers;
 using LiteNetLib;
 using Serilog;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Extensions;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Roster;
 using TaleWorlds.CampaignSystem.Settlements;
@@ -32,19 +39,28 @@ internal class TradeHandler : IHandler
     private readonly IObjectManager objectManager;
     private readonly INetwork network;
     private readonly ITroopRosterInterface troopRosterInterface;
+    private readonly IPlayerManager playerManager;
+    private readonly ISessionWorkshopPlayerDataInterface workshopPlayerData;
+    private readonly IBattleLootGrantRegistry battleLootGrants;
 
     public TradeHandler(
         IInventoryLogicInterface inventoryLogicInterface,
         IMessageBroker messageBroker,
         IObjectManager objectManager,
         INetwork network,
-        ITroopRosterInterface troopRosterInterface)
+        ITroopRosterInterface troopRosterInterface,
+        IPlayerManager playerManager,
+        ISessionWorkshopPlayerDataInterface workshopPlayerData,
+        IBattleLootGrantRegistry battleLootGrants)
     {
         this.inventoryLogicInterface = inventoryLogicInterface;
         this.messageBroker = messageBroker;
         this.objectManager = objectManager;
         this.network = network;
         this.troopRosterInterface = troopRosterInterface;
+        this.playerManager = playerManager;
+        this.workshopPlayerData = workshopPlayerData;
+        this.battleLootGrants = battleLootGrants;
 
         messageBroker.Subscribe<TradeAttempted>(Handle_TradeAttempted);
         messageBroker.Subscribe<CompleteTrade>(Handle_CompleteTrade);
@@ -89,7 +105,7 @@ internal class TradeHandler : IHandler
 
         if (what.CanGainXpFromDiscarding)
         {
-            soldItems = ResolveLeftLootIds(what.FromRoster._data);
+            soldItems = ResolveLeftLootIds(what.FromRoster.ToArray());
         }
 
         var characterIdEquipmentsData = ResolveCharacterIdEquipmentsData(what.OwnerParty, what.InitialCharacterEquipment);
@@ -100,8 +116,8 @@ internal class TradeHandler : IHandler
             fromRosterId,
             fromRosterId is null,
             toRosterId,
-            what.FromRoster._data,
-            what.ToRoster._data,
+            what.FromRoster.ToArray(),
+            what.ToRoster.ToArray(),
             characterIdEquipmentsData,
             what.IsTrading,
             what.CanGainXpFromDiscarding,
@@ -128,89 +144,928 @@ internal class TradeHandler : IHandler
         var message = payload.What;
         var peer = payload.Who as NetPeer;
 
-        GameThread.RunSafe(() =>
+        GameThread.RunSafe(() => ServerTransactionOutcome.Execute(
+            peer, ServerTransactionOutcome.Trade, () =>
         {
-            ItemRoster fromRoster = null;
-            if (!message.IsFromItemRosterNull && !objectManager.TryGetObjectWithLogging<ItemRoster>(message.FromItemRosterId, out fromRoster)) return;
+            if (!ServerTransactionOutcome.TryResolvePlayer(
+                    peer,
+                    playerManager,
+                    objectManager,
+                    message.HeroId,
+                    message.OwnerPartyId,
+                    out var player,
+                    out Hero hero,
+                    out MobileParty ownerParty,
+                    out string authenticationReason))
+            {
+                RejectTrade(peer, authenticationReason);
+                return;
+            }
 
-            if (!objectManager.TryGetObjectWithLogging<ItemRoster>(message.ToItemRosterId, out var toRoster)) return;
-            if (!objectManager.TryGetObjectWithLogging<Hero>(message.HeroId, out var hero)) return;
-            if (!objectManager.TryGetObjectWithLogging<MobileParty>(message.OwnerPartyId, out var ownerParty)) return;
-            if (!objectManager.TryGetObjectWithLogging<TroopRoster>(message.TroopRosterId, out var troopRoster)) return;
-            if (!objectManager.TryGetObjectWithLogging<Hero>(message.InitialHeroId, out var initialHero)) return;
+            ItemRoster fromRoster = null;
+            if (!message.IsFromItemRosterNull && !objectManager.TryGetObjectWithLogging<ItemRoster>(message.FromItemRosterId, out fromRoster))
+            {
+                RejectTrade(peer, "The merchant inventory is no longer available.");
+                return;
+            }
+
+            if (!objectManager.TryGetObjectWithLogging<ItemRoster>(message.ToItemRosterId, out var toRoster) ||
+                !objectManager.TryGetObjectWithLogging<TroopRoster>(message.TroopRosterId, out var troopRoster) ||
+                !objectManager.TryGetObjectWithLogging<Hero>(message.InitialHeroId, out var initialHero))
+            {
+                RejectTrade(peer, "Your trade state is no longer available.");
+                return;
+            }
+
+            if (!ReferenceEquals(toRoster, ownerParty.ItemRoster) ||
+                !ReferenceEquals(troopRoster, ownerParty.MemberRoster) ||
+                initialHero != hero &&
+                (initialHero.Clan != hero.Clan ||
+                 initialHero.PartyBelongedTo != ownerParty))
+            {
+                RejectTrade(peer, "Trade ownership did not match the connected player.");
+                return;
+            }
 
             SettlementComponent currentSettlementComponent = null;
             if (!message.IsSettlementComponentNull &&
-                !objectManager.TryGetObjectWithLogging<SettlementComponent>(message.CurrentSettlementComponentId, out currentSettlementComponent)) return;
+                !objectManager.TryGetObjectWithLogging<SettlementComponent>(message.CurrentSettlementComponentId, out currentSettlementComponent))
+            {
+                RejectTrade(peer, "The trading settlement is no longer available.");
+                return;
+            }
 
             MobileParty currentMobileParty = null;
-            if (message.CurrentMobilePartyId != null && !objectManager.TryGetObjectWithLogging<MobileParty>(message.CurrentMobilePartyId, out currentMobileParty)) return;
+            if (message.CurrentMobilePartyId != null && !objectManager.TryGetObjectWithLogging<MobileParty>(message.CurrentMobilePartyId, out currentMobileParty))
+            {
+                RejectTrade(peer, "The trading party is no longer available.");
+                return;
+            }
 
             var boughtItems = ResolveTradeItems(message.BoughtItems);
             var soldItems = ResolveTradeItems(message.SoldItems);
+            if (boughtItems.Count != (message.BoughtItems?.Length ?? 0) ||
+                soldItems.Count != (message.SoldItems?.Length ?? 0) ||
+                message.CharacterIdEquipmentsData == null)
+            {
+                RejectTrade(peer, "The submitted trade contained invalid items.");
+                return;
+            }
             ResolveCharacterEquipmentsData(message.CharacterIdEquipmentsData, out var characterEquipmentsData);
 
-            var fromItemRosterData = message.FromItemRosterData;
-            var toItemRosterData = message.ToItemRosterData;
-            var totalAmount = message.TotalAmount;
-
-            // Undo any purchases that are no longer present in the roster
-            // When looting, taken items are treated as bought items. Don't need to manage changed rosters in these cases
-            if (fromRoster != null)
+            BattleLootClaim battleLootClaim = null;
+            bool isBattleLootClaim = false;
+            if (!message.IsTrading &&
+                !message.IsManagingWarehouse &&
+                fromRoster == null &&
+                currentMobileParty == null &&
+                currentSettlementComponent == null)
             {
-                foreach (var boughtItem in boughtItems)
+                BattleLootClaimStatus claimStatus = battleLootGrants.TryBeginClaim(
+                    player.ControllerId,
+                    player.HeroId,
+                    message.OwnerPartyId,
+                    boughtItems.Select(item => item.Item1),
+                    message.FromItemRosterData,
+                    out battleLootClaim,
+                    out string claimReason);
+                if (claimStatus == BattleLootClaimStatus.Rejected)
                 {
-                    int difference = fromRoster.GetItemNumber(boughtItem.Item1.EquipmentElement.Item) - boughtItem.Item1.Amount;
+                    RejectTrade(peer, claimReason);
+                    return;
+                }
+                isBattleLootClaim = claimStatus == BattleLootClaimStatus.Accepted;
+            }
 
-                    if (difference < 0)
-                    {
-                        int fromRosterDataIndex = fromItemRosterData.FindIndex(rosterElement => rosterElement.EquipmentElement.Equals(boughtItem.Item1));
-                        if (fromRosterDataIndex >= 0) fromItemRosterData[fromRosterDataIndex].Amount -= difference;
-                        else fromItemRosterData.AddItem(new ItemRosterElement(boughtItem.Item1.EquipmentElement, -difference));
+            List<(ItemRosterElement, int)> ownedSoldItems = isBattleLootClaim
+                ? battleLootClaim.ReturnedOwnedItems
+                    .Select(item => (item, 0))
+                    .ToList()
+                : soldItems;
+            List<(ItemRosterElement, int)> postEffectSoldItems = isBattleLootClaim
+                ? battleLootClaim.DiscardedItems
+                    .Select(item => (item, 0))
+                    .ToList()
+                : soldItems;
 
-                        int toRosterDataIndex = toItemRosterData.FindIndex(rosterElement => rosterElement.EquipmentElement.Equals(boughtItem.Item1));
-                        if (toRosterDataIndex >= 0) toItemRosterData[toRosterDataIndex].Amount += difference;
-                        else toItemRosterData.AddItem(new ItemRosterElement(boughtItem.Item1.EquipmentElement, difference));
+            if (!TryValidateTrade(
+                    message,
+                    hero,
+                    ownerParty,
+                    fromRoster,
+                    toRoster,
+                    currentMobileParty,
+                    currentSettlementComponent,
+                    initialHero,
+                    characterEquipmentsData,
+                    boughtItems,
+                    ownedSoldItems,
+                    isBattleLootClaim,
+                    out int totalAmount,
+                    out int merchantGold,
+                    out List<(ItemRosterElement, int)> authoritativeBoughtItems,
+                    out List<(ItemRosterElement, int)> authoritativeSoldItems,
+                    out ItemRosterElement[] authoritativeOwnedRoster,
+                    out string validationReason))
+            {
+                battleLootGrants.Release(battleLootClaim);
+                RejectTrade(peer, validationReason);
+                return;
+            }
+            if (message.IsTrading && totalAmount > hero.Gold)
+            {
+                battleLootGrants.Release(battleLootClaim);
+                RejectTrade(peer, "You no longer have enough denars for this trade.");
+                return;
+            }
+            boughtItems = authoritativeBoughtItems;
+            soldItems = isBattleLootClaim
+                ? postEffectSoldItems
+                : authoritativeSoldItems;
 
-                        totalAmount -= boughtItem.Item2;
-                    }
+            ItemRosterElement[] fromItemRosterData = NormalizeRosterData(
+                message.FromItemRosterData);
+            ItemRosterElement[] toItemRosterData = authoritativeOwnedRoster;
+            ItemRosterElement[] toRosterBefore = toRoster?.ToArray();
+            ItemRosterElement[] fromRosterBefore = fromRoster?.ToArray();
+            Dictionary<CharacterObject, Equipment[]> equipmentBefore =
+                CloneEquipment(characterEquipmentsData.Keys);
+            int heroGoldBefore = hero.Gold;
+            int settlementGoldBefore = currentSettlementComponent?.Gold ?? 0;
+            Hero merchantHero = currentMobileParty?.Party.LeaderHero;
+            int merchantHeroGoldBefore = merchantHero?.Gold ?? 0;
+            int merchantPartyGoldBefore =
+                currentMobileParty?.PartyTradeGold ?? 0;
+            string warehouseSettlementId = null;
+            ItemRosterElement[] warehouseBefore = null;
+            if (message.IsManagingWarehouse &&
+                currentSettlementComponent?.Settlement != null &&
+                objectManager.TryGetId(
+                    currentSettlementComponent.Settlement,
+                    out warehouseSettlementId))
+            {
+                warehouseBefore = workshopPlayerData.GetWarehouseRoster(
+                    message.HeroId, warehouseSettlementId).ToArray();
+            }
+
+            try
+            {
+                if (toRoster != null)
+                    inventoryLogicInterface.UpdateRosterWithData(
+                        toRoster, toItemRosterData);
+                if (fromRoster != null && message.IsTrading)
+                {
+                    foreach (var boughtItem in boughtItems)
+                        fromRoster.AddToCounts(
+                            boughtItem.Item1.EquipmentElement,
+                            -boughtItem.Item1.Amount);
+                    foreach (var soldItem in soldItems)
+                        fromRoster.AddToCounts(
+                            soldItem.Item1.EquipmentElement,
+                            soldItem.Item1.Amount);
+                }
+                else if (fromRoster != null)
+                    inventoryLogicInterface.UpdateRosterWithData(
+                        fromRoster, fromItemRosterData);
+                else if (warehouseBefore != null)
+                    workshopPlayerData.UpdateWarehouseRoster(
+                        message.HeroId,
+                        warehouseSettlementId,
+                        fromItemRosterData);
+
+                inventoryLogicInterface.UpdateEquipmentWithData(
+                    ownerParty, characterEquipmentsData, initialHero);
+                inventoryLogicInterface.ApplyTradeGold(
+                    fromRoster,
+                    toRoster,
+                    message.IsTrading,
+                    hero,
+                    totalAmount,
+                    merchantGold,
+                    currentMobileParty,
+                    currentSettlementComponent);
+                if (!battleLootGrants.Consume(battleLootClaim))
+                    throw new InvalidOperationException(
+                        "The server battle-loot grant changed during its authoritative commit.");
+                battleLootClaim = null;
+            }
+            catch (Exception exception)
+            {
+                bool rollbackSucceeded = false;
+                try
+                {
+                    hero.Gold = heroGoldBefore;
+                    if (currentSettlementComponent != null)
+                        currentSettlementComponent.ChangeGold(
+                            settlementGoldBefore -
+                            currentSettlementComponent.Gold);
+                    if (merchantHero != null)
+                        merchantHero.Gold = merchantHeroGoldBefore;
+                    if (currentMobileParty != null)
+                        currentMobileParty.PartyTradeGold =
+                            merchantPartyGoldBefore;
+                    if (toRoster != null)
+                        inventoryLogicInterface.UpdateRosterWithData(
+                            toRoster, toRosterBefore);
+                    if (fromRoster != null)
+                        inventoryLogicInterface.UpdateRosterWithData(
+                            fromRoster, fromRosterBefore);
+                    if (warehouseBefore != null)
+                        workshopPlayerData.UpdateWarehouseRoster(
+                            message.HeroId,
+                            warehouseSettlementId,
+                            warehouseBefore);
+                    inventoryLogicInterface.UpdateEquipmentWithData(
+                        ownerParty, equipmentBefore, initialHero);
+                    rollbackSucceeded = true;
+                }
+                catch (Exception rollbackException)
+                {
+                    logger.Error(
+                        rollbackException,
+                        "Trade rollback failed for {HeroId}",
+                        message.HeroId);
+                }
+                if (rollbackSucceeded)
+                {
+                    battleLootGrants.Release(battleLootClaim);
+                }
+                else if (!battleLootGrants.Consume(battleLootClaim))
+                {
+                    logger.Error(
+                        "Failed to forfeit the battle-loot grant after an incomplete rollback for {HeroId}",
+                        message.HeroId);
+                }
+                logger.Error(
+                    exception,
+                    "Trade core commit failed for {HeroId}",
+                    message.HeroId);
+                RejectTrade(
+                    peer,
+                    "The trade could not be committed safely. Please try again.");
+                return;
+            }
+
+            TryPostTradeEffect(() => network.SendAll(
+                new UpdateEquipmentClients(
+                    message.CharacterIdEquipmentsData,
+                    message.OwnerPartyId,
+                    message.InitialHeroId)), "equipment broadcast");
+            if (warehouseBefore != null)
+                TryPostTradeEffect(() => network.Send(
+                    peer,
+                    new ManageWarehouseRoster(
+                        warehouseSettlementId,
+                        fromItemRosterData)), "warehouse broadcast");
+            TryPostTradeEffect(() => inventoryLogicInterface
+                .ApplyPostTradeEffects(
+                    message.IsTrading,
+                    message.CanGainXpFromDiscarding &&
+                        !message.IsTrading &&
+                        !message.IsManagingWarehouse &&
+                        fromRoster == null &&
+                        currentMobileParty == null &&
+                        currentSettlementComponent == null,
+                    hero,
+                    totalAmount,
+                    currentMobileParty,
+                    currentSettlementComponent,
+                    boughtItems,
+                    soldItems), "trade progression effects");
+            ServerTransactionOutcome.Accept(
+                peer, ServerTransactionOutcome.Trade);
+        }));
+    }
+
+    private bool TryValidateTrade(
+        CompleteTrade message,
+        Hero hero,
+        MobileParty ownerParty,
+        ItemRoster fromRoster,
+        ItemRoster toRoster,
+        MobileParty currentMobileParty,
+        SettlementComponent currentSettlementComponent,
+        Hero initialHero,
+        Dictionary<CharacterObject, Equipment[]> submittedEquipment,
+        List<(ItemRosterElement, int)> boughtItems,
+        List<(ItemRosterElement, int)> soldItems,
+        bool isBattleLootClaim,
+        out int totalAmount,
+        out int merchantGold,
+        out List<(ItemRosterElement, int)> authoritativeBoughtItems,
+        out List<(ItemRosterElement, int)> authoritativeSoldItems,
+        out ItemRosterElement[] authoritativeOwnedRoster,
+        out string reason)
+    {
+        totalAmount = 0;
+        merchantGold = 0;
+        authoritativeBoughtItems = boughtItems;
+        authoritativeSoldItems = soldItems;
+        authoritativeOwnedRoster = null;
+        reason = "The trade no longer matches the server state.";
+
+        if (fromRoster != null && ReferenceEquals(fromRoster, toRoster))
+        {
+            reason = "The source and destination inventory cannot be the same roster.";
+            return false;
+        }
+
+        if (boughtItems.Any(item =>
+                item.Item1.EquipmentElement.IsQuestItem) ||
+            soldItems.Any(item =>
+                item.Item1.EquipmentElement.IsQuestItem))
+        {
+            reason = "Quest items cannot be traded or moved from their inventory.";
+            return false;
+        }
+
+        if (toRoster == null || !TryBuildAuthoritativeOwnedInventory(
+                ownerParty,
+                initialHero,
+                message.ToItemRosterData,
+                submittedEquipment,
+                boughtItems,
+                soldItems,
+                out authoritativeOwnedRoster))
+        {
+            reason = "The submitted inventory did not match the transferred items.";
+            return false;
+        }
+
+        if (!message.IsTrading)
+        {
+            if (message.IsManagingWarehouse)
+            {
+                Settlement settlement = currentSettlementComponent?.Settlement;
+                if (settlement == null || ownerParty.CurrentSettlement != settlement ||
+                    !objectManager.TryGetId(settlement, out string settlementId) ||
+                    !TryValidateExternalRosterSnapshot(
+                        workshopPlayerData.GetWarehouseRoster(
+                            message.HeroId, settlementId),
+                        message.FromItemRosterData,
+                        boughtItems,
+                        soldItems))
+                {
+                    reason = "The warehouse inventory changed before the transfer completed.";
+                    return false;
                 }
             }
-
-            // Update rosters with new data
-            if (toRoster != null) inventoryLogicInterface.UpdateRosterWithData(toRoster, toItemRosterData);
-            if (fromRoster != null) inventoryLogicInterface.UpdateRosterWithData(fromRoster, fromItemRosterData);
-            else if (message.IsManagingWarehouse)
+            else if (fromRoster != null)
             {
-                // Manage warehouse rosters separately as they involve more complicated logic
-                MessageBroker.Instance.Publish(this, new WarehouseRosterManaged(payload.Who as NetPeer, hero, currentSettlementComponent.Settlement, fromItemRosterData));
+                if (!IsAuthorizedNonTradingSource(
+                        hero,
+                        ownerParty,
+                        fromRoster,
+                        currentMobileParty,
+                        currentSettlementComponent) ||
+                    !TryValidateExternalRosterSnapshot(
+                        fromRoster,
+                        message.FromItemRosterData,
+                        boughtItems,
+                        soldItems))
+                {
+                    reason = "The other inventory changed before the transfer completed.";
+                    return false;
+                }
             }
+            else if (boughtItems.Count != 0 && !isBattleLootClaim)
+            {
+                reason = "The transferred items had no authoritative source.";
+                return false;
+            }
+            return true;
+        }
 
-            // Update hero equipment with new data
-            inventoryLogicInterface.UpdateEquipmentWithData(ownerParty, characterEquipmentsData, initialHero);
-            network.SendAll(new UpdateEquipmentClients(message.CharacterIdEquipmentsData, message.OwnerPartyId, message.InitialHeroId));
+        if (fromRoster == null)
+            return false;
 
-            // Update troop roster for if items were donated
-            troopRosterInterface.UpdateWithData(troopRoster, message.TroopRosterData, hero);
+        PartyBase merchantParty;
+        IMarketData marketData;
+        TownMarketData pricingMarketData = null;
+        if (currentSettlementComponent != null)
+        {
+            Settlement settlement = currentSettlementComponent.Settlement;
+            if (settlement == null || ownerParty.CurrentSettlement != settlement ||
+                !ReferenceEquals(fromRoster, settlement.ItemRoster))
+            {
+                reason = "You are no longer trading in that settlement.";
+                return false;
+            }
+            merchantParty = currentSettlementComponent.Owner;
+            merchantGold = currentSettlementComponent.Gold;
+            marketData = settlement.IsVillage
+                ? settlement.Village?.MarketData
+                : settlement.Town?.MarketData;
+            pricingMarketData = settlement.IsVillage
+                ? null
+                : settlement.Town?.MarketData;
+        }
+        else if (currentMobileParty != null)
+        {
+            if (ReferenceEquals(currentMobileParty, ownerParty) ||
+                !ReferenceEquals(fromRoster, currentMobileParty.ItemRoster) ||
+                !IsMobilePartyInteractionAvailable(
+                    ownerParty, currentMobileParty))
+            {
+                reason = "The trading party no longer matches this interaction.";
+                return false;
+            }
+            merchantParty = currentMobileParty.Party;
+            merchantGold = currentMobileParty.PartyTradeGold;
+            Settlement nearest = SettlementHelper
+                .FindNearestTownToMobileParty(
+                    ownerParty,
+                    MobileParty.NavigationType.All)?.Settlement;
+            marketData = nearest?.Town?.MarketData;
+        }
+        else
+        {
+            reason = "The merchant is no longer available.";
+            return false;
+        }
 
-            inventoryLogicInterface.ApplyDoneLogic(
-                fromRoster,
-                toRoster,
-                message.IsTrading,
-                message.CanGainXpFromDiscarding,
-                hero,
-                totalAmount,
-                message.MerchantGold,
-                currentMobileParty,
-                currentSettlementComponent,
+        if (!TryBuildAuthoritativeTradeHistory(
+                ownerParty,
+                merchantParty,
+                marketData,
+                pricingMarketData,
+                merchantGold,
                 boughtItems,
-                soldItems
-            );
-        });
+                soldItems,
+                out totalAmount,
+                out authoritativeBoughtItems,
+                out authoritativeSoldItems,
+                out reason))
+            return false;
+
+        foreach (var bought in boughtItems
+                     .GroupBy(item => item.Item1.EquipmentElement)
+                     .Select(group => new
+                     {
+                         Element = group.Key,
+                         Amount = group.Sum(item => (long)item.Item1.Amount)
+                     }))
+        {
+            int index = fromRoster.FindIndexOfElement(
+                bought.Element);
+            if (index < 0 ||
+                bought.Amount > int.MaxValue ||
+                fromRoster.GetElementCopyAtIndex(index).Amount < bought.Amount)
+            {
+                reason = "One or more purchased items are no longer in stock.";
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsMobilePartyInteractionAvailable(
+        MobileParty ownerParty,
+        MobileParty merchantParty)
+    {
+        if (ownerParty?.IsActive != true ||
+            merchantParty?.IsActive != true ||
+            merchantParty.Party?.IsActive != true ||
+            ownerParty.MapEvent != null ||
+            merchantParty.MapEvent != null ||
+            merchantParty.IsBandit ||
+            !(merchantParty.IsLordParty ||
+              merchantParty.IsCaravan ||
+              merchantParty.IsVillager) ||
+            ownerParty.MapFaction == null ||
+            merchantParty.MapFaction == null ||
+            FactionManager.IsAtWarAgainstFaction(
+                ownerParty.MapFaction,
+                merchantParty.MapFaction))
+            return false;
+        if (ownerParty.CurrentSettlement != null &&
+            ownerParty.CurrentSettlement == merchantParty.CurrentSettlement)
+            return true;
+        if (ownerParty.Army != null && ownerParty.Army == merchantParty.Army)
+            return true;
+        if (ownerParty.CurrentSettlement != null ||
+            merchantParty.CurrentSettlement != null)
+            return false;
+
+        float radius = Campaign.Current.Models.EncounterModel
+            .GetEncounterJoiningRadius;
+        return ownerParty.Position.ToVec2().Distance(
+            merchantParty.Position.ToVec2()) <= radius;
+    }
+
+    private static bool IsAuthorizedNonTradingSource(
+        Hero hero,
+        MobileParty ownerParty,
+        ItemRoster fromRoster,
+        MobileParty currentMobileParty,
+        SettlementComponent currentSettlementComponent)
+    {
+        if (ownerParty == null || fromRoster == null)
+            return false;
+        if (ReferenceEquals(fromRoster, ownerParty.ItemRoster))
+            return true;
+
+        Settlement settlement = currentSettlementComponent?.Settlement ??
+            ownerParty.CurrentSettlement;
+        if (settlement != null && ownerParty.CurrentSettlement == settlement &&
+            settlement.OwnerClan == hero?.Clan &&
+            ReferenceEquals(fromRoster, settlement.Stash))
+            return true;
+
+        if (currentMobileParty == null ||
+            !ReferenceEquals(fromRoster, currentMobileParty.ItemRoster) ||
+            currentMobileParty.ActualClan == null ||
+            currentMobileParty.ActualClan != hero?.Clan)
+            return false;
+        if (currentMobileParty.MapEvent != null &&
+            currentMobileParty.MapEvent == ownerParty.MapEvent)
+            return true;
+        if (currentMobileParty.Army != null &&
+            currentMobileParty.Army == ownerParty.Army)
+            return true;
+
+        float radius = Campaign.Current.Models.EncounterModel
+            .GetEncounterJoiningRadius;
+        return ownerParty.Position.ToVec2().Distance(
+            currentMobileParty.Position.ToVec2()) <= radius;
+    }
+
+    private static bool TryValidateExternalRosterSnapshot(
+        IEnumerable<ItemRosterElement> currentRoster,
+        ItemRosterElement[] submittedRoster,
+        IEnumerable<(ItemRosterElement, int)> takenFromExternal,
+        IEnumerable<(ItemRosterElement, int)> givenToExternal)
+    {
+        if (currentRoster == null || submittedRoster == null)
+            return false;
+        if (submittedRoster.Any(element =>
+                element.EquipmentElement.Item == null
+                    ? element.Amount != 0
+                    : element.Amount < 0))
+            return false;
+        Dictionary<EquipmentElement, long> expected = CountOwnedItems(
+            currentRoster, Enumerable.Empty<Equipment>());
+        foreach (var item in takenFromExternal)
+            AddOwnedCount(
+                expected, item.Item1.EquipmentElement, -item.Item1.Amount);
+        foreach (var item in givenToExternal)
+            AddOwnedCount(
+                expected, item.Item1.EquipmentElement, item.Item1.Amount);
+        Dictionary<EquipmentElement, long> submitted = CountOwnedItems(
+            submittedRoster, Enumerable.Empty<Equipment>());
+        foreach (EquipmentElement empty in expected
+                     .Where(pair => pair.Value == 0)
+                     .Select(pair => pair.Key)
+                     .ToArray())
+            expected.Remove(empty);
+        return expected.Count == submitted.Count && expected.All(pair =>
+            pair.Value >= 0 && submitted.TryGetValue(pair.Key, out long value) &&
+            value == pair.Value);
+    }
+
+    private static bool TryBuildAuthoritativeTradeHistory(
+        MobileParty ownerParty,
+        PartyBase merchantParty,
+        IMarketData marketData,
+        TownMarketData pricingMarketData,
+        int merchantGold,
+        IEnumerable<(ItemRosterElement, int)> boughtItems,
+        IEnumerable<(ItemRosterElement, int)> soldItems,
+        out int totalAmount,
+        out List<(ItemRosterElement, int)> authoritativeBoughtItems,
+        out List<(ItemRosterElement, int)> authoritativeSoldItems,
+        out string reason)
+    {
+        totalAmount = 0;
+        authoritativeBoughtItems = new List<(ItemRosterElement, int)>();
+        authoritativeSoldItems = new List<(ItemRosterElement, int)>();
+        reason = "The submitted trade values were invalid.";
+        var marketState = new Dictionary<ItemCategory, ItemData>();
+        long boughtTotal = 0;
+        long soldTotal = 0;
+        foreach (var bought in boughtItems)
+        {
+            if (bought.Item1.Amount <= 0 ||
+                bought.Item1.EquipmentElement.Item == null)
+                return false;
+            if (!TryPriceTradeRow(
+                    bought.Item1,
+                    false,
+                    ownerParty,
+                    merchantParty,
+                    marketData,
+                    pricingMarketData,
+                    marketState,
+                    out int rowTotal))
+                return false;
+            boughtTotal += rowTotal;
+            authoritativeBoughtItems.Add((bought.Item1, rowTotal));
+        }
+        foreach (var sold in soldItems)
+        {
+            if (sold.Item1.Amount <= 0 ||
+                sold.Item1.EquipmentElement.Item == null)
+                return false;
+            if (!TryPriceTradeRow(
+                    sold.Item1,
+                    true,
+                    ownerParty,
+                    merchantParty,
+                    marketData,
+                    pricingMarketData,
+                    marketState,
+                    out int rowTotal))
+                return false;
+            soldTotal += rowTotal;
+            authoritativeSoldItems.Add((sold.Item1, rowTotal));
+        }
+
+        long rawTotal = boughtTotal - soldTotal;
+        long expectedTotal = rawTotal < 0
+            ? Math.Max(rawTotal, -(long)Math.Max(0, merchantGold))
+            : rawTotal;
+        if (expectedTotal < int.MinValue || expectedTotal > int.MaxValue)
+            return false;
+        totalAmount = (int)expectedTotal;
+        return true;
+    }
+
+    private static bool TryPriceTradeRow(
+        ItemRosterElement row,
+        bool isSelling,
+        MobileParty ownerParty,
+        PartyBase merchantParty,
+        IMarketData marketData,
+        TownMarketData pricingMarketData,
+        IDictionary<ItemCategory, ItemData> marketState,
+        out int rowTotal)
+    {
+        rowTotal = 0;
+        ItemObject item = row.EquipmentElement.Item;
+        ItemCategory category = item?.GetItemCategory();
+        long total = 0;
+        for (int index = 0; index < row.Amount; index++)
+        {
+            int price;
+            if (pricingMarketData != null && category != null)
+            {
+                if (!marketState.TryGetValue(category, out ItemData state))
+                    state = pricingMarketData.GetCategoryData(category);
+                price = Campaign.Current.Models.TradeItemPriceFactorModel.GetPrice(
+                    row.EquipmentElement,
+                    ownerParty,
+                    merchantParty,
+                    isSelling,
+                    state.InStoreValue,
+                    state.Supply,
+                    state.Demand);
+                long nextInStore = state.InStore + (isSelling ? 1L : -1L);
+                long nextInStoreValue = state.InStoreValue +
+                    (isSelling ? (long)item.Value : -(long)item.Value);
+                if (nextInStore < int.MinValue || nextInStore > int.MaxValue ||
+                    nextInStoreValue < int.MinValue ||
+                    nextInStoreValue > int.MaxValue)
+                    return false;
+                marketState[category] = new ItemData(
+                    state.Supply,
+                    state.Demand,
+                    (int)nextInStore,
+                    (int)nextInStoreValue);
+            }
+            else
+            {
+                price = marketData?.GetPrice(
+                    row.EquipmentElement,
+                    ownerParty,
+                    isSelling,
+                    merchantParty) ?? row.EquipmentElement.ItemValue;
+            }
+            total += Math.Max(0, price);
+            if (total > int.MaxValue)
+                return false;
+        }
+        rowTotal = (int)total;
+        return true;
+    }
+
+    private static bool TryBuildAuthoritativeOwnedInventory(
+        MobileParty ownerParty,
+        Hero initialHero,
+        ItemRosterElement[] submittedRoster,
+        Dictionary<CharacterObject, Equipment[]> submittedEquipment,
+        IEnumerable<(ItemRosterElement, int)> boughtItems,
+        IEnumerable<(ItemRosterElement, int)> soldItems,
+        out ItemRosterElement[] authoritativeRoster)
+    {
+        authoritativeRoster = null;
+        if (submittedRoster == null || submittedEquipment == null)
+            return false;
+        if (submittedRoster.Any(element =>
+                element.EquipmentElement.Item == null
+                    ? element.Amount != 0
+                    : element.Amount < 0))
+            return false;
+
+        var expectedCharacters = new HashSet<CharacterObject>();
+        foreach (TroopRosterElement element in ownerParty.MemberRoster.GetTroopRoster())
+        {
+            if (element.Character?.IsHero == true)
+                expectedCharacters.Add(element.Character);
+        }
+        if (initialHero?.CharacterObject != null)
+            expectedCharacters.Add(initialHero.CharacterObject);
+        if (submittedEquipment.Keys.Any(
+                character => !expectedCharacters.Contains(character)) ||
+            submittedEquipment.Values.Any(
+                equipments => equipments == null || equipments.Length != 3 ||
+                    equipments.Count(equipment =>
+                        equipment?._equipmentType ==
+                            Equipment.EquipmentType.Battle) != 1 ||
+                    equipments.Count(equipment =>
+                        equipment?._equipmentType ==
+                            Equipment.EquipmentType.Civilian) != 1 ||
+                    equipments.Count(equipment =>
+                        equipment?._equipmentType ==
+                            Equipment.EquipmentType.Stealth) != 1))
+            return false;
+
+        // Build the transaction on the current server state, not on the client's
+        // inventory-screen opening snapshot. Food consumption and other authoritative
+        // party updates can legitimately occur while the inventory screen is open.
+        // The submitted final equipment remains an intent; the final item roster is
+        // derived here so a stale client can neither overwrite newer state nor duplicate
+        // an item by racing an asynchronous roster update.
+        Dictionary<EquipmentElement, long> available = CountOwnedItems(
+            ownerParty.ItemRoster,
+            expectedCharacters.SelectMany(character => new[]
+            {
+                character.FirstBattleEquipment,
+                character.FirstCivilianEquipment,
+                character.FirstStealthEquipment
+            }));
+        foreach (var bought in boughtItems)
+        {
+            if (bought.Item1.EquipmentElement.Item == null ||
+                bought.Item1.Amount <= 0 ||
+                !TryAddOwnedCount(
+                    available,
+                    bought.Item1.EquipmentElement,
+                    bought.Item1.Amount))
+                return false;
+        }
+        foreach (var sold in soldItems)
+        {
+            if (sold.Item1.EquipmentElement.Item == null ||
+                sold.Item1.Amount <= 0 ||
+                !TryAddOwnedCount(
+                    available,
+                    sold.Item1.EquipmentElement,
+                    -(long)sold.Item1.Amount))
+                return false;
+        }
+
+        IEnumerable<Equipment> finalEquipment =
+            expectedCharacters.SelectMany(character =>
+                submittedEquipment.TryGetValue(
+                    character, out Equipment[] equipments)
+                    ? equipments
+                    : new[]
+                    {
+                        character.FirstBattleEquipment,
+                        character.FirstCivilianEquipment,
+                        character.FirstStealthEquipment
+                    });
+        foreach (Equipment equipment in finalEquipment)
+        {
+            if (equipment == null)
+                continue;
+            for (int index = 0; index < Equipment.EquipmentSlotLength; index++)
+            {
+                EquipmentElement element = equipment[(EquipmentIndex)index];
+                if (element.Item != null &&
+                    (!TryAddOwnedCount(available, element, -1) ||
+                     available[element] < 0))
+                    return false;
+            }
+        }
+
+        var result = new List<ItemRosterElement>();
+        foreach (KeyValuePair<EquipmentElement, long> item in available)
+        {
+            if (item.Value < 0 || item.Value > int.MaxValue)
+                return false;
+            if (item.Value > 0)
+                result.Add(new ItemRosterElement(item.Key, (int)item.Value));
+        }
+        authoritativeRoster = result.ToArray();
+        return true;
+    }
+
+    private static Dictionary<EquipmentElement, long> CountOwnedItems(
+        IEnumerable<ItemRosterElement> roster,
+        IEnumerable<Equipment> equipments)
+    {
+        var result = new Dictionary<EquipmentElement, long>();
+        foreach (ItemRosterElement element in roster ??
+                     Enumerable.Empty<ItemRosterElement>())
+        {
+            if (element.EquipmentElement.Item == null || element.Amount < 0)
+                continue;
+            AddOwnedCount(result, element.EquipmentElement, element.Amount);
+        }
+        foreach (Equipment equipment in equipments ?? Enumerable.Empty<Equipment>())
+        {
+            if (equipment == null)
+                continue;
+            for (int index = 0; index < Equipment.EquipmentSlotLength; index++)
+            {
+                EquipmentElement element = equipment[(EquipmentIndex)index];
+                if (element.Item != null)
+                    AddOwnedCount(result, element, 1);
+            }
+        }
+        foreach (EquipmentElement empty in result
+                     .Where(pair => pair.Value == 0)
+                     .Select(pair => pair.Key)
+                     .ToArray())
+            result.Remove(empty);
+        return result;
+    }
+
+    private static ItemRosterElement[] NormalizeRosterData(
+        IEnumerable<ItemRosterElement> roster)
+    {
+        return (roster ?? Enumerable.Empty<ItemRosterElement>())
+            .Where(element =>
+                element.EquipmentElement.Item != null && element.Amount > 0)
+            .ToArray();
+    }
+
+    private static void AddOwnedCount(
+        IDictionary<EquipmentElement, long> counts,
+        EquipmentElement element,
+        long change)
+    {
+        counts.TryGetValue(element, out long current);
+        counts[element] = current + change;
+    }
+
+    private static bool TryAddOwnedCount(
+        IDictionary<EquipmentElement, long> counts,
+        EquipmentElement element,
+        long change)
+    {
+        counts.TryGetValue(element, out long current);
+        try
+        {
+            counts[element] = checked(current + change);
+            return true;
+        }
+        catch (OverflowException)
+        {
+            return false;
+        }
+    }
+
+    private static void RejectTrade(NetPeer peer, string reason)
+    {
+        ServerTransactionOutcome.Reject(
+            peer, ServerTransactionOutcome.Trade, reason);
+    }
+
+    private static Dictionary<CharacterObject, Equipment[]> CloneEquipment(
+        IEnumerable<CharacterObject> characters)
+    {
+        return characters.ToDictionary(
+            character => character,
+            character => new[]
+            {
+                new Equipment(character.FirstBattleEquipment),
+                new Equipment(character.FirstCivilianEquipment),
+                new Equipment(character.FirstStealthEquipment)
+            });
+    }
+
+    private static void TryPostTradeEffect(Action action, string operation)
+    {
+        try
+        {
+            action?.Invoke();
+        }
+        catch (Exception exception)
+        {
+            logger.Error(
+                exception,
+                "Trade committed, but {Operation} failed",
+                operation);
+        }
     }
 
     private void Handle_UpdateEquipmentClients(MessagePayload<UpdateEquipmentClients> obj)
     {
+        if (ModInformation.IsServer) return;
+
         GameThread.RunSafe(() =>
         {
             using (new AllowedThread())

--- a/source/GameInterface/Services/Inventory/Interfaces/InventoryLogicInterface.cs
+++ b/source/GameInterface/Services/Inventory/Interfaces/InventoryLogicInterface.cs
@@ -22,14 +22,21 @@ namespace GameInterface.Services.Inventory.Interfaces
 {
     public interface IInventoryLogicInterface : IGameAbstraction
     {
-        void ApplyDoneLogic(
+        void ApplyTradeGold(
             ItemRoster fromRoster,
             ItemRoster toRoster,
+            bool isTrading,
+            Hero ownerHero,
+            int totalAmount,
+            int merchantGold,
+            MobileParty currentMobileParty,
+            SettlementComponent currentSettlementComponent);
+
+        void ApplyPostTradeEffects(
             bool isTrading,
             bool isDiscardDonating,
             Hero ownerHero,
             int totalAmount,
-            int merchantGold,
             MobileParty currentMobileParty,
             SettlementComponent currentSettlementComponent,
             List<(ItemRosterElement, int)> boughtItems,
@@ -55,64 +62,42 @@ namespace GameInterface.Services.Inventory.Interfaces
             this.defaultItemDiscardModelInterface = defaultItemDiscardModelInterface;
         }
 
-        public void ApplyDoneLogic(
+        public void ApplyTradeGold(
             ItemRoster fromRoster,
             ItemRoster toRoster,
+            bool isTrading,
+            Hero ownerHero,
+            int totalAmount,
+            int merchantGold,
+            MobileParty currentMobileParty,
+            SettlementComponent currentSettlementComponent)
+        {
+            if (!isTrading)
+                return;
+            PartyBase partyBase = currentMobileParty?.Party ??
+                currentSettlementComponent?.Owner;
+            if (ownerHero?.CharacterObject != null)
+                GiveGoldAction.ApplyBetweenCharacters(null, ownerHero, MathF.Min(-totalAmount, merchantGold), false);
+            if (currentSettlementComponent != null)
+                currentSettlementComponent.ChangeGold(totalAmount);
+            else if (currentMobileParty?.Party.LeaderHero != null)
+                GiveGoldAction.ApplyBetweenCharacters(null, currentMobileParty.Party.LeaderHero, totalAmount, false);
+            else if (partyBase != null)
+                GiveGoldAction.ApplyForCharacterToParty(null, partyBase, totalAmount, false);
+        }
+
+        public void ApplyPostTradeEffects(
             bool isTrading,
             bool isDiscardDonating,
             Hero ownerHero,
             int totalAmount,
-            int merchantGold,
             MobileParty currentMobileParty,
             SettlementComponent currentSettlementComponent,
             List<ValueTuple<ItemRosterElement, int>> boughtItems,
             List<ValueTuple<ItemRosterElement, int>> soldItems)
         {
-            GameThread.RunSafe(() =>
-            {
-                ApplyDoneLogicInternal(
-                        fromRoster,
-                        toRoster,
-                        isTrading,
-                        isDiscardDonating,
-                        ownerHero,
-                        totalAmount,
-                        merchantGold,
-                        currentMobileParty,
-                        currentSettlementComponent,
-                        boughtItems,
-                        soldItems);
-            });
-        }
-
-        private void ApplyDoneLogicInternal(
-            ItemRoster fromRoster,
-            ItemRoster toRoster,
-            bool isTrading, 
-            bool isDiscardDonating,
-            Hero ownerHero,
-            int totalAmount,
-            int merchantGold,
-            MobileParty currentMobileParty,
-            SettlementComponent currentSettlementComponent,
-            List<ValueTuple<ItemRosterElement, int>> boughtItems,
-            List<ValueTuple<ItemRosterElement, int>> soldItems)
-        {
-            PartyBase partyBase = null;
-            if (currentMobileParty != null)
-            {
-                partyBase = currentMobileParty.Party;
-            }
-            else if (currentSettlementComponent != null)
-            {
-                partyBase = currentSettlementComponent.Owner;
-            }
-
             if (ownerHero.CharacterObject != null && ownerHero != null && isTrading)
             {
-                // Transfers gold between player and other party (if party does not have enough gold, sends all gold)
-                // Note: Total amount = transactional debt which is negative
-                GiveGoldAction.ApplyBetweenCharacters(null, ownerHero, MathF.Min(-totalAmount, merchantGold), false);
                 if (currentSettlementComponent != null && currentSettlementComponent.IsTown && ownerHero.CharacterObject.GetPerkValue(DefaultPerks.Trade.TrickleDown))
                 {
                     int total = 0;
@@ -155,22 +140,12 @@ namespace GameInterface.Services.Inventory.Interfaces
             }
 
             sessionTradePlayerDataInterface.UpdatePlayerInventory(ownerHero, boughtItems, soldItems, isTrading);
-            if (currentSettlementComponent != null && isTrading)
+            if (currentMobileParty?.Party.LeaderHero != null && isTrading)
             {
-                // Sets the gold of the other party
-                currentSettlementComponent.ChangeGold(totalAmount);
-            }
-            else if (((currentMobileParty != null) ? currentMobileParty.Party.LeaderHero : null) != null && isTrading)
-            {
-                GiveGoldAction.ApplyBetweenCharacters(null, currentMobileParty.Party.LeaderHero, totalAmount, false);
                 if (currentMobileParty.Party.LeaderHero.CompanionOf != null)
                 {
                     currentMobileParty.AddTaxGold((int)(totalAmount * 0.1f));
                 }
-            }
-            else if (partyBase != null && partyBase.LeaderHero == null && isTrading)
-            {
-                GiveGoldAction.ApplyForCharacterToParty(null, partyBase, totalAmount, false);
             }
         }
 
@@ -186,44 +161,41 @@ namespace GameInterface.Services.Inventory.Interfaces
 
         public void UpdateEquipmentWithData(MobileParty mobileParty, Dictionary<CharacterObject, Equipment[]> characterEquipments, Hero initialHero)
         {
-            GameThread.RunSafe(() =>
+            foreach (KeyValuePair<CharacterObject, Equipment[]> characterEquipment in characterEquipments)
             {
-                foreach (KeyValuePair<CharacterObject, Equipment[]> characterEquipment in characterEquipments)
+                CharacterObject character = characterEquipment.Key;
+
+                foreach (Equipment equipment in characterEquipment.Value)
                 {
-                    CharacterObject character = characterEquipment.Key;
-
-                    foreach (Equipment equipment in characterEquipment.Value)
+                    Equipment targetEquipment = null;
+                    if (equipment._equipmentType == EquipmentType.Battle)
                     {
-                        Equipment targetEquipment = null;
-                        if (equipment._equipmentType == EquipmentType.Battle)
-                        {
-                            targetEquipment = character.FirstBattleEquipment;
-                        }
-                        else if (equipment._equipmentType == EquipmentType.Civilian)
-                        {
-                            targetEquipment = character.FirstCivilianEquipment;
-                        }
-                        else if (equipment._equipmentType == EquipmentType.Stealth)
-                        {
-                            targetEquipment = character.FirstStealthEquipment;
-                        }
+                        targetEquipment = character.FirstBattleEquipment;
+                    }
+                    else if (equipment._equipmentType == EquipmentType.Civilian)
+                    {
+                        targetEquipment = character.FirstCivilianEquipment;
+                    }
+                    else if (equipment._equipmentType == EquipmentType.Stealth)
+                    {
+                        targetEquipment = character.FirstStealthEquipment;
+                    }
 
-                        if (targetEquipment != null)
+                    if (targetEquipment != null)
+                    {
+                        for (int i = 0; i < EquipmentSlotLength; i++)
                         {
-                            for (int i = 0; i < EquipmentSlotLength; i++)
-                            {
-                                targetEquipment._itemSlots[i] = equipment._itemSlots[i];
-                            }
+                            targetEquipment._itemSlots[i] = equipment._itemSlots[i];
                         }
                     }
                 }
+            }
 
-                mobileParty.Party.SetVisualAsDirty();
-                UpdateMissionHeroVisuals(mobileParty);
+            mobileParty.Party.SetVisualAsDirty();
+            UpdateMissionHeroVisuals(mobileParty);
 
-                // When concluding an inventory screen managing a hero not in the main party, need to also update their party's visual
-                initialHero.PartyBelongedTo.Party.SetVisualAsDirty();
-            });
+            // When concluding an inventory screen managing a hero not in the main party, need to also update their party's visual
+            initialHero.PartyBelongedTo.Party.SetVisualAsDirty();
         }
 
         // Find and update all visuals of agents in a mission for managed heroes

--- a/source/GameInterface/Services/ItemRosters/Patches/ItemRosterLifetimePatches.cs
+++ b/source/GameInterface/Services/ItemRosters/Patches/ItemRosterLifetimePatches.cs
@@ -15,8 +15,20 @@ internal class PartyBasePatch
 {
     [HarmonyPatch(nameof(PartyBase.ItemRoster), MethodType.Setter)]
     [HarmonyPrefix]
+    [HarmonyPriority(Priority.First)]
     public static void ItemRosterSetterPrefix(PartyBase __instance, ItemRoster value)
     {
+        if (!ModInformation.IsClient &&
+            !CallOriginalPolicy.IsOriginalAllowed() &&
+            value != null &&
+            !ItemRosterPatch.IsRegistered(value))
+        {
+            // ItemRoster's tiny constructor can be inlined by the runtime, bypassing its lifetime patch.
+            // Assignment to a PartyBase is the reliable boundary that proves this is persistent state.
+            // Register synchronously before the generated ItemRoster reference-sync prefix resolves its id.
+            MessageBroker.Instance.Publish(null, new ItemRosterCreated(value));
+        }
+
         if (ModInformation.IsClient) return;
 
         ItemRosterLookup.Set(value, __instance);

--- a/source/GameInterface/Services/ItemRosters/Patches/ItemRosterPatch.cs
+++ b/source/GameInterface/Services/ItemRosters/Patches/ItemRosterPatch.cs
@@ -4,6 +4,7 @@ using Common.Messaging;
 using Common.Util;
 using GameInterface.Policies;
 using GameInterface.Services.ItemRosters.Messages;
+using GameInterface.Services.ObjectManager;
 using GameInterface.Services.TownMarketDatas.Patches;
 using HarmonyLib;
 using Serilog;
@@ -16,6 +17,14 @@ namespace GameInterface.Services.ItemRosters.Patches
     internal class ItemRosterPatch
     {
         private static readonly ILogger Logger = LogManager.GetLogger<ItemRosterPatch>();
+
+        // Temporary loot, workshop and calculation rosters deliberately have no network identity. Publishing
+        // their mutations can never succeed and needlessly allocates, dispatches and logs on the game thread.
+        // Persistent party/settlement/stash rosters are registered and continue through this path normally.
+        internal static bool IsRegistered(ItemRoster roster) =>
+            roster != null &&
+            ContainerProvider.TryResolve<IObjectManager>(out var objectManager) &&
+            objectManager.TryGetId(roster, out _);
 
         [HarmonyPatch(nameof(ItemRoster.AddToCounts), new[] { typeof(EquipmentElement), typeof(int) })]
         [HarmonyPrefix]
@@ -45,6 +54,8 @@ namespace GameInterface.Services.ItemRosters.Patches
 
             if (ModInformation.IsClient) return;
 
+            if (!IsRegistered(__instance)) return;
+
             var message = new ItemRosterUpdated(
                 __instance,
                 rosterElement.Item,
@@ -66,7 +77,8 @@ namespace GameInterface.Services.ItemRosters.Patches
                 return false; // Disallow on clients
             } 
 
-            MessageBroker.Instance.Publish(__instance, new ItemRosterCleared(__instance));
+            if (IsRegistered(__instance))
+                MessageBroker.Instance.Publish(__instance, new ItemRosterCleared(__instance));
 
             return true; // Allow on server
         }

--- a/source/GameInterface/Services/Locations/Conversations/Patches/LocationConversationPatches.cs
+++ b/source/GameInterface/Services/Locations/Conversations/Patches/LocationConversationPatches.cs
@@ -5,7 +5,9 @@ using GameInterface.Services.Locations.Messages.Conversation;
 using HarmonyLib;
 using SandBox.Conversation.MissionLogics;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Conversation;
 using TaleWorlds.MountAndBlade;
+using System;
 
 namespace GameInterface.Services.Locations.Conversations.Patches;
 
@@ -97,10 +99,39 @@ internal static class LocationConversationPatches
     [HarmonyPostfix]
     static void OnConversationEndPostfix()
     {
+        ReleaseHeldConversation();
+    }
+
+    [HarmonyPatch(typeof(ConversationManager), nameof(ConversationManager.EndConversation))]
+    [HarmonyFinalizer]
+    static Exception ConversationManagerEndConversationFinalizer(Exception __exception)
+    {
+        // This is the canonical lower-level lifecycle boundary. MissionConversationLogic subscribes
+        // its own end callback only after conversation setup, so a conversation that ends during setup
+        // (or a close-window path that bypasses that callback) could otherwise reserve the NPC forever.
+        // A finalizer also runs when native conversation teardown throws. Preserve that exception after
+        // making the best-effort release attempt.
+        ReleaseHeldConversation();
+        return __exception;
+    }
+
+    private static void ReleaseHeldConversation()
+    {
         if (heldNpcKey == null) return;
 
-        heldNpcKey = null;
-        MessageBroker.Instance.Publish(null, new LocationConversationEnded());
+        try
+        {
+            // Keep the local marker until publish completes. If the synchronous broker/send path throws,
+            // the mission-end/next-mission lifecycle gets another chance instead of forgetting a server
+            // reservation that may still be live. Duplicate successful releases are server-idempotent.
+            MessageBroker.Instance.Publish(null, new LocationConversationEnded());
+            heldNpcKey = null;
+        }
+        catch
+        {
+            // Release is cleanup and must never replace the native conversation exception or abort mission
+            // teardown. Retaining heldNpcKey deliberately schedules a later lifecycle retry.
+        }
     }
 
     [HarmonyPatch(typeof(MissionConversationLogic), "OnBehaviorInitialize")]
@@ -128,9 +159,16 @@ internal static class LocationConversationPatches
     {
         if (!pending.HasValue && heldNpcKey == null) return;
 
-        pending = null;
-        heldNpcKey = null;
-        MessageBroker.Instance.Publish(null, new LocationConversationEnded());
+        try
+        {
+            MessageBroker.Instance.Publish(null, new LocationConversationEnded());
+            pending = null;
+            heldNpcKey = null;
+        }
+        catch
+        {
+            // Retain both markers so OnEndMission/OnBehaviorInitialize can retry the release.
+        }
     }
 
     /// <summary>
@@ -144,6 +182,10 @@ internal static class LocationConversationPatches
         var p = pending.Value;
         pending = null;
 
+        // The server has already granted and reserved this NPC. Record the hold before any local validation
+        // or setup so every abandoned/throwing approval has durable release state.
+        heldNpcKey = LocationConversationTracker.ComposeKey(p.LocationId, p.CharacterId);
+
         // MissionConversationLogic.Current dereferences Mission.Current; the player may have left the scene
         // before the approval arrived. Release the lock and bail rather than crash.
         var logic = Mission.Current != null ? MissionConversationLogic.Current : null;
@@ -152,21 +194,19 @@ internal static class LocationConversationPatches
         if (logic == null || conversationManager == null || conversationManager.IsConversationInProgress
             || p.Agent == null || !p.Agent.IsActive())
         {
-            MessageBroker.Instance.Publish(null, new LocationConversationEnded());
+            ReleaseHeldConversation();
             return;
         }
 
         // Hold before starting so a conversation that ends synchronously still releases. If the start throws
         // the conversation never opened (no end callback), so release here and clear the hold.
-        heldNpcKey = LocationConversationTracker.ComposeKey(p.LocationId, p.CharacterId);
         try
         {
             logic.StartConversation(p.Agent, setActionsInstantly: false);
         }
         catch
         {
-            heldNpcKey = null;
-            MessageBroker.Instance.Publish(null, new LocationConversationEnded());
+            ReleaseHeldConversation();
             throw;
         }
     }

--- a/source/GameInterface/Services/Locations/SettlementPopulationTracker.cs
+++ b/source/GameInterface/Services/Locations/SettlementPopulationTracker.cs
@@ -83,6 +83,15 @@ internal class SettlementPopulationTracker : IHandler
 
             if (party.IsPlayerParty())
             {
+                var alreadyTrackedHere =
+                    playerPartySettlements.TryGetValue(partyId, out var previousSettlementId) &&
+                    previousSettlementId == settlementId;
+
+                if (!alreadyTrackedHere && previousSettlementId != null)
+                {
+                    RemoveCompanionEntries(partyId);
+                }
+
                 playerPartySettlements[partyId] = settlementId;
 
                 if (populatedSettlements.ContainsKey(settlement.StringId) == false)
@@ -91,7 +100,13 @@ internal class SettlementPopulationTracker : IHandler
                     PopulateSettlement(settlement);
                 }
 
-                AddCompanionEntries(partyId, party, settlement);
+                // Campaign-entry recovery can report a party that was already
+                // tracked here before a disconnect. Do not add its companions a
+                // second time; the authoritative snapshot below restores the client.
+                if (!alreadyTrackedHere)
+                {
+                    AddCompanionEntries(partyId, party, settlement);
+                }
                 BroadcastRosterSnapshot(settlement, settlementId);
             }
             else if (HasPlayerVisitors(settlementId) && party.LeaderHero != null)

--- a/source/GameInterface/Services/MapEvents/BattleLootGrantRegistry.cs
+++ b/source/GameInterface/Services/MapEvents/BattleLootGrantRegistry.cs
@@ -1,0 +1,395 @@
+using System;
+using System.Collections.Generic;
+using Common.Logging;
+using Serilog;
+using TaleWorlds.Core;
+
+namespace GameInterface.Services.MapEvents;
+
+internal enum BattleLootClaimStatus
+{
+    NoGrant,
+    Accepted,
+    Rejected
+}
+
+internal sealed class BattleLootClaim
+{
+    internal readonly string ControllerId;
+    internal readonly long Generation;
+    internal readonly long Token;
+    internal readonly ItemRosterElement[] DiscardedItems;
+    internal readonly ItemRosterElement[] ReturnedOwnedItems;
+
+    internal BattleLootClaim(
+        string controllerId,
+        long generation,
+        long token,
+        ItemRosterElement[] discardedItems,
+        ItemRosterElement[] returnedOwnedItems)
+    {
+        ControllerId = controllerId;
+        Generation = generation;
+        Token = token;
+        DiscardedItems = discardedItems;
+        ReturnedOwnedItems = returnedOwnedItems;
+    }
+}
+
+internal interface IBattleLootGrantRegistry
+{
+    void Stage(
+        string controllerId,
+        string ownerHeroId,
+        string ownerPartyId,
+        string mapEventId,
+        IEnumerable<ItemRosterElement> items);
+
+    void Forfeit(string controllerId);
+
+    BattleLootClaimStatus TryBeginClaim(
+        string controllerId,
+        string ownerHeroId,
+        string ownerPartyId,
+        IEnumerable<ItemRosterElement> requestedItems,
+        IEnumerable<ItemRosterElement> remainingItems,
+        out BattleLootClaim claim,
+        out string reason);
+
+    bool Consume(BattleLootClaim claim);
+
+    void Release(BattleLootClaim claim);
+}
+
+/// <summary>
+/// Session-scoped authority for the temporary item roster shown after a battle. The loot roster has no
+/// object-manager id, so the normal external-roster trade validation cannot authenticate it. This registry
+/// captures the server-authored award before it is sent to the winning client and permits one atomic claim
+/// containing only a subset of that exact award.
+/// </summary>
+internal sealed class BattleLootGrantRegistry : IBattleLootGrantRegistry
+{
+    private const int TombstoneLimitPerController = 64;
+    private static readonly ILogger Logger = LogManager.GetLogger<BattleLootGrantRegistry>();
+
+    private sealed class Grant
+    {
+        internal readonly string OwnerHeroId;
+        internal readonly string OwnerPartyId;
+        internal readonly string MapEventId;
+        internal readonly long Generation;
+        internal readonly Dictionary<EquipmentElement, long> Items;
+        internal long ActiveToken;
+
+        internal Grant(
+            string ownerHeroId,
+            string ownerPartyId,
+            string mapEventId,
+            long generation,
+            Dictionary<EquipmentElement, long> items)
+        {
+            OwnerHeroId = ownerHeroId;
+            OwnerPartyId = ownerPartyId;
+            MapEventId = mapEventId;
+            Generation = generation;
+            Items = items;
+        }
+    }
+
+    private sealed class Tombstones
+    {
+        internal readonly Queue<string> Order = new();
+        internal readonly HashSet<string> MapEventIds = new(StringComparer.Ordinal);
+    }
+
+    private readonly object gate = new();
+    private readonly Dictionary<string, Grant> grants = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Tombstones> tombstones = new(StringComparer.Ordinal);
+    private long nextGeneration;
+    private long nextToken;
+
+    public void Stage(
+        string controllerId,
+        string ownerHeroId,
+        string ownerPartyId,
+        string mapEventId,
+        IEnumerable<ItemRosterElement> items)
+    {
+        if (string.IsNullOrEmpty(controllerId) ||
+            string.IsNullOrEmpty(ownerHeroId) ||
+            string.IsNullOrEmpty(ownerPartyId) ||
+            string.IsNullOrEmpty(mapEventId))
+        {
+            return;
+        }
+
+        lock (gate)
+        {
+            if (IsSettledLocked(controllerId, mapEventId))
+                return;
+
+            if (grants.TryGetValue(controllerId, out Grant existing))
+            {
+                if (string.Equals(existing.MapEventId, mapEventId, StringComparison.Ordinal))
+                {
+                    // Result publication can be retried. Preserve the first immutable grant instead of
+                    // refreshing it or replacing an in-flight claim.
+                    return;
+                }
+            }
+
+            Dictionary<EquipmentElement, long> counts = CountItems(items, out bool valid);
+            if (!valid || counts.Count == 0)
+            {
+                ForfeitLocked(controllerId);
+                RememberSettledLocked(controllerId, mapEventId);
+                return;
+            }
+
+            if (existing != null)
+            {
+                Logger.Warning(
+                    "Forfeiting unclaimed battle loot for controller {ControllerId}, map event {OldMapEventId}, " +
+                    "because a newer grant for {NewMapEventId} arrived",
+                    controllerId,
+                    existing.MapEventId,
+                    mapEventId);
+                ForfeitLocked(controllerId);
+            }
+
+            grants[controllerId] = new Grant(
+                ownerHeroId,
+                ownerPartyId,
+                mapEventId,
+                ++nextGeneration,
+                counts);
+        }
+    }
+
+    public void Forfeit(string controllerId)
+    {
+        if (string.IsNullOrEmpty(controllerId))
+            return;
+
+        lock (gate)
+            ForfeitLocked(controllerId);
+    }
+
+    public BattleLootClaimStatus TryBeginClaim(
+        string controllerId,
+        string ownerHeroId,
+        string ownerPartyId,
+        IEnumerable<ItemRosterElement> requestedItems,
+        IEnumerable<ItemRosterElement> remainingItems,
+        out BattleLootClaim claim,
+        out string reason)
+    {
+        claim = null;
+        reason = null;
+
+        lock (gate)
+        {
+            if (string.IsNullOrEmpty(controllerId) ||
+                !grants.TryGetValue(controllerId, out Grant grant) ||
+                !string.Equals(grant.OwnerHeroId, ownerHeroId, StringComparison.Ordinal) ||
+                !string.Equals(grant.OwnerPartyId, ownerPartyId, StringComparison.Ordinal))
+            {
+                return BattleLootClaimStatus.NoGrant;
+            }
+
+            if (grant.ActiveToken != 0)
+            {
+                reason = "Your previous battle-loot claim is still being processed.";
+                return BattleLootClaimStatus.Rejected;
+            }
+
+            Dictionary<EquipmentElement, long> requested =
+                CountItems(requestedItems, out bool valid);
+            if (!valid)
+            {
+                reason = "The submitted battle loot contained invalid item counts.";
+                return BattleLootClaimStatus.Rejected;
+            }
+
+            // The left-hand loot roster is a temporary client-only InventoryLogic roster.
+            // Bannerlord can rebuild or dispose it before DoneLogic is serialized, so it is
+            // not an authoritative snapshot of the award. Parse it only to reject malformed
+            // state; ownership is proven by the immutable server grant and the requested
+            // bought-item subset below.
+            CountItems(remainingItems, out valid);
+            if (!valid)
+            {
+                reason = "The submitted battle-loot roster contained invalid item counts.";
+                return BattleLootClaimStatus.Rejected;
+            }
+
+            foreach (KeyValuePair<EquipmentElement, long> item in requested)
+            {
+                if (!grant.Items.TryGetValue(item.Key, out long available) ||
+                    item.Value > available)
+                {
+                    reason = "The selected items were not present in your server-awarded battle loot.";
+                    return BattleLootClaimStatus.Rejected;
+                }
+            }
+
+            var discardedAward = new Dictionary<EquipmentElement, long>();
+            foreach (KeyValuePair<EquipmentElement, long> item in grant.Items)
+            {
+                requested.TryGetValue(item.Key, out long taken);
+                long notTaken = item.Value - taken;
+                if (notTaken > 0)
+                    discardedAward[item.Key] = notTaken;
+            }
+
+            if (!TryCreateRosterElements(
+                    discardedAward, out ItemRosterElement[] discarded))
+            {
+                reason = "The submitted battle-loot roster was too large to validate safely.";
+                return BattleLootClaimStatus.Rejected;
+            }
+
+            long token = ++nextToken;
+            grant.ActiveToken = token;
+            claim = new BattleLootClaim(
+                controllerId,
+                grant.Generation,
+                token,
+                discarded,
+                Array.Empty<ItemRosterElement>());
+            return BattleLootClaimStatus.Accepted;
+        }
+    }
+
+    public bool Consume(BattleLootClaim claim)
+    {
+        if (claim == null)
+            return true;
+
+        lock (gate)
+        {
+            if (!TryGetMatchingGrant(claim, out _))
+                return false;
+
+            Grant grant = grants[claim.ControllerId];
+            RememberSettledLocked(claim.ControllerId, grant.MapEventId);
+            grants.Remove(claim.ControllerId);
+            return true;
+        }
+    }
+
+    public void Release(BattleLootClaim claim)
+    {
+        if (claim == null)
+            return;
+
+        lock (gate)
+        {
+            if (TryGetMatchingGrant(claim, out Grant grant))
+                grant.ActiveToken = 0;
+        }
+    }
+
+    private bool TryGetMatchingGrant(BattleLootClaim claim, out Grant grant)
+    {
+        return grants.TryGetValue(claim.ControllerId, out grant) &&
+            grant.Generation == claim.Generation &&
+            grant.ActiveToken == claim.Token;
+    }
+
+    private void ForfeitLocked(string controllerId)
+    {
+        if (!grants.TryGetValue(controllerId, out Grant grant))
+            return;
+
+        RememberSettledLocked(controllerId, grant.MapEventId);
+        grants.Remove(controllerId);
+    }
+
+    private bool IsSettledLocked(string controllerId, string mapEventId) =>
+        tombstones.TryGetValue(controllerId, out Tombstones settled) &&
+        settled.MapEventIds.Contains(mapEventId);
+
+    private void RememberSettledLocked(string controllerId, string mapEventId)
+    {
+        if (string.IsNullOrEmpty(controllerId) || string.IsNullOrEmpty(mapEventId))
+            return;
+
+        if (!tombstones.TryGetValue(controllerId, out Tombstones settled))
+        {
+            settled = new Tombstones();
+            tombstones.Add(controllerId, settled);
+        }
+
+        if (!settled.MapEventIds.Add(mapEventId))
+            return;
+
+        settled.Order.Enqueue(mapEventId);
+        while (settled.Order.Count > TombstoneLimitPerController)
+            settled.MapEventIds.Remove(settled.Order.Dequeue());
+    }
+
+    private static Dictionary<EquipmentElement, long> CountItems(
+        IEnumerable<ItemRosterElement> items,
+        out bool valid)
+    {
+        valid = true;
+        var result = new Dictionary<EquipmentElement, long>();
+        if (items == null)
+            return result;
+
+        foreach (ItemRosterElement item in items)
+        {
+            if (item.EquipmentElement.Item == null)
+            {
+                // ItemRoster._data may contain default backing-capacity rows. They carry no state and
+                // must not invalidate an otherwise authoritative snapshot.
+                if (item.Amount == 0)
+                    continue;
+
+                valid = false;
+                return result;
+            }
+            if (item.Amount <= 0)
+            {
+                valid = false;
+                return result;
+            }
+
+            result.TryGetValue(item.EquipmentElement, out long current);
+            long next;
+            try
+            {
+                next = checked(current + item.Amount);
+            }
+            catch (OverflowException)
+            {
+                valid = false;
+                return result;
+            }
+            result[item.EquipmentElement] = next;
+        }
+
+        return result;
+    }
+
+    private static bool TryCreateRosterElements(
+        IEnumerable<KeyValuePair<EquipmentElement, long>> counts,
+        out ItemRosterElement[] elements)
+    {
+        var result = new List<ItemRosterElement>();
+        foreach (KeyValuePair<EquipmentElement, long> item in counts)
+        {
+            if (item.Value <= 0 || item.Value > int.MaxValue)
+            {
+                elements = null;
+                return false;
+            }
+            result.Add(new ItemRosterElement(
+                item.Key,
+                (int)item.Value));
+        }
+        elements = result.ToArray();
+        return true;
+    }
+}

--- a/source/GameInterface/Services/MapEvents/BattlePartyGrantRegistry.cs
+++ b/source/GameInterface/Services/MapEvents/BattlePartyGrantRegistry.cs
@@ -1,0 +1,402 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Common.Logging;
+using GameInterface.Services.ObjectManager;
+using GameInterface.Services.TroopRosters.Data;
+using Serilog;
+using TaleWorlds.CampaignSystem;
+
+namespace GameInterface.Services.MapEvents;
+
+internal enum BattlePartyClaimStatus
+{
+    NoGrant,
+    Accepted,
+    Rejected
+}
+
+internal sealed class BattlePartyClaim
+{
+    internal readonly string ControllerId;
+    internal readonly long Generation;
+    internal readonly TroopRosterData MemberSourceDelta;
+    internal readonly TroopRosterData PrisonerSourceDelta;
+    internal long Token;
+
+    internal BattlePartyClaim(
+        string controllerId,
+        long generation,
+        TroopRosterData memberSourceDelta,
+        TroopRosterData prisonerSourceDelta)
+    {
+        ControllerId = controllerId;
+        Generation = generation;
+        MemberSourceDelta = memberSourceDelta;
+        PrisonerSourceDelta = prisonerSourceDelta;
+    }
+}
+
+internal interface IBattlePartyGrantRegistry
+{
+    void Stage(
+        string controllerId,
+        string ownerHeroId,
+        string ownerPartyId,
+        string mapEventId,
+        TroopRosterData awardedMembers,
+        TroopRosterData awardedPrisoners);
+
+    void Forfeit(string controllerId);
+
+    BattlePartyClaimStatus TryPrepareClaim(
+        string controllerId,
+        string ownerHeroId,
+        string ownerPartyId,
+        TroopRosterData memberSourceDelta,
+        TroopRosterData prisonerSourceDelta,
+        out BattlePartyClaim claim,
+        out string reason);
+
+    bool TryActivate(BattlePartyClaim claim);
+    bool Consume(BattlePartyClaim claim);
+    void Release(BattlePartyClaim claim);
+}
+
+/// <summary>
+/// Session-scoped authority for the ownerless temporary member/prisoner rosters shown after a
+/// battle. The client sends only their deltas when it closes that party screen, so the normal
+/// PartyBase ownership checks cannot authenticate the source. This registry binds those deltas
+/// to the exact server-authored award and permits one reversible commit.
+/// </summary>
+internal sealed class BattlePartyGrantRegistry : IBattlePartyGrantRegistry
+{
+    private const int TombstoneLimitPerController = 64;
+    private static readonly ILogger Logger =
+        LogManager.GetLogger<BattlePartyGrantRegistry>();
+
+    private readonly struct Award
+    {
+        internal readonly int Number;
+        internal readonly int Wounded;
+        internal readonly int Xp;
+
+        internal Award(int number, int wounded, int xp)
+        {
+            Number = number;
+            Wounded = wounded;
+            Xp = xp;
+        }
+    }
+
+    private sealed class Grant
+    {
+        internal readonly string OwnerHeroId;
+        internal readonly string OwnerPartyId;
+        internal readonly string MapEventId;
+        internal readonly long Generation;
+        internal readonly Dictionary<string, Award> Members;
+        internal readonly Dictionary<string, Award> Prisoners;
+        internal long ActiveToken;
+
+        internal Grant(
+            string ownerHeroId,
+            string ownerPartyId,
+            string mapEventId,
+            long generation,
+            Dictionary<string, Award> members,
+            Dictionary<string, Award> prisoners)
+        {
+            OwnerHeroId = ownerHeroId;
+            OwnerPartyId = ownerPartyId;
+            MapEventId = mapEventId;
+            Generation = generation;
+            Members = members;
+            Prisoners = prisoners;
+        }
+    }
+
+    private sealed class Tombstones
+    {
+        internal readonly Queue<string> Order = new();
+        internal readonly HashSet<string> MapEventIds =
+            new(StringComparer.Ordinal);
+    }
+
+    private readonly object gate = new();
+    private readonly Dictionary<string, Grant> grants =
+        new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Tombstones> tombstones =
+        new(StringComparer.Ordinal);
+    private readonly IObjectManager objectManager;
+    private long nextGeneration;
+    private long nextToken;
+
+    public BattlePartyGrantRegistry(IObjectManager objectManager)
+    {
+        this.objectManager = objectManager;
+    }
+
+    public void Stage(
+        string controllerId,
+        string ownerHeroId,
+        string ownerPartyId,
+        string mapEventId,
+        TroopRosterData awardedMembers,
+        TroopRosterData awardedPrisoners)
+    {
+        if (string.IsNullOrEmpty(controllerId) ||
+            string.IsNullOrEmpty(ownerHeroId) ||
+            string.IsNullOrEmpty(ownerPartyId) ||
+            string.IsNullOrEmpty(mapEventId))
+            return;
+
+        lock (gate)
+        {
+            if (IsSettledLocked(controllerId, mapEventId))
+                return;
+            if (grants.TryGetValue(controllerId, out Grant existing) &&
+                string.Equals(
+                    existing.MapEventId, mapEventId, StringComparison.Ordinal))
+                return;
+
+            Dictionary<string, Award> members =
+                ReadAward(awardedMembers, out bool valid);
+            Dictionary<string, Award> prisoners =
+                ReadAward(awardedPrisoners, out bool prisonersValid);
+            if (!valid || !prisonersValid ||
+                members.Count == 0 && prisoners.Count == 0)
+            {
+                ForfeitLocked(controllerId);
+                RememberSettledLocked(controllerId, mapEventId);
+                return;
+            }
+
+            if (existing != null)
+            {
+                Logger.Warning(
+                    "Forfeiting unclaimed battle party award for controller {ControllerId}, " +
+                    "map event {OldMapEventId}, because {NewMapEventId} arrived",
+                    controllerId,
+                    existing.MapEventId,
+                    mapEventId);
+                ForfeitLocked(controllerId);
+            }
+
+            grants[controllerId] = new Grant(
+                ownerHeroId,
+                ownerPartyId,
+                mapEventId,
+                ++nextGeneration,
+                members,
+                prisoners);
+        }
+    }
+
+    public void Forfeit(string controllerId)
+    {
+        if (string.IsNullOrEmpty(controllerId))
+            return;
+        lock (gate)
+            ForfeitLocked(controllerId);
+    }
+
+    public BattlePartyClaimStatus TryPrepareClaim(
+        string controllerId,
+        string ownerHeroId,
+        string ownerPartyId,
+        TroopRosterData memberSourceDelta,
+        TroopRosterData prisonerSourceDelta,
+        out BattlePartyClaim claim,
+        out string reason)
+    {
+        claim = null;
+        reason = null;
+        lock (gate)
+        {
+            if (string.IsNullOrEmpty(controllerId) ||
+                !grants.TryGetValue(controllerId, out Grant grant) ||
+                !string.Equals(
+                    grant.OwnerHeroId, ownerHeroId, StringComparison.Ordinal) ||
+                !string.Equals(
+                    grant.OwnerPartyId, ownerPartyId, StringComparison.Ordinal))
+                return BattlePartyClaimStatus.NoGrant;
+            if (grant.ActiveToken != 0)
+            {
+                reason = "Your previous post-battle party claim is still being processed.";
+                return BattlePartyClaimStatus.Rejected;
+            }
+            if (!ValidateRemovalDelta(
+                    grant.Members, memberSourceDelta, out reason) ||
+                !ValidateRemovalDelta(
+                    grant.Prisoners, prisonerSourceDelta, out reason))
+                return BattlePartyClaimStatus.Rejected;
+
+            claim = new BattlePartyClaim(
+                controllerId,
+                grant.Generation,
+                NormalizeDelta(memberSourceDelta),
+                NormalizeDelta(prisonerSourceDelta));
+            return BattlePartyClaimStatus.Accepted;
+        }
+    }
+
+    public bool TryActivate(BattlePartyClaim claim)
+    {
+        if (claim == null)
+            return true;
+        lock (gate)
+        {
+            if (!grants.TryGetValue(claim.ControllerId, out Grant grant) ||
+                grant.Generation != claim.Generation ||
+                grant.ActiveToken != 0)
+                return false;
+            claim.Token = ++nextToken;
+            grant.ActiveToken = claim.Token;
+            return true;
+        }
+    }
+
+    public bool Consume(BattlePartyClaim claim)
+    {
+        if (claim == null)
+            return true;
+        lock (gate)
+        {
+            if (!TryGetMatchingGrant(claim, out Grant grant))
+                return false;
+            RememberSettledLocked(claim.ControllerId, grant.MapEventId);
+            grants.Remove(claim.ControllerId);
+            return true;
+        }
+    }
+
+    public void Release(BattlePartyClaim claim)
+    {
+        if (claim == null || claim.Token == 0)
+            return;
+        lock (gate)
+        {
+            if (TryGetMatchingGrant(claim, out Grant grant))
+                grant.ActiveToken = 0;
+            claim.Token = 0;
+        }
+    }
+
+    private bool TryGetMatchingGrant(BattlePartyClaim claim, out Grant grant) =>
+        grants.TryGetValue(claim.ControllerId, out grant) &&
+        grant.Generation == claim.Generation &&
+        grant.ActiveToken == claim.Token && claim.Token != 0;
+
+    private Dictionary<string, Award> ReadAward(
+        TroopRosterData data,
+        out bool valid)
+    {
+        valid = true;
+        var result = new Dictionary<string, Award>(StringComparer.Ordinal);
+        foreach (TroopRosterElementData element in
+                 data.Data ?? Array.Empty<TroopRosterElementData>())
+        {
+            if (string.IsNullOrEmpty(element.CharacterId) ||
+                element.Number <= 0 ||
+                element.WoundedNumber < 0 ||
+                element.WoundedNumber > element.Number ||
+                element.Xp < 0 ||
+                result.ContainsKey(element.CharacterId))
+            {
+                valid = false;
+                return result;
+            }
+            if (!objectManager.TryGetObject(
+                    element.CharacterId, out CharacterObject character) ||
+                character == null)
+            {
+                valid = false;
+                return result;
+            }
+            // Hero prisoners are resolved by the dedicated capture/release
+            // conversation flow before the party loot screen opens.
+            if (character.IsHero)
+                continue;
+            result.Add(
+                element.CharacterId,
+                new Award(
+                    element.Number, element.WoundedNumber, element.Xp));
+        }
+        return result;
+    }
+
+    private bool ValidateRemovalDelta(
+        IReadOnlyDictionary<string, Award> award,
+        TroopRosterData delta,
+        out string reason)
+    {
+        reason = "The selected post-battle troops no longer match the server award.";
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (TroopRosterElementData element in
+                 delta.Data ?? Array.Empty<TroopRosterElementData>())
+        {
+            if (string.IsNullOrEmpty(element.CharacterId) ||
+                !seen.Add(element.CharacterId))
+                return false;
+            if (!objectManager.TryGetObject(
+                    element.CharacterId, out CharacterObject character) ||
+                character == null || character.IsHero)
+                return false;
+            if (element.Number == 0 &&
+                element.WoundedNumber == 0 && element.Xp == 0)
+                continue;
+            award.TryGetValue(element.CharacterId, out Award available);
+            // PartyDone transmits one net delta per character. A player can take
+            // awarded wounded troops while leaving healthy troops of the same
+            // character behind (or the reverse), so the individual number,
+            // wounded and XP components are not required to share a sign. The
+            // authoritative invariant is that applying the net delta to the
+            // immutable virtual award leaves a valid roster element. Global role
+            // conservation and the authoritative right-roster commit separately
+            // prove that any positive virtual-left contents came from the player.
+            long finalNumber = available.Number + (long)element.Number;
+            long finalWounded = available.Wounded +
+                (long)element.WoundedNumber;
+            long finalXp = available.Xp + (long)element.Xp;
+            if (finalNumber < 0 || finalNumber > int.MaxValue ||
+                finalWounded < 0 || finalWounded > finalNumber ||
+                finalXp < 0 || finalXp > int.MaxValue)
+                return false;
+        }
+        return true;
+    }
+
+    private static TroopRosterData NormalizeDelta(TroopRosterData data) =>
+        new((data.Data ?? Array.Empty<TroopRosterElementData>()).Where(element =>
+            element.Number != 0 || element.WoundedNumber != 0 ||
+            element.Xp != 0));
+
+    private void ForfeitLocked(string controllerId)
+    {
+        if (!grants.TryGetValue(controllerId, out Grant grant))
+            return;
+        RememberSettledLocked(controllerId, grant.MapEventId);
+        grants.Remove(controllerId);
+    }
+
+    private bool IsSettledLocked(string controllerId, string mapEventId) =>
+        tombstones.TryGetValue(controllerId, out Tombstones settled) &&
+        settled.MapEventIds.Contains(mapEventId);
+
+    private void RememberSettledLocked(string controllerId, string mapEventId)
+    {
+        if (string.IsNullOrEmpty(controllerId) || string.IsNullOrEmpty(mapEventId))
+            return;
+        if (!tombstones.TryGetValue(controllerId, out Tombstones settled))
+        {
+            settled = new Tombstones();
+            tombstones.Add(controllerId, settled);
+        }
+        if (!settled.MapEventIds.Add(mapEventId))
+            return;
+        settled.Order.Enqueue(mapEventId);
+        while (settled.Order.Count > TombstoneLimitPerController)
+            settled.MapEventIds.Remove(settled.Order.Dequeue());
+    }
+}

--- a/source/GameInterface/Services/MapEvents/Handlers/BattleJoinLeaveHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/BattleJoinLeaveHandler.cs
@@ -9,6 +9,7 @@ using GameInterface.Services.MapEvents.Initialization;
 using GameInterface.Services.MapEvents.Messages;
 using GameInterface.Services.MapEvents.Messages.Leave;
 using GameInterface.Services.MapEvents.Messages.Start;
+using GameInterface.Services.MapEvents.Patches;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
 using GameInterface.Services.SiegeEvents.Interfaces;
@@ -117,8 +118,11 @@ internal class BattleJoinLeaveHandler : IHandler
                         if (trackParties)
                             mapEvent.TroopUpgradeTracker.AddParty(mapEventParty);
                         var mobileParty = mapEventParty.Party.MobileParty;
-                        if (mobileParty != null && positions != null && i < positions.Length)
+                        if (mobileParty != null && positions != null &&
+                            i < positions.Length && positions[i].IsValid())
+                        {
                             mobileParty.Position = positions[i];
+                        }
                     }
                 }
             }
@@ -229,6 +233,17 @@ internal class BattleJoinLeaveHandler : IHandler
                     if (mapEvent.IsActiveSlowVillageRaid() && data.Side == BattleSideEnum.Defender)
                     {
                         Logger.Warning("Ignoring defender join request: map event {MapEventId} is an active slow village raid", data.MapEventId);
+                        return;
+                    }
+                    // Revalidate inside the same game-thread action that commits
+                    // membership. The earlier request check may have run just
+                    // before the ten-hour campaign window elapsed.
+                    if (mapEvent.BattleStartTime != CampaignTime.Zero &&
+                        !InteractionPatches.IsWithinAiJoinWindow(mapEvent))
+                    {
+                        Logger.Warning(
+                            "Ignoring join request: reinforcement window closed for map event {MapEventId}",
+                            data.MapEventId);
                         return;
                     }
                     var side = mapEvent.GetMapEventSide(data.Side);

--- a/source/GameInterface/Services/MapEvents/Handlers/MapEventResultsHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/MapEventResultsHandler.cs
@@ -2,6 +2,7 @@
 using Common.Logging;
 using Common.Messaging;
 using Common.Network;
+using Common.Network.Messages;
 using Common.Util;
 using GameInterface.Services.MapEvents.Data;
 using GameInterface.Services.MapEvents.Interfaces;
@@ -10,7 +11,11 @@ using GameInterface.Services.MapEventParties;
 using GameInterface.Services.MapEventParties.Messages;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
+using GameInterface.Services.TroopRosters.Data;
 using Serilog;
+using System;
+using System.Collections.Generic;
+using LiteNetLib;
 using TaleWorlds.CampaignSystem.Encounters;
 using TaleWorlds.CampaignSystem.MapEvents;
 using TaleWorlds.CampaignSystem.Party;
@@ -28,6 +33,10 @@ internal class MapEventResultsHandler : IHandler
     private readonly IMapEventResultsInterface mapEventResultsInterface;
     private readonly IMapEventContributionBarrier contributionBarrier;
     private readonly IPlayerManager playerManager;
+    private readonly IBattleLootGrantRegistry battleLootGrants;
+    private readonly IBattlePartyGrantRegistry battlePartyGrants;
+    private readonly object lootPeerGate = new();
+    private readonly Dictionary<NetPeer, string> lootControllerByPeer = new();
 
     public MapEventResultsHandler(
         IMessageBroker messageBroker,
@@ -35,7 +44,9 @@ internal class MapEventResultsHandler : IHandler
         IObjectManager objectManager,
         IMapEventResultsInterface mapEventResultsInterface,
         IMapEventContributionBarrier contributionBarrier,
-        IPlayerManager playerManager)
+        IPlayerManager playerManager,
+        IBattleLootGrantRegistry battleLootGrants,
+        IBattlePartyGrantRegistry battlePartyGrants)
     {
         this.messageBroker = messageBroker;
         this.network = network;
@@ -43,10 +54,13 @@ internal class MapEventResultsHandler : IHandler
         this.mapEventResultsInterface = mapEventResultsInterface;
         this.contributionBarrier = contributionBarrier;
         this.playerManager = playerManager;
+        this.battleLootGrants = battleLootGrants;
+        this.battlePartyGrants = battlePartyGrants;
 
         messageBroker.Subscribe<CommitMapEventResults>(Handle_CommitMapEventResults);
         messageBroker.Subscribe<NetworkCommitMapEventResults>(Handle_NetworkCommitMapEventResults);
         messageBroker.Subscribe<MapEventContributionFlushRequested>(Handle_MapEventContributionFlushRequested);
+        messageBroker.Subscribe<PlayerDisconnected>(Handle_PlayerDisconnected);
     }
 
     public void Dispose()
@@ -54,6 +68,7 @@ internal class MapEventResultsHandler : IHandler
         messageBroker.Unsubscribe<CommitMapEventResults>(Handle_CommitMapEventResults);
         messageBroker.Unsubscribe<NetworkCommitMapEventResults>(Handle_NetworkCommitMapEventResults);
         messageBroker.Unsubscribe<MapEventContributionFlushRequested>(Handle_MapEventContributionFlushRequested);
+        messageBroker.Unsubscribe<PlayerDisconnected>(Handle_PlayerDisconnected);
     }
 
     private void Handle_MapEventContributionFlushRequested(
@@ -88,6 +103,43 @@ internal class MapEventResultsHandler : IHandler
                     continue;
                 }
 
+                lock (lootPeerGate)
+                    lootControllerByPeer[peer] = player.ControllerId;
+
+                if (mapEvent.WinningSide == playerSide)
+                {
+                    ItemRosterElement[] awardedItems = null;
+                    networkPlayerLootData.LootedItems?.TryGetValue(
+                        playerMapEventPartyId,
+                        out awardedItems);
+                    battleLootGrants.Stage(
+                        player.ControllerId,
+                        player.HeroId,
+                        player.MobilePartyId,
+                        mapEventId,
+                        awardedItems ?? Array.Empty<ItemRosterElement>());
+                    var awardedMembers = new TroopRosterData(
+                        Array.Empty<TroopRosterElementData>());
+                    var awardedPrisoners = new TroopRosterData(
+                        Array.Empty<TroopRosterElementData>());
+                    networkPlayerLootData.LootedMembers?.TryGetValue(
+                        playerMapEventPartyId, out awardedMembers);
+                    networkPlayerLootData.LootedPrisoners?.TryGetValue(
+                        playerMapEventPartyId, out awardedPrisoners);
+                    battlePartyGrants.Stage(
+                        player.ControllerId,
+                        player.HeroId,
+                        player.MobilePartyId,
+                        mapEventId,
+                        awardedMembers,
+                        awardedPrisoners);
+                }
+                else
+                {
+                    battleLootGrants.Forfeit(player.ControllerId);
+                    battlePartyGrants.Forfeit(player.ControllerId);
+                }
+
                 network.Send(peer, new NetworkCommitMapEventResults(
                     mapEventId,
                     mapEvent.WinningSide,
@@ -96,6 +148,25 @@ internal class MapEventResultsHandler : IHandler
                     networkPlayerLootData));
             }
         });
+    }
+
+    private void Handle_PlayerDisconnected(MessagePayload<PlayerDisconnected> payload)
+    {
+        if (ModInformation.IsClient || payload?.What?.PlayerId == null)
+            return;
+
+        string controllerId = null;
+        lock (lootPeerGate)
+        {
+            if (lootControllerByPeer.TryGetValue(payload.What.PlayerId, out controllerId))
+                lootControllerByPeer.Remove(payload.What.PlayerId);
+        }
+
+        if (!string.IsNullOrEmpty(controllerId))
+        {
+            battleLootGrants.Forfeit(controllerId);
+            battlePartyGrants.Forfeit(controllerId);
+        }
     }
 
     private void Handle_NetworkCommitMapEventResults(MessagePayload<NetworkCommitMapEventResults> obj)

--- a/source/GameInterface/Services/MapEvents/Interfaces/MapEventResultsInterface.cs
+++ b/source/GameInterface/Services/MapEvents/Interfaces/MapEventResultsInterface.cs
@@ -59,7 +59,7 @@ public class MapEventResultsInterface : IMapEventResultsInterface
             {
                 if (!objectManager.TryGetIdWithLogging(playerLootedItems.Key, out var mapEventPartyId)) continue;
 
-                lootedItems[mapEventPartyId] = playerLootedItems.Value._data;
+                lootedItems[mapEventPartyId] = playerLootedItems.Value.ToArray();
             }
 
             foreach (var playerLootedMembers in playerLootData.LootedMembers)

--- a/source/GameInterface/Services/MapEvents/MapEventSync.cs
+++ b/source/GameInterface/Services/MapEvents/MapEventSync.cs
@@ -19,7 +19,13 @@ internal class MapEventSync : IAutoSync
         autoSyncBuilder.AddProperty(AccessTools.Property(typeof(MapEvent), nameof(MapEvent.State)));
         autoSyncBuilder.AddProperty(AccessTools.Property(typeof(MapEvent), nameof(MapEvent.TroopUpgradeTracker)), debug: true);
 
-        autoSyncBuilder.AddField(AccessTools.Field(typeof(MapEvent), nameof(MapEvent.MapEventVisual)), debug: true);
+        // DedicatedServer.Core supplies a private headless IMapEventVisual. It is authoritative server state,
+        // but it has no corresponding client object and is intentionally absent from the ObjectManager.
+        // Preserve the wire contract for graphical hosts while skipping only that unregistered reference.
+        autoSyncBuilder.AddField(
+            AccessTools.Field(typeof(MapEvent), nameof(MapEvent.MapEventVisual)),
+            debug: true,
+            skipUnregisteredReference: true);
         autoSyncBuilder.AddField(AccessTools.Field(typeof(MapEvent), nameof(MapEvent.DiplomaticallyFinished)));
         autoSyncBuilder.AddField(AccessTools.Field(typeof(MapEvent), nameof(MapEvent.StrengthOfSide)));
         //autoSyncBuilder.AddField(AccessTools.Field(typeof(MapEvent), nameof(MapEvent._battleResultExplainers)));

--- a/source/GameInterface/Services/MapEvents/Patches/EncounterManagerPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/EncounterManagerPatches.cs
@@ -36,6 +36,12 @@ internal class EncounterManagerPatches
         if (IsAwaitingMissionExit(attackerParty?.Party))
             return false;
 
+        if (InteractionPatches.TrySuppressExpiredReinforcement(
+                attackerParty?.Party, settlement?.Party?.MapEvent))
+        {
+            return false;
+        }
+
         if (RaidAiInterventionSuppression.ShouldSuppressSettlementEncounter(attackerParty, settlement))
             return false;
 
@@ -62,6 +68,12 @@ internal class EncounterManagerPatches
 
         if (IsAwaitingMissionExit(attackerParty) || IsAwaitingMissionExit(defenderParty))
             return false;
+
+        if (InteractionPatches.TrySuppressExpiredReinforcement(
+                attackerParty, defenderParty))
+        {
+            return false;
+        }
 
         if (CallOriginalPolicy.IsOriginalAllowed()) return true;
 

--- a/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
@@ -361,16 +361,13 @@ internal class InteractionPatches
 {
     private sealed class PlayerBattleWindows
     {
-        public CampaignTime AiJoinWindowExpiresAt { get; }
         public CampaignTime GoldFoodConsumptionWindowExpiresAt { get; }
 
-        public PlayerBattleWindows(int aiJoinWindowHours, int goldFoodConsumptionWindowHours = 24)
+        public PlayerBattleWindows(int goldFoodConsumptionWindowHours = 24)
         {
-            AiJoinWindowExpiresAt = CampaignTime.HoursFromNow(aiJoinWindowHours);
             GoldFoodConsumptionWindowExpiresAt = CampaignTime.HoursFromNow(goldFoodConsumptionWindowHours);
         }
 
-        public bool AiJoinWindowExpired => CampaignTime.Now > AiJoinWindowExpiresAt;
         public bool GoldFoodConsumptionExpired => CampaignTime.Now > GoldFoodConsumptionWindowExpiresAt;
     }
 
@@ -402,11 +399,76 @@ internal class InteractionPatches
     private static readonly ConditionalWeakTable<MapEvent, PlayerBattleWindows> playerBattleWindows = new();
     private static readonly ConditionalWeakTable<MapEvent, object> initializingPlayerBattles = new();
 
-    /// <summary>True while a player's battle is still within its post-start window for AI parties to join as
-    /// reinforcements (<see cref="ModConfigProvider.ModOptions.PlayerBattleAiJoinWindowHours"/>). The window is opened after
-    /// initialization; only the server ever populates it, so this is a server-side query.</summary>
+    /// <summary>True while any battle is inside the authoritative campaign-time
+    /// reinforcement window. Player and AI joins use this same battle-start
+    /// clock, capped at ten in-game hours.</summary>
     public static bool IsWithinAiJoinWindow(MapEvent mapEvent)
-        => playerBattleWindows.TryGetValue(mapEvent, out var window) && !window.AiJoinWindowExpired;
+    {
+        if (mapEvent == null || mapEvent.BattleStartTime == CampaignTime.Zero)
+            return false;
+
+        float elapsedHours = mapEvent.BattleStartTime.ElapsedHoursUntilNow;
+        int configuredHours = Math.Max(
+            0,
+            Math.Min(
+                10,
+                ModConfigProvider.ModOptions.PlayerBattleAiJoinWindowHours));
+        return elapsedHours >= 0f && elapsedHours <= configuredHours;
+    }
+
+    /// <summary>
+    /// Rejects a party that is trying to enter an already-running battle after
+    /// the shared reinforcement window. This must run at the encounter/join
+    /// operation boundary. Cancelling PartyBase.MapEventSide itself is unsafe:
+    /// native StartBattleAction continues into OnStartBattle and dereferences
+    /// the membership it assumes the setter created.
+    /// </summary>
+    internal static bool TrySuppressExpiredReinforcement(
+        PartyBase joiningParty,
+        MapEvent targetMapEvent)
+    {
+        if (ModInformation.IsClient || joiningParty == null ||
+            targetMapEvent == null || joiningParty.MapEvent == targetMapEvent ||
+            targetMapEvent.BattleStartTime == CampaignTime.Zero ||
+            IsWithinAiJoinWindow(targetMapEvent))
+        {
+            return false;
+        }
+
+        // A rejected AI encounter would otherwise be attempted again every
+        // campaign tick. Stop it and ask the authoritative AI to choose again.
+        // Player requests receive their correlated rejection in the Coop
+        // request handlers and must not have their movement rewritten here.
+        var mobileParty = joiningParty.MobileParty;
+        if (mobileParty?.IsPlayerParty() != true)
+            RaidAiInterventionSuppression.HoldParty(mobileParty);
+
+        return true;
+    }
+
+    internal static bool TrySuppressExpiredReinforcement(
+        PartyBase firstParty,
+        PartyBase secondParty)
+    {
+        if (firstParty == null || secondParty == null)
+            return false;
+
+        if (firstParty.MapEvent != null &&
+            firstParty.MapEvent != secondParty.MapEvent)
+        {
+            return TrySuppressExpiredReinforcement(
+                secondParty, firstParty.MapEvent);
+        }
+
+        if (secondParty.MapEvent != null &&
+            secondParty.MapEvent != firstParty.MapEvent)
+        {
+            return TrySuppressExpiredReinforcement(
+                firstParty, secondParty.MapEvent);
+        }
+
+        return false;
+    }
 
     internal static bool IsInitializingPlayerBattle(MapEvent mapEvent)
         => initializingPlayerBattles.TryGetValue(mapEvent, out _);
@@ -480,16 +542,9 @@ internal class InteractionPatches
             return;
         }
 
-        if (__instance.IsRaidHostileAction() && MapEventConfig.AllowRaidAiIntervention)
-            return;
-
-        // Allow AI to join if no players are involved
-        if (!__instance.ContainsPlayerParty())
-            return;
-
-        // A player's battle stays open to AI reinforcements for a campaign day after it begins. While the
-        // window is open, AI may keep joining; once it expires —
-        // or if no window was opened for this event — no more AI may join a player's battle.
+        // Every battle uses the same authoritative campaign-time reinforcement
+        // window. This includes AI-only battles and raid intervention: special
+        // native eligibility can still deny a join, but cannot extend the clock.
         if (IsInitializingPlayerBattle(__instance) || IsWithinAiJoinWindow(__instance))
             return;
 
@@ -522,7 +577,7 @@ internal class InteractionPatches
         initializingPlayerBattles.Remove(__instance);
         playerBattleWindows.GetValue(
             __instance,
-            _ => new PlayerBattleWindows(ModConfigProvider.ModOptions.PlayerBattleAiJoinWindowHours));
+            _ => new PlayerBattleWindows());
         MessageBroker.Instance.Publish(__instance, new PlayerJoinedBattle());
     }
 

--- a/source/GameInterface/Services/MapEvents/Patches/StartBattleActionPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/StartBattleActionPatches.cs
@@ -17,6 +17,15 @@ internal class StartBattleActionPatches
     [HarmonyPrefix]
     public static bool PrefixApply(PartyBase attackerParty, PartyBase defenderParty, object subject, MapEvent.BattleTypes battleType)
     {
+        // Server-side direct AI encounters can reach StartBattleAction without
+        // calling MapEvent.CanPartyJoinBattle. Reject before native mutates the
+        // side and before OnStartBattle assumes that mutation succeeded.
+        if (InteractionPatches.TrySuppressExpiredReinforcement(
+                attackerParty, defenderParty))
+        {
+            return false;
+        }
+
         if (CallOriginalPolicy.IsOriginalAllowed()) return true;
 
         if (ModInformation.IsClient)

--- a/source/GameInterface/Services/MapEvents/RaidAiInterventionSuppression.cs
+++ b/source/GameInterface/Services/MapEvents/RaidAiInterventionSuppression.cs
@@ -134,7 +134,7 @@ internal static class RaidAiInterventionSuppression
         return settlement?.Party?.MapEvent?.IsRaidAiInterventionSuppressed() == true;
     }
 
-    private static void HoldParty(MobileParty party)
+    internal static void HoldParty(MobileParty party)
     {
         if (ModInformation.IsClient)
             return;

--- a/source/GameInterface/Services/MobileParties/Data/MobilePartyBehaviorSnapshot.cs
+++ b/source/GameInterface/Services/MobileParties/Data/MobilePartyBehaviorSnapshot.cs
@@ -135,6 +135,28 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
         state = default;
         if (liveParties == null || liveSettlements == null)
             return FailCreation("live campaign objects are unavailable", out failure);
+        if (party?.Ai == null)
+            return FailCreation("party AI is unavailable", out failure);
+        if (!TryGetCompactId(party, out _))
+            return FailCreation("party is not registered", out failure);
+
+        if (!TryResolveAuthoritativeJoinPosition(party, out CampaignVec2 joinPosition))
+        {
+            return FailCreation(
+                $"party '{party?.StringId}' has no valid authoritative campaign position",
+                out failure);
+        }
+
+        if (!IsValidCoordinate(party.Position))
+        {
+            // Repair the authoritative object before capturing the baseline. Sending a client-local
+            // fallback would make the join appear successful while the server retained an invalid
+            // position and could broadcast it again on the next movement update.
+            party.Position = joinPosition;
+            Logger.Warning(
+                "Repaired invalid authoritative join position for party {PartyId}",
+                party.StringId);
+        }
 
         bool created = TryCreate(party, out PartyBehaviorUpdateData behavior, out failure);
         if (TryGetInvalidJoinReferences(
@@ -186,6 +208,7 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
 
         // Preserve a removed move target as its last point instead of resetting the party to Hold.
         PreserveUnavailableMoveTarget(party, liveParties, ref behavior);
+        behavior.PartyPosition = joinPosition;
 
         state = new MobilePartyJoinState
         {
@@ -305,6 +328,11 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
             PartyBehaviorUpdateData behavior = states[i].Behavior;
             if (string.IsNullOrEmpty(behavior.MobilePartyId))
                 return RejectJoinBaseline($"state {i} has no mobile-party id");
+            if (!IsValidCoordinate(behavior.PartyPosition))
+            {
+                return RejectJoinBaseline(
+                    $"state {i} party '{behavior.MobilePartyId}' has an invalid authoritative position");
+            }
             if (!this.objectManager.TryGetObject(
                 behavior.MobilePartyId,
                 out MobileParty party))
@@ -461,6 +489,8 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
     private static void ApplyJoinState(MobileParty party, MobilePartyJoinState state)
     {
         party.IsCurrentlyAtSea = state.IsCurrentlyAtSea;
+        // TryApplyJoinBaseline validates every state before beforeApply is invoked, so application
+        // never substitutes stale client-local geography for an invalid server position.
         party.Position = state.Behavior.PartyPosition;
         party.EventPositionAdder = state.EventPositionAdder;
         party.ArmyPositionAdder = state.ArmyPositionAdder;
@@ -470,6 +500,30 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
         party.StartTransitionNextFrameToExitFromPort = state.StartTransitionNextFrameToExitFromPort;
         party.ForceAiNoPathMode = state.ForceAiNoPathMode;
     }
+
+    private static bool TryResolveAuthoritativeJoinPosition(
+        MobileParty party,
+        out CampaignVec2 position)
+    {
+        position = party?.Position ?? CampaignVec2.Invalid;
+        if (IsValidCoordinate(position))
+            return true;
+
+        position = party?.CurrentSettlement?.GatePosition ?? CampaignVec2.Invalid;
+        if (IsValidCoordinate(position))
+            return true;
+
+        position = party?.LeaderHero?.GetCampaignPosition() ?? CampaignVec2.Invalid;
+        if (IsValidCoordinate(position))
+            return true;
+
+        position = party?.LeaderHero?.LastKnownClosestSettlement?.GatePosition ??
+            CampaignVec2.Invalid;
+        return IsValidCoordinate(position);
+    }
+
+    private static bool IsValidCoordinate(CampaignVec2 position) =>
+        position.ToVec2().IsValid;
 
     private static void ApplyBehavior(ResolvedBehaviorUpdate resolved, bool resetPath)
     {

--- a/source/GameInterface/Services/MobileParties/Handlers/MobilePartyBehaviorHandler.cs
+++ b/source/GameInterface/Services/MobileParties/Handlers/MobilePartyBehaviorHandler.cs
@@ -174,6 +174,8 @@ internal class MobilePartyBehaviorHandler : IHandler
 
     private static void ApplyForcedPosition(MobileParty party, CampaignVec2 position, bool isCurrentlyAtSea)
     {
+        if (!position.ToVec2().IsValid)
+            return;
         party.Position = position;
 
         if (party.IsCurrentlyAtSea != isCurrentlyAtSea)
@@ -185,6 +187,8 @@ internal class MobilePartyBehaviorHandler : IHandler
         CampaignVec2 position,
         bool isCurrentlyAtSea)
     {
+        if (!position.ToVec2().IsValid)
+            return null;
         ApplyForcedPosition(party, position, isCurrentlyAtSea);
 
         if (party.Army == null)
@@ -247,7 +251,7 @@ internal class MobilePartyBehaviorHandler : IHandler
         CampaignVec2 currentPosition,
         CampaignVec2 authoritativePosition)
     {
-        return !isSelfEcho &&
+        return authoritativePosition.ToVec2().IsValid && !isSelfEcho &&
             (forcePosition || isHolding || currentPosition.IsOnLand != authoritativePosition.IsOnLand);
     }
 }

--- a/source/GameInterface/Services/MobileParties/Patches/PartyTradeGoldPatch.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/PartyTradeGoldPatch.cs
@@ -1,5 +1,7 @@
 ﻿using HarmonyLib;
 using TaleWorlds.CampaignSystem.Party;
+using Common;
+using GameInterface.Services.Clans.Patches;
 using TaleWorlds.Library;
 
 namespace GameInterface.Services.MobileParties.Patches;
@@ -21,5 +23,13 @@ internal class PartyTradeGoldPatch
             return false;
         }
         return true;
+    }
+
+    [HarmonyPatch(nameof(MobileParty.PartyTradeGold), MethodType.Setter)]
+    [HarmonyPostfix]
+    static void PartyTradeGoldSetPostfix(MobileParty __instance)
+    {
+        if (ModInformation.IsClient && __instance?.IsCaravan == true)
+            ClanPartyItemVMPatches.RefreshCaravanIncome(__instance);
     }
 }

--- a/source/GameInterface/Services/MobileParties/Patches/ResetCachedPatch.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/ResetCachedPatch.cs
@@ -1,5 +1,6 @@
 ﻿using Common;
 using Common.Messaging;
+using GameInterface.Policies;
 using GameInterface.Services.MobileParties.Messages;
 using HarmonyLib;
 using TaleWorlds.CampaignSystem.Party;
@@ -13,7 +14,10 @@ internal class ResetCachedPatch
     [HarmonyPostfix]
     public static void ResetCachedPostfix(MobileParty __instance)
     {
-        if (ModInformation.IsClient) return;
+        // Save loading resets every party before campaign objects are registered. Those resets are
+        // local initialization, not network state changes. The policy also prevents received applies
+        // from echoing back through this postfix.
+        if (ModInformation.IsClient || CallOriginalPolicy.IsOriginalAllowed()) return;
 
         var message = new ResetMobilePartyCached(__instance);
         MessageBroker.Instance.Publish(__instance, message);

--- a/source/GameInterface/Services/Party/Handlers/PartyDoneLogicHandler.cs
+++ b/source/GameInterface/Services/Party/Handlers/PartyDoneLogicHandler.cs
@@ -1,17 +1,20 @@
-﻿using Common;
+using Common;
 using Common.Logging;
 using Common.Messaging;
 using Common.Network;
 using GameInterface.Services.GameDebug.Messages;
 using GameInterface.Services.Heroes.Extensions;
+using GameInterface.Services.MapEvents;
 using GameInterface.Services.MapEventParties;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Party.Data;
 using GameInterface.Services.Party.Messages;
 using GameInterface.Services.PlayerCaptivityService.Messages;
+using GameInterface.Services.Players;
 using GameInterface.Services.TroopRosters.Data;
 using GameInterface.Services.TroopRosters.Interfaces;
 using GameInterface.Services.TroopRosters.Messages;
+using GameInterface.Services.Transactions;
 using GameInterface.Services.UI.Notifications.Messages;
 using LiteNetLib;
 using Serilog;
@@ -21,6 +24,8 @@ using System.Linq;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.CharacterDevelopment;
+using TaleWorlds.CampaignSystem.Issues;
+using TaleWorlds.CampaignSystem.MapEvents;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Roster;
 using TaleWorlds.CampaignSystem.Settlements;
@@ -39,17 +44,23 @@ internal class PartyDoneLogicHandler : IHandler
     private readonly IObjectManager objectManager;
     private readonly INetwork network;
     private readonly ITroopRosterInterface troopRosterInterface;
+    private readonly IPlayerManager playerManager;
+    private readonly IBattlePartyGrantRegistry battlePartyGrants;
 
     public PartyDoneLogicHandler(
         IMessageBroker messageBroker,
         IObjectManager objectManager,
         INetwork network,
-        ITroopRosterInterface troopRosterInterface)
+        ITroopRosterInterface troopRosterInterface,
+        IPlayerManager playerManager,
+        IBattlePartyGrantRegistry battlePartyGrants)
     {
         this.messageBroker = messageBroker;
         this.objectManager = objectManager;
         this.network = network;
         this.troopRosterInterface = troopRosterInterface;
+        this.playerManager = playerManager;
+        this.battlePartyGrants = battlePartyGrants;
 
         messageBroker.Subscribe<PartyDoneLogicAttempted>(Handle_PartyDoneLogicAttempted);
         messageBroker.Subscribe<NetworkCompleteDoneLogic>(Handle_CompletePartyDoneLogic);
@@ -104,7 +115,11 @@ internal class PartyDoneLogicHandler : IHandler
             leftPrisonerRosterData,
             rightMemberRosterData,
             rightPrisonerRosterData,
-            obj.What.RightOwnerPartyItemRoster._data,
+            // ItemRoster._data is the backing-capacity array and contains
+            // default padding rows. Send only the logical roster contents so
+            // normal party upgrades/prisoner commits are not rejected as an
+            // invalid inventory snapshot.
+            obj.What.RightOwnerPartyItemRoster.ToArray(),
             upgradedTroopHistory,
             leftPartyId,
             leftPrisonerRosterId,
@@ -139,15 +154,161 @@ internal class PartyDoneLogicHandler : IHandler
         var message = obj.What;
         var requester = obj.Who as NetPeer;
         
-        GameThread.RunSafe(() =>
+        GameThread.RunSafe(() => ServerTransactionOutcome.Execute(
+            requester, ServerTransactionOutcome.Party, () =>
         {
-            if (!objectManager.TryGetObjectWithLogging<Hero>(message.MainHeroId, out var mainHero)) return;
+            string authenticationReason =
+                "The server could not authenticate this player.";
+            if (!playerManager.TryGetPlayer(requester, out var registeredPlayer) ||
+                !ServerTransactionOutcome.TryResolvePlayer(
+                    requester,
+                    playerManager,
+                    objectManager,
+                    message.MainHeroId,
+                    registeredPlayer?.MobilePartyId,
+                    out _,
+                    out Hero mainHero,
+                    out MobileParty playerParty,
+                    out authenticationReason))
+            {
+                ServerTransactionOutcome.Reject(
+                    requester, ServerTransactionOutcome.Party,
+                    authenticationReason);
+                return;
+            }
 
-            if (!TryResolveCompleteDoneLogic(message, out var leftParty, out var leftPrisonerRoster, out var upgradedTroopHistory)) return;
+            if (!TryResolveCompleteDoneLogic(
+                    message, out var leftParty, out var leftPrisonerRoster,
+                    out var upgradedTroopHistory))
+            {
+                ServerTransactionOutcome.Reject(
+                    requester, ServerTransactionOutcome.Party,
+                    "The other party is no longer available.");
+                return;
+            }
+            TroopRoster questRoster = null;
+            int? questGoldChange = null;
+            if (message.PartyScreenMode ==
+                    Helpers.PartyScreenHelper.PartyScreenMode.QuestTroopManage &&
+                !TryResolveQuestTroopSource(
+                    mainHero,
+                    message,
+                    upgradedTroopHistory,
+                    out questRoster,
+                    out questGoldChange,
+                    out string questReason))
+            {
+                ServerTransactionOutcome.Reject(
+                    requester,
+                    ServerTransactionOutcome.Party,
+                    questReason);
+                return;
+            }
+            BattlePartyClaim battlePartyClaim = null;
+            if (leftParty == null && leftPrisonerRoster == null &&
+                questRoster == null &&
+                message.PartyScreenMode ==
+                    Helpers.PartyScreenHelper.PartyScreenMode.Loot &&
+                message.ApplyReleasedAndTakenPrisonerActions)
+            {
+                BattlePartyClaimStatus claimStatus =
+                    battlePartyGrants.TryPrepareClaim(
+                        registeredPlayer.ControllerId,
+                        registeredPlayer.HeroId,
+                        registeredPlayer.MobilePartyId,
+                        message.LeftMemberRosterData,
+                        message.LeftPrisonerRosterData,
+                        out battlePartyClaim,
+                        out string claimReason);
+                if (claimStatus == BattlePartyClaimStatus.Rejected)
+                {
+                    ServerTransactionOutcome.Reject(
+                        requester,
+                        ServerTransactionOutcome.Party,
+                        claimReason);
+                    return;
+                }
+            }
+            if (!IsAuthorizedPartySource(
+                    mainHero,
+                    playerParty,
+                    leftParty,
+                    leftPrisonerRoster,
+                    questRoster,
+                    battlePartyClaim,
+                    message,
+                    out bool allowBattleRescue))
+            {
+                ServerTransactionOutcome.Reject(
+                    requester, ServerTransactionOutcome.Party,
+                    "The other party is not available to this player.");
+                return;
+            }
 
             var releasedPrisonersRoster = FlattenedTroopSerializer.Deserialize(message.ReleasedPrisonersRoster, objectManager);
             var takenPrisonersRoster = FlattenedTroopSerializer.Deserialize(message.TakenPrisonersRoster, objectManager);
             var recruitedPrisonersRoster = FlattenedTroopSerializer.Deserialize(message.RecruitedPrisonersRoster, objectManager);
+            bool hasPrisonerDonation =
+                PartyScreenHelperHandler.TryGetPendingPrisonerDonation(
+                    requester,
+                    out DonatePrisoners pendingDonation);
+            if (hasPrisonerDonation && !TryValidatePrisonerDonation(
+                    pendingDonation,
+                    playerParty,
+                    releasedPrisonersRoster,
+                    message.RightPrisonerRosterData,
+                    out string donationReason))
+            {
+                ServerTransactionOutcome.Reject(
+                    requester,
+                    ServerTransactionOutcome.Party,
+                    donationReason);
+                return;
+            }
+            bool hasGarrisonDonation =
+                PartyScreenHelperHandler.TryGetPendingGarrisonDonation(
+                    requester,
+                    out DonateToGarrison pendingGarrisonDonation);
+            MobileParty donationGarrison = null;
+            Settlement donationSettlement = null;
+            bool createdDonationGarrison = false;
+            if (hasGarrisonDonation && !TryValidateGarrisonDonation(
+                    pendingGarrisonDonation,
+                    playerParty,
+                    message,
+                    out donationSettlement,
+                    out donationGarrison,
+                    out createdDonationGarrison,
+                    out string garrisonDonationReason))
+            {
+                ServerTransactionOutcome.Reject(
+                    requester,
+                    ServerTransactionOutcome.Party,
+                    garrisonDonationReason);
+                return;
+            }
+            bool isRansom = message.PartyScreenMode ==
+                Helpers.PartyScreenHelper.PartyScreenMode.Ransom;
+            TroopRoster ransomPrisoners = null;
+            if (isRansom && !TryBuildAuthoritativeRansomSale(
+                    playerParty,
+                    message,
+                    upgradedTroopHistory,
+                    out ransomPrisoners,
+                    out string ransomReason))
+            {
+                RollbackCreatedDonationGarrison(
+                    donationGarrison, createdDonationGarrison);
+                logger.Warning(
+                    "Rejected ransom sale for {MainHeroId}: {Reason}",
+                    message.MainHeroId,
+                    ransomReason);
+                ServerTransactionOutcome.Reject(
+                    requester,
+                    ServerTransactionOutcome.Party,
+                    ransomReason);
+                return;
+            }
             var releasedPlayerCaptivityEvents = new List<PlayerCaptivityEndedByServer>();
             var leftPrisonerRosterData = message.LeftPrisonerRosterData;
             var rightPrisonerRosterData = message.RightPrisonerRosterData;
@@ -157,7 +318,8 @@ internal class PartyDoneLogicHandler : IHandler
             // filtered delta would always reject a legitimate dismissal (the -1 entry is gone).
             var signedRightPrisonerRosterData = rightPrisonerRosterData;
             // SellPrisonersHandler owns ransom releases so the same player is not released twice.
-            if (message.PartyScreenMode != Helpers.PartyScreenHelper.PartyScreenMode.Ransom)
+            if (!hasPrisonerDonation &&
+                message.PartyScreenMode != Helpers.PartyScreenHelper.PartyScreenMode.Ransom)
             {
                 releasedPlayerCaptivityEvents = CreatePlayerCaptivityReleaseEvents(
                     message.LeftPrisonerRosterData,
@@ -171,8 +333,11 @@ internal class PartyDoneLogicHandler : IHandler
                     out rightPrisonerRosterData);
             }
             var takenHeroCharacterIds = new HashSet<string>();
+            bool validatePrisonerActions =
+                message.ApplyReleasedAndTakenPrisonerActions ||
+                hasPrisonerDonation;
             var actionRostersAreValid =
-                !message.ApplyReleasedAndTakenPrisonerActions ||
+                !validatePrisonerActions ||
                 TryValidatePrisonerActionRosters(
                     releasedPrisonersRoster,
                     takenPrisonersRoster,
@@ -180,7 +345,12 @@ internal class PartyDoneLogicHandler : IHandler
                     out takenHeroCharacterIds);
             if (!actionRostersAreValid)
             {
+                RollbackCreatedDonationGarrison(
+                    donationGarrison, createdDonationGarrison);
                 logger.Error("Rejected Party screen prisoner actions because transfer history did not match the signed right-prisoner delta");
+                ServerTransactionOutcome.Reject(
+                    requester, ServerTransactionOutcome.Party,
+                    "Prisoner changes no longer match the server state.");
                 return;
             }
             if (message.ApplyReleasedAndTakenPrisonerActions)
@@ -194,37 +364,641 @@ internal class PartyDoneLogicHandler : IHandler
                 mainHero,
                 leftParty,
                 leftPrisonerRoster,
+                questRoster,
                 message,
                 leftPrisonerRosterData,
                 rightPrisonerRosterData);
+            if (hasGarrisonDonation)
+                rosterDeltas.Add((
+                    donationGarrison.MemberRoster,
+                    message.LeftMemberRosterData));
 
-            // Only apply deltas if not ransoming. SellPrisonersAction already changes troop rosters
-            if (message.PartyScreenMode != Helpers.PartyScreenHelper.PartyScreenMode.Ransom)
+            if (!TryValidatePartyCommit(
+                    mainHero,
+                    message,
+                    upgradedTroopHistory,
+                    rosterDeltas,
+                    hasPrisonerDonation,
+                    hasGarrisonDonation,
+                    questGoldChange,
+                    battlePartyClaim == null
+                        ? Array.Empty<TroopRosterData>()
+                        : new[]
+                        {
+                            battlePartyClaim.MemberSourceDelta,
+                            battlePartyClaim.PrisonerSourceDelta
+                        },
+                    out string commitReason))
             {
-                if (!troopRosterInterface.TryApplyTroopRosterDeltas(rosterDeltas))
-                {
-                    logger.Warning(
-                        "Rejected party changes for {MainHeroId}: {Reason}",
-                        message.MainHeroId,
-                        PartyChangedMessage);
-                    if (requester != null)
-                    {
-                        network.Send(requester, new SendInformationMessage(PartyChangedMessage));
-                    }
-                    return;
-                }
+                RollbackCreatedDonationGarrison(
+                    donationGarrison, createdDonationGarrison);
+                ServerTransactionOutcome.Reject(
+                    requester,
+                    ServerTransactionOutcome.Party,
+                    commitReason);
+                return;
             }
-            PublishPlayerCaptivityReleaseEvents(releasedPlayerCaptivityEvents);
-            ApplyRightOwnerPartyItemRoster(mainHero, message);
-            if (message.ApplyReleasedAndTakenPrisonerActions)
-                ApplyReleasedAndTakenPrisonerActions(mainHero, releasedPrisonersRoster, takenPrisonersRoster);
-            NotifyTakenPrisonersChanged(takenPrisonersRoster);
-            ApplyPartyRewardChanges(mainHero, message);
-            ApplyUpgradedTroopHistory(mainHero, upgradedTroopHistory);
-            ApplyPrisonerRecruitmentEffects(mainHero, message, recruitedPrisonersRoster);
+            if (!TryValidateRosterRoleChanges(
+                    playerParty,
+                    recruitedPrisonersRoster,
+                    takenPrisonersRoster,
+                    upgradedTroopHistory,
+                    message.LeftMemberRosterData,
+                    message.LeftPrisonerRosterData,
+                    message.RightMemberRosterData,
+                    signedRightPrisonerRosterData,
+                    allowBattleRescue,
+                    battlePartyClaim))
+            {
+                RollbackCreatedDonationGarrison(
+                    donationGarrison, createdDonationGarrison);
+                ServerTransactionOutcome.Reject(
+                    requester, ServerTransactionOutcome.Party,
+                    "Recruited prisoners no longer match the party changes.");
+                return;
+            }
 
-            ApplyRosterOrder(mainHero.PartyBelongedTo.MemberRoster, message.RightMemberOrderData);
-        });
+            if (!battlePartyGrants.TryActivate(battlePartyClaim))
+            {
+                ServerTransactionOutcome.Reject(
+                    requester,
+                    ServerTransactionOutcome.Party,
+                    "Your post-battle party award changed before it could be committed.");
+                return;
+            }
+
+            // Commit the authoritative rosters, inventory and gold as one reversible core.
+            // Later campaign notifications are effects of that committed state and must never
+            // turn a completed action into a retryable rejection.
+            ItemRosterElement[] itemRosterBefore =
+                mainHero.PartyBelongedTo.ItemRoster.ToArray();
+            var prisonerRosterBefore =
+                playerParty.PrisonRoster.GetTroopRoster();
+            int goldBefore = mainHero.Gold;
+            bool rostersApplied = false;
+            try
+            {
+                // SellPrisonersAction owns ransom roster changes.
+                if (!isRansom)
+                {
+                    if (!troopRosterInterface.TryApplyTroopRosterDeltas(
+                            rosterDeltas))
+                        throw new InvalidOperationException(PartyChangedMessage);
+                    rostersApplied = true;
+                }
+                // The ransom screen cannot mutate inventory. Retain the live
+                // authoritative roster instead of overwriting it with the
+                // screen-open client snapshot while food consumption continues.
+                if (!isRansom)
+                    ApplyRightOwnerPartyItemRoster(mainHero, message);
+                ApplyPartyRewardChanges(
+                    mainHero,
+                    message,
+                    suppressInfluence:
+                        hasPrisonerDonation || hasGarrisonDonation);
+                if (isRansom)
+                    SellPrisonersHandler.ApplySale(
+                        playerParty, ransomPrisoners);
+                if (!battlePartyGrants.Consume(battlePartyClaim))
+                    throw new InvalidOperationException(
+                        "The server post-battle party award changed during its commit.");
+                battlePartyClaim = null;
+            }
+            catch (Exception exception)
+            {
+                battlePartyGrants.Release(battlePartyClaim);
+                mainHero.Gold = goldBefore;
+                // Ransom mutates the prisoner roster outside rosterDeltas. Normal party
+                // operations are rolled back by the inverse deltas below; restoring both
+                // would apply the prisoner rollback twice.
+                if (isRansom)
+                {
+                    playerParty.PrisonRoster.Clear();
+                    foreach (TroopRosterElement element in prisonerRosterBefore)
+                        playerParty.PrisonRoster.AddToCounts(
+                            element.Character,
+                            element.Number,
+                            false,
+                            element.WoundedNumber,
+                            element.Xp,
+                            true);
+                }
+                mainHero.PartyBelongedTo.ItemRoster.Clear();
+                mainHero.PartyBelongedTo.ItemRoster.Add(itemRosterBefore);
+                bool rolledBack = !rostersApplied ||
+                    troopRosterInterface.TryApplyTroopRosterDeltas(
+                        InvertRosterDeltas(rosterDeltas));
+                if (rolledBack)
+                    RollbackCreatedDonationGarrison(
+                        donationGarrison, createdDonationGarrison);
+                logger.Error(
+                    exception,
+                    "Rolled back rejected party commit for {MainHeroId}; rosterRollback={RosterRollback}",
+                    message.MainHeroId,
+                    rolledBack);
+                if (requester != null)
+                    network.Send(
+                        requester,
+                        new SendInformationMessage(PartyChangedMessage));
+                ServerTransactionOutcome.Reject(
+                    requester, ServerTransactionOutcome.Party,
+                    PartyChangedMessage);
+                return;
+            }
+
+            // The state commit above is final. Consume one-shot donation state before
+            // any throwable notification so it cannot contaminate the next action.
+            if (hasPrisonerDonation)
+                PartyScreenHelperHandler.ClearPendingPrisonerDonation(requester);
+            if (hasGarrisonDonation)
+                PartyScreenHelperHandler.ClearPendingGarrisonDonation(requester);
+            if (isRansom)
+                SellPrisonersHandler.ClearPendingSale(requester);
+
+            // Each post-commit effect is isolated. A stale hero/reference must not
+            // prevent unrelated rewards and progression from being applied.
+            TryPostPartyEffect(
+                () => PublishPlayerCaptivityReleaseEvents(releasedPlayerCaptivityEvents),
+                message.MainHeroId,
+                "captivity release events");
+            if (message.ApplyReleasedAndTakenPrisonerActions)
+                TryPostPartyEffect(
+                    () => ApplyReleasedAndTakenPrisonerActions(
+                        mainHero, releasedPrisonersRoster, takenPrisonersRoster),
+                    message.MainHeroId,
+                    "prisoner actions");
+            TryPostPartyEffect(
+                () => NotifyTakenPrisonersChanged(takenPrisonersRoster),
+                message.MainHeroId,
+                "prisoner settlement notification");
+            if (hasPrisonerDonation)
+                TryPostPartyEffect(
+                    () => ApplyPrisonerDonation(
+                        playerParty,
+                        releasedPrisonersRoster,
+                        playerParty.CurrentSettlement),
+                    message.MainHeroId,
+                    "prisoner donation rewards");
+            if (hasGarrisonDonation)
+                TryPostPartyEffect(
+                    () => ApplyGarrisonDonation(
+                        mainHero,
+                        donationSettlement,
+                        message.LeftMemberRosterData),
+                    message.MainHeroId,
+                    "garrison donation rewards");
+            TryPostPartyEffect(
+                () => ApplyUpgradedTroopHistory(mainHero, upgradedTroopHistory),
+                message.MainHeroId,
+                "troop upgrade effects");
+            TryPostPartyEffect(
+                () => ApplyPrisonerRecruitmentEffects(
+                    mainHero, message, recruitedPrisonersRoster),
+                message.MainHeroId,
+                "prisoner recruitment effects");
+            TryPostPartyEffect(
+                () => ApplyRosterOrder(
+                    mainHero.PartyBelongedTo.MemberRoster,
+                    message.RightMemberOrderData),
+                message.MainHeroId,
+                "party roster order");
+            if (isRansom)
+                TryPostPartyEffect(
+                    () => SellPrisonersHandler.NotifySaleCommitted(
+                        requester, playerParty),
+                    message.MainHeroId,
+                    "ransom roster refresh");
+            ServerTransactionOutcome.Accept(
+                requester, ServerTransactionOutcome.Party);
+        }));
+    }
+
+    private bool TryResolveQuestTroopSource(
+        Hero mainHero,
+        NetworkCompleteDoneLogic message,
+        IReadOnlyCollection<Tuple<CharacterObject, CharacterObject, int>> upgrades,
+        out TroopRoster questRoster,
+        out int? expectedGoldChange,
+        out string reason)
+    {
+        questRoster = null;
+        expectedGoldChange = null;
+        reason = "The quest troop selection no longer matches the server state.";
+
+        // OpenScreenAsQuest uses an ownerless left roster, so its authoritative
+        // identity is the active IssueBase.AlternativeSolutionSentTroops roster.
+        // Never accept a client-created dummy roster as the source of troops.
+        if (mainHero?.Clan == null ||
+            !string.IsNullOrEmpty(message.LeftPartyId) ||
+            !string.IsNullOrEmpty(message.LeftPrisonerRosterId) ||
+            upgrades?.Count > 0 ||
+            HasAnyDelta(message.LeftPrisonerRosterData) ||
+            HasAnyDelta(message.RightPrisonerRosterData) ||
+            (message.ReleasedPrisonersRoster?.Length ?? 0) != 0 ||
+            (message.TakenPrisonersRoster?.Length ?? 0) != 0 ||
+            (message.RecruitedPrisonersRoster?.Length ?? 0) != 0 ||
+            message.ApplyReleasedAndTakenPrisonerActions ||
+            message.DoNotApplyGoldTransactions ||
+            message.PartyInfluenceChangeAmount != 0 ||
+            message.PartyMoraleChangeAmount != 0)
+            return false;
+
+        if (!TryReadQuestTransferDeltas(
+                message.LeftMemberRosterData,
+                message.RightMemberRosterData,
+                out Dictionary<CharacterObject, TroopRosterElementData> transfers))
+            return false;
+
+        IssueBase matchedIssue = null;
+        TroopRoster matchedRoster = null;
+        int matchedGold = 0;
+        var issues = Campaign.Current?.IssueManager?.Issues;
+        if (issues == null)
+            return false;
+
+        foreach (IssueBase issue in issues.Values)
+        {
+            Hero companion = issue?.AlternativeSolutionHero;
+            if (issue == null || !issue.IsOngoingWithoutQuest ||
+                !issue.IsThereAlternativeSolution || companion == null ||
+                companion.Clan != mainHero.Clan ||
+                issue.AlternativeSolutionSentTroops == null)
+                continue;
+
+            if (!TryBuildQuestRosterAndGold(
+                    issue, transfers, out TroopRoster proposed,
+                    out int proposedGold))
+                continue;
+
+            // The old wire has no issue ID. Ambiguity is therefore rejected
+            // instead of guessing and moving troops into another active issue.
+            if (matchedIssue != null)
+                return false;
+            matchedIssue = issue;
+            matchedRoster = issue.AlternativeSolutionSentTroops;
+            matchedGold = proposedGold;
+        }
+
+        if (matchedIssue == null)
+            return false;
+        questRoster = matchedRoster;
+        expectedGoldChange = matchedGold;
+        return true;
+    }
+
+    private bool TryReadQuestTransferDeltas(
+        TroopRosterData leftData,
+        TroopRosterData rightData,
+        out Dictionary<CharacterObject, TroopRosterElementData> transfers)
+    {
+        transfers = new Dictionary<CharacterObject, TroopRosterElementData>();
+        var right = new Dictionary<CharacterObject, TroopRosterElementData>();
+        foreach (TroopRosterElementData element in
+                 leftData.Data ?? Array.Empty<TroopRosterElementData>())
+        {
+            if (!objectManager.TryGetObject(
+                    element.CharacterId, out CharacterObject character) ||
+                character == null || character.IsHero ||
+                character.IsNotTransferableInPartyScreen ||
+                element.Number == 0 ||
+                element.Number > 0 &&
+                    (element.WoundedNumber < 0 ||
+                     element.WoundedNumber > element.Number || element.Xp < 0) ||
+                element.Number < 0 &&
+                    (element.WoundedNumber > 0 ||
+                     element.WoundedNumber < element.Number || element.Xp > 0) ||
+                transfers.ContainsKey(character))
+                return false;
+            transfers.Add(character, element);
+        }
+        foreach (TroopRosterElementData element in
+                 rightData.Data ?? Array.Empty<TroopRosterElementData>())
+        {
+            if (!objectManager.TryGetObject(
+                    element.CharacterId, out CharacterObject character) ||
+                character == null || right.ContainsKey(character))
+                return false;
+            right.Add(character, element);
+        }
+
+        return transfers.Count > 0 && transfers.Count == right.Count &&
+            transfers.All(pair =>
+                right.TryGetValue(pair.Key, out TroopRosterElementData other) &&
+                other.Number == -pair.Value.Number &&
+                other.WoundedNumber == -pair.Value.WoundedNumber &&
+                other.Xp == -pair.Value.Xp);
+    }
+
+    private static bool TryBuildQuestRosterAndGold(
+        IssueBase issue,
+        IReadOnlyDictionary<CharacterObject, TroopRosterElementData> transfers,
+        out TroopRoster proposed,
+        out int expectedGold)
+    {
+        proposed = TroopRoster.CreateDummyTroopRoster();
+        expectedGold = 0;
+        try
+        {
+            var current = new Dictionary<CharacterObject,
+                (int number, int wounded, int xp)>();
+            foreach (TroopRosterElement element in
+                     issue.AlternativeSolutionSentTroops.GetTroopRoster())
+            {
+                current[element.Character] = (
+                    element.Number, element.WoundedNumber, element.Xp);
+                proposed.AddToCounts(
+                    element.Character,
+                    element.Number,
+                    false,
+                    element.WoundedNumber,
+                    element.Xp,
+                    true);
+            }
+
+            foreach (var transfer in transfers)
+            {
+                if (!issue.IsTroopTypeNeededByAlternativeSolution(transfer.Key))
+                    return false;
+                TroopRosterElementData delta = transfer.Value;
+                current.TryGetValue(transfer.Key, out var before);
+                long finalNumber = (long)before.number + delta.Number;
+                long finalWounded = (long)before.wounded + delta.WoundedNumber;
+                long finalXp = (long)before.xp + delta.Xp;
+                if (finalNumber < 0 || finalNumber > int.MaxValue ||
+                    finalWounded < 0 || finalWounded > finalNumber ||
+                    finalXp < 0 || finalXp > int.MaxValue ||
+                    finalNumber == 0 && finalXp != 0)
+                    return false;
+                proposed.AddToCounts(
+                    transfer.Key,
+                    delta.Number,
+                    false,
+                    delta.WoundedNumber,
+                    delta.Xp,
+                    true);
+            }
+
+            int needed = issue.GetTotalAlternativeSolutionNeededMenCount();
+            if (needed <= 1 || proposed.TotalManCount > needed + 1 ||
+                proposed.TotalRegulars < needed ||
+                proposed.TotalRegulars - proposed.TotalWoundedRegulars < needed ||
+                !issue.DoTroopsSatisfyAlternativeSolution(proposed, out _))
+                return false;
+
+            int days = issue.GetTotalAlternativeSolutionDurationInDays();
+            if (days < 0)
+                return false;
+            long cost = 0;
+            foreach (TroopRosterElement element in proposed.GetTroopRoster())
+            {
+                cost += (long)element.Character.TroopWage *
+                    element.Number * days;
+                if (cost > int.MaxValue)
+                    return false;
+            }
+            expectedGold = -(int)cost;
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool HasAnyDelta(TroopRosterData data)
+        => (data.Data ?? Array.Empty<TroopRosterElementData>()).Any(element =>
+            element.Number != 0 || element.WoundedNumber != 0 ||
+            element.Xp != 0);
+
+    private bool TryBuildAuthoritativeRansomSale(
+        MobileParty playerParty,
+        NetworkCompleteDoneLogic message,
+        IReadOnlyCollection<Tuple<CharacterObject, CharacterObject, int>> upgrades,
+        out TroopRoster requestedPrisoners,
+        out string reason)
+    {
+        requestedPrisoners = null;
+        reason = "The prisoner sale no longer matches the server state. Reopen the ransom screen and try again.";
+
+        if (playerParty?.IsActive != true ||
+            playerParty.MapEvent != null ||
+            playerParty.CurrentSettlement?.Town == null ||
+            HasAnyDelta(message.LeftMemberRosterData) ||
+            HasAnyDelta(message.RightMemberRosterData) ||
+            (upgrades?.Count ?? 0) != 0 ||
+            (message.ReleasedPrisonersRoster?.Length ?? 0) != 0 ||
+            (message.TakenPrisonersRoster?.Length ?? 0) != 0 ||
+            (message.RecruitedPrisonersRoster?.Length ?? 0) != 0 ||
+            message.ApplyReleasedAndTakenPrisonerActions ||
+            !message.DoNotApplyGoldTransactions ||
+            message.PartyInfluenceChangeAmount != 0 ||
+            message.PartyMoraleChangeAmount != 0)
+            return false;
+
+        TroopRosterElementData[] left = message.LeftPrisonerRosterData.Data ??
+            Array.Empty<TroopRosterElementData>();
+        TroopRosterElementData[] right = message.RightPrisonerRosterData.Data ??
+            Array.Empty<TroopRosterElementData>();
+        if (left.Length == 0 || left.Length != right.Length ||
+            left.Any(element => string.IsNullOrEmpty(element.CharacterId)) ||
+            right.Any(element => string.IsNullOrEmpty(element.CharacterId)) ||
+            left.Select(element => element.CharacterId)
+                .Distinct(StringComparer.Ordinal).Count() != left.Length ||
+            right.Select(element => element.CharacterId)
+                .Distinct(StringComparer.Ordinal).Count() != right.Length)
+            return false;
+
+        Dictionary<string, TroopRosterElementData> rightById = right
+            .ToDictionary(element => element.CharacterId, StringComparer.Ordinal);
+        requestedPrisoners = new TroopRoster();
+        foreach (TroopRosterElementData sale in left)
+        {
+            if (sale.Number <= 0 || sale.WoundedNumber < 0 ||
+                sale.WoundedNumber > sale.Number || sale.Xp < 0 ||
+                !rightById.TryGetValue(
+                    sale.CharacterId, out TroopRosterElementData removal) ||
+                removal.Number != -sale.Number ||
+                removal.WoundedNumber != -sale.WoundedNumber ||
+                removal.Xp != -sale.Xp ||
+                !objectManager.TryGetObject(
+                    sale.CharacterId, out CharacterObject character) ||
+                character == null)
+                return false;
+
+            int availableIndex = playerParty.PrisonRoster
+                .FindIndexOfTroop(character);
+            if (availableIndex < 0)
+                return false;
+            TroopRosterElement available = playerParty.PrisonRoster
+                .GetElementCopyAtIndex(availableIndex);
+            int requestedHealthy = sale.Number - sale.WoundedNumber;
+            int availableHealthy = available.Number - available.WoundedNumber;
+            if (sale.Number > available.Number ||
+                sale.WoundedNumber > available.WoundedNumber ||
+                requestedHealthy > availableHealthy ||
+                sale.Xp > available.Xp)
+                return false;
+
+            requestedPrisoners.AddToCounts(
+                character,
+                sale.Number,
+                false,
+                sale.WoundedNumber,
+                sale.Xp,
+                true);
+        }
+
+        return true;
+    }
+
+    private static bool IsAuthorizedPartySource(
+        Hero mainHero,
+        MobileParty playerParty,
+        PartyBase leftParty,
+        TroopRoster leftPrisonerRoster,
+        TroopRoster questRoster,
+        BattlePartyClaim battlePartyClaim,
+        NetworkCompleteDoneLogic message,
+        out bool allowBattleRescue)
+    {
+        allowBattleRescue = false;
+        PartyBase source = leftParty ?? leftPrisonerRoster?.OwnerParty;
+        if (source == null)
+        {
+            if (battlePartyClaim != null)
+            {
+                allowBattleRescue = true;
+                // The prepared grant has already authenticated both ownerless
+                // source deltas. Global conservation and role validation below
+                // bind every positive destination delta to those sources while
+                // still allowing the native screen to leave owned regulars behind.
+                return true;
+            }
+            if (message.PartyScreenMode ==
+                Helpers.PartyScreenHelper.PartyScreenMode.QuestTroopManage)
+                return questRoster != null;
+            // Native dismiss/ransom/quest screens use ownerless dummy rosters.
+            // Non-quest dummy rosters may receive units, but must never be used
+            // as a source.
+            return HasNoNegativeNumberDelta(message.LeftMemberRosterData) &&
+                HasNoNegativeNumberDelta(message.LeftPrisonerRosterData);
+        }
+        if (source == playerParty?.Party)
+            return true;
+        if (source.Settlement != null &&
+            source.Settlement == playerParty?.CurrentSettlement)
+        {
+            // A player may donate into a settlement they do not own, but may
+            // only withdraw from a settlement controlled by their clan.
+            return source.Settlement.OwnerClan == mainHero?.Clan ||
+                HasNoNegativeNumberDelta(message.LeftMemberRosterData) &&
+                HasNoNegativeNumberDelta(message.LeftPrisonerRosterData);
+        }
+
+        MobileParty mobile = source.MobileParty;
+        if (mobile == null || playerParty == null)
+            return false;
+        if (mobile.ActualClan == mainHero?.Clan)
+        {
+            if (mobile.CurrentSettlement != null &&
+                mobile.CurrentSettlement == playerParty.CurrentSettlement)
+                return true;
+            if (mobile.Army != null && mobile.Army == playerParty.Army)
+                return true;
+            if (mobile.CurrentSettlement != null ||
+                playerParty.CurrentSettlement != null)
+                return false;
+
+            float radius = Campaign.Current.Models.EncounterModel
+                .GetEncounterJoiningRadius;
+            return playerParty.Position.ToVec2().Distance(
+                mobile.Position.ToVec2()) <= radius;
+        }
+
+        // A defeated non-clan party may only provide losses during the active
+        // map-event loot flow. In particular, a living enemy member cannot be
+        // moved directly into the player's member roster. Rescued prisoners
+        // may become members and are validated again by role conservation.
+        MapEvent mapEvent = mobile.MapEvent;
+        bool resolvedVictory = mapEvent != null &&
+            (mapEvent.BattleState == BattleState.AttackerVictory ||
+             mapEvent.BattleState == BattleState.DefenderVictory);
+        if (!resolvedVictory || mapEvent != playerParty.MapEvent ||
+            mobile.Party.MapEventSide == null ||
+            playerParty.Party.MapEventSide == null ||
+            mobile.Party.MapEventSide !=
+                mapEvent.GetMapEventSide(mapEvent.DefeatedSide) ||
+            playerParty.Party.MapEventSide !=
+                mapEvent.GetMapEventSide(mapEvent.WinningSide) ||
+            !message.ApplyReleasedAndTakenPrisonerActions ||
+            !HasNoPositiveNumberDelta(message.LeftMemberRosterData) ||
+            !HasNoPositiveNumberDelta(message.LeftPrisonerRosterData) ||
+            !HasNoNegativeNumberDelta(message.RightMemberRosterData) ||
+            !HasNoNegativeNumberDelta(message.RightPrisonerRosterData) ||
+            !RightMemberAdditionsComeFromLeftPrisoners(message))
+            return false;
+
+        allowBattleRescue = true;
+        return true;
+    }
+
+    private static bool HasNoNegativeNumberDelta(TroopRosterData data)
+    {
+        return (data.Data ?? Array.Empty<TroopRosterElementData>())
+            .All(element => element.Number >= 0);
+    }
+
+    private static bool HasNoPositiveNumberDelta(TroopRosterData data)
+    {
+        return (data.Data ?? Array.Empty<TroopRosterElementData>())
+            .All(element => element.Number <= 0);
+    }
+
+    private static bool RightMemberAdditionsComeFromLeftPrisoners(
+        NetworkCompleteDoneLogic message)
+    {
+        Dictionary<string, long> prisonerRemovals =
+            SumNumberDeltasById(message.LeftPrisonerRosterData);
+        Dictionary<string, long> memberAdditions =
+            SumNumberDeltasById(message.RightMemberRosterData);
+        foreach (var addition in memberAdditions.Where(pair => pair.Value > 0))
+        {
+            prisonerRemovals.TryGetValue(addition.Key, out long removal);
+            if (removal > -addition.Value)
+                return false;
+        }
+        return true;
+    }
+
+    private static Dictionary<string, long> SumNumberDeltasById(
+        TroopRosterData data)
+    {
+        var result = new Dictionary<string, long>(StringComparer.Ordinal);
+        foreach (TroopRosterElementData element in
+                 data.Data ?? Array.Empty<TroopRosterElementData>())
+        {
+            if (string.IsNullOrEmpty(element.CharacterId))
+                continue;
+            result.TryGetValue(element.CharacterId, out long current);
+            result[element.CharacterId] = current + element.Number;
+        }
+        return result;
+    }
+
+    private static List<(TroopRoster roster, TroopRosterData delta)>
+        InvertRosterDeltas(
+            IEnumerable<(TroopRoster roster, TroopRosterData delta)> deltas)
+    {
+        return deltas.Select(entry => (
+            entry.roster,
+            new TroopRosterData((entry.delta.Data ??
+                Array.Empty<TroopRosterElementData>())
+                .Select(element => new TroopRosterElementData(
+                    element.CharacterId,
+                    -element.Number,
+                    -element.WoundedNumber,
+                    -element.Xp)))))
+            .ToList();
     }
 
     private bool TryResolveCompleteDoneLogic(
@@ -264,6 +1038,7 @@ internal class PartyDoneLogicHandler : IHandler
         Hero mainHero,
         PartyBase leftParty,
         TroopRoster leftPrisonerRoster,
+        TroopRoster questRoster,
         NetworkCompleteDoneLogic message,
         TroopRosterData leftPrisonerRosterData,
         TroopRosterData rightPrisonerRosterData)
@@ -281,10 +1056,373 @@ internal class PartyDoneLogicHandler : IHandler
         {
             rosterDeltas.Add((leftPrisonerRoster, leftPrisonerRosterData));
         }
+        else if (questRoster != null)
+        {
+            rosterDeltas.Add((questRoster, message.LeftMemberRosterData));
+        }
 
         rosterDeltas.Add((mainHero.PartyBelongedTo.MemberRoster, message.RightMemberRosterData));
         rosterDeltas.Add((mainHero.PartyBelongedTo.PrisonRoster, rightPrisonerRosterData));
         return rosterDeltas;
+    }
+
+    private bool TryValidatePartyCommit(
+        Hero mainHero,
+        NetworkCompleteDoneLogic message,
+        IReadOnlyCollection<Tuple<CharacterObject, CharacterObject, int>> upgrades,
+        IReadOnlyCollection<(TroopRoster roster, TroopRosterData delta)> deltas,
+        bool hasPrisonerDonation,
+        bool hasGarrisonDonation,
+        int? questGoldChange,
+        IEnumerable<TroopRosterData> virtualSourceDeltas,
+        out string reason)
+    {
+        reason = "The party changes were not valid for the current server state.";
+        if (message.DoNotApplyGoldTransactions !=
+            (message.PartyScreenMode ==
+             Helpers.PartyScreenHelper.PartyScreenMode.Ransom))
+            return false;
+        var globalDeltas = new Dictionary<CharacterObject,
+            (long number, long wounded, long xp)>();
+        IEnumerable<TroopRosterData> allDeltas =
+            deltas.Select(entry => entry.delta).Concat(
+                virtualSourceDeltas ?? Enumerable.Empty<TroopRosterData>());
+        foreach (TroopRosterData delta in allDeltas)
+        {
+            foreach (TroopRosterElementData element in
+                     delta.Data ?? Array.Empty<TroopRosterElementData>())
+            {
+                if (!objectManager.TryGetObject(
+                        element.CharacterId,
+                        out CharacterObject character) || character == null)
+                    return false;
+                globalDeltas.TryGetValue(character, out var current);
+                globalDeltas[character] = (
+                    current.number + element.Number,
+                    current.wounded + element.WoundedNumber,
+                    current.xp + element.Xp);
+            }
+        }
+
+        long goldCost = 0;
+        var requiredItems = new Dictionary<ItemCategory, int>();
+        var requiredSourceCounts = new Dictionary<CharacterObject, int>();
+        var requiredTargetCounts = new Dictionary<CharacterObject, int>();
+        var requiredSourceXp = new Dictionary<CharacterObject, long>();
+        var expectedNumberDeltas = new Dictionary<CharacterObject, long>();
+        var expectedXpDeltas = new Dictionary<CharacterObject, long>();
+        foreach (Tuple<CharacterObject, CharacterObject, int> upgrade in
+                 upgrades ?? Array.Empty<Tuple<CharacterObject, CharacterObject, int>>())
+        {
+            CharacterObject source = upgrade.Item1;
+            CharacterObject target = upgrade.Item2;
+            int count = upgrade.Item3;
+            if (source == null || target == null || count <= 0)
+                return false;
+            int targetIndex = Array.IndexOf(source.UpgradeTargets, target);
+            if (targetIndex < 0)
+                return false;
+
+            goldCost += (long)source.GetUpgradeGoldCost(
+                mainHero.PartyBelongedTo.Party,
+                targetIndex) * count;
+            long xpCost = (long)source.GetUpgradeXpCost(
+                mainHero.PartyBelongedTo.Party,
+                targetIndex) * count;
+            AddCount(requiredSourceCounts, source, count);
+            AddCount(requiredTargetCounts, target, count);
+            AddLongCount(expectedNumberDeltas, source, -count);
+            AddLongCount(expectedNumberDeltas, target, count);
+            AddLongCount(expectedXpDeltas, source, -xpCost);
+            requiredSourceXp.TryGetValue(source, out long existingXp);
+            requiredSourceXp[source] = existingXp + xpCost;
+
+            ItemCategory category = target.UpgradeRequiresItemFromCategory;
+            if (category != null)
+            {
+                requiredItems.TryGetValue(category, out int required);
+                if (required > int.MaxValue - count)
+                    return false;
+                requiredItems[category] = required + count;
+            }
+        }
+
+        foreach (var required in requiredSourceCounts)
+        {
+            if (!globalDeltas.TryGetValue(required.Key, out var delta) ||
+                delta.number > -required.Value ||
+                delta.xp > -requiredSourceXp[required.Key])
+                return false;
+        }
+        foreach (var required in requiredTargetCounts)
+        {
+            if (!globalDeltas.TryGetValue(required.Key, out var delta) ||
+                delta.number < required.Value)
+                return false;
+        }
+
+        // Transfers between rosters net to zero. Upgrades are the only valid
+        // source of positive global troop/XP/wounded deltas. Extra negative
+        // number deltas are dismissals, but a wounded-only negative delta is
+        // healing and must never be accepted.
+        long totalWoundedDelta = 0;
+        foreach (CharacterObject character in globalDeltas.Keys
+                     .Union(expectedNumberDeltas.Keys)
+                     .Union(expectedXpDeltas.Keys))
+        {
+            globalDeltas.TryGetValue(character, out var actual);
+            expectedNumberDeltas.TryGetValue(
+                character, out long expectedNumber);
+            expectedXpDeltas.TryGetValue(character, out long expectedXp);
+            if (actual.number > expectedNumber ||
+                actual.xp > expectedXp ||
+                actual.wounded < 0 &&
+                    (actual.number >= 0 || actual.wounded < actual.number) ||
+                actual.wounded > 0 &&
+                    (!requiredTargetCounts.TryGetValue(
+                        character, out int upgradedTargetCount) ||
+                     actual.wounded > upgradedTargetCount))
+                return false;
+            totalWoundedDelta += actual.wounded;
+        }
+        if (totalWoundedDelta > 0)
+            return false;
+
+        bool isRansom = message.PartyScreenMode ==
+            Helpers.PartyScreenHelper.PartyScreenMode.Ransom;
+        if (!isRansom && !TryValidateUpgradeItems(
+                mainHero.PartyBelongedTo.ItemRoster,
+                message.RightOwnerPartyItemRosterData,
+                requiredItems))
+            return false;
+
+        if (message.PartyScreenMode ==
+            Helpers.PartyScreenHelper.PartyScreenMode.QuestTroopManage)
+        {
+            if (!questGoldChange.HasValue ||
+                message.PartyGoldChangeAmount != questGoldChange.Value ||
+                questGoldChange.Value < 0 &&
+                    mainHero.Gold < -(long)questGoldChange.Value)
+                return false;
+        }
+        else if (!message.DoNotApplyGoldTransactions)
+        {
+            if (goldCost > int.MaxValue ||
+                message.PartyGoldChangeAmount != -(int)goldCost ||
+                mainHero.Gold < goldCost)
+                return false;
+        }
+
+        if (!hasPrisonerDonation && !hasGarrisonDonation &&
+            message.PartyInfluenceChangeAmount != 0)
+            return false;
+
+        return true;
+    }
+
+    private bool TryValidateRosterRoleChanges(
+        MobileParty playerParty,
+        FlattenedTroopRoster recruited,
+        FlattenedTroopRoster taken,
+        IReadOnlyCollection<Tuple<CharacterObject, CharacterObject, int>> upgrades,
+        TroopRosterData leftMemberDelta,
+        TroopRosterData leftPrisonerDelta,
+        TroopRosterData rightMemberDelta,
+        TroopRosterData rightPrisonerDelta,
+        bool allowBattleRescue,
+        BattlePartyClaim battlePartyClaim)
+    {
+        Dictionary<CharacterObject, int> recruitedCounts =
+            GetFlattenedCounts(recruited);
+        Dictionary<CharacterObject, int> takenCounts =
+            GetFlattenedCounts(taken);
+        Dictionary<CharacterObject, long> rightMemberCounts =
+            SumNumberDeltas(rightMemberDelta);
+        Dictionary<CharacterObject, long> rightPrisonerCounts =
+            SumNumberDeltas(rightPrisonerDelta);
+        Dictionary<CharacterObject, long> leftMemberCounts =
+            SumNumberDeltas(leftMemberDelta);
+        Dictionary<CharacterObject, long> leftPrisonerCounts =
+            SumNumberDeltas(leftPrisonerDelta);
+        var expectedUpgradeMember = new Dictionary<CharacterObject, long>();
+        foreach (Tuple<CharacterObject, CharacterObject, int> upgrade in
+                 upgrades ?? Array.Empty<Tuple<CharacterObject, CharacterObject, int>>())
+        {
+            AddLongCount(expectedUpgradeMember, upgrade.Item1, -upgrade.Item3);
+            AddLongCount(expectedUpgradeMember, upgrade.Item2, upgrade.Item3);
+        }
+
+        var characters = new HashSet<CharacterObject>(rightMemberCounts.Keys);
+        characters.UnionWith(rightPrisonerCounts.Keys);
+        characters.UnionWith(leftMemberCounts.Keys);
+        characters.UnionWith(leftPrisonerCounts.Keys);
+        characters.UnionWith(recruitedCounts.Keys);
+        characters.UnionWith(takenCounts.Keys);
+        characters.UnionWith(expectedUpgradeMember.Keys);
+        foreach (CharacterObject character in characters)
+        {
+            rightMemberCounts.TryGetValue(character, out long rightMember);
+            rightPrisonerCounts.TryGetValue(character, out long rightPrisoner);
+            leftMemberCounts.TryGetValue(character, out long leftMember);
+            leftPrisonerCounts.TryGetValue(character, out long leftPrisoner);
+            recruitedCounts.TryGetValue(character, out int recruitedCount);
+            takenCounts.TryGetValue(character, out int takenCount);
+            expectedUpgradeMember.TryGetValue(
+                character, out long upgradeMember);
+
+            if (battlePartyClaim != null)
+            {
+                long claimedMembers = Math.Max(0L, -leftMember);
+                long claimedPrisoners = Math.Max(0L, -leftPrisoner);
+                long grantMaximumMember =
+                    upgradeMember + recruitedCount + claimedMembers;
+                long grantMaximumPrisoner =
+                    claimedPrisoners - recruitedCount;
+                if (rightMember > grantMaximumMember ||
+                    rightPrisoner > grantMaximumPrisoner)
+                    return false;
+                if (recruitedCount > 0 &&
+                    (rightMember < recruitedCount ||
+                     rightPrisoner - claimedPrisoners > -recruitedCount ||
+                     playerParty == null ||
+                     Campaign.Current.Models
+                         .PrisonerRecruitmentCalculationModel
+                         .CalculateRecruitableNumber(
+                             playerParty.Party, character) < recruitedCount))
+                    return false;
+                continue;
+            }
+
+            long rescuedCount = allowBattleRescue
+                ? Math.Min(Math.Max(0L, rightMember),
+                    Math.Max(0L, -leftPrisoner))
+                : 0L;
+            long transferredPrisoners = Math.Min(
+                Math.Max(0L, rightPrisoner),
+                Math.Max(0L, -leftPrisoner));
+            long capturedCount = allowBattleRescue
+                ? Math.Max(0L, rightPrisoner - transferredPrisoners)
+                : 0L;
+            if (allowBattleRescue &&
+                (capturedCount > Math.Max(0L, -leftMember) ||
+                 takenCount != capturedCount))
+                return false;
+            long actualMember = leftMember + rightMember;
+            long actualPrisoner = leftPrisoner + rightPrisoner;
+            long maximumMember = upgradeMember + recruitedCount + rescuedCount;
+            long maximumPrisoner =
+                capturedCount -
+                recruitedCount - rescuedCount;
+
+            // Dismissals/releases may make a role more negative, but only
+            // upgrades, qualified recruitment, battle capture and rescued
+            // prisoners may create a positive role delta.
+            if (actualMember > maximumMember ||
+                actualPrisoner > maximumPrisoner)
+                return false;
+
+            if (recruitedCount > 0 &&
+                (rightMember < recruitedCount ||
+                 rightPrisoner > -recruitedCount ||
+                 playerParty == null ||
+                Campaign.Current.Models.PrisonerRecruitmentCalculationModel
+                    .CalculateRecruitableNumber(
+                        playerParty.Party, character) < recruitedCount))
+                return false;
+        }
+        return true;
+    }
+
+    private Dictionary<CharacterObject, long> SumNumberDeltas(
+        TroopRosterData data)
+    {
+        var result = new Dictionary<CharacterObject, long>();
+        foreach (TroopRosterElementData element in
+                 data.Data ?? Array.Empty<TroopRosterElementData>())
+        {
+            if (!objectManager.TryGetObject(
+                    element.CharacterId,
+                    out CharacterObject character) || character == null)
+                return new Dictionary<CharacterObject, long>();
+            result.TryGetValue(character, out long current);
+            result[character] = current + element.Number;
+        }
+        return result;
+    }
+
+    private static void AddCount(
+        IDictionary<CharacterObject, int> counts,
+        CharacterObject character,
+        int amount)
+    {
+        counts.TryGetValue(character, out int current);
+        counts[character] = current + amount;
+    }
+
+    private static void AddLongCount(
+        IDictionary<CharacterObject, long> counts,
+        CharacterObject character,
+        long amount)
+    {
+        counts.TryGetValue(character, out long current);
+        counts[character] = current + amount;
+    }
+
+    private static bool TryValidateUpgradeItems(
+        ItemRoster currentRoster,
+        ItemRosterElement[] submittedRoster,
+        IReadOnlyDictionary<ItemCategory, int> requiredItems)
+    {
+        if (currentRoster == null || submittedRoster == null)
+            return false;
+        var current = new Dictionary<EquipmentElement, int>();
+        foreach (ItemRosterElement element in currentRoster)
+        {
+            if (element.EquipmentElement.Item == null || element.Amount < 0)
+                return false;
+            current[element.EquipmentElement] = element.Amount;
+        }
+        var submitted = new Dictionary<EquipmentElement, int>();
+        foreach (ItemRosterElement element in submittedRoster)
+        {
+            if (element.EquipmentElement.Item == null)
+            {
+                // Older clients sent ItemRoster._data rather than ToArray().
+                // Its unused capacity is represented by null/zero rows and
+                // carries no state. A null row with a non-zero amount remains
+                // invalid and is rejected.
+                if (element.Amount == 0)
+                    continue;
+                return false;
+            }
+            if (element.Amount < 0 ||
+                submitted.ContainsKey(element.EquipmentElement))
+                return false;
+            if (element.Amount > 0)
+                submitted[element.EquipmentElement] = element.Amount;
+        }
+
+        var removedByCategory = new Dictionary<ItemCategory, int>();
+        foreach (EquipmentElement element in current.Keys.Union(submitted.Keys))
+        {
+            current.TryGetValue(element, out int before);
+            submitted.TryGetValue(element, out int after);
+            if (after > before)
+                return false;
+            int removed = before - after;
+            if (removed == 0)
+                continue;
+            ItemCategory category = element.Item?.ItemCategory;
+            if (category == null || !requiredItems.ContainsKey(category))
+                return false;
+            removedByCategory.TryGetValue(category, out int existing);
+            removedByCategory[category] = existing + removed;
+        }
+
+        return requiredItems.Count == removedByCategory.Count &&
+            requiredItems.All(pair =>
+                removedByCategory.TryGetValue(pair.Key, out int removed) &&
+                removed == pair.Value);
     }
 
     private void PublishPlayerCaptivityReleaseEvents(List<PlayerCaptivityEndedByServer> releasedPlayerCaptivityEvents)
@@ -300,6 +1438,13 @@ internal class PartyDoneLogicHandler : IHandler
         mainHero.PartyBelongedTo.ItemRoster.Clear();
         foreach (var itemRosterElement in message.RightOwnerPartyItemRosterData ?? Enumerable.Empty<ItemRosterElement>())
         {
+            // v1.4.17 and older clients serialized ItemRoster._data, whose unused
+            // capacity is represented by default null/zero rows. Validation above
+            // rejects any state-bearing null row; do not feed harmless padding back
+            // into Bannerlord's roster implementation during a compatible retry.
+            if (itemRosterElement.EquipmentElement.Item == null &&
+                itemRosterElement.Amount == 0)
+                continue;
             mainHero.PartyBelongedTo.ItemRoster.Add(itemRosterElement);
         }
     }
@@ -327,30 +1472,249 @@ internal class PartyDoneLogicHandler : IHandler
         var signedDeltas = (rightPrisonerRosterData.Data ?? Array.Empty<TroopRosterElementData>())
             .GroupBy(element => element.CharacterId)
             .ToDictionary(group => group.Key, group => group.Sum(element => element.Number));
+        Dictionary<string, int> released =
+            GetActionCountsById(releasedPrisonersRoster);
+        Dictionary<string, int> taken =
+            GetActionCountsById(takenPrisonersRoster);
+        if (released == null || taken == null)
+            return false;
 
-        return ActionsMatchDelta(releasedPrisonersRoster, signedDeltas, expectedSign: -1) &&
-               ActionsMatchDelta(takenPrisonersRoster, signedDeltas, expectedSign: 1);
+        var characterIds = new HashSet<string>(signedDeltas.Keys);
+        characterIds.UnionWith(released.Keys);
+        characterIds.UnionWith(taken.Keys);
+        return characterIds.All(characterId =>
+        {
+            signedDeltas.TryGetValue(characterId, out int delta);
+            released.TryGetValue(characterId, out int releasedCount);
+            taken.TryGetValue(characterId, out int takenCount);
+            return delta == takenCount - releasedCount;
+        });
     }
 
-    private bool ActionsMatchDelta(
-        FlattenedTroopRoster actionRoster,
-        IReadOnlyDictionary<string, int> signedDeltas,
-        int expectedSign)
+    private static void TryPostPartyEffect(
+        Action action,
+        string mainHeroId,
+        string operation)
+    {
+        try
+        {
+            action?.Invoke();
+        }
+        catch (Exception exception)
+        {
+            logger.Error(
+                exception,
+                "Party commit completed for {MainHeroId}, but {Operation} failed",
+                mainHeroId,
+                operation);
+        }
+    }
+
+    private bool TryValidatePrisonerDonation(
+        DonatePrisoners donation,
+        MobileParty playerParty,
+        FlattenedTroopRoster releasedPrisoners,
+        TroopRosterData rightPrisonerDelta,
+        out string reason)
+    {
+        reason = "The prisoner donation no longer matches the server state.";
+        Settlement settlement = playerParty?.CurrentSettlement;
+        if (settlement == null ||
+            !objectManager.TryGetId(settlement, out string settlementId) ||
+            !objectManager.TryGetId(playerParty.Party, out string partyId) ||
+            !string.Equals(
+                donation.CurrentSettlementId,
+                settlementId,
+                StringComparison.Ordinal) ||
+            !string.Equals(
+                donation.RightPartyId,
+                partyId,
+                StringComparison.Ordinal))
+            return false;
+
+        FlattenedTroopRoster staged = FlattenedTroopSerializer.Deserialize(
+            donation.RightSidePrisonerRoster,
+            objectManager);
+        Dictionary<CharacterObject, int> releasedCounts =
+            GetFlattenedCounts(releasedPrisoners);
+        Dictionary<CharacterObject, int> stagedCounts =
+            GetFlattenedCounts(staged);
+        if (releasedCounts.Count == 0 ||
+            releasedCounts.Count != stagedCounts.Count ||
+            releasedCounts.Any(pair =>
+                !stagedCounts.TryGetValue(pair.Key, out int count) ||
+                count != pair.Value))
+            return false;
+
+        var signedDeltas = new Dictionary<CharacterObject, int>();
+        foreach (TroopRosterElementData element in
+                 rightPrisonerDelta.Data ?? Array.Empty<TroopRosterElementData>())
+        {
+            if (!objectManager.TryGetObject(
+                    element.CharacterId,
+                    out CharacterObject character) ||
+                character == null || signedDeltas.ContainsKey(character))
+                return false;
+            if (element.Number != 0)
+                signedDeltas.Add(character, element.Number);
+        }
+
+        return signedDeltas.Count == releasedCounts.Count &&
+            releasedCounts.All(pair =>
+                signedDeltas.TryGetValue(pair.Key, out int delta) &&
+                delta == -pair.Value);
+    }
+
+    private static Dictionary<CharacterObject, int> GetFlattenedCounts(
+        FlattenedTroopRoster roster)
+    {
+        var counts = new Dictionary<CharacterObject, int>();
+        if (roster == null)
+            return counts;
+        foreach (FlattenedTroopRosterElement element in roster)
+        {
+            if (element.Troop == null)
+                continue;
+            counts.TryGetValue(element.Troop, out int count);
+            counts[element.Troop] = count + 1;
+        }
+        return counts;
+    }
+
+    private bool TryValidateGarrisonDonation(
+        DonateToGarrison donation,
+        MobileParty playerParty,
+        NetworkCompleteDoneLogic message,
+        out Settlement settlement,
+        out MobileParty garrison,
+        out bool createdGarrison,
+        out string reason)
+    {
+        settlement = playerParty?.CurrentSettlement;
+        garrison = settlement?.Town?.GarrisonParty;
+        createdGarrison = false;
+        reason = "The garrison donation no longer matches the server state.";
+        if (settlement?.Town == null ||
+            message.PartyScreenMode !=
+                Helpers.PartyScreenHelper.PartyScreenMode.TroopsManage ||
+            message.LeftPartyId != null ||
+            !objectManager.TryGetId(settlement, out string settlementId) ||
+            !string.Equals(
+                donation.CurrentSettlementId,
+                settlementId,
+                StringComparison.Ordinal))
+            return false;
+
+        TroopRosterElementData[] leftData =
+            message.LeftMemberRosterData.Data ??
+            Array.Empty<TroopRosterElementData>();
+        TroopRosterElementData[] rightData =
+            message.RightMemberRosterData.Data ??
+            Array.Empty<TroopRosterElementData>();
+        if (leftData.Any(element => string.IsNullOrEmpty(element.CharacterId)) ||
+            rightData.Any(element => string.IsNullOrEmpty(element.CharacterId)) ||
+            leftData.Select(element => element.CharacterId).Distinct().Count() !=
+                leftData.Length ||
+            rightData.Select(element => element.CharacterId).Distinct().Count() !=
+                rightData.Length)
+            return false;
+        var left = leftData.ToDictionary(element => element.CharacterId);
+        var right = rightData.ToDictionary(element => element.CharacterId);
+        if (left.Count == 0 || left.Count != right.Count)
+            return false;
+        if (donation.Troops == null || donation.Troops.Count == 0 ||
+            donation.Troops.Any(troop =>
+                string.IsNullOrEmpty(troop.CharacterId) || troop.Count <= 0))
+            return false;
+        Dictionary<string, int> staged = donation.Troops
+            .GroupBy(troop => troop.CharacterId, StringComparer.Ordinal)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Sum(troop => troop.Count),
+                StringComparer.Ordinal);
+        if (staged.Count != left.Count)
+            return false;
+        long donated = 0;
+        foreach (var pair in left)
+        {
+            TroopRosterElementData add = pair.Value;
+            if (add.Number <= 0 || add.WoundedNumber < 0 ||
+                add.WoundedNumber > add.Number || add.Xp < 0 ||
+                !staged.TryGetValue(pair.Key, out int stagedCount) ||
+                stagedCount != add.Number ||
+                !right.TryGetValue(pair.Key, out TroopRosterElementData remove) ||
+                remove.Number != -add.Number ||
+                remove.WoundedNumber != -add.WoundedNumber ||
+                remove.Xp != -add.Xp)
+                return false;
+            donated += add.Number;
+        }
+        if (donated > int.MaxValue)
+            return false;
+
+        if (garrison == null)
+        {
+            try
+            {
+                settlement.AddGarrisonParty();
+                garrison = settlement.Town.GarrisonParty;
+                createdGarrison = garrison != null;
+            }
+            catch (Exception exception)
+            {
+                logger.Error(
+                    exception,
+                    "Failed to create a garrison for donation at {Settlement}",
+                    settlement.StringId);
+                return false;
+            }
+        }
+        if (garrison == null)
+            return false;
+
+        bool fits = (long)garrison.Party.NumberOfAllMembers + donated <=
+            garrison.Party.PartySizeLimit;
+        if (!fits)
+            RollbackCreatedDonationGarrison(garrison, createdGarrison);
+        return fits;
+    }
+
+    private static void RollbackCreatedDonationGarrison(
+        MobileParty garrison,
+        bool createdGarrison)
+    {
+        if (!createdGarrison || garrison == null ||
+            garrison.MemberRoster.TotalManCount != 0 ||
+            garrison.PrisonRoster.TotalManCount != 0)
+            return;
+        try
+        {
+            DestroyPartyAction.Apply(null, garrison);
+        }
+        catch (Exception exception)
+        {
+            logger.Error(
+                exception,
+                "Failed to roll back a newly-created empty garrison {Party}",
+                garrison.StringId);
+        }
+    }
+
+    private Dictionary<string, int> GetActionCountsById(
+        FlattenedTroopRoster actionRoster)
     {
         var actionCounts = new Dictionary<string, int>();
         foreach (var element in actionRoster)
         {
             if (element.Troop == null ||
                 !objectManager.TryGetIdWithLogging(element.Troop, out var characterId))
-                return false;
+                return null;
 
             actionCounts.TryGetValue(characterId, out var count);
             actionCounts[characterId] = count + 1;
         }
 
-        return actionCounts.All(action =>
-            signedDeltas.TryGetValue(action.Key, out var delta) &&
-            delta == expectedSign * action.Value);
+        return actionCounts;
     }
 
     internal static TroopRosterData FilterTakenHeroAdditions(
@@ -415,18 +1779,92 @@ internal class PartyDoneLogicHandler : IHandler
         CampaignEventDispatcher.Instance.OnPrisonersChangeInSettlement(Settlement.CurrentSettlement, takenPrisonersRoster, null, true);
     }
 
-    private static void ApplyPartyRewardChanges(Hero mainHero, NetworkCompleteDoneLogic message)
+    private static void ApplyPartyRewardChanges(
+        Hero mainHero,
+        NetworkCompleteDoneLogic message,
+        bool suppressInfluence)
     {
         if (!message.DoNotApplyGoldTransactions)
         {
             GiveGoldAction.ApplyBetweenCharacters(null, mainHero, message.PartyGoldChangeAmount, false);
         }
-        if (message.PartyInfluenceChangeAmount != 0)
+        if (!suppressInfluence && message.PartyInfluenceChangeAmount != 0)
         {
             // Influence goes to the requesting player's clan (mainHero), not the local machine's
             // Hero.MainHero - which is null on a dedicated server (NRE) and the wrong clan otherwise.
             GainKingdomInfluenceAction.ApplyForLeavingTroopToGarrison(mainHero, (float)message.PartyInfluenceChangeAmount);
         }
+    }
+
+    private static void ApplyPrisonerDonation(
+        MobileParty playerParty,
+        FlattenedTroopRoster donatedPrisoners,
+        Settlement settlement)
+    {
+        if (playerParty == null || settlement == null ||
+            donatedPrisoners == null ||
+            donatedPrisoners.IsEmpty<FlattenedTroopRosterElement>())
+            return;
+        float influence = 0f;
+        foreach (CharacterObject character in donatedPrisoners.Troops)
+        {
+            if (character?.IsHero == true)
+                EnterSettlementAction.ApplyForPrisoner(
+                    character.HeroObject,
+                    settlement);
+            if (character != null)
+                influence += Campaign.Current.Models.PrisonerDonationModel
+                    .CalculateInfluenceGainAfterPrisonerDonation(
+                        playerParty.Party, character, settlement);
+        }
+        CampaignEventDispatcher.Instance.OnPrisonerDonatedToSettlement(
+            playerParty,
+            donatedPrisoners,
+            settlement);
+        if (influence > 0f && playerParty.LeaderHero != null)
+            GainKingdomInfluenceAction.ApplyForLeavingTroopToGarrison(
+                playerParty.LeaderHero, (int)influence);
+    }
+
+    private void ApplyGarrisonDonation(
+        Hero mainHero,
+        Settlement settlement,
+        TroopRosterData donatedData)
+    {
+        if (mainHero?.PartyBelongedTo == null || settlement == null)
+            return;
+        TroopRoster donated = TroopRoster.CreateDummyTroopRoster();
+        float influence = 0f;
+        foreach (TroopRosterElementData data in
+                 donatedData.Data ?? Array.Empty<TroopRosterElementData>())
+        {
+            if (!objectManager.TryGetObject(
+                    data.CharacterId, out CharacterObject character) ||
+                character == null || data.Number <= 0)
+                continue;
+            donated.AddToCounts(
+                character,
+                data.Number,
+                false,
+                data.WoundedNumber,
+                data.Xp,
+                true,
+                -1);
+            if (character.IsHero)
+                EnterSettlementAction.ApplyForCharacterOnly(
+                    character.HeroObject, settlement);
+            influence += data.Number * Campaign.Current.Models
+                .PrisonerDonationModel
+                .CalculateInfluenceGainAfterTroopDonation(
+                    mainHero.PartyBelongedTo.Party,
+                    character,
+                    settlement);
+        }
+        CampaignEventDispatcher.Instance.OnTroopGivenToSettlement(
+            mainHero, settlement, donated);
+        if (influence > 0f)
+            GainKingdomInfluenceAction.ApplyForLeavingTroopToGarrison(
+                mainHero, (int)influence);
     }
 
     private static void ApplyUpgradedTroopHistory(Hero mainHero, List<Tuple<CharacterObject, CharacterObject, int>> upgradedTroopHistory)

--- a/source/GameInterface/Services/Party/Handlers/PartyScreenHelperHandler.cs
+++ b/source/GameInterface/Services/Party/Handlers/PartyScreenHelperHandler.cs
@@ -1,17 +1,24 @@
-﻿using Common;
+using Common;
 using Common.Logging;
 using Common.Messaging;
 using Common.Network;
+using Common.Util;
 using GameInterface.Services.Clans.Messages;
 using GameInterface.Services.Heroes.Extensions;
 using GameInterface.Services.MapEventParties;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Party.Messages;
+using GameInterface.Services.Players;
+using GameInterface.Services.TroopRosters.Data;
 using GameInterface.Services.TroopRosters.Interfaces;
+using GameInterface.Services.Transactions;
 using Helpers;
 using LiteNetLib;
 using Serilog;
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.Party;
@@ -24,22 +31,30 @@ namespace GameInterface.Services.Party.Handlers;
 internal class PartyScreenHelperHandler : IHandler
 {
     private static readonly ILogger logger = LogManager.GetLogger<PartyScreenHelperHandler>();
+    private static readonly object DonationGate = new();
+    private static readonly ConditionalWeakTable<NetPeer, PendingDonation>
+        PendingDonations = new();
+    private static readonly ConditionalWeakTable<NetPeer, PendingGarrisonDonation>
+        PendingGarrisonDonations = new();
 
     private readonly IMessageBroker messageBroker;
     private readonly IObjectManager objectManager;
     private readonly INetwork network;
     private readonly ITroopRosterInterface troopRosterInterface;
+    private readonly IPlayerManager playerManager;
 
     public PartyScreenHelperHandler(
         IMessageBroker messageBroker,
         IObjectManager objectManager,
         INetwork network,
-        ITroopRosterInterface troopRosterInterface)
+        ITroopRosterInterface troopRosterInterface,
+        IPlayerManager playerManager)
     {
         this.messageBroker = messageBroker;
         this.objectManager = objectManager;
         this.network = network;
         this.troopRosterInterface = troopRosterInterface;
+        this.playerManager = playerManager;
 
         messageBroker.Subscribe<NewClanPartyScreenClosed>(Handle_NewClanPartyScreenClosed);
         messageBroker.Subscribe<CreateClanPartyAfterScreenClose>(Handle_CreateClanPartyAfterScreenClose);
@@ -51,6 +66,8 @@ internal class PartyScreenHelperHandler : IHandler
         messageBroker.Subscribe<DoManageGarrison>(Handle_DoManageGarrison);
         messageBroker.Subscribe<PrisonersReleasedAndTaken>(Handle_PrisonersReleasedAndTaken);
         messageBroker.Subscribe<ReleaseAndTakePrisoners>(Handle_ReleaseAndTakePrisoners);
+        if (ModInformation.IsServer)
+            ServerTransactionOutcome.Completed += HandleTransactionCompleted;
     }
 
     public void Dispose()
@@ -65,6 +82,17 @@ internal class PartyScreenHelperHandler : IHandler
         messageBroker.Unsubscribe<DoManageGarrison>(Handle_DoManageGarrison);
         messageBroker.Unsubscribe<PrisonersReleasedAndTaken>(Handle_PrisonersReleasedAndTaken);
         messageBroker.Unsubscribe<ReleaseAndTakePrisoners>(Handle_ReleaseAndTakePrisoners);
+        if (ModInformation.IsServer)
+            ServerTransactionOutcome.Completed -= HandleTransactionCompleted;
+    }
+
+    private static void HandleTransactionCompleted(
+        NetPeer peer, int kind, bool success, string _)
+    {
+        if (kind != ServerTransactionOutcome.Party || success)
+            return;
+        ClearPendingPrisonerDonation(peer);
+        ClearPendingGarrisonDonation(peer);
     }
 
     private void Handle_NewClanPartyScreenClosed(MessagePayload<NewClanPartyScreenClosed> obj)
@@ -86,59 +114,321 @@ internal class PartyScreenHelperHandler : IHandler
 
     private void Handle_CreateClanPartyAfterScreenClose(MessagePayload<CreateClanPartyAfterScreenClose> obj)
     {
-        GameThread.RunSafe(() =>
+        NetPeer peer = obj.Who as NetPeer;
+        GameThread.RunSafe(() => ServerTransactionOutcome.Execute(
+            peer, ServerTransactionOutcome.ClanParty, () =>
         {
-            if (!objectManager.TryGetObjectWithLogging<Hero>(obj.What.MainHeroId, out var mainHero)) return;
-            if (!objectManager.TryGetObjectWithLogging<Hero>(obj.What.NewLeaderHeroId, out var newLeaderHero)) return;
+            string authenticationReason =
+                "The server could not authenticate this player.";
+            if (!playerManager.TryGetPlayer(peer, out var registeredPlayer) ||
+                !ServerTransactionOutcome.TryResolvePlayer(
+                    peer,
+                    playerManager,
+                    objectManager,
+                    obj.What.MainHeroId,
+                    registeredPlayer?.MobilePartyId,
+                    out _,
+                    out Hero mainHero,
+                    out MobileParty sourceParty,
+                    out authenticationReason))
+            {
+                ServerTransactionOutcome.Reject(
+                    peer, ServerTransactionOutcome.ClanParty,
+                    authenticationReason);
+                return;
+            }
+            if (!objectManager.TryGetObjectWithLogging<Hero>(
+                    obj.What.NewLeaderHeroId, out var newLeaderHero) ||
+                newLeaderHero == null || newLeaderHero == mainHero ||
+                newLeaderHero.Clan != mainHero.Clan ||
+                newLeaderHero.PartyBelongedTo != sourceParty ||
+                newLeaderHero.PartyBelongedToAsPrisoner != null ||
+                newLeaderHero.IsChild ||
+                !newLeaderHero.CanLeadParty() ||
+                !newLeaderHero.CanBeGovernorOrHavePartyRole() ||
+                newLeaderHero.GovernorOf != null ||
+                newLeaderHero.HeroState != Hero.CharacterStates.Active ||
+                sourceParty.MapEvent != null ||
+                sourceParty.IsCurrentlyAtSea ||
+                sourceParty.IsInRaftState ||
+                mainHero.Clan.WarPartyComponents.Count >=
+                    mainHero.Clan.WarPartyLimit)
+            {
+                ServerTransactionOutcome.Reject(
+                    peer, ServerTransactionOutcome.ClanParty,
+                    "The selected clan-party leader is no longer available.");
+                return;
+            }
+
+            List<TroopRosterElement> members = troopRosterInterface
+                .UnpackTroopRosterData(obj.What.LeftMemberRosterData)
+                .ToList();
+            List<TroopRosterElement> prisoners = troopRosterInterface
+                .UnpackTroopRosterData(obj.What.LeftPrisonRosterData)
+                .ToList();
+            if (!ValidateClanPartyRoster(
+                    sourceParty.MemberRoster,
+                    members,
+                    newLeaderHero.CharacterObject,
+                    requireLeader: true) ||
+                !ValidateClanPartyRoster(
+                    sourceParty.PrisonRoster,
+                    prisoners,
+                    leader: null,
+                    requireLeader: false))
+            {
+                ServerTransactionOutcome.Reject(
+                    peer, ServerTransactionOutcome.ClanParty,
+                    "The selected clan-party troops no longer match your party.");
+                return;
+            }
 
             int partyGoldLowerThreshold = Campaign.Current.Models.ClanFinanceModel.PartyGoldLowerThreshold;
-            if (newLeaderHero.Gold < partyGoldLowerThreshold)
+            int requiredGold = Math.Max(
+                0, partyGoldLowerThreshold - newLeaderHero.Gold);
+            if (mainHero.Gold < requiredGold)
             {
-                GiveGoldAction.ApplyBetweenCharacters(mainHero, newLeaderHero, partyGoldLowerThreshold - newLeaderHero.Gold, false);
-            }
-            MobileParty mobileParty = MobilePartyHelper.CreateNewClanMobileParty(newLeaderHero, newLeaderHero.Clan);
-            foreach (var troopRosterElement in troopRosterInterface.UnpackTroopRosterData(obj.What.LeftMemberRosterData))
-            {
-                if (troopRosterElement.Character != newLeaderHero.CharacterObject)
-                {
-                    mobileParty.MemberRoster.Add(troopRosterElement);
-                    //rightOwnerParty.MemberRoster.AddToCounts(troopRosterElement.Character, -troopRosterElement.Number, false, -troopRosterElement.WoundedNumber, -troopRosterElement.Xp, true, -1);
-                }
-            }
-            foreach (var troopRosterElement in troopRosterInterface.UnpackTroopRosterData(obj.What.LeftPrisonRosterData))
-            {
-                mobileParty.PrisonRoster.Add(troopRosterElement);
-                //rightOwnerParty.PrisonRoster.AddToCounts(troopRosterElement2.Character, -troopRosterElement2.Number, false, -troopRosterElement2.WoundedNumber, -troopRosterElement2.Xp, true, -1);
+                ServerTransactionOutcome.Reject(
+                    peer, ServerTransactionOutcome.ClanParty,
+                    "You no longer have enough denars to create that party.");
+                return;
             }
 
-            network.Send(obj.Who as NetPeer, new RefreshPartiesList());
-        });
+            if (!TryBuildClanPartyTransferData(
+                    members.Where(element =>
+                        element.Character != newLeaderHero.CharacterObject),
+                    out TroopRosterData memberRemove,
+                    out TroopRosterData memberAdd) ||
+                !TryBuildClanPartyTransferData(
+                    prisoners,
+                    out TroopRosterData prisonerRemove,
+                    out TroopRosterData prisonerAdd))
+            {
+                ServerTransactionOutcome.Reject(
+                    peer, ServerTransactionOutcome.ClanParty,
+                    "A transferred troop could not be resolved.");
+                return;
+            }
+
+            int leaderIndexBefore = sourceParty.MemberRoster.FindIndexOfTroop(
+                newLeaderHero.CharacterObject);
+            int leaderWoundedBefore = sourceParty.MemberRoster
+                .GetElementWoundedNumber(leaderIndexBefore);
+            int leaderXpBefore = sourceParty.MemberRoster
+                .GetElementXp(leaderIndexBefore);
+            int mainGoldBefore = mainHero.Gold;
+            int leaderGoldBefore = newLeaderHero.Gold;
+            MobileParty mobileParty = null;
+            List<(TroopRoster roster, TroopRosterData delta)> deltas = null;
+            bool transfersApplied = false;
+            bool committed = false;
+            string failure = "The clan party could not be created.";
+            try
+            {
+                mobileParty = MobilePartyHelper.CreateNewClanMobileParty(
+                    newLeaderHero, newLeaderHero.Clan);
+                if (mobileParty == null)
+                    throw new InvalidOperationException(failure);
+
+                deltas = new List<(TroopRoster roster, TroopRosterData delta)>
+                {
+                    (sourceParty.MemberRoster, memberRemove),
+                    (mobileParty.MemberRoster, memberAdd),
+                    (sourceParty.PrisonRoster, prisonerRemove),
+                    (mobileParty.PrisonRoster, prisonerAdd)
+                };
+                failure =
+                    "The clan-party transfer changed before it could be committed.";
+                if (!troopRosterInterface.TryApplyTroopRosterDeltas(deltas))
+                    throw new InvalidOperationException(failure);
+                transfersApplied = true;
+
+                // Remote-player parties are not Bannerlord's global MainParty,
+                // so vanilla may leave the leader in the source roster.
+                int leaderIndex = sourceParty.MemberRoster.FindIndexOfTroop(
+                    newLeaderHero.CharacterObject);
+                if (leaderIndex >= 0)
+                {
+                    int wounded = sourceParty.MemberRoster
+                        .GetElementWoundedNumber(leaderIndex);
+                    int xp = sourceParty.MemberRoster.GetElementXp(leaderIndex);
+                    sourceParty.MemberRoster.AddToCounts(
+                        newLeaderHero.CharacterObject,
+                        -1,
+                        false,
+                        -Math.Min(1, wounded),
+                        -xp,
+                        true,
+                        -1);
+                }
+                if (requiredGold > 0)
+                    GiveGoldAction.ApplyBetweenCharacters(
+                        mainHero, newLeaderHero, requiredGold, false);
+                committed = true;
+            }
+            catch (Exception exception)
+            {
+                logger.Error(
+                    exception,
+                    "Rolling back failed clan-party creation for {LeaderId}",
+                    obj.What.NewLeaderHeroId);
+            }
+
+            if (!committed)
+            {
+                mainHero.Gold = mainGoldBefore;
+                newLeaderHero.Gold = leaderGoldBefore;
+                if (transfersApplied && deltas != null)
+                    troopRosterInterface.TryApplyTroopRosterDeltas(
+                        InvertRosterDeltas(deltas));
+                if (mobileParty?.IsActive == true)
+                    DestroyPartyAction.Apply(null, mobileParty);
+                RestoreClanPartyLeader(
+                    sourceParty,
+                    newLeaderHero,
+                    leaderWoundedBefore,
+                    leaderXpBefore);
+                ServerTransactionOutcome.Reject(
+                    peer, ServerTransactionOutcome.ClanParty, failure);
+                return;
+            }
+
+            try
+            {
+                network.Send(peer, new RefreshPartiesList());
+            }
+            catch (Exception exception)
+            {
+                logger.Warning(
+                    exception,
+                    "Clan party committed, but the party-list refresh could not be sent");
+            }
+            ServerTransactionOutcome.Accept(
+                peer, ServerTransactionOutcome.ClanParty);
+        }));
+    }
+
+    private bool ValidateClanPartyRoster(
+        TroopRoster source,
+        IReadOnlyCollection<TroopRosterElement> requested,
+        CharacterObject leader,
+        bool requireLeader)
+    {
+        if (source == null || requested == null)
+            return false;
+        var seen = new HashSet<CharacterObject>();
+        int leaderCount = 0;
+        foreach (TroopRosterElement element in requested)
+        {
+            if (element.Character == null || element.Number <= 0 ||
+                element.WoundedNumber < 0 ||
+                element.WoundedNumber > element.Number || element.Xp < 0 ||
+                !seen.Add(element.Character))
+                return false;
+            int index = source.FindIndexOfTroop(element.Character);
+            if (index < 0 || source.GetElementNumber(index) < element.Number ||
+                source.GetElementWoundedNumber(index) < element.WoundedNumber ||
+                source.GetElementXp(index) < element.Xp ||
+                source.GetElementNumber(index) - element.Number == 0 &&
+                source.GetElementXp(index) - element.Xp != 0)
+                return false;
+            if (element.Character == leader)
+                leaderCount += element.Number;
+        }
+        return !requireLeader || leaderCount == 1;
+    }
+
+    private bool TryBuildClanPartyTransferData(
+        IEnumerable<TroopRosterElement> requested,
+        out TroopRosterData removeData,
+        out TroopRosterData addData)
+    {
+        var remove = new List<TroopRosterElementData>();
+        var add = new List<TroopRosterElementData>();
+        removeData = default;
+        addData = default;
+        foreach (TroopRosterElement element in requested)
+        {
+            if (!objectManager.TryGetId(element.Character, out string id))
+                return false;
+            remove.Add(new TroopRosterElementData(
+                id, -element.Number, -element.WoundedNumber, -element.Xp));
+            add.Add(new TroopRosterElementData(
+                id, element.Number, element.WoundedNumber, element.Xp));
+        }
+        removeData = new TroopRosterData(remove);
+        addData = new TroopRosterData(add);
+        return true;
+    }
+
+    private static List<(TroopRoster roster, TroopRosterData delta)>
+        InvertRosterDeltas(
+            IEnumerable<(TroopRoster roster, TroopRosterData delta)> deltas)
+    {
+        return deltas.Select(entry => (
+            entry.roster,
+            new TroopRosterData((entry.delta.Data ??
+                Array.Empty<TroopRosterElementData>())
+                .Select(element => new TroopRosterElementData(
+                    element.CharacterId,
+                    -element.Number,
+                    -element.WoundedNumber,
+                    -element.Xp)))))
+            .ToList();
+    }
+
+    private static void RestoreClanPartyLeader(
+        MobileParty sourceParty,
+        Hero leader,
+        int wounded,
+        int xp)
+    {
+        if (sourceParty == null || leader?.CharacterObject == null ||
+            sourceParty.MemberRoster.Contains(leader.CharacterObject))
+            return;
+        sourceParty.MemberRoster.AddToCounts(
+            leader.CharacterObject,
+            1,
+            false,
+            Math.Min(1, Math.Max(0, wounded)),
+            Math.Max(0, xp),
+            true,
+            -1);
     }
 
     private void Handle_GarrisonDonated(MessagePayload<GarrisonDonated> obj)
     {
         if (!objectManager.TryGetIdWithLogging(obj.What.CurrentSettlement, out var currentSettlementId)) return;
         var troops = new List<DonateTroop>();
-
         for (int i = 0; i < obj.What.LeftMemberRoster.Count; i++)
         {
-            var element = obj.What.LeftMemberRoster.GetElementCopyAtIndex(i);
-
-            if (!objectManager.TryGetIdWithLogging(element.Character, out var characterId))
+            TroopRosterElement element =
+                obj.What.LeftMemberRoster.GetElementCopyAtIndex(i);
+            if (element.Number <= 0 ||
+                !objectManager.TryGetIdWithLogging(
+                    element.Character, out string characterId))
                 continue;
-
-            troops.Add(new DonateTroop(
-                characterId,
-                element.Number));
+            troops.Add(new DonateTroop(characterId, element.Number));
         }
 
         var message = new DonateToGarrison(currentSettlementId, troops);
-
         network.SendAll(message);
     }
 
     private void Handle_DonateToGarrison(MessagePayload<DonateToGarrison> obj)
     {
+        if (ModInformation.IsServer && obj.Who is NetPeer peer)
+        {
+            lock (DonationGate)
+            {
+                PendingGarrisonDonations.Remove(peer);
+                PendingGarrisonDonations.Add(
+                    peer,
+                    new PendingGarrisonDonation(obj.What, DateTime.UtcNow));
+            }
+            return;
+        }
+
         if (!objectManager.TryGetObjectWithLogging<Settlement>(obj.What.CurrentSettlementId, out var currentSettlement)) return;
 
         GameThread.RunSafe(() =>
@@ -149,23 +439,18 @@ internal class PartyScreenHelperHandler : IHandler
                 currentSettlement.AddGarrisonParty();
                 garrisonParty = currentSettlement.Town.GarrisonParty;
             }
-            foreach (var troop in obj.What.Troops)
+            foreach (DonateTroop troop in obj.What.Troops)
             {
-                if (!objectManager.TryGetObjectWithLogging<CharacterObject>(
-                    troop.CharacterId,
-                    out var character))
+                if (troop.Count <= 0 ||
+                    !objectManager.TryGetObjectWithLogging(
+                        troop.CharacterId, out CharacterObject character))
                     continue;
-
                 garrisonParty.AddElementToMemberRoster(
-                    character,
-                    troop.Count,
-                    false);
-
+                    character, troop.Count, false);
                 if (character.IsHero)
                 {
                     EnterSettlementAction.ApplyForCharacterOnly(
-                        character.HeroObject,
-                        currentSettlement);
+                        character.HeroObject, currentSettlement);
                 }
             }
         });
@@ -183,6 +468,18 @@ internal class PartyScreenHelperHandler : IHandler
 
     private void Handle_DonatePrisoners(MessagePayload<DonatePrisoners> obj)
     {
+        if (ModInformation.IsServer && obj.Who is NetPeer peer)
+        {
+            lock (DonationGate)
+            {
+                PendingDonations.Remove(peer);
+                PendingDonations.Add(
+                    peer,
+                    new PendingDonation(obj.What, DateTime.UtcNow));
+            }
+            return;
+        }
+
         FlattenedTroopRoster rightSidePrisonerRoster = FlattenedTroopSerializer.Deserialize(obj.What.RightSidePrisonerRoster, objectManager);
         if (!objectManager.TryGetObjectWithLogging<Settlement>(obj.What.CurrentSettlementId, out var currentSettlement)) return;
         if (!objectManager.TryGetObjectWithLogging<PartyBase>(obj.What.RightPartyId, out var rightParty)) return;
@@ -200,6 +497,91 @@ internal class PartyScreenHelperHandler : IHandler
         });
     }
 
+    internal static bool TryGetPendingPrisonerDonation(
+        NetPeer peer,
+        out DonatePrisoners donation)
+    {
+        donation = default;
+        if (peer == null)
+            return false;
+        lock (DonationGate)
+        {
+            if (!PendingDonations.TryGetValue(peer, out PendingDonation pending))
+                return false;
+            if (DateTime.UtcNow - pending.CreatedUtc > TimeSpan.FromSeconds(30))
+            {
+                PendingDonations.Remove(peer);
+                return false;
+            }
+            donation = pending.Message;
+            return true;
+        }
+    }
+
+    internal static void ClearPendingPrisonerDonation(NetPeer peer)
+    {
+        if (peer == null)
+            return;
+        lock (DonationGate)
+            PendingDonations.Remove(peer);
+    }
+
+    internal static bool TryGetPendingGarrisonDonation(
+        NetPeer peer,
+        out DonateToGarrison donation)
+    {
+        donation = default;
+        if (peer == null)
+            return false;
+        lock (DonationGate)
+        {
+            if (!PendingGarrisonDonations.TryGetValue(
+                    peer, out PendingGarrisonDonation pending))
+                return false;
+            if (DateTime.UtcNow - pending.CreatedUtc > TimeSpan.FromSeconds(30))
+            {
+                PendingGarrisonDonations.Remove(peer);
+                return false;
+            }
+            donation = pending.Message;
+            return true;
+        }
+    }
+
+    internal static void ClearPendingGarrisonDonation(NetPeer peer)
+    {
+        if (peer == null)
+            return;
+        lock (DonationGate)
+            PendingGarrisonDonations.Remove(peer);
+    }
+
+    private sealed class PendingDonation
+    {
+        internal readonly DonatePrisoners Message;
+        internal readonly DateTime CreatedUtc;
+
+        internal PendingDonation(DonatePrisoners message, DateTime createdUtc)
+        {
+            Message = message;
+            CreatedUtc = createdUtc;
+        }
+    }
+
+    private sealed class PendingGarrisonDonation
+    {
+        internal readonly DonateToGarrison Message;
+        internal readonly DateTime CreatedUtc;
+
+        internal PendingGarrisonDonation(
+            DonateToGarrison message,
+            DateTime createdUtc)
+        {
+            Message = message;
+            CreatedUtc = createdUtc;
+        }
+    }
+
     private void Handle_GarrisonManaged(MessagePayload<GarrisonManaged> obj)
     {
         if (!objectManager.TryGetIdWithLogging(obj.What.CurrentSettlement, out var currentSettlementId)) return;
@@ -212,6 +594,8 @@ internal class PartyScreenHelperHandler : IHandler
 
     private void Handle_DoManageGarrison(MessagePayload<DoManageGarrison> obj)
     {
+        if (ModInformation.IsServer) return;
+
         if (!objectManager.TryGetObjectWithLogging<Settlement>(obj.What.CurrentSettlementId, out var currentSettlement)) return;
         if (!objectManager.TryGetObjectWithLogging<TroopRoster>(obj.What.LeftMemberRosterId, out var leftMemberRoster)) return;
         if (!objectManager.TryGetObjectWithLogging<TroopRoster>(obj.What.LeftPrisonerRosterId, out var leftPrisonerRoster)) return;
@@ -248,6 +632,8 @@ internal class PartyScreenHelperHandler : IHandler
 
     private void Handle_ReleaseAndTakePrisoners(MessagePayload<ReleaseAndTakePrisoners> obj)
     {
+        if (ModInformation.IsServer) return;
+
         FlattenedTroopRoster takenPrisonerRoster = FlattenedTroopSerializer.Deserialize(obj.What.TakenPrisonerRoster, objectManager);
         FlattenedTroopRoster releasedPrisonerRoster = FlattenedTroopSerializer.Deserialize(obj.What.ReleasedPrisonerRoster, objectManager);
 

--- a/source/GameInterface/Services/Party/Handlers/SellPrisonersHandler.cs
+++ b/source/GameInterface/Services/Party/Handlers/SellPrisonersHandler.cs
@@ -2,11 +2,17 @@
 using Common.Messaging;
 using Common.Network;
 using Common.Network.Coalescing;
+using Common.Network.Messages;
+using Common.Util;
 using GameInterface.Services.GameMenus.Messages;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Party.Messages;
+using GameInterface.Services.Players;
+using GameInterface.Services.TroopRosters.Data;
 using GameInterface.Services.TroopRosters.Interfaces;
 using LiteNetLib;
+using System;
+using System.Collections.Generic;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Roster;
 using static GameInterface.Services.ObjectManager.ObjectManager;
@@ -21,6 +27,10 @@ internal class SellPrisonersHandler : IHandler
     private readonly ITroopRosterInterface troopRosterInterface;
     private readonly IPrisonerSaleProcessor prisonerSaleProcessor;
     private readonly ISendCoalescer sendCoalescer;
+    private readonly IPlayerManager playerManager;
+    private readonly object pendingGate = new();
+    private readonly Dictionary<NetPeer, PendingSale> pendingSales = new();
+    private static SellPrisonersHandler serverInstance;
 
     public SellPrisonersHandler(
         IMessageBroker messageBroker,
@@ -28,6 +38,7 @@ internal class SellPrisonersHandler : IHandler
         INetwork network,
         ITroopRosterInterface troopRosterInterface,
         IPrisonerSaleProcessor prisonerSaleProcessor,
+        IPlayerManager playerManager,
         ISendCoalescer sendCoalescer = null)
     {
         this.messageBroker = messageBroker;
@@ -35,16 +46,25 @@ internal class SellPrisonersHandler : IHandler
         this.network = network;
         this.troopRosterInterface = troopRosterInterface;
         this.prisonerSaleProcessor = prisonerSaleProcessor;
+        this.playerManager = playerManager;
         this.sendCoalescer = sendCoalescer;
 
         messageBroker.Subscribe<PrisonersSold>(Handle_PrisonersSold);
         messageBroker.Subscribe<SellPrisoners>(Handle_SellPrisoners);
+        messageBroker.Subscribe<PlayerDisconnected>(Handle_PlayerDisconnected);
+        if (ModInformation.IsServer)
+            serverInstance = this;
     }
 
     public void Dispose()
     {
         messageBroker.Unsubscribe<PrisonersSold>(Handle_PrisonersSold);
         messageBroker.Unsubscribe<SellPrisoners>(Handle_SellPrisoners);
+        messageBroker.Unsubscribe<PlayerDisconnected>(Handle_PlayerDisconnected);
+        lock (pendingGate)
+            pendingSales.Clear();
+        if (ReferenceEquals(serverInstance, this))
+            serverInstance = null;
     }
 
     private void Handle_PrisonersSold(MessagePayload<PrisonersSold> obj)
@@ -59,22 +79,115 @@ internal class SellPrisonersHandler : IHandler
 
     private void Handle_SellPrisoners(MessagePayload<SellPrisoners> obj)
     {
+        if (!ModInformation.IsServer || obj.Who is not NetPeer peer)
+            return;
         GameThread.RunSafe(() =>
         {
-            if (!objectManager.TryGetObjectWithLogging<PartyBase>(obj.What.SellingPartyId, out var sellingParty)) return;
+            if (!playerManager.TryGetPlayer(peer, out var player) ||
+                player == null ||
+                !objectManager.TryGetObject(
+                    player.MobilePartyId, out MobileParty playerParty) ||
+                !objectManager.TryGetObjectWithLogging<PartyBase>(
+                    obj.What.SellingPartyId, out var sellingParty) ||
+                sellingParty != playerParty.Party ||
+                !playerParty.IsActive || playerParty.MapEvent != null ||
+                playerParty.CurrentSettlement?.Town == null)
+                return;
 
-            TroopRoster leftPrisonerRoster = new();
-            troopRosterInterface.UpdateWithData(leftPrisonerRoster, obj.What.LeftPrisonerRosterData, sellingParty.LeaderHero);
-            prisonerSaleProcessor.Sell(sellingParty, leftPrisonerRoster);
-
-            objectManager.TryGetId(sellingParty.PrisonRoster, out var rosterId);
-            var compactId = Compact(rosterId, typeof(TroopRoster));
-
-            sendCoalescer?.FlushInstance(compactId, network);
-
-            // Refresh the menu to show updated menu items
-            if (!objectManager.TryGetIdWithLogging(sellingParty.LeaderHero, out var heroId)) return;
-            network.Send(obj.Who as NetPeer, new RefreshGameMenu(heroId, "town_backstreet"));
+            lock (pendingGate)
+                pendingSales[peer] = new PendingSale(
+                    playerParty,
+                    obj.What.LeftPrisonerRosterData,
+                    DateTime.UtcNow.AddSeconds(30));
         });
+    }
+
+    private void Handle_PlayerDisconnected(MessagePayload<PlayerDisconnected> obj)
+    {
+        if (!ModInformation.IsServer) return;
+        lock (pendingGate)
+            pendingSales.Remove(obj.What.PlayerId);
+    }
+
+    internal static bool TryGetPendingSale(
+        NetPeer peer,
+        MobileParty expectedParty,
+        out TroopRoster requestedPrisoners)
+    {
+        requestedPrisoners = null;
+        SellPrisonersHandler current = serverInstance;
+        if (current == null || peer == null || expectedParty == null)
+            return false;
+        PendingSale pending;
+        lock (current.pendingGate)
+        {
+            if (!current.pendingSales.TryGetValue(peer, out pending) ||
+                pending.ExpiresUtc < DateTime.UtcNow ||
+                pending.Party != expectedParty)
+            {
+                current.pendingSales.Remove(peer);
+                return false;
+            }
+        }
+
+        requestedPrisoners = new TroopRoster();
+        current.troopRosterInterface.UpdateWithData(
+            requestedPrisoners,
+            pending.RosterData,
+            expectedParty.LeaderHero);
+        return true;
+    }
+
+    internal static void ApplySale(
+        MobileParty expectedParty,
+        TroopRoster requestedPrisoners)
+    {
+        SellPrisonersHandler current = serverInstance ??
+            throw new InvalidOperationException(
+                "The prisoner sale service is unavailable.");
+        current.prisonerSaleProcessor.Sell(
+            expectedParty.Party, requestedPrisoners);
+    }
+
+    internal static void NotifySaleCommitted(
+        NetPeer peer,
+        MobileParty expectedParty)
+    {
+        SellPrisonersHandler current = serverInstance;
+        if (current == null || peer == null || expectedParty == null)
+            return;
+        current.objectManager.TryGetId(
+            expectedParty.PrisonRoster, out var rosterId);
+        var compactId = Compact(rosterId, typeof(TroopRoster));
+        current.sendCoalescer?.FlushInstance(compactId, current.network);
+        if (current.objectManager.TryGetId(
+                expectedParty.LeaderHero, out var heroId))
+            current.network.Send(
+                peer, new RefreshGameMenu(heroId, "town_backstreet"));
+    }
+
+    internal static void ClearPendingSale(NetPeer peer)
+    {
+        SellPrisonersHandler current = serverInstance;
+        if (current == null || peer == null) return;
+        lock (current.pendingGate)
+            current.pendingSales.Remove(peer);
+    }
+
+    private sealed class PendingSale
+    {
+        internal readonly MobileParty Party;
+        internal readonly TroopRosterData RosterData;
+        internal readonly DateTime ExpiresUtc;
+
+        internal PendingSale(
+            MobileParty party,
+            TroopRosterData rosterData,
+            DateTime expiresUtc)
+        {
+            Party = party;
+            RosterData = rosterData;
+            ExpiresUtc = expiresUtc;
+        }
     }
 }

--- a/source/GameInterface/Services/PlayerCaptivityService/Handlers/PlayerCaptivityClientHandler.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Handlers/PlayerCaptivityClientHandler.cs
@@ -293,6 +293,16 @@ internal class PlayerCaptivityClientHandler : IHandler
 
         GameThread.RunSafe(() =>
         {
+            // CampaignVec2.IsValid resolves campaign navigation data; never run it on the
+            // network poll thread or after Campaign.Current has already torn down.
+            if (Campaign.Current == null || !releasePosition.IsValid())
+            {
+                Logger.Error(
+                    "Refused invalid released-player position for {PartyId}",
+                    playerPartyId);
+                return;
+            }
+
             if (!objectManager.TryGetObjectWithLogging<MobileParty>(playerPartyId, out var playerParty))
                 return;
 

--- a/source/GameInterface/Services/PlayerCaptivityService/Handlers/PlayerCaptivityServerHandler.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Handlers/PlayerCaptivityServerHandler.cs
@@ -60,6 +60,7 @@ internal class PlayerCaptivityServerHandler : IHandler
     private readonly INetwork network;
     private readonly IMessageBroker messageBroker;
     private readonly IPlayerManager playerManager;
+    private readonly HashSet<string> invalidCaptorPositionsLogged = new HashSet<string>();
 
     public PlayerCaptivityServerHandler(
         IObjectManager objectManager,
@@ -452,7 +453,6 @@ internal class PlayerCaptivityServerHandler : IHandler
         var facilitatorId = payload.What.FacilitatorId;
         var detail = payload.What.Detail;
         var ransomAmount = payload.What.RansomAmount;
-        var releasePosition = payload.What.PlayerPartyPosition;
         var peer = payload.Who as NetPeer;
 
         // The release touches party/roster game state the main-thread tick also touches, so defer the
@@ -474,6 +474,23 @@ internal class PlayerCaptivityServerHandler : IHandler
 
                 PlayerCaptivityLogger.Debug("Handle_NetworkEndPlayerCaptivityAttempted (server): hero={HeroId} party={PartyId} detail={Detail} facilitator={FacilitatorId}",
                     playerHero.StringId, playerParty.StringId, detail, facilitator?.StringId);
+
+                // Use authoritative campaign geography only. The position in
+                // the client request is not trusted, and no invalid position is
+                // ever installed or broadcast.
+                if (!TryResolveReleasePosition(
+                        playerHero,
+                        playerParty,
+                        GetReleasePosition(
+                            playerHero.PartyBelongedToAsPrisoner,
+                            CampaignVec2.Invalid),
+                        out CampaignVec2 releasePosition))
+                {
+                    Logger.Error(
+                        "Could not resolve a valid release position for {HeroId}; captivity remains active",
+                        playerHero.StringId);
+                    return;
+                }
 
                 ReleasePlayerFromCaptivity(playerHero, playerParty, detail, facilitator, releasePosition);
 
@@ -516,9 +533,21 @@ internal class PlayerCaptivityServerHandler : IHandler
             playerHero.StringId, playerParty.StringId, payload.What.Detail);
 
         var captorParty = playerHero.PartyBelongedToAsPrisoner;
-        var releasePosition = payload.What.HasReleasePosition
+        var preferredReleasePosition = payload.What.HasReleasePosition
             ? payload.What.ReleasePosition
             : GetReleasePosition(captorParty, playerParty.Position);
+
+        if (!TryResolveReleasePosition(
+                playerHero,
+                playerParty,
+                preferredReleasePosition,
+                out CampaignVec2 releasePosition))
+        {
+            Logger.Error(
+                "Could not resolve a valid release position for {HeroId}; captivity remains active",
+                playerHero.StringId);
+            return;
+        }
 
         ReleasePlayerFromCaptivity(playerHero, playerParty, payload.What.Detail, payload.What.Facilitator, releasePosition);
     }
@@ -611,12 +640,42 @@ internal class PlayerCaptivityServerHandler : IHandler
         // would be meaningless.
         if (captorParty?.IsActive == true && captorParty.IsMobile && !captorParty.MobileParty.IsCurrentlyAtSea)
         {
-            playerParty.TeleportPartyToOutSideOfEncounterRadius();
+            // The parked captive party can itself hold an invalid position. Seed native separation from
+            // the already-validated release coordinate, retain its valid result, and fail back to the seed
+            // if navigation cannot produce one. The old order called the helper on the invalid parked
+            // position and then overwrote its result later in this method.
+            CampaignVec2 releaseSeed = releasePosition;
+            playerParty.Position = releaseSeed;
+            try
+            {
+                playerParty.TeleportPartyToOutSideOfEncounterRadius();
+                if (playerParty.Position.IsValid())
+                {
+                    releasePosition = playerParty.Position;
+                }
+                else
+                {
+                    releasePosition = releaseSeed;
+                    playerParty.Position = releaseSeed;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(
+                    ex,
+                    "Could not separate released party {PartyId} from its captor; using validated release position",
+                    playerParty.StringId);
+                releasePosition = releaseSeed;
+                playerParty.Position = releaseSeed;
+            }
         }
 
         if (captorParty != null && captorParty.IsSettlement)
         {
-            playerParty.DisembarkToPosition(captorParty.Settlement.GatePosition);
+            // releasePosition has already passed the authoritative fallback chain. Using the
+            // settlement gate again here could reinstall the invalid coordinate that the chain
+            // deliberately rejected; DisembarkToPosition writes both Position and TargetPosition.
+            playerParty.DisembarkToPosition(releasePosition);
         }
         else if (captorParty != null && captorParty.IsMobile)
         {
@@ -686,8 +745,54 @@ internal class PlayerCaptivityServerHandler : IHandler
         return captorParty.Position;
     }
 
+    private static bool TryResolveReleasePosition(
+        Hero playerHero,
+        MobileParty playerParty,
+        CampaignVec2 preferredPosition,
+        out CampaignVec2 releasePosition)
+    {
+        if (preferredPosition.IsValid())
+        {
+            releasePosition = preferredPosition;
+            return true;
+        }
+
+        if (playerParty?.Position.IsValid() == true)
+        {
+            releasePosition = playerParty.Position;
+            return true;
+        }
+
+        CampaignVec2 heroPosition = playerHero?.GetCampaignPosition() ??
+            CampaignVec2.Invalid;
+        if (heroPosition.IsValid())
+        {
+            releasePosition = heroPosition;
+            return true;
+        }
+
+        CampaignVec2 settlementPosition =
+            playerHero?.LastKnownClosestSettlement?.GatePosition ??
+            CampaignVec2.Invalid;
+        if (settlementPosition.IsValid())
+        {
+            releasePosition = settlementPosition;
+            return true;
+        }
+
+        releasePosition = CampaignVec2.Invalid;
+        return false;
+    }
+
     private void SyncReleasePosition(MobileParty playerParty, CampaignVec2 releasePosition)
     {
+        if (!releasePosition.IsValid())
+        {
+            Logger.Error(
+                "Refused to broadcast an invalid release position for {PartyId}",
+                playerParty?.StringId);
+            return;
+        }
         if (!objectManager.TryGetIdWithLogging(playerParty, out string playerPartyId)) return;
 
         network.SendAll(new NetworkPlayerCaptivityReleasePositionSet(playerPartyId, releasePosition));
@@ -773,7 +878,37 @@ internal class PlayerCaptivityServerHandler : IHandler
 
             if (captorParty == null) continue;
 
-            mobileParty.Position = captorParty.Position;
+            CampaignVec2 captorPosition = captorParty.Position;
+            string partyKey = mobileParty.StringId ?? hero.StringId ?? "unknown-player-party";
+            if (captorPosition.IsValid())
+            {
+                invalidCaptorPositionsLogged.Remove(partyKey);
+                mobileParty.Position = captorPosition;
+                continue;
+            }
+
+            // Never propagate an invalid captor coordinate through the normal movement sync. Keep
+            // the captive party at its last valid authoritative location; if that is invalid too,
+            // repair it from the same server-owned hero/settlement fallback used by release.
+            if (!mobileParty.Position.IsValid() &&
+                TryResolveReleasePosition(
+                    hero,
+                    mobileParty,
+                    CampaignVec2.Invalid,
+                    out CampaignVec2 fallbackPosition))
+            {
+                mobileParty.Position = fallbackPosition;
+            }
+
+            if (invalidCaptorPositionsLogged.Add(partyKey))
+            {
+                Logger.Warning(
+                    "Refused invalid captive-follow position from captor {CaptorId} for party {PartyId}",
+                    captorParty.MobileParty?.StringId ??
+                        captorParty.Settlement?.StringId ??
+                        "unknown-captor",
+                    partyKey);
+            }
         }
     }
 

--- a/source/GameInterface/Services/Players/PlayerManager.cs
+++ b/source/GameInterface/Services/Players/PlayerManager.cs
@@ -45,6 +45,16 @@ public interface IPlayerManager
     /// </summary>
     void SetPeer(string controllerId, NetPeer peer);
 
+    bool TrySetPeerIfAvailable(
+        string controllerId, NetPeer peer, out NetPeer existingPeer);
+
+    bool TryReserveNewController(
+        string controllerId, NetPeer peer, out NetPeer existingPeer);
+
+    bool TryCommitReservedPlayer(string controllerId, NetPeer peer, Player player);
+
+    void ReleaseNewControllerReservation(NetPeer peer);
+
     /// <summary>
     /// Resolves the currently associated peer for a registered controller.
     /// </summary>
@@ -97,6 +107,7 @@ public class PlayerManager : IPlayerManager
     private readonly IControllerIdProvider controllerIdProvider;
     private readonly ConcurrentDictionary<NetPeer, Player> peerToPlayer = new();
     private readonly Dictionary<string, NetPeer> controllerToPeer = new();
+    private readonly Dictionary<string, NetPeer> newControllerReservations = new();
 
     // Guards _players and controllerToPeer: registrations mutate on the game thread (e.g. a
     // player deletion) while join handlers read them on the network thread.
@@ -273,6 +284,115 @@ public class PlayerManager : IPlayerManager
         }
     }
 
+    public bool TrySetPeerIfAvailable(
+        string controllerId, NetPeer peer, out NetPeer existingPeer)
+    {
+        existingPeer = null;
+        lock (registrySync)
+        {
+            if (!_players.TryGetValue(controllerId, out var player))
+            {
+                logger.Error(
+                    "Cannot associate peer with unregistered controller {ControllerId}",
+                    controllerId);
+                return false;
+            }
+
+            if (controllerToPeer.TryGetValue(controllerId, out var currentPeer) &&
+                !ReferenceEquals(currentPeer, peer))
+            {
+                if (currentPeer?.ConnectionState == ConnectionState.Connected)
+                {
+                    existingPeer = currentPeer;
+                    return false;
+                }
+
+                peerToPlayer.TryRemove(currentPeer, out _);
+            }
+
+            peerToPlayer[peer] = player;
+            controllerToPeer[controllerId] = peer;
+            return true;
+        }
+    }
+
+    public bool TryReserveNewController(
+        string controllerId, NetPeer peer, out NetPeer existingPeer)
+    {
+        existingPeer = null;
+        if (string.IsNullOrWhiteSpace(controllerId) || peer == null)
+            return false;
+
+        lock (registrySync)
+        {
+            var reservationForPeer = newControllerReservations.FirstOrDefault(pair =>
+                ReferenceEquals(pair.Value, peer));
+            if (!string.IsNullOrEmpty(reservationForPeer.Key))
+            {
+                if (reservationForPeer.Key == controllerId) return true;
+                existingPeer = peer;
+                return false;
+            }
+
+            if (_players.ContainsKey(controllerId))
+            {
+                controllerToPeer.TryGetValue(controllerId, out existingPeer);
+                return false;
+            }
+
+            if (newControllerReservations.TryGetValue(controllerId, out var reservedPeer))
+            {
+                if (ReferenceEquals(reservedPeer, peer)) return true;
+                existingPeer = reservedPeer;
+                return false;
+            }
+
+            newControllerReservations[controllerId] = peer;
+            return true;
+        }
+    }
+
+    public bool TryCommitReservedPlayer(string controllerId, NetPeer peer, Player player)
+    {
+        if (player == null || player.ControllerId != controllerId || peer == null)
+            return false;
+
+        lock (registrySync)
+        {
+            if (!newControllerReservations.TryGetValue(controllerId, out var owner) ||
+                !ReferenceEquals(owner, peer) ||
+                peer.ConnectionState != ConnectionState.Connected ||
+                _players.ContainsKey(controllerId))
+                return false;
+
+            _players.Add(controllerId, player);
+            newControllerReservations.Remove(controllerId);
+            peerToPlayer[peer] = player;
+            controllerToPeer[controllerId] = peer;
+        }
+
+        AddPlayerObject<MobileParty>(player.ControllerId, player.MobilePartyId);
+        AddPlayerObject<Hero>(player.ControllerId, player.HeroId);
+        AddPlayerObject<Clan>(player.ControllerId, player.ClanId);
+        return true;
+    }
+
+    public void ReleaseNewControllerReservation(NetPeer peer)
+    {
+        if (peer == null) return;
+
+        lock (registrySync)
+        {
+            foreach (var controllerId in newControllerReservations
+                         .Where(pair => ReferenceEquals(pair.Value, peer))
+                         .Select(pair => pair.Key)
+                         .ToArray())
+            {
+                newControllerReservations.Remove(controllerId);
+            }
+        }
+    }
+
     public bool TryGetPeer(string controllerId, out NetPeer peer)
     {
         lock (registrySync)
@@ -285,6 +405,14 @@ public class PlayerManager : IPlayerManager
     {
         lock (registrySync)
         {
+            foreach (var controllerId in newControllerReservations
+                         .Where(pair => ReferenceEquals(pair.Value, peer))
+                         .Select(pair => pair.Key)
+                         .ToArray())
+            {
+                newControllerReservations.Remove(controllerId);
+            }
+
             if (!peerToPlayer.TryRemove(peer, out var player)) return;
 
             if (controllerToPeer.TryGetValue(player.ControllerId, out var currentPeer) &&

--- a/source/GameInterface/Services/Players/PlayerPartyRestorer.cs
+++ b/source/GameInterface/Services/Players/PlayerPartyRestorer.cs
@@ -16,6 +16,8 @@ public interface IPlayerPartyRestorer
 {
     bool TryRestore(Player player, out Player restoredPlayer);
     void Restore(Hero hero, MobileParty party);
+    void RestoreMemberships(Hero hero, MobileParty party);
+    void RestorePartyLeader(Hero hero, MobileParty party);
 }
 
 internal class PlayerPartyRestorer : IPlayerPartyRestorer
@@ -188,6 +190,39 @@ internal class PlayerPartyRestorer : IPlayerPartyRestorer
 
     public void Restore(Hero hero, MobileParty party)
     {
+        RestoreMemberships(hero, party);
+        RestorePartyLeader(hero, party);
+    }
+
+    public void RestoreMemberships(Hero hero, MobileParty party)
+    {
+        if (hero == null)
+            throw new ArgumentNullException(nameof(hero));
+        if (party == null)
+            throw new ArgumentNullException(nameof(party));
+        if (hero.Clan == null || hero.CharacterObject == null)
+            throw new InvalidOperationException("The transferred player hero has no clan or character object.");
+        if (party.Party == null ||
+            party.Party.MobileParty != party ||
+            party.PartyComponent == null ||
+            party.MemberRoster == null ||
+            party.PrisonRoster == null ||
+            party.ItemRoster == null)
+        {
+            throw new InvalidOperationException("The transferred player party graph is incomplete.");
+        }
+
+        // Binary hero transfer reconstructs MobileParty and PartyComponent separately. On the
+        // dedicated runtime the component's non-saved back-reference can therefore still be null
+        // here even though the MobileParty already owns that component. Native ChangePartyLeader
+        // dereferences PartyComponent.MobileParty immediately, so restore the invariant before any
+        // membership/leader operation. A component pointing at another party is corrupt and must
+        // fail closed instead of mutating either graph.
+        if (party.PartyComponent.MobileParty == null)
+            party.PartyComponent.MobileParty = party;
+        else if (party.PartyComponent.MobileParty != party)
+            throw new InvalidOperationException("The transferred player party component belongs to another party.");
+
         // Transferred root references can be missing from clan, roster, and party-component state.
         if (!hero.Clan.Heroes.Contains(hero))
             hero.Clan.OnLordAdded(hero);
@@ -195,9 +230,6 @@ internal class PlayerPartyRestorer : IPlayerPartyRestorer
         if (hero.IsPrisoner || hero.PartyBelongedToAsPrisoner != null)
         {
             hero.PartyBelongedTo = null;
-
-            if (party.LeaderHero != null)
-                party.ChangePartyLeader(null);
 
             var heroCount = party.MemberRoster.GetTroopCount(hero.CharacterObject);
             if (heroCount > 0)
@@ -215,6 +247,23 @@ internal class PlayerPartyRestorer : IPlayerPartyRestorer
 
         if (party.MemberRoster.GetTroopCount(hero.CharacterObject) == 0)
             party.MemberRoster.AddToCounts(hero.CharacterObject, 1, insertAtFront: true);
+    }
+
+    public void RestorePartyLeader(Hero hero, MobileParty party)
+    {
+        if (hero == null)
+            throw new ArgumentNullException(nameof(hero));
+        if (party == null)
+            throw new ArgumentNullException(nameof(party));
+        if (party.PartyComponent == null || party.PartyComponent.MobileParty != party)
+            throw new InvalidOperationException("The transferred player party component is not ready.");
+
+        if (hero.IsPrisoner || hero.PartyBelongedToAsPrisoner != null)
+        {
+            if (party.LeaderHero != null)
+                party.ChangePartyLeader(null);
+            return;
+        }
 
         if (party.LeaderHero != hero)
             party.ChangePartyLeader(hero);

--- a/source/GameInterface/Services/Save/Interfaces/SaveInterface.cs
+++ b/source/GameInterface/Services/Save/Interfaces/SaveInterface.cs
@@ -1,6 +1,7 @@
 ﻿using Common.Logging;
 using Serilog;
 using System;
+using System.Threading;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
@@ -17,6 +18,9 @@ public interface ISaveInterface : IGameAbstraction
 internal class SaveInterface : ISaveInterface
 {
     private readonly ILogger Logger = LogManager.GetLogger<SaveInterface>();
+    private static readonly AsyncLocal<int> TransferSaveDepth = new AsyncLocal<int>();
+
+    internal static bool IsTransferSaveInProgress => TransferSaveDepth.Value > 0;
 
     public SaveResults SaveCurrentGame()
     {
@@ -35,7 +39,15 @@ internal class SaveInterface : ISaveInterface
         CampaignEventDispatcher.Instance.OnBeforeSave();
 
         var saveDriver = new CoopInMemSaveDriver();
-        Game.Current.Save(metaData, "TransferSave", saveDriver, (SaveResult) => { });
+        TransferSaveDepth.Value++;
+        try
+        {
+            Game.Current.Save(metaData, "TransferSave", saveDriver, (SaveResult) => { });
+        }
+        finally
+        {
+            TransferSaveDepth.Value--;
+        }
 
         return new SaveResults(true, saveDriver.Data, Campaign.Current?.UniqueGameId);
     }

--- a/source/GameInterface/Services/Save/Patches/SavePatches.cs
+++ b/source/GameInterface/Services/Save/Patches/SavePatches.cs
@@ -3,6 +3,7 @@ using Common.Messaging;
 using GameInterface.Services.Heroes.Messages;
 using GameInterface.Services.Save.Commands;
 using GameInterface.Services.Save.Messages;
+using GameInterface.Services.Heroes.Interfaces;
 using HarmonyLib;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.Core;
@@ -14,7 +15,7 @@ class SavePatches
 {
     static bool Prefix(Game __instance, ref string saveName)
     {
-        if (ModInformation.IsServer)
+        if (ModInformation.IsServer && !SaveInterface.IsTransferSaveInProgress)
         {
             MessageBroker.Instance.Publish(__instance, new GameSaved(saveName));
         }
@@ -28,7 +29,7 @@ internal class SaveStartedPatch
 {
     static void Prefix(SaveHandler __instance)
     {
-        if (ModInformation.IsServer)
+        if (ModInformation.IsServer && !SaveInterface.IsTransferSaveInProgress)
         {
             MessageBroker.Instance.Publish(__instance, new GameSaveStateChanged(true));
             SaveDebugCommand.HoldForEvidenceIfRequested();
@@ -41,7 +42,7 @@ internal class SaveEndedPatch
 {
     static void Postfix(SaveHandler __instance)
     {
-        if (ModInformation.IsServer)
+        if (ModInformation.IsServer && !SaveInterface.IsTransferSaveInProgress)
         {
             MessageBroker.Instance.Publish(__instance, new GameSaveStateChanged(false));
         }

--- a/source/GameInterface/Services/Smithing/Handlers/CraftingCampaignBehaviorCraftingHandler.cs
+++ b/source/GameInterface/Services/Smithing/Handlers/CraftingCampaignBehaviorCraftingHandler.cs
@@ -1,431 +1,1196 @@
-﻿using Common;
+using Common;
 using Common.Logging;
 using Common.Messaging;
 using Common.Network;
 using Common.Network.Coalescing;
 using Common.Util;
+using GameInterface.Serialization;
+using GameInterface.Services.ItemObjects.Interfaces;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Players;
 using GameInterface.Services.Smithing.Interfaces;
 using GameInterface.Services.Smithing.Messages;
 using GameInterface.Services.Smithing.Patches;
+using GameInterface.Services.Transactions;
 using LiteNetLib;
 using Serilog;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.CampaignBehaviors;
 using TaleWorlds.CampaignSystem.CraftingSystem;
 using TaleWorlds.CampaignSystem.GameState;
+using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Roster;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
 using TaleWorlds.Localization;
+using TaleWorlds.ObjectSystem;
 using static GameInterface.Services.ObjectManager.ObjectManager;
 
-namespace GameInterface.Services.Smithing.Handlers;
-
-internal class CraftingCampaignBehaviorCraftingHandler : IHandler
+namespace GameInterface.Services.Smithing.Handlers
 {
-    private static readonly ILogger Logger = LogManager.GetLogger<CraftingCampaignBehaviorCraftingHandler>();
-
-    private readonly IMessageBroker messageBroker;
-    private readonly IObjectManager objectManager;
-    private readonly INetwork network;
-    private readonly ICraftingCampaignBehaviorInterface craftingCampaignBehaviorInterface;
-    private readonly ISendCoalescer sendCoalescer;
-
-    public CraftingCampaignBehaviorCraftingHandler(
-        IMessageBroker messageBroker,
-        IObjectManager objectManager,
-        INetwork network,
-        ICraftingCampaignBehaviorInterface craftingCampaignBehaviorInterface,
-        ISendCoalescer sendCoalescer = null)
+    internal class CraftingCampaignBehaviorCraftingHandler : IHandler
     {
-        this.messageBroker = messageBroker;
-        this.objectManager = objectManager;
-        this.network = network;
-        this.craftingCampaignBehaviorInterface = craftingCampaignBehaviorInterface;
-        this.sendCoalescer = sendCoalescer;
+        private static readonly ILogger Logger = LogManager.GetLogger<CraftingCampaignBehaviorCraftingHandler>();
+        private readonly IMessageBroker messageBroker;
+        private readonly IObjectManager objectManager;
+        private readonly INetwork network;
+        private readonly IBinaryPackageFactory binaryPackageFactory;
+        private readonly IItemObjectInterface itemObjectInterface;
+        private readonly ISessionCraftingPlayerDataInterface sessionCraftingPlayerDataInterface;
+        private readonly ISendCoalescer sendCoalescer;
+        private readonly IPlayerManager playerManager;
+        private readonly ICraftingCampaignBehaviorInterface craftingCampaignBehaviorInterface;
 
-        messageBroker.Subscribe<DoSmelting>(Handle_DoSmelting);
-        messageBroker.Subscribe<NetworkDoSmelting>(Handle_NetworkDoSmelting);
-
-        messageBroker.Subscribe<DoRefinement>(Handle_DoRefinement);
-        messageBroker.Subscribe<NetworkDoRefinement>(Handle_NetworkDoRefinement);
-
-        messageBroker.Subscribe<CreatedCraftedWeaponInternal>(Handle_CreatedCraftedWeaponInternal);
-        messageBroker.Subscribe<NetworkCreateCraftedWeaponInternalServer>(Handle_NetworkCreateCraftedWeaponInternalServer);
-        messageBroker.Subscribe<NetworkCreateCraftedWeaponInternalClients>(Handle_NetworkCreateCraftedWeaponInternalClients);
-        messageBroker.Subscribe<NetworkAddCraftedItemToRoster>(Handle_NetworkAddCraftedItemToRoster);
-
-        messageBroker.Subscribe<NetworkSetHeroCraftingStamina>(Handle_NetworkSetHeroCraftingStamina);
-
-        messageBroker.Subscribe<AddSkillXpFromCrafting>(Handle_AddSkillXpFromCrafting);
-        messageBroker.Subscribe<NetworkAddSkillXpFromCrafting>(Handle_NetworkAddSkillXpFromCrafting);
-    }
-
-    public void Dispose()
-    {
-        messageBroker.Unsubscribe<DoSmelting>(Handle_DoSmelting);
-        messageBroker.Unsubscribe<NetworkDoSmelting>(Handle_NetworkDoSmelting);
-
-        messageBroker.Unsubscribe<DoRefinement>(Handle_DoRefinement);
-        messageBroker.Unsubscribe<NetworkDoRefinement>(Handle_NetworkDoRefinement);
-
-        messageBroker.Unsubscribe<CreatedCraftedWeaponInternal>(Handle_CreatedCraftedWeaponInternal);
-        messageBroker.Unsubscribe<NetworkCreateCraftedWeaponInternalServer>(Handle_NetworkCreateCraftedWeaponInternalServer);
-        messageBroker.Unsubscribe<NetworkCreateCraftedWeaponInternalClients>(Handle_NetworkCreateCraftedWeaponInternalClients);
-        messageBroker.Unsubscribe<NetworkAddCraftedItemToRoster>(Handle_NetworkAddCraftedItemToRoster);
-
-        messageBroker.Unsubscribe<NetworkSetHeroCraftingStamina>(Handle_NetworkSetHeroCraftingStamina);
-
-        messageBroker.Unsubscribe<AddSkillXpFromCrafting>(Handle_AddSkillXpFromCrafting);
-        messageBroker.Unsubscribe<NetworkAddSkillXpFromCrafting>(Handle_NetworkAddSkillXpFromCrafting);
-    }
-
-    private void Handle_DoSmelting(MessagePayload<DoSmelting> obj)
-    {
-        if (!objectManager.TryGetIdWithLogging(obj.What.CraftingHero, out var craftingHeroId)) return;
-
-        NetworkDoSmelting message = new(craftingHeroId, obj.What.EquipmentElement);
-        network.SendAll(message);
-    }
-
-    private void Handle_NetworkDoSmelting(MessagePayload<NetworkDoSmelting> obj)
-    {
-        var data = obj.What;
-
-        GameThread.RunSafe(() =>
+        public CraftingCampaignBehaviorCraftingHandler(
+            IMessageBroker messageBroker,
+            IObjectManager objectManager,
+            INetwork network,
+            IBinaryPackageFactory binaryPackageFactory,
+            IItemObjectInterface itemObjectInterface,
+            ISessionCraftingPlayerDataInterface sessionCraftingPlayerDataInterface,
+            IPlayerManager playerManager,
+            ICraftingCampaignBehaviorInterface craftingCampaignBehaviorInterface,
+            ISendCoalescer sendCoalescer = null)
         {
-            // Get required objects using interface & objectManager
-            craftingCampaignBehaviorInterface.TryGetCraftingBehavior(out var craftingCampaignBehavior);
-            if (!objectManager.TryGetObjectWithLogging(data.CraftingHeroId, out Hero craftingHero)) return;
+            this.messageBroker = messageBroker;
+            this.objectManager = objectManager;
+            this.network = network;
+            this.binaryPackageFactory = binaryPackageFactory;
+            this.itemObjectInterface = itemObjectInterface;
+            this.sessionCraftingPlayerDataInterface = sessionCraftingPlayerDataInterface;
+            this.playerManager = playerManager;
+            this.craftingCampaignBehaviorInterface = craftingCampaignBehaviorInterface;
+            this.sendCoalescer = sendCoalescer;
 
-            // Replace original TaleWorlds implementation
-            var newHeroCraftingStamina = craftingCampaignBehaviorInterface.DoSmelting(craftingCampaignBehavior, craftingHero, data.EquipmentElement);
+            messageBroker.Subscribe<DoSmelting>(Handle);
+            messageBroker.Subscribe<NetworkDoSmelting>(Handle);
+            messageBroker.Subscribe<DoRefinement>(Handle);
+            messageBroker.Subscribe<NetworkDoRefinement>(Handle);
+            messageBroker.Subscribe<CreatedCraftedWeaponInternal>(Handle);
+            messageBroker.Subscribe<NetworkCreateCraftedWeaponInternalServer>(Handle);
+            messageBroker.Subscribe<NetworkCreateCraftedWeaponInternalClients>(Handle);
+            messageBroker.Subscribe<NetworkAddCraftedItemToRoster>(Handle);
 
-            // Update stamina on clients
-            network.SendAll(new NetworkSetHeroCraftingStamina(data.CraftingHeroId, newHeroCraftingStamina));
+            messageBroker.Subscribe<NetworkSetHeroCraftingStamina>(Handle);
 
-            // Refresh client view model
-            FlushCoalescer(craftingHero.PartyBelongedTo.ItemRoster);
-            network.Send(obj.Who as NetPeer, new NetworkRefreshSmelting());
-        });
-    }
+            messageBroker.Subscribe<AddSkillXpFromCrafting>(Handle);
+            messageBroker.Subscribe<NetworkAddSkillXpFromCrafting>(Handle);
+        }
 
-    private void Handle_DoRefinement(MessagePayload<DoRefinement> obj)
-    {
-        if (!objectManager.TryGetIdWithLogging(obj.What.CraftingHero, out var craftingHeroId)) return;
-
-        // Need to reconstruct formula at the other end
-        Crafting.RefiningFormula formula = obj.What.RefiningFormula;
-
-        NetworkDoRefinement message = new(
-            craftingHeroId,
-            formula.Input1,
-            formula.Input1Count,
-            formula.Input2,
-            formula.Input2Count,
-            formula.Output,
-            formula.OutputCount,
-            formula.Output2,
-            formula.Output2Count
-        );
-        network.SendAll(message);
-    }
-
-    private void Handle_NetworkDoRefinement(MessagePayload<NetworkDoRefinement> obj)
-    {
-        var data = obj.What;
-
-        GameThread.RunSafe(() =>
+        public void Dispose()
         {
-            // Get required objects using interface & objectManager
-            craftingCampaignBehaviorInterface.TryGetCraftingBehavior(out var craftingCampaignBehavior);
-            if (!objectManager.TryGetObjectWithLogging(data.CraftingHeroId, out Hero craftingHero)) return;
+            messageBroker.Unsubscribe<DoSmelting>(Handle);
+            messageBroker.Unsubscribe<NetworkDoSmelting>(Handle);
+            messageBroker.Unsubscribe<DoRefinement>(Handle);
+            messageBroker.Unsubscribe<NetworkDoRefinement>(Handle);
+            messageBroker.Unsubscribe<CreatedCraftedWeaponInternal>(Handle);
+            messageBroker.Unsubscribe<NetworkCreateCraftedWeaponInternalServer>(Handle);
+            messageBroker.Unsubscribe<NetworkCreateCraftedWeaponInternalClients>(Handle);
+            messageBroker.Unsubscribe<NetworkAddCraftedItemToRoster>(Handle);
 
-            // Rebuild formula on server
-            var formula = new Crafting.RefiningFormula(
-                data.Input1, data.Input1Count,
-                data.Input2, data.Input2Count,
-                data.Output1, data.Output1Count,
-                data.Output2, data.Output2Count);
+            messageBroker.Unsubscribe<NetworkSetHeroCraftingStamina>(Handle);
 
-            // Replace original TaleWorlds implementation
-            var newHeroCraftingStamina = craftingCampaignBehaviorInterface.DoRefinement(craftingCampaignBehavior, craftingHero, formula);
+            messageBroker.Unsubscribe<AddSkillXpFromCrafting>(Handle);
+            messageBroker.Unsubscribe<NetworkAddSkillXpFromCrafting>(Handle);
+        }
 
-            // Update stamina on clients
-            network.SendAll(new NetworkSetHeroCraftingStamina(data.CraftingHeroId, newHeroCraftingStamina));
-
-            // Refresh client view model
-            FlushCoalescer(craftingHero.PartyBelongedTo.ItemRoster);
-            network.Send(obj.Who as NetPeer, new NetworkRefreshRefinement(data.CraftingHeroId));
-        });
-    }
-
-    private void Handle_CreatedCraftedWeaponInternal(MessagePayload<CreatedCraftedWeaponInternal> obj)
-    {
-        var data = obj.What;
-
-        if (!objectManager.TryGetIdWithLogging(data.CraftingHero, out var craftingHeroId)) return;
-        if (!objectManager.TryGetIdWithLogging(data.WeaponDesign.Template, out var craftingTemplateId)) return;
-        if (!objectManager.TryGetIdWithLogging(data.PlayerHero, out var playerHeroId)) return;
-        if (!objectManager.TryGetIdWithLogging(data.CurrentSettlement, out var currentSettlementId)) return;
-
-        string itemModifierGroupId = null;
-        if (data.CraftingLogic.CurrentItemModifierGroup != null && !objectManager.TryGetIdWithLogging(data.CraftingLogic.CurrentItemModifierGroup, out itemModifierGroupId)) return;
-
-        string cultureId = null;
-        if (data.CultureObject != null && !objectManager.TryGetIdWithLogging(data.CultureObject, out cultureId)) return;
-
-        if (!PackUsedPieces(data.WeaponDesign, out var craftingPieceIds, out var scalePercentages)) return;
-
-        var weaponModifierId = "";
-        if (data.WeaponModifier != null && !objectManager.TryGetIdWithLogging(data.WeaponModifier, out weaponModifierId)) return;
-
-        string craftingOrderId = null;
-        if (data.CraftingOrder != null && !objectManager.TryGetIdWithLogging(data.CraftingOrder, out craftingOrderId)) return;
-
-        NetworkCreateCraftedWeaponInternalServer message = new(
-            data.IsFreeMode,
-            craftingHeroId,
-            data.Name,
-            cultureId,
-            craftingTemplateId,
-            data.WeaponDesign.WeaponName?.ToString() ?? "",
-            craftingPieceIds,
-            scalePercentages,
-            weaponModifierId,
-            playerHeroId,
-            itemModifierGroupId,
-            craftingOrderId,
-            currentSettlementId
-        );
-        network.SendAll(message);
-    }
-
-    private void Handle_NetworkCreateCraftedWeaponInternalServer(MessagePayload<NetworkCreateCraftedWeaponInternalServer> obj)
-    {
-        var data = obj.What;
-
-        GameThread.RunSafe(() =>
+        private void Handle(MessagePayload<DoSmelting> obj)
         {
-            craftingCampaignBehaviorInterface.TryGetCraftingBehavior(out var craftingCampaignBehavior);
-            if (!objectManager.TryGetObjectWithLogging(data.CraftingHeroId, out Hero craftingHero)) return;
-            if (!objectManager.TryGetObjectWithLogging(data.CraftingTemplateId, out CraftingTemplate craftingTemplate)) return;
+            SendSmeltingDone(obj.What);
+        }
 
-            ItemModifierGroup itemModifierGroup = null;
-            if (data.ItemModifierGroupId != null && !objectManager.TryGetObjectWithLogging(data.ItemModifierGroupId, out itemModifierGroup)) return;
+        private void Handle(MessagePayload<NetworkDoSmelting> obj)
+        {
+            DoSmelting(obj.What, obj.Who as NetPeer);
+        }
 
-            if (!GetUsedPieces(data.WeaponDesignElementCraftingPieceIds, data.WeaponDesignElementScalePercentages, out WeaponDesignElement[] usedPieces)) return;
+        private void Handle(MessagePayload<DoRefinement> obj)
+        {
+            SendRefinementDone(obj.What);
+        }
 
-            ItemModifier weaponModifier = null;
-            if (data.WeaponModifierId != "" && !objectManager.TryGetObjectWithLogging(data.WeaponModifierId, out weaponModifier)) return;
+        private void Handle(MessagePayload<NetworkDoRefinement> obj)
+        {
+            DoRefinement(obj.What, obj.Who as NetPeer);
+        }
 
-            CultureObject culture = null;
-            if (data.CultureId != null && !objectManager.TryGetObjectWithLogging(data.CultureId, out culture)) return;
+        private void Handle(MessagePayload<CreatedCraftedWeaponInternal> obj)
+        {
+            SendInternallyCreatedWeapon(obj.What);
+        }
 
-            // Replace original TaleWorlds implementation
-            string nextCraftedItemId = craftingCampaignBehavior.GetNextCraftedItemId();
-            var newHeroCraftingStamina = craftingCampaignBehaviorInterface.CreateCraftedWeaponInternal(
-                craftingCampaignBehavior,
-                craftingHero,
-                craftingTemplate,
-                itemModifierGroup,
-                usedPieces,
-                weaponModifier,
-                culture,
-                data.IsFreeMode,
-                data.Name,
-                data.WeaponName,
-                nextCraftedItemId);
+        private void Handle(MessagePayload<NetworkCreateCraftedWeaponInternalServer> obj)
+        {
+            CreateCraftedWeaponInternalServer(
+                obj.What, obj.Who as NetPeer);
+        }
 
-            // Update stamina on clients
-            network.SendAll(new NetworkSetHeroCraftingStamina(data.CraftingHeroId, newHeroCraftingStamina));
+        private void Handle(MessagePayload<NetworkCreateCraftedWeaponInternalClients> obj)
+        {
+            if (ModInformation.IsServer) return;
+            CreateCraftedWeaponInternalClients(obj.What);
+        }
 
-            // Create weapon on all clients
-            NetworkCreateCraftedWeaponInternalClients message = new(data, nextCraftedItemId);
-            network.SendAll(message);
+        private void Handle(MessagePayload<NetworkAddCraftedItemToRoster> obj)
+        {
+            if (ModInformation.IsServer) return;
+            AddCraftedItemToRoster(obj.What);
+        }
 
-            // Complete order on server and send result to clients
-            if (!data.IsFreeMode)
+        private void Handle(MessagePayload<NetworkSetHeroCraftingStamina> obj)
+        {
+            if (ModInformation.IsServer) return;
+            SetHeroCraftingStaminaClients(obj.What);
+        }
+
+        private void Handle(MessagePayload<AddSkillXpFromCrafting> obj)
+        {
+            GameThread.RunSafe(() =>
             {
-                if (!objectManager.TryGetObjectWithLogging<Settlement>(data.CurrentSettlementId, out var currentSettlement)) return;
-                if (!objectManager.TryGetObjectWithLogging<CraftingOrder>(data.CraftingOrderId, out var craftingOrder)) return;
-                if (!objectManager.TryGetObjectWithLogging<ItemObject>(nextCraftedItemId, out var craftedItem)) return;
-                if (!objectManager.TryGetObjectWithLogging<Hero>(data.PlayerHeroId, out var playerHero)) return;
+                if (!objectManager.TryGetIdWithLogging(obj.What.CraftingHero, out var craftingHeroId)) return;
 
-                messageBroker.Publish(this, new CompleteOrderServer(
-                    currentSettlement.Town,
-                    craftingOrder,
-                    craftedItem,
-                    craftingHero,
-                    playerHero));
-            }
-        });
-    }
+                network.SendAll(new NetworkAddSkillXpFromCrafting(craftingHeroId, obj.What.Xp));
+            });
+        }
 
-    private void Handle_NetworkCreateCraftedWeaponInternalClients(MessagePayload<NetworkCreateCraftedWeaponInternalClients> obj)
-    {
-        var data = obj.What;
-
-        GameThread.RunSafe(() =>
+        private void Handle(MessagePayload<NetworkAddSkillXpFromCrafting> obj)
         {
-            using (new AllowedThread())
+            NetPeer peer = obj.Who as NetPeer;
+            GameThread.RunSafe(() => ServerTransactionOutcome.Execute(
+                peer, ServerTransactionOutcome.CraftXp, () =>
             {
-                if (!craftingCampaignBehaviorInterface.TryGetCraftingBehavior(out var craftingBehavior)) return;
-                if (!objectManager.TryGetObjectWithLogging(data.CraftingTemplateId, out CraftingTemplate craftingTemplate)) return;
-                if (!objectManager.TryGetObjectWithLogging(data.PlayerHeroId, out Hero playerHero)) return;
-                if (!objectManager.TryGetObjectWithLogging(data.CraftingHeroId, out Hero craftingHero)) return;
-                if (!objectManager.TryGetObjectWithLogging(data.CurrentSettlementId, out Settlement currentSettlement)) return;
+                if (!ServerTransactionOutcome.TryResolveOwnedCraftingHero(
+                        peer,
+                        playerManager,
+                        objectManager,
+                        obj.What.CraftingHeroId,
+                        out _,
+                        out _,
+                        out _,
+                        out string authenticationReason) ||
+                    !ServerTransactionOutcome.TryConsumeCraftXp(
+                        peer, obj.What.CraftingHeroId) ||
+                    float.IsNaN(obj.What.Xp) ||
+                    float.IsInfinity(obj.What.Xp) || obj.What.Xp < 0f)
+                {
+                    ServerTransactionOutcome.Reject(
+                        peer, ServerTransactionOutcome.CraftXp,
+                        string.IsNullOrEmpty(authenticationReason)
+                            ? "Crafting experience was not linked to an accepted craft."
+                            : authenticationReason);
+                    return;
+                }
 
-                ItemModifierGroup itemModifierGroup = null;
-                if (data.ItemModifierGroupId != null && !objectManager.TryGetObjectWithLogging(data.ItemModifierGroupId, out itemModifierGroup)) return;
+                // XP is calculated and applied with the accepted craft on the
+                // server. This paired legacy packet is confirmation only.
+                ServerTransactionOutcome.Accept(
+                    peer, ServerTransactionOutcome.CraftXp);
+            }));
+        }
 
-                if (!GetUsedPieces(data.WeaponDesignElementCraftingPieceIds, data.WeaponDesignElementScalePercentages, out WeaponDesignElement[] usedPieces)) return;
+        private void SendSmeltingDone(DoSmelting obj)
+        {
+            if (!objectManager.TryGetIdWithLogging(obj.CraftingHero, out var craftingHeroId)) return;
+            network.SendAll(new NetworkDoSmelting(
+                craftingHeroId, obj.EquipmentElement));
+        }
 
-                ItemModifier weaponModifier = null;
-                if (data.WeaponModifierId != "" && !objectManager.TryGetObjectWithLogging(data.WeaponModifierId, out weaponModifier)) return;
+        private void DoSmelting(NetworkDoSmelting obj, NetPeer peer)
+        {
+            GameThread.RunSafe(() => ServerTransactionOutcome.Execute(
+                peer, ServerTransactionOutcome.Smelt, () =>
+            {
+                if (!ServerTransactionOutcome.TryResolveOwnedCraftingHero(
+                        peer,
+                        playerManager,
+                        objectManager,
+                        obj.CraftingHeroId,
+                        out var player,
+                        out Hero authorizedHero,
+                        out MobileParty playerParty,
+                        out string authenticationReason))
+                {
+                    RejectSmithing(
+                        peer,
+                        ServerTransactionOutcome.Smelt,
+                        authenticationReason);
+                    return;
+                }
+                if (!craftingCampaignBehaviorInterface.TryGetCraftingBehavior(out CraftingCampaignBehavior craftingCampaignBehavior) ||
+                    authorizedHero?.PartyBelongedTo == null ||
+                    !IsSmithyAvailable(playerParty))
+                {
+                    RejectSmithing(peer, ServerTransactionOutcome.Smelt,
+                        "The smithing state is no longer available.");
+                    return;
+                }
+                Hero craftingHero = authorizedHero;
 
-                CultureObject culture = null;
-                if (data.CultureId != null && !objectManager.TryGetObjectWithLogging(data.CultureId, out culture)) return;
-
-                CraftingOrder craftingOrder = null;
-                if (data.CraftingOrderId != null && !objectManager.TryGetObjectWithLogging(data.CraftingOrderId, out craftingOrder)) return;
+                EquipmentElement equipmentElement = obj.EquipmentElement;
+                ItemObject item = equipmentElement.Item;
+                if (item == null)
+                {
+                    RejectSmithing(peer, ServerTransactionOutcome.Smelt,
+                        "The selected item is no longer available.");
+                    return;
+                }
+                if (equipmentElement.IsQuestItem)
+                {
+                    RejectSmithing(peer, ServerTransactionOutcome.Smelt,
+                        "Quest items cannot be smelted.");
+                    return;
+                }
 
                 // Replace original TaleWorlds implementation
-                string nextCraftedItemId = data.NextCraftedItemId;
-                WeaponDesign weaponDesign = new WeaponDesign(craftingTemplate, new TextObject(data.WeaponName), usedPieces);
-                if (data.IsFreeMode)
+                ItemRoster itemRoster = craftingHero.PartyBelongedTo.ItemRoster;
+                int[] smeltingOutputForItem = Campaign.Current.Models.SmithingModel.GetSmeltingOutputForItem(item);
+
+                int smeltItemIndex = itemRoster.FindIndexOfElement(equipmentElement);
+                if (smeltItemIndex < 0 || itemRoster.GetElementCopyAtIndex(smeltItemIndex).Amount < 1)
+                {
+                    RejectSmithing(peer, ServerTransactionOutcome.Smelt,
+                        "That item is no longer available to smelt.");
+                    return;
+                }
+                int energyCostForSmelting = Campaign.Current.Models.SmithingModel.GetEnergyCostForSmelting(item, craftingHero);
+                int currentStamina = craftingCampaignBehavior.GetHeroCraftingStamina(craftingHero);
+                if (energyCostForSmelting < 0 || currentStamina < energyCostForSmelting)
+                {
+                    RejectSmithing(peer, ServerTransactionOutcome.Smelt,
+                        "The selected hero does not have enough smithing stamina.");
+                    return;
+                }
+                ItemRosterElement[] itemRosterBefore = itemRoster.ToArray();
+                int newHeroCraftingStamina =
+                    currentStamina - energyCostForSmelting;
+                try
+                {
+                    itemRoster.AddToCounts(equipmentElement, -1);
+                    for (int i = 8; i >= 0; i--)
+                    {
+                        if (smeltingOutputForItem[i] != 0)
+                            itemRoster.AddToCounts(
+                                Campaign.Current.Models.SmithingModel
+                                    .GetCraftingMaterialItem(
+                                        (CraftingMaterials)i),
+                                smeltingOutputForItem[i]);
+                    }
+                    craftingCampaignBehavior.SetHeroCraftingStamina(
+                        craftingHero, newHeroCraftingStamina);
+                }
+                catch (Exception exception)
+                {
+                    RestoreSmithingCore(
+                        itemRoster,
+                        itemRosterBefore,
+                        craftingCampaignBehavior,
+                        craftingHero,
+                        currentStamina,
+                        exception,
+                        "smelting");
+                    RejectSmithing(
+                        peer,
+                        ServerTransactionOutcome.Smelt,
+                        "Smelting could not be committed safely.");
+                    return;
+                }
+
+                TryPostCommit(() => craftingHero.AddSkillXp(
+                    DefaultSkills.Crafting,
+                    Campaign.Current.Models.SmithingModel
+                        .GetSkillXpForSmelting(equipmentElement.Item)),
+                    "smelting skill XP");
+                TryPostCommit(() => network.SendAll(
+                    new NetworkSetHeroCraftingStamina(
+                        obj.CraftingHeroId,
+                        newHeroCraftingStamina)), "smelting stamina");
+                TryPostCommit(() => CampaignEventDispatcher.Instance
+                    .OnEquipmentSmeltedByHero(
+                        craftingHero, equipmentElement),
+                    "equipment-smelted event");
+
+                if (item.WeaponDesign?.Template != null &&
+                    objectManager.TryGetId(
+                        item.WeaponDesign.Template, out string templateId))
+                {
+                    TryPostCommit(() =>
+                    {
+                        int researchGain = Campaign.Current.Models.SmithingModel
+                            .GetPartResearchGainForSmeltingItem(
+                                item, craftingHero);
+                        CraftingCampaignBehaviorResearchPointHandler
+                            .AllowAuthoritativeResearch(
+                                peer,
+                                player.HeroId,
+                                templateId,
+                                researchGain);
+                    }, "smelting research permit");
+                }
+
+                TryPostCommit(() =>
+                {
+                    objectManager.TryGetId(itemRoster, out var rosterId);
+                    var compactId = Compact(rosterId, typeof(ItemRoster));
+                    sendCoalescer?.FlushInstance(compactId, network);
+                }, "smelting roster flush");
+                TryPostCommit(() => network.SendAll(
+                    new NetworkRefreshSmelting()), "smelting refresh");
+                ServerTransactionOutcome.Accept(
+                    peer, ServerTransactionOutcome.Smelt);
+            }));
+        }
+
+        private void SendRefinementDone(DoRefinement obj)
+        {
+            if (!objectManager.TryGetIdWithLogging(obj.CraftingHero, out var craftingHeroId)) return;
+
+            // Need to reconstruct formula at the other end
+            Crafting.RefiningFormula formula = obj.RefiningFormula;
+
+            // Send to server from client
+            NetworkDoRefinement message = new(
+                craftingHeroId,
+                formula.Input1,
+                formula.Input1Count,
+                formula.Input2,
+                formula.Input2Count,
+                formula.Output,
+                formula.OutputCount,
+                formula.Output2,
+                formula.Output2Count
+            );
+            network.SendAll(message);
+        }
+
+        private void DoRefinement(NetworkDoRefinement obj, NetPeer peer)
+        {
+            GameThread.RunSafe(() => ServerTransactionOutcome.Execute(
+                peer, ServerTransactionOutcome.Refine, () =>
+            {
+                if (!ServerTransactionOutcome.TryResolveOwnedCraftingHero(
+                        peer,
+                        playerManager,
+                        objectManager,
+                        obj.CraftingHeroId,
+                        out _,
+                        out Hero authorizedHero,
+                        out MobileParty playerParty,
+                        out string authenticationReason))
+                {
+                    if (string.IsNullOrEmpty(authenticationReason))
+                        authenticationReason =
+                            "The crafting request did not belong to this player.";
+                    RejectSmithing(
+                        peer,
+                        ServerTransactionOutcome.Refine,
+                        authenticationReason);
+                    return;
+                }
+                // Get objects from objectManager
+                if (!craftingCampaignBehaviorInterface.TryGetCraftingBehavior(out CraftingCampaignBehavior craftingCampaignBehavior) ||
+                    authorizedHero?.PartyBelongedTo == null ||
+                    !IsSmithyAvailable(playerParty))
+                {
+                    RejectSmithing(peer, ServerTransactionOutcome.Refine,
+                        "The smithing state is no longer available.");
+                    return;
+                }
+                Hero craftingHero = authorizedHero;
+
+                // Rebuild formula on server
+                var formula = new Crafting.RefiningFormula(
+                    obj.Input1, obj.Input1Count,
+                    obj.Input2, obj.Input2Count,
+                    obj.Output1, obj.Output1Count,
+                    obj.Output2, obj.Output2Count);
+
+                if (!Campaign.Current.Models.SmithingModel
+                        .GetRefiningFormulas(craftingHero)
+                        .Any(candidate => RefiningFormulasMatch(
+                            candidate, formula)))
+                {
+                    RejectSmithing(peer, ServerTransactionOutcome.Refine,
+                        "That refining formula is not available to this hero.");
+                    return;
+                }
+
+                // Replace original TaleWorlds implementation
+                ItemRoster itemRoster = craftingHero.PartyBelongedTo.ItemRoster;
+                var requiredMaterials = new Dictionary<CraftingMaterials, int>();
+                AddRequiredMaterial(
+                    requiredMaterials, formula.Input1, formula.Input1Count);
+                AddRequiredMaterial(
+                    requiredMaterials, formula.Input2, formula.Input2Count);
+                foreach (KeyValuePair<CraftingMaterials, int> required in requiredMaterials)
+                {
+                    ItemObject material = Campaign.Current.Models.SmithingModel
+                        .GetCraftingMaterialItem(required.Key);
+                    if (required.Value < 0 ||
+                        itemRoster.GetItemNumber(material) < required.Value)
+                    {
+                        RejectSmithing(peer, ServerTransactionOutcome.Refine,
+                            "The required smithing materials are no longer available.");
+                        return;
+                    }
+                }
+                int energyCostForRefining = Campaign.Current.Models.SmithingModel
+                    .GetEnergyCostForRefining(ref formula, craftingHero);
+                int currentStamina = craftingCampaignBehavior
+                    .GetHeroCraftingStamina(craftingHero);
+                if (energyCostForRefining < 0 ||
+                    currentStamina < energyCostForRefining)
+                {
+                    RejectSmithing(peer, ServerTransactionOutcome.Refine,
+                        "The selected hero does not have enough smithing stamina.");
+                    return;
+                }
+                ItemRosterElement[] itemRosterBefore = itemRoster.ToArray();
+                int newHeroCraftingStamina =
+                    currentStamina - energyCostForRefining;
+                try
+                {
+                    if (formula.Input1Count > 0)
+                        itemRoster.AddToCounts(
+                            Campaign.Current.Models.SmithingModel
+                                .GetCraftingMaterialItem(formula.Input1),
+                            -formula.Input1Count);
+                    if (formula.Input2Count > 0)
+                        itemRoster.AddToCounts(
+                            Campaign.Current.Models.SmithingModel
+                                .GetCraftingMaterialItem(formula.Input2),
+                            -formula.Input2Count);
+                    if (formula.OutputCount > 0)
+                        itemRoster.AddToCounts(
+                            Campaign.Current.Models.SmithingModel
+                                .GetCraftingMaterialItem(formula.Output),
+                            formula.OutputCount);
+                    if (formula.Output2Count > 0)
+                        itemRoster.AddToCounts(
+                            Campaign.Current.Models.SmithingModel
+                                .GetCraftingMaterialItem(formula.Output2),
+                            formula.Output2Count);
+                    craftingCampaignBehavior.SetHeroCraftingStamina(
+                        craftingHero, newHeroCraftingStamina);
+                }
+                catch (Exception exception)
+                {
+                    RestoreSmithingCore(
+                        itemRoster,
+                        itemRosterBefore,
+                        craftingCampaignBehavior,
+                        craftingHero,
+                        currentStamina,
+                        exception,
+                        "refining");
+                    RejectSmithing(
+                        peer,
+                        ServerTransactionOutcome.Refine,
+                        "Refining could not be committed safely.");
+                    return;
+                }
+
+                TryPostCommit(() =>
+                {
+                    Crafting.RefiningFormula xpFormula = formula;
+                    craftingHero.AddSkillXp(
+                        DefaultSkills.Crafting,
+                        Campaign.Current.Models.SmithingModel
+                            .GetSkillXpForRefining(ref xpFormula));
+                }, "refining skill XP");
+                TryPostCommit(() => network.SendAll(
+                    new NetworkSetHeroCraftingStamina(
+                        obj.CraftingHeroId,
+                        newHeroCraftingStamina)), "refining stamina");
+                TryPostCommit(() => CampaignEventDispatcher.Instance
+                    .OnItemsRefined(craftingHero, formula),
+                    "items-refined event");
+                TryPostCommit(() =>
+                {
+                    objectManager.TryGetId(itemRoster, out var rosterId);
+                    var compactId = Compact(rosterId, typeof(ItemRoster));
+                    sendCoalescer?.FlushInstance(compactId, network);
+                }, "refining roster flush");
+                TryPostCommit(() => network.SendAll(
+                    new NetworkRefreshRefinement(obj.CraftingHeroId)),
+                    "refining refresh");
+                ServerTransactionOutcome.Accept(
+                    peer, ServerTransactionOutcome.Refine);
+            }));
+        }
+
+        private void SendInternallyCreatedWeapon(CreatedCraftedWeaponInternal obj)
+        {
+            if (!objectManager.TryGetIdWithLogging(obj.CraftingHero, out var craftingHeroId)) return;
+            if (!objectManager.TryGetIdWithLogging(obj.WeaponDesign.Template, out var craftingTemplateId)) return;
+            if (!objectManager.TryGetIdWithLogging(obj.PlayerHero, out var playerHeroId)) return;
+            if (!objectManager.TryGetIdWithLogging(obj.CurrentSettlement, out var currentSettlementId)) return;
+
+            string itemModifierGroupId = null;
+            if (obj.CraftingLogic.CurrentItemModifierGroup != null && !objectManager.TryGetIdWithLogging(obj.CraftingLogic.CurrentItemModifierGroup, out itemModifierGroupId)) return;
+
+            string cultureId = null;
+            if (obj.CultureObject != null && !objectManager.TryGetIdWithLogging(obj.CultureObject, out cultureId)) return;
+
+            var weaponDesignElementCraftingPieceIds = new List<string>();
+            var weaponDesignElementScalePercentages = new List<int>();
+            foreach (var weaponDesignElement in obj.WeaponDesign._usedPieces)
+            {
+                if (!weaponDesignElement._craftingPiece.IsValid) // Skip invalid crafting pieces, e.g. Axe doesn't have a guard
+                {
+                    weaponDesignElementCraftingPieceIds.Add("");
+                    weaponDesignElementScalePercentages.Add(-1);
+                    continue;
+                }
+
+                if (!objectManager.TryGetIdWithLogging(weaponDesignElement._craftingPiece, out var currentCraftingPieceId)) return;
+                weaponDesignElementCraftingPieceIds.Add(currentCraftingPieceId);
+                weaponDesignElementScalePercentages.Add(weaponDesignElement._scalePercentage);
+            }
+
+            var weaponModifierId = "";
+            if (obj.WeaponModifier != null && !objectManager.TryGetIdWithLogging(obj.WeaponModifier, out weaponModifierId)) return;
+
+            string craftingOrderId = null;
+            if (obj.CraftingOrder != null && !objectManager.TryGetIdWithLogging(obj.CraftingOrder, out craftingOrderId)) return;
+
+            // Send to server from client
+            NetworkCreateCraftedWeaponInternalServer message = new(
+                obj.IsFreeMode,
+                craftingHeroId,
+                obj.Name,
+                cultureId,
+                craftingTemplateId,
+                obj.WeaponDesign.WeaponName?.ToString() ?? "",
+                weaponDesignElementCraftingPieceIds,
+                weaponDesignElementScalePercentages,
+                weaponModifierId,
+                playerHeroId,
+                itemModifierGroupId,
+                craftingOrderId,
+                currentSettlementId
+            );
+            network.SendAll(message);
+        }
+
+        private void CreateCraftedWeaponInternalServer(
+            NetworkCreateCraftedWeaponInternalServer obj,
+            NetPeer peer)
+        {
+            GameThread.RunSafe(() => ServerTransactionOutcome.Execute(
+                peer, ServerTransactionOutcome.Craft, () =>
+            {
+                if (!ServerTransactionOutcome.TryResolveOwnedCraftingHero(
+                        peer,
+                        playerManager,
+                        objectManager,
+                        obj.CraftingHeroId,
+                        out var player,
+                        out Hero authorizedHero,
+                        out MobileParty playerParty,
+                        out string authenticationReason) ||
+                    !string.Equals(
+                        player.HeroId,
+                        obj.PlayerHeroId,
+                        StringComparison.Ordinal))
+                {
+                    RejectSmithing(
+                        peer,
+                        ServerTransactionOutcome.Craft,
+                        authenticationReason);
+                    return;
+                }
+                if (!craftingCampaignBehaviorInterface.TryGetCraftingBehavior(out CraftingCampaignBehavior craftingCampaignBehavior) ||
+                    !objectManager.TryGetObjectWithLogging(obj.CraftingTemplateId, out CraftingTemplate craftingTemplate) ||
+                    authorizedHero?.PartyBelongedTo == null ||
+                    !IsSmithyAvailable(playerParty))
+                {
+                    RejectSmithing(peer, ServerTransactionOutcome.Craft,
+                        "The smithing state is no longer available.");
+                    return;
+                }
+                Hero craftingHero = authorizedHero;
+                CultureObject culture = craftingHero.Culture;
+                if (!objectManager.TryGetObjectWithLogging(
+                        player.HeroId, out Hero playerHero) ||
+                    !objectManager.TryGetIdWithLogging(
+                        playerParty.CurrentSettlement,
+                        out string authoritativeSettlementId))
+                {
+                    RejectSmithing(peer, ServerTransactionOutcome.Craft,
+                        "The player smithing context could not be resolved.");
+                    return;
+                }
+                string cultureId = null;
+                if (culture != null &&
+                    !objectManager.TryGetIdWithLogging(culture, out cultureId))
+                {
+                    RejectSmithing(peer, ServerTransactionOutcome.Craft,
+                        "The crafting culture could not be resolved.");
+                    return;
+                }
+
+                ItemModifierGroup itemModifierGroup =
+                    craftingTemplate.ItemModifierGroup;
+
+                if (!TryGetAuthorizedUsedPieces(
+                        player.HeroId,
+                        craftingTemplate,
+                        obj.WeaponDesignElementCraftingPieceIds,
+                        obj.WeaponDesignElementScalePercentages,
+                        out WeaponDesignElement[] usedPieces))
+                {
+                    RejectSmithing(peer, ServerTransactionOutcome.Craft,
+                        "The selected weapon pieces are invalid or not unlocked.");
+                    return;
+                }
+
+                Settlement currentSettlement = null;
+                CraftingOrder craftingOrder = null;
+                if (!obj.IsFreeMode &&
+                    !TryResolveExactCraftingOrder(
+                        craftingCampaignBehavior,
+                        craftingHero.PartyBelongedTo,
+                        craftingTemplate,
+                        authoritativeSettlementId,
+                        obj.CraftingOrderId,
+                        out currentSettlement,
+                        out craftingOrder))
+                {
+                    RejectSmithing(peer, ServerTransactionOutcome.Craft,
+                        "The selected crafting order is no longer available in this town.");
+                    return;
+                }
+
+                // Replace original TaleWorlds implementation
+
+                string nextCraftedItemId = craftingCampaignBehavior.GetNextCraftedItemId();
+                WeaponDesign weaponDesign = new WeaponDesign(craftingTemplate, new TextObject(obj.WeaponName), usedPieces);
+                if (obj.IsFreeMode)
                 {
                     weaponDesign = new WeaponDesign(weaponDesign.Template, weaponDesign.WeaponName, weaponDesign.UsedPieces, nextCraftedItemId);
                 }
-
-                var craftedItemObject = craftingCampaignBehaviorInterface.CreateAndRegisterCraftedItem(weaponDesign, data.Name, culture, itemModifierGroup, nextCraftedItemId);
-                CampaignEventDispatcher.Instance.OnNewItemCrafted(craftedItemObject, weaponModifier, !data.IsFreeMode);
-
-                // Only run on crafting client
-                if (playerHero == Hero.MainHero)
+                ItemModifier weaponModifier = obj.IsFreeMode
+                    ? Campaign.Current.Models.SmithingModel
+                        .GetCraftedWeaponModifier(weaponDesign, craftingHero)
+                    : null;
+                string weaponModifierId = string.Empty;
+                if (weaponModifier != null &&
+                    !objectManager.TryGetIdWithLogging(
+                        weaponModifier, out weaponModifierId))
                 {
-                    if (GameStateManager.Current.ActiveState is CraftingState currentState)
+                    RejectSmithing(peer, ServerTransactionOutcome.Craft,
+                        "The server could not resolve the crafted weapon quality.");
+                    return;
+                }
+                string itemModifierGroupId = string.Empty;
+                if (itemModifierGroup != null &&
+                    !objectManager.TryGetIdWithLogging(
+                        itemModifierGroup, out itemModifierGroupId))
+                {
+                    RejectSmithing(peer, ServerTransactionOutcome.Craft,
+                        "The server could not resolve the smithing modifier group.");
+                    return;
+                }
+
+                // Implement CraftingCampaignBehavior.SpendMaterials(weaponDesign) here as it needs the party roster, MainParty on server won't be correct
+                ItemRoster itemRoster = craftingHero.PartyBelongedTo.ItemRoster;
+                int[] smithingCostsForWeaponDesign = Campaign.Current.Models.SmithingModel.GetSmithingCostsForWeaponDesign(weaponDesign);
+                if (!HasSmithingMaterials(
+                        itemRoster, smithingCostsForWeaponDesign))
+                {
+                    RejectSmithing(peer, ServerTransactionOutcome.Craft,
+                        "The required smithing materials are no longer available.");
+                    return;
+                }
+
+                ItemObject craftedItemObject = new ItemObject();
+                using (new AllowedThread())
+                {
+                    ItemObject.InitAsPlayerCraftedItem(ref craftedItemObject);
+                    Crafting.GenerateItem(
+                        weaponDesign,
+                        obj.Name,
+                        culture,
+                        itemModifierGroup,
+                        ref craftedItemObject,
+                        nextCraftedItemId);
+                }
+
+                int energyCostForSmithing = Campaign.Current.Models.SmithingModel.GetEnergyCostForSmithing(craftedItemObject, craftingHero);
+                int currentStamina = craftingCampaignBehavior.GetHeroCraftingStamina(craftingHero);
+                if (energyCostForSmithing < 0 || currentStamina < energyCostForSmithing)
+                {
+                    RejectSmithing(peer, ServerTransactionOutcome.Craft,
+                        "The selected hero does not have enough smithing stamina.");
+                    return;
+                }
+
+                ItemRosterElement[] itemRosterBefore = itemRoster.ToArray();
+                bool mapped = false;
+                bool registered = false;
+                int newHeroCraftingStamina =
+                    currentStamina - energyCostForSmithing;
+                try
+                {
+                    for (int i = 8; i >= 0; i--)
                     {
-                        currentState.CraftingLogic._craftedItemObject = craftedItemObject;
+                        if (smithingCostsForWeaponDesign[i] != 0)
+                            itemRoster.AddToCounts(
+                                Campaign.Current.Models.SmithingModel
+                                    .GetCraftingMaterialItem(
+                                        (CraftingMaterials)i),
+                                smithingCostsForWeaponDesign[i]);
                     }
 
-                    // Update client's WeaponDesignVM to be referencing this crafted item instead
-                    messageBroker.Publish(this, new UpdateCraftedItem(craftedItemObject));
+                    objectManager.AddExisting(
+                        nextCraftedItemId, craftedItemObject);
+                    mapped = true;
+                    MBObjectManager.Instance.RegisterObject<ItemObject>(
+                        craftedItemObject);
+                    registered = true;
 
-                    AddItemToHistoryPatch.OverrideAddItemToHistory(ref craftingBehavior, craftedItemObject);
+                    if (obj.IsFreeMode)
+                    {
+                        if (weaponModifier == null)
+                            itemRoster.AddToCounts(craftedItemObject, 1);
+                        else
+                            itemRoster.AddToCounts(
+                                new EquipmentElement(
+                                    craftedItemObject,
+                                    weaponModifier,
+                                    null,
+                                    false),
+                                1);
+                    }
+                    craftingCampaignBehavior.SetHeroCraftingStamina(
+                        craftingHero, newHeroCraftingStamina);
+                    if (!obj.IsFreeMode)
+                    {
+                        // Complete the order and its gold transfer inside this
+                        // same reversible craft commit.
+                        messageBroker.Publish(this, new CompleteOrderServer(
+                            currentSettlement.Town,
+                            craftingOrder,
+                            craftedItemObject,
+                            craftingHero,
+                            playerHero));
+                    }
                 }
-
-                if (!objectManager.TryGetIdWithLogging(craftedItemObject, out var craftedItemId)) return;
-
-                // Add to item rosters after the item has finished being created on clients
-                // Won't resolve on clients when running AddToCounts otherwise
-                if (data.IsFreeMode)
+                catch (Exception exception)
                 {
-                    var message = new NetworkAddCraftedItemToRoster(craftedItemId, data.PlayerHeroId, data.WeaponModifierId);
-                    network.SendAll(message);
+                    try
+                    {
+                        craftingCampaignBehavior.SetHeroCraftingStamina(
+                            craftingHero, currentStamina);
+                        itemRoster.Clear();
+                        itemRoster.Add(itemRosterBefore);
+                        if (registered)
+                            MBObjectManager.Instance.UnregisterObject(
+                                craftedItemObject);
+                        if (mapped)
+                            objectManager.Remove(craftedItemObject);
+                    }
+                    catch (Exception rollbackException)
+                    {
+                        Logger.Error(
+                            rollbackException,
+                            "Smithing rollback failed for {ItemId}",
+                            nextCraftedItemId);
+                    }
+                    Logger.Error(
+                        exception,
+                        "Smithing core commit failed for {ItemId}",
+                        nextCraftedItemId);
+                    RejectSmithing(
+                        peer,
+                        ServerTransactionOutcome.Craft,
+                        "The weapon could not be committed safely.");
+                    return;
                 }
-            }
-        });
-    }
 
-    private void Handle_NetworkAddCraftedItemToRoster(MessagePayload<NetworkAddCraftedItemToRoster> obj)
-    {
-        var data = obj.What;
-
-        GameThread.RunSafe(() =>
-        {
-            if (!objectManager.TryGetObjectWithLogging(data.CraftedItemId, out ItemObject craftedItemObject)) return;
-            if (!objectManager.TryGetObjectWithLogging(data.PlayerHeroId, out Hero playerHero)) return;
-
-            ItemModifier weaponModifier = null;
-            if (data.WeaponModifierId != "" && !objectManager.TryGetObjectWithLogging(data.WeaponModifierId, out weaponModifier)) return;
-
-            if (playerHero.PartyBelongedTo.ItemRoster.FindIndexOfItem(craftedItemObject) == -1)
-            {
-                craftingCampaignBehaviorInterface.AddCraftedItemToRoster(playerHero.PartyBelongedTo.ItemRoster, weaponModifier, craftedItemObject);
-            }
-        });
-    }
-
-    private void Handle_NetworkSetHeroCraftingStamina(MessagePayload<NetworkSetHeroCraftingStamina> obj)
-    {
-        var data = obj.What;
-        
-        GameThread.RunSafe(() =>
-        {
-            if (!craftingCampaignBehaviorInterface.TryGetCraftingBehavior(out var craftingBehavior)) return;
-            if (!objectManager.TryGetObjectWithLogging(data.CraftingHeroId, out Hero craftingHero)) return;
-
-            craftingBehavior.GetRecordForCompanion(craftingHero).CraftingStamina = MathF.Max(0, data.Value);
-        });
-    }
-
-    private void Handle_AddSkillXpFromCrafting(MessagePayload<AddSkillXpFromCrafting> obj)
-    {
-        if (!objectManager.TryGetIdWithLogging(obj.What.CraftingHero, out var craftingHeroId)) return;
-
-        network.SendAll(new NetworkAddSkillXpFromCrafting(craftingHeroId, obj.What.Xp));
-    }
-
-    private void Handle_NetworkAddSkillXpFromCrafting(MessagePayload<NetworkAddSkillXpFromCrafting> obj)
-    {
-        GameThread.RunSafe(() =>
-        {
-            if (!objectManager.TryGetObjectWithLogging<Hero>(obj.What.CraftingHeroId, out var craftingHero)) return;
-
-            craftingHero.AddSkillXp(DefaultSkills.Crafting, obj.What.Xp);
-        });
-    }
-
-    private bool PackUsedPieces(WeaponDesign weaponDesign, out List<string> craftingPieceIds, out List<int> scalePercentages)
-    {
-        craftingPieceIds = new List<string>();
-        scalePercentages = new List<int>();
-        foreach (var weaponDesignElement in weaponDesign._usedPieces)
-        {
-            if (!weaponDesignElement._craftingPiece.IsValid) // Skip invalid crafting pieces, e.g. Axe doesn't have a guard
-            {
-                craftingPieceIds.Add("");
-                scalePercentages.Add(-1);
-                continue;
-            }
-
-            if (!objectManager.TryGetIdWithLogging(weaponDesignElement._craftingPiece, out var currentCraftingPieceId)) return false;
-            craftingPieceIds.Add(currentCraftingPieceId);
-            scalePercentages.Add(weaponDesignElement._scalePercentage);
+                // Core state is committed. Each notification is best-effort and
+                // cannot make this same transaction retry the material spend.
+                TryPostCommit(() => network.SendAll(
+                    new NetworkSetHeroCraftingStamina(
+                        obj.CraftingHeroId,
+                        newHeroCraftingStamina)), "crafting stamina");
+                TryPostCommit(() => CampaignEventDispatcher.Instance
+                    .OnNewItemCrafted(
+                        craftedItemObject,
+                        weaponModifier,
+                        !obj.IsFreeMode), "crafted-item event");
+                TryPostCommit(() =>
+                {
+                    int researchGain = Campaign.Current.Models.SmithingModel
+                        .GetPartResearchGainForSmithingItem(
+                            craftedItemObject, craftingHero, obj.IsFreeMode);
+                    CraftingCampaignBehaviorResearchPointHandler
+                        .AllowAuthoritativeResearch(
+                            peer,
+                            player.HeroId,
+                            obj.CraftingTemplateId,
+                            researchGain);
+                }, "crafting research permit");
+                TryPostCommit(() =>
+                {
+                    float craftingXp = obj.IsFreeMode
+                        ? Campaign.Current.Models.SmithingModel
+                            .GetSkillXpForSmithingInFreeBuildMode(
+                                craftedItemObject)
+                        : craftingOrder.GetOrderExperience(
+                                craftedItemObject,
+                                craftingCampaignBehavior
+                                    .GetCurrentItemModifier()) +
+                            Campaign.Current.Models.SmithingModel
+                                .GetSkillXpForSmithingInCraftingOrderMode(
+                                    craftedItemObject);
+                    craftingHero.AddSkillXp(
+                        DefaultSkills.Crafting, craftingXp);
+                }, "crafting skill XP");
+                var sanitizedRequest = new NetworkCreateCraftedWeaponInternalServer(
+                    obj.IsFreeMode,
+                    obj.CraftingHeroId,
+                    obj.Name,
+                    cultureId,
+                    obj.CraftingTemplateId,
+                    obj.WeaponName,
+                    obj.WeaponDesignElementCraftingPieceIds,
+                    obj.WeaponDesignElementScalePercentages,
+                    weaponModifierId,
+                    player.HeroId,
+                    itemModifierGroupId,
+                    obj.IsFreeMode ? null : obj.CraftingOrderId,
+                    authoritativeSettlementId);
+                TryPostCommit(() => network.SendAll(
+                    new NetworkCreateCraftedWeaponInternalClients(
+                        sanitizedRequest, nextCraftedItemId)),
+                    "crafted-item broadcast");
+                TryPostCommit(() =>
+                {
+                    IReadOnlyList<string> history =
+                        sessionCraftingPlayerDataInterface
+                            .AppendCraftingHistory(
+                                player.HeroId, nextCraftedItemId);
+                    network.SendAll(new NetworkUpdateCraftedItemHistory(
+                        player.HeroId, history.ToList()));
+                }, "crafted-item history");
+                ServerTransactionOutcome.AllowCraftRename(
+                    peer, nextCraftedItemId);
+                ServerTransactionOutcome.AllowCraftXp(peer, obj.CraftingHeroId);
+                ServerTransactionOutcome.Accept(
+                    peer, ServerTransactionOutcome.Craft);
+            }));
         }
 
-        return true;
-    }
-
-    private bool GetUsedPieces(List<string> craftingPieceIds, List<int> scalePercentages, out WeaponDesignElement[] usedPieces)
-    {
-        usedPieces = null;
-        List<WeaponDesignElement> usedPiecesList = new();
-        for (int i = 0; i < craftingPieceIds.Count; i++)
+        private void CreateCraftedWeaponInternalClients(NetworkCreateCraftedWeaponInternalClients obj)
         {
-            if (craftingPieceIds[i] == "")
+            GameThread.RunSafe(() =>
             {
-                usedPiecesList.Add(WeaponDesignElement.GetInvalidPieceForType((CraftingPiece.PieceTypes)i));
-                continue;
-            }
+                using (new AllowedThread())
+                {
+                    if (!craftingCampaignBehaviorInterface.TryGetCraftingBehavior(out CraftingCampaignBehavior craftingCampaignBehavior)) return;
+                    if (!objectManager.TryGetObjectWithLogging(obj.CraftingTemplateId, out CraftingTemplate craftingTemplate)) return;
+                    if (!objectManager.TryGetObjectWithLogging(obj.PlayerHeroId, out Hero playerHero)) return;
+                    if (!objectManager.TryGetObjectWithLogging(obj.CraftingHeroId, out Hero craftingHero)) return;
+                    if (!objectManager.TryGetObjectWithLogging(obj.CurrentSettlementId, out Settlement currentSettlement)) return;
 
-            if (!objectManager.TryGetObjectWithLogging(craftingPieceIds[i], out CraftingPiece currentCraftingPiece)) return false;
+                    ItemModifierGroup itemModifierGroup = null;
+                    if (obj.ItemModifierGroupId != null && !objectManager.TryGetObjectWithLogging(obj.ItemModifierGroupId, out itemModifierGroup)) return;
 
-            usedPiecesList.Add(new WeaponDesignElement(currentCraftingPiece, scalePercentages[i]));
+                    if (!GetUsedPieces(obj.WeaponDesignElementCraftingPieceIds, obj.WeaponDesignElementScalePercentages, out WeaponDesignElement[] usedPieces)) return;
+
+                    ItemModifier weaponModifier = null;
+                    if (obj.WeaponModifierId != "" && !objectManager.TryGetObjectWithLogging(obj.WeaponModifierId, out weaponModifier)) return;
+
+                    CultureObject culture = null;
+                    if (obj.CultureId != null && !objectManager.TryGetObjectWithLogging(obj.CultureId, out culture)) return;
+
+                    CraftingOrder craftingOrder = null;
+                    if (obj.CraftingOrderId != null && !objectManager.TryGetObjectWithLogging(obj.CraftingOrderId, out craftingOrder)) return;
+
+                    // Replace original TaleWorlds implementation
+                    string nextCraftedItemId = obj.NextCraftedItemId;
+                    WeaponDesign weaponDesign = new WeaponDesign(craftingTemplate, new TextObject(obj.WeaponName), usedPieces);
+                    if (obj.IsFreeMode)
+                    {
+                        weaponDesign = new WeaponDesign(weaponDesign.Template, weaponDesign.WeaponName, weaponDesign.UsedPieces, nextCraftedItemId);
+                    }
+
+                    ItemObject craftedItemObject = craftingCampaignBehaviorInterface
+                        .CreateAndRegisterCraftedItem(
+                            weaponDesign,
+                            obj.Name,
+                            culture,
+                            itemModifierGroup,
+                            nextCraftedItemId);
+                    CampaignEventDispatcher.Instance.OnNewItemCrafted(
+                        craftedItemObject, weaponModifier, !obj.IsFreeMode);
+
+                    if (playerHero == Hero.MainHero)
+                    {
+                        if (GameStateManager.Current.ActiveState is CraftingState currentState)
+                            currentState.CraftingLogic._craftedItemObject = craftedItemObject;
+
+                        messageBroker.Publish(this, new UpdateCraftedItem(craftedItemObject));
+                        AddItemToHistoryPatch.OverrideAddItemToHistory(ref craftingCampaignBehavior, craftedItemObject);
+                    }
+
+                    if (obj.IsFreeMode &&
+                        objectManager.TryGetIdWithLogging(craftedItemObject, out string craftedItemId))
+                    {
+                        network.SendAll(new NetworkAddCraftedItemToRoster(
+                            craftedItemId,
+                            obj.PlayerHeroId,
+                            obj.WeaponModifierId));
+                    }
+                }
+            });
         }
 
-        usedPieces = usedPiecesList.ToArray();
-        return true;
-    }
+        private void AddCraftedItemToRoster(NetworkAddCraftedItemToRoster obj)
+        {
+            GameThread.RunSafe(() =>
+            {
+                if (!objectManager.TryGetObjectWithLogging(
+                        obj.CraftedItemId, out ItemObject craftedItemObject) ||
+                    !objectManager.TryGetObjectWithLogging(
+                        obj.PlayerHeroId, out Hero playerHero))
+                    return;
 
-    private void FlushCoalescer(ItemRoster itemRoster)
-    {
-        objectManager.TryGetId(itemRoster, out var rosterId);
-        var compactId = Compact(rosterId, typeof(ItemRoster));
+                ItemModifier weaponModifier = null;
+                if (obj.WeaponModifierId != "" &&
+                    !objectManager.TryGetObjectWithLogging(
+                        obj.WeaponModifierId, out weaponModifier))
+                    return;
 
-        sendCoalescer?.FlushInstance(compactId, network);
+                if (playerHero.PartyBelongedTo?.ItemRoster
+                        .FindIndexOfItem(craftedItemObject) == -1)
+                {
+                    craftingCampaignBehaviorInterface.AddCraftedItemToRoster(
+                        playerHero.PartyBelongedTo.ItemRoster,
+                        weaponModifier,
+                        craftedItemObject);
+                }
+            });
+        }
+
+        private bool GetUsedPieces(List<string> craftingPieceIds, List<int> scalePercentages, out WeaponDesignElement[] usedPieces)
+        {
+            usedPieces = null;
+            List<WeaponDesignElement> usedPiecesList = new();
+            for (int i = 0; i < craftingPieceIds.Count; i++)
+            {
+                if (craftingPieceIds[i] == "")
+                {
+                    usedPiecesList.Add(WeaponDesignElement.GetInvalidPieceForType((CraftingPiece.PieceTypes)i));
+                    continue;
+                }
+
+                if (!objectManager.TryGetObjectWithLogging(craftingPieceIds[i], out CraftingPiece currentCraftingPiece)) return false;
+
+                usedPiecesList.Add(new WeaponDesignElement(currentCraftingPiece, scalePercentages[i]));
+            }
+
+            usedPieces = usedPiecesList.ToArray();
+            return true;
+        }
+
+        private bool TryGetAuthorizedUsedPieces(
+            string playerHeroId,
+            CraftingTemplate template,
+            List<string> craftingPieceIds,
+            List<int> scalePercentages,
+            out WeaponDesignElement[] usedPieces)
+        {
+            usedPieces = null;
+            int pieceTypeCount =
+                (int)CraftingPiece.PieceTypes.NumberOfPieceTypes;
+            if (template == null || string.IsNullOrEmpty(playerHeroId) ||
+                craftingPieceIds == null || scalePercentages == null ||
+                craftingPieceIds.Count != pieceTypeCount ||
+                scalePercentages.Count != pieceTypeCount)
+                return false;
+
+            var opened = new HashSet<string>(
+                sessionCraftingPlayerDataInterface.GetOpenedCraftingPieces(
+                    playerHeroId, template.StringId) ??
+                Array.Empty<string>(),
+                StringComparer.Ordinal);
+            var result = new WeaponDesignElement[pieceTypeCount];
+            for (int i = 0; i < pieceTypeCount; i++)
+            {
+                CraftingPiece.PieceTypes expectedType =
+                    (CraftingPiece.PieceTypes)i;
+                string pieceId = craftingPieceIds[i];
+                int scale = scalePercentages[i];
+                if (!template.IsPieceTypeUsable(expectedType))
+                {
+                    if (!string.IsNullOrEmpty(pieceId) || scale != -1)
+                        return false;
+                    result[i] = WeaponDesignElement.GetInvalidPieceForType(
+                        expectedType);
+                    continue;
+                }
+
+                if (string.IsNullOrEmpty(pieceId) || scale < 90 || scale > 110 ||
+                    !objectManager.TryGetObject(
+                        pieceId, out CraftingPiece piece) || piece == null ||
+                    !piece.IsValid || piece.PieceType != expectedType ||
+                    !template.Pieces.Contains(piece) ||
+                    piece.IsHiddenOnDesigner && !piece.IsGivenByDefault ||
+                    !piece.IsGivenByDefault && !opened.Contains(pieceId) ||
+                    piece.FullScale && scale != 100)
+                    return false;
+                result[i] = new WeaponDesignElement(piece, scale);
+            }
+
+            usedPieces = result;
+            return true;
+        }
+
+        private bool TryResolveExactCraftingOrder(
+            CraftingCampaignBehavior behavior,
+            MobileParty party,
+            CraftingTemplate template,
+            string settlementId,
+            string craftingOrderId,
+            out Settlement settlement,
+            out CraftingOrder craftingOrder)
+        {
+            settlement = null;
+            craftingOrder = null;
+            if (string.IsNullOrEmpty(settlementId) ||
+                string.IsNullOrEmpty(craftingOrderId) ||
+                !objectManager.TryGetObject(settlementId, out settlement) ||
+                !objectManager.TryGetObject(craftingOrderId, out craftingOrder) ||
+                settlement != party?.CurrentSettlement ||
+                settlement?.Town == null || behavior == null || template == null ||
+                craftingOrder?.WeaponDesignTemplate?.Template != template ||
+                !behavior.CraftingOrders.TryGetValue(
+                    settlement.Town,
+                    out CraftingCampaignBehavior.CraftingOrderSlots slots) ||
+                slots == null)
+                return false;
+
+            CraftingOrder resolvedOrder = craftingOrder;
+            return slots.Slots.Concat(slots.CustomOrders)
+                .Any(order => ReferenceEquals(order, resolvedOrder));
+        }
+
+        private static void TryPostCommit(Action action, string operation)
+        {
+            try
+            {
+                action?.Invoke();
+            }
+            catch (Exception exception)
+            {
+                Logger.Error(
+                    exception,
+                    "Smithing committed, but {Operation} failed",
+                    operation);
+            }
+        }
+
+        private static void RestoreSmithingCore(
+            ItemRoster itemRoster,
+            ItemRosterElement[] itemRosterBefore,
+            CraftingCampaignBehavior behavior,
+            Hero craftingHero,
+            int staminaBefore,
+            Exception commitException,
+            string operation)
+        {
+            try
+            {
+                itemRoster.Clear();
+                itemRoster.Add(itemRosterBefore);
+                behavior.SetHeroCraftingStamina(
+                    craftingHero, staminaBefore);
+            }
+            catch (Exception rollbackException)
+            {
+                Logger.Error(
+                    rollbackException,
+                    "Smithing rollback failed during {Operation}",
+                    operation);
+            }
+            Logger.Error(
+                commitException,
+                "Smithing core commit failed during {Operation}",
+                operation);
+        }
+
+        private static bool RefiningFormulasMatch(
+            Crafting.RefiningFormula left,
+            Crafting.RefiningFormula right)
+        {
+            return left.Input1 == right.Input1 &&
+                left.Input1Count == right.Input1Count &&
+                left.Input2 == right.Input2 &&
+                left.Input2Count == right.Input2Count &&
+                left.Output == right.Output &&
+                left.OutputCount == right.OutputCount &&
+                left.Output2 == right.Output2 &&
+                left.Output2Count == right.Output2Count;
+        }
+
+        private static void AddRequiredMaterial(
+            IDictionary<CraftingMaterials, int> required,
+            CraftingMaterials material,
+            int amount)
+        {
+            if (amount <= 0)
+                return;
+            required.TryGetValue(material, out int current);
+            required[material] = current + amount;
+        }
+
+        private static bool HasSmithingMaterials(
+            ItemRoster itemRoster,
+            int[] costs)
+        {
+            if (itemRoster == null || costs == null || costs.Length < 9)
+                return false;
+            for (int i = 0; i <= 8; i++)
+            {
+                int required = -costs[i];
+                if (required <= 0)
+                    continue;
+                ItemObject material = Campaign.Current.Models.SmithingModel
+                    .GetCraftingMaterialItem((CraftingMaterials)i);
+                if (itemRoster.GetItemNumber(material) < required)
+                    return false;
+            }
+            return true;
+        }
+
+        private static void RejectSmithing(
+            NetPeer peer, int kind, string reason)
+        {
+            CraftingCampaignBehaviorResearchPointHandler
+                .DiscardPendingResearch(peer);
+            ServerTransactionOutcome.Reject(peer, kind, reason);
+        }
+
+        private static bool IsSmithyAvailable(MobileParty playerParty)
+            => playerParty?.IsActive == true &&
+               playerParty.MapEvent == null &&
+               playerParty.CurrentSettlement?.Town != null;
+
+        private void SetHeroCraftingStaminaClients(NetworkSetHeroCraftingStamina obj)
+        {
+            GameThread.RunSafe(() =>
+            {
+                if (!craftingCampaignBehaviorInterface.TryGetCraftingBehavior(out CraftingCampaignBehavior craftingCampaignBehavior)) return;
+                if (!objectManager.TryGetObjectWithLogging(obj.CraftingHeroId, out Hero craftingHero)) return;
+
+                craftingCampaignBehavior.GetRecordForCompanion(craftingHero).CraftingStamina = MathF.Max(0, obj.Value);
+            });
+        }
     }
 }

--- a/source/GameInterface/Services/Smithing/Handlers/CraftingCampaignBehaviorHistoryHandler.cs
+++ b/source/GameInterface/Services/Smithing/Handlers/CraftingCampaignBehaviorHistoryHandler.cs
@@ -1,6 +1,8 @@
-﻿using Common.Logging;
+using Common.Logging;
 using Common.Messaging;
+using Common;
 using Common.Network;
+using Common.Util;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Smithing.Interfaces;
 using GameInterface.Services.Smithing.Messages;
@@ -8,57 +10,42 @@ using Serilog;
 using System.Collections.Generic;
 using TaleWorlds.Core;
 
-namespace GameInterface.Services.Smithing.Handlers;
-
-internal class CraftingCampaignBehaviorHistoryHandler : IHandler
+namespace GameInterface.Services.Smithing.Handlers
 {
-    private static readonly ILogger Logger = LogManager.GetLogger<CraftingCampaignBehaviorHistoryHandler>();
-
-    private readonly IMessageBroker messageBroker;
-    private readonly IObjectManager objectManager;
-    private readonly INetwork network;
-    private readonly ISessionCraftingPlayerDataInterface sessionCraftingPlayerDataInterface;
-
-    public CraftingCampaignBehaviorHistoryHandler(
-        IMessageBroker messageBroker,
-        IObjectManager objectManager,
-        INetwork network,
-        ISessionCraftingPlayerDataInterface sessionCraftingPlayerDataInterface)
+    internal class CraftingCampaignBehaviorHistoryHandler : IHandler
     {
-        this.messageBroker = messageBroker;
-        this.objectManager = objectManager;
-        this.network = network;
-        this.sessionCraftingPlayerDataInterface = sessionCraftingPlayerDataInterface;
+        private static readonly ILogger Logger = LogManager.GetLogger<CraftingCampaignBehaviorHistoryHandler>();
+        private readonly IMessageBroker messageBroker;
+        private readonly IObjectManager objectManager;
+        private readonly INetwork network;
+        private readonly ISessionCraftingPlayerDataInterface sessionCraftingPlayerDataInterface;
 
-        messageBroker.Subscribe<UpdateCraftedItemHistory>(Handle_UpdateCraftedItemHistory);
-        messageBroker.Subscribe<NetworkUpdateCraftedItemHistory>(Handle_NetworkUpdateCraftedItemHistory);
-    }
-
-    public void Dispose()
-    {
-        messageBroker.Unsubscribe<UpdateCraftedItemHistory>(Handle_UpdateCraftedItemHistory);
-        messageBroker.Unsubscribe<NetworkUpdateCraftedItemHistory>(Handle_NetworkUpdateCraftedItemHistory);
-    }
-
-    private void Handle_UpdateCraftedItemHistory(MessagePayload<UpdateCraftedItemHistory> obj)
-    {
-        if (!objectManager.TryGetIdWithLogging(obj.What.MainHero, out string playerHeroId)) return;
-
-        List<string> craftedItemHistoryIds = new List<string>();
-        foreach (ItemObject item in obj.What.CraftedItemHistory)
+        public CraftingCampaignBehaviorHistoryHandler(
+            IMessageBroker messageBroker,
+            IObjectManager objectManager,
+            INetwork network,
+            ISessionCraftingPlayerDataInterface sessionCraftingPlayerDataInterface)
         {
-            if (!objectManager.TryGetIdWithLogging(item, out string currentItemId)) return;
-            craftedItemHistoryIds.Add(currentItemId);
+            this.messageBroker = messageBroker;
+            this.objectManager = objectManager;
+            this.network = network;
+            this.sessionCraftingPlayerDataInterface = sessionCraftingPlayerDataInterface;
+            messageBroker.Subscribe<NetworkUpdateCraftedItemHistory>(Handle);
         }
-        
-        network.SendAll(new NetworkUpdateCraftedItemHistory(playerHeroId, craftedItemHistoryIds));
-    }
 
-    private void Handle_NetworkUpdateCraftedItemHistory(MessagePayload<NetworkUpdateCraftedItemHistory> obj)
-    {
-        // Save crafting history on server in CoopSession
-        sessionCraftingPlayerDataInterface.UpdateCraftingHistory(
-            obj.What.PlayerHeroId,
-            obj.What.CraftedItemHistoryIds);
+        public void Dispose()
+        {
+            messageBroker.Unsubscribe<NetworkUpdateCraftedItemHistory>(Handle);
+        }
+
+        private void Handle(MessagePayload<NetworkUpdateCraftedItemHistory> obj)
+        {
+            // Craft history is produced by the authoritative craft commit.
+            // Never accept a client-provided absolute history on the server.
+            if (ModInformation.IsServer) return;
+            sessionCraftingPlayerDataInterface.UpdateCraftingHistory(
+                obj.What.PlayerHeroId,
+                obj.What.CraftedItemHistoryIds);
+        }
     }
 }

--- a/source/GameInterface/Services/Smithing/Handlers/CraftingCampaignBehaviorResearchPointHandler.cs
+++ b/source/GameInterface/Services/Smithing/Handlers/CraftingCampaignBehaviorResearchPointHandler.cs
@@ -1,81 +1,404 @@
-﻿using Common.Logging;
+using Common.Logging;
+using Common;
 using Common.Messaging;
 using Common.Network;
+using Common.Network.Messages;
+using Common.Util;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Players;
 using GameInterface.Services.Smithing.Interfaces;
 using GameInterface.Services.Smithing.Messages;
+using GameInterface.Services.Transactions;
+using LiteNetLib;
 using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
 
-namespace GameInterface.Services.Smithing.Handlers;
-
-internal class CraftingCampaignBehaviorResearchPointHandler : IHandler
+namespace GameInterface.Services.Smithing.Handlers
 {
-    private static readonly ILogger Logger = LogManager.GetLogger<CraftingCampaignBehaviorResearchPointHandler>();
-
-    private readonly IMessageBroker messageBroker;
-    private readonly IObjectManager objectManager;
-    private readonly INetwork network;
-    private readonly ISessionCraftingPlayerDataInterface sessionCraftingPlayerDataInterface;
-
-    public CraftingCampaignBehaviorResearchPointHandler(
-        IMessageBroker messageBroker,
-        IObjectManager objectManager,
-        INetwork network,
-        ISessionCraftingPlayerDataInterface sessionCraftingPlayerDataInterface)
+    internal class CraftingCampaignBehaviorResearchPointHandler : IHandler
     {
-        this.messageBroker = messageBroker;
-        this.objectManager = objectManager;
-        this.network = network;
-        this.sessionCraftingPlayerDataInterface = sessionCraftingPlayerDataInterface;
+        private static readonly ILogger Logger = LogManager.GetLogger<CraftingCampaignBehaviorResearchPointHandler>();
+        private readonly IMessageBroker messageBroker;
+        private readonly IObjectManager objectManager;
+        private readonly INetwork network;
+        private readonly ISessionCraftingPlayerDataInterface sessionCraftingPlayerDataInterface;
+        private readonly IPlayerManager playerManager;
+        private readonly object gate = new();
+        private readonly Dictionary<NetPeer, PendingResearch> pending = new();
+        private readonly Dictionary<NetPeer, ResearchPermit> permits = new();
+        private static CraftingCampaignBehaviorResearchPointHandler serverInstance;
 
-        messageBroker.Subscribe<UpdateResearchPoints>(Handle_UpdateResearchPoints);
-        messageBroker.Subscribe<NetworkUpdateResearchPoints>(Handle_NetworkUpdateResearchPoints);
+        public CraftingCampaignBehaviorResearchPointHandler(
+            IMessageBroker messageBroker,
+            IObjectManager objectManager,
+            INetwork network,
+            ISessionCraftingPlayerDataInterface sessionCraftingPlayerDataInterface,
+            IPlayerManager playerManager)
+        {
+            this.messageBroker = messageBroker;
+            this.objectManager = objectManager;
+            this.network = network;
+            this.sessionCraftingPlayerDataInterface = sessionCraftingPlayerDataInterface;
+            this.playerManager = playerManager;
+            if (ModInformation.IsServer)
+            {
+                serverInstance = this;
+                ServerTransactionOutcome.Completed +=
+                    HandleTransactionCompleted;
+            }
+            messageBroker.Subscribe<UpdateResearchPoints>(Handle);
+            messageBroker.Subscribe<NetworkUpdateResearchPoints>(Handle);
+            messageBroker.Subscribe<OpenCraftingPart>(Handle);
+            messageBroker.Subscribe<NetworkOpenCraftingPart>(Handle);
+            messageBroker.Subscribe<PlayerDisconnected>(HandleDisconnected);
+        }
 
-        messageBroker.Subscribe<OpenCraftingPart>(Handle_OpenCraftingPart);
-        messageBroker.Subscribe<NetworkOpenCraftingPart>(Handle_NetworkOpenCraftingPart);
-    }
+        public void Dispose()
+        {
+            messageBroker.Unsubscribe<UpdateResearchPoints>(Handle);
+            messageBroker.Unsubscribe<NetworkUpdateResearchPoints>(Handle);
+            messageBroker.Unsubscribe<OpenCraftingPart>(Handle);
+            messageBroker.Unsubscribe<NetworkOpenCraftingPart>(Handle);
+            messageBroker.Unsubscribe<PlayerDisconnected>(HandleDisconnected);
+            if (ReferenceEquals(serverInstance, this))
+            {
+                ServerTransactionOutcome.Completed -=
+                    HandleTransactionCompleted;
+                serverInstance = null;
+            }
+            lock (gate)
+            {
+                pending.Clear();
+                permits.Clear();
+            }
+        }
 
-    public void Dispose()
-    {
-        messageBroker.Unsubscribe<UpdateResearchPoints>(Handle_UpdateResearchPoints);
-        messageBroker.Unsubscribe<NetworkUpdateResearchPoints>(Handle_NetworkUpdateResearchPoints);
+        private void Handle(MessagePayload<UpdateResearchPoints> obj)
+        {
+            if (!objectManager.TryGetIdWithLogging(obj.What.MainHero, out string playerHeroId)) return;
+            if (!objectManager.TryGetIdWithLogging(obj.What.CraftingTemplate, out string craftingTemplateId)) return;
 
-        messageBroker.Unsubscribe<OpenCraftingPart>(Handle_OpenCraftingPart);
-        messageBroker.Unsubscribe<NetworkOpenCraftingPart>(Handle_NetworkOpenCraftingPart);
-    }
+            network.SendAll(new NetworkUpdateResearchPoints(playerHeroId, craftingTemplateId, obj.What.NewXp));
+        }
 
-    private void Handle_UpdateResearchPoints(MessagePayload<UpdateResearchPoints> obj)
-    {
-        if (!objectManager.TryGetIdWithLogging(obj.What.MainHero, out string playerHeroId)) return;
-        if (!objectManager.TryGetIdWithLogging(obj.What.CraftingTemplate, out string craftingTemplateId)) return;
+        private void Handle(MessagePayload<NetworkUpdateResearchPoints> obj)
+        {
+            if (ModInformation.IsServer && obj.Who is NetPeer peer)
+            {
+                GameThread.RunSafe(() => StageResearch(peer, obj.What));
+                return;
+            }
+            sessionCraftingPlayerDataInterface.SetCraftingPieceXp(
+                obj.What.PlayerHeroId,
+                obj.What.CraftingTemplateId,
+                obj.What.NewXp);
+        }
 
-        network.SendAll(new NetworkUpdateResearchPoints(playerHeroId, craftingTemplateId, obj.What.NewXp));
-    }
+        private void Handle(MessagePayload<OpenCraftingPart> obj)
+        {
+            if (!objectManager.TryGetIdWithLogging(obj.What.MainHero, out string playerHeroId)) return;
+            if (!objectManager.TryGetIdWithLogging(obj.What.CraftingTemplate, out string craftingTemplateId)) return;
+            if (!objectManager.TryGetIdWithLogging(obj.What.CraftingPiece, out string craftingPieceId)) return;
 
-    private void Handle_NetworkUpdateResearchPoints(MessagePayload<NetworkUpdateResearchPoints> obj)
-    {
-        // Save crafting piece xp on server in CoopSession
-        sessionCraftingPlayerDataInterface.SetCraftingPieceXp(
-            obj.What.PlayerHeroId,
-            obj.What.CraftingTemplateId,
-            obj.What.NewXp);
-    }
+            network.SendAll(new NetworkOpenCraftingPart(playerHeroId, craftingTemplateId, craftingPieceId));
+        }
 
-    private void Handle_OpenCraftingPart(MessagePayload<OpenCraftingPart> obj)
-    {
-        if (!objectManager.TryGetIdWithLogging(obj.What.MainHero, out string playerHeroId)) return;
-        if (!objectManager.TryGetIdWithLogging(obj.What.CraftingTemplate, out string craftingTemplateId)) return;
-        if (!objectManager.TryGetIdWithLogging(obj.What.CraftingPiece, out string craftingPieceId)) return;
+        private void Handle(MessagePayload<NetworkOpenCraftingPart> obj)
+        {
+            if (ModInformation.IsServer && obj.Who is NetPeer peer)
+            {
+                GameThread.RunSafe(() => StageOpenedPart(peer, obj.What));
+                return;
+            }
+            sessionCraftingPlayerDataInterface.UnlockCraftingPiece(
+                obj.What.PlayerHeroId,
+                obj.What.CraftingTemplateId,
+                obj.What.CraftingPieceId);
+        }
 
-        network.SendAll(new NetworkOpenCraftingPart(playerHeroId, craftingTemplateId, craftingPieceId));
-    }
+        private void HandleDisconnected(
+            MessagePayload<PlayerDisconnected> obj)
+        {
+            if (!ModInformation.IsServer) return;
+            lock (gate)
+            {
+                pending.Remove(obj.What.PlayerId);
+                permits.Remove(obj.What.PlayerId);
+            }
+        }
 
-    private void Handle_NetworkOpenCraftingPart(MessagePayload<NetworkOpenCraftingPart> obj)
-    {
-        // Save unlocked piece on server in CoopSession
-        sessionCraftingPlayerDataInterface.UnlockCraftingPiece(
-            obj.What.PlayerHeroId,
-            obj.What.CraftingTemplateId,
-            obj.What.CraftingPieceId);
+        internal static void AllowAuthoritativeResearch(
+            NetPeer peer,
+            string playerHeroId,
+            string craftingTemplateId,
+            int gain)
+        {
+            serverInstance?.AllowResearch(
+                peer, playerHeroId, craftingTemplateId, gain);
+        }
+
+        internal static void DiscardPendingResearch(NetPeer peer)
+        {
+            CraftingCampaignBehaviorResearchPointHandler current =
+                serverInstance;
+            if (current == null || peer == null)
+                return;
+            lock (current.gate)
+            {
+                current.pending.Remove(peer);
+                current.permits.Remove(peer);
+            }
+        }
+
+        private static void HandleTransactionCompleted(
+            NetPeer peer,
+            int kind,
+            bool success,
+            string message)
+        {
+            if (!success &&
+                (kind == ServerTransactionOutcome.Smelt ||
+                 kind == ServerTransactionOutcome.Craft))
+                DiscardPendingResearch(peer);
+        }
+
+        private void StageResearch(
+            NetPeer peer,
+            NetworkUpdateResearchPoints message)
+        {
+            if (!TryAuthenticate(peer, message.PlayerHeroId) ||
+                string.IsNullOrEmpty(message.CraftingTemplateId) ||
+                float.IsNaN(message.NewXp) ||
+                float.IsInfinity(message.NewXp) || message.NewXp < 0f)
+                return;
+            lock (gate)
+            {
+                PendingResearch state = GetPending(
+                    peer, message.PlayerHeroId, message.CraftingTemplateId);
+                state.NewXp = message.NewXp;
+                state.HasXp = true;
+            }
+            TryCommit(peer);
+        }
+
+        private void StageOpenedPart(
+            NetPeer peer,
+            NetworkOpenCraftingPart message)
+        {
+            if (!TryAuthenticate(peer, message.PlayerHeroId) ||
+                string.IsNullOrEmpty(message.CraftingTemplateId) ||
+                string.IsNullOrEmpty(message.CraftingPieceId))
+                return;
+            lock (gate)
+            {
+                PendingResearch state = GetPending(
+                    peer, message.PlayerHeroId, message.CraftingTemplateId);
+                if (state.OpenedPieceIds.Count >= 32 ||
+                    state.OpenedPieceIds.Contains(message.CraftingPieceId))
+                    return;
+                state.OpenedPieceIds.Add(message.CraftingPieceId);
+            }
+        }
+
+        private void AllowResearch(
+            NetPeer peer,
+            string playerHeroId,
+            string craftingTemplateId,
+            int gain)
+        {
+            if (peer == null || gain < 0 ||
+                !TryAuthenticate(peer, playerHeroId))
+                return;
+            lock (gate)
+            {
+                permits[peer] = new ResearchPermit(
+                    playerHeroId,
+                    craftingTemplateId,
+                    gain,
+                    DateTime.UtcNow.AddSeconds(30));
+            }
+            TryCommit(peer);
+        }
+
+        private void TryCommit(NetPeer peer)
+        {
+            PendingResearch staged;
+            ResearchPermit permit;
+            lock (gate)
+            {
+                if (!pending.TryGetValue(peer, out staged) ||
+                    !permits.TryGetValue(peer, out permit) ||
+                    !staged.HasXp)
+                    return;
+                pending.Remove(peer);
+                permits.Remove(peer);
+            }
+            if (DateTime.UtcNow > staged.ExpiresUtc ||
+                DateTime.UtcNow > permit.ExpiresUtc ||
+                !string.Equals(staged.PlayerHeroId, permit.PlayerHeroId,
+                    StringComparison.Ordinal) ||
+                !string.Equals(staged.TemplateId, permit.TemplateId,
+                    StringComparison.Ordinal) ||
+                !TryValidateResearch(staged, permit, out float finalXp))
+            {
+                Logger.Warning(
+                    "Rejected smithing research update for {HeroId}",
+                    permit.PlayerHeroId);
+                return;
+            }
+
+            sessionCraftingPlayerDataInterface.SetCraftingPieceXp(
+                permit.PlayerHeroId, permit.TemplateId, finalXp);
+            network.SendAll(new NetworkUpdateResearchPoints(
+                permit.PlayerHeroId, permit.TemplateId, finalXp));
+            foreach (string pieceId in staged.OpenedPieceIds)
+            {
+                sessionCraftingPlayerDataInterface.UnlockCraftingPiece(
+                    permit.PlayerHeroId, permit.TemplateId, pieceId);
+                network.SendAll(new NetworkOpenCraftingPart(
+                    permit.PlayerHeroId, permit.TemplateId, pieceId));
+            }
+        }
+
+        private bool TryValidateResearch(
+            PendingResearch staged,
+            ResearchPermit permit,
+            out float finalXp)
+        {
+            finalXp = 0f;
+            if (!objectManager.TryGetObject(
+                    permit.TemplateId, out CraftingTemplate template) ||
+                template == null)
+                return false;
+
+            var opened = new HashSet<string>(
+                sessionCraftingPlayerDataInterface.GetOpenedCraftingPieces(
+                    permit.PlayerHeroId, permit.TemplateId),
+                StringComparer.Ordinal);
+            float xp = sessionCraftingPlayerDataInterface.GetCraftingPieceXp(
+                permit.PlayerHeroId, permit.TemplateId) + permit.Gain;
+            int total = template.Pieces.Count;
+            foreach (string pieceId in staged.OpenedPieceIds)
+            {
+                int openedCount = CountOpened(template, opened);
+                float required = Campaign.Current.Models.SmithingModel
+                    .ResearchPointsNeedForNewPart(total, openedCount);
+                if (!(xp > required) ||
+                    !objectManager.TryGetObject(
+                        pieceId, out CraftingPiece piece) ||
+                    piece == null || piece.IsGivenByDefault ||
+                    piece.IsHiddenOnDesigner || opened.Contains(pieceId) ||
+                    !template.Pieces.Contains(piece))
+                    return false;
+                int minimumTier = template.Pieces
+                    .Where(candidate =>
+                        !candidate.IsGivenByDefault &&
+                        !candidate.IsHiddenOnDesigner &&
+                        objectManager.TryGetId(candidate, out string id) &&
+                        !opened.Contains(id))
+                    .Select(candidate => candidate.PieceTier)
+                    .DefaultIfEmpty(int.MaxValue)
+                    .Min();
+                if (piece.PieceTier != minimumTier)
+                    return false;
+                xp -= required;
+                opened.Add(pieceId);
+            }
+
+            int finalOpenedCount = CountOpened(template, opened);
+            float nextRequired = Campaign.Current.Models.SmithingModel
+                .ResearchPointsNeedForNewPart(total, finalOpenedCount);
+            bool hasEligible = template.Pieces.Any(candidate =>
+                !candidate.IsGivenByDefault &&
+                !candidate.IsHiddenOnDesigner &&
+                objectManager.TryGetId(candidate, out string id) &&
+                !opened.Contains(id));
+            if (hasEligible && xp > nextRequired ||
+                Math.Abs(xp - staged.NewXp) > 0.01f)
+                return false;
+            finalXp = xp;
+            return true;
+        }
+
+        private int CountOpened(
+            CraftingTemplate template,
+            ISet<string> opened)
+        {
+            return template.Pieces.Count(piece =>
+                piece.IsGivenByDefault ||
+                objectManager.TryGetId(piece, out string id) &&
+                opened.Contains(id));
+        }
+
+        private bool TryAuthenticate(NetPeer peer, string playerHeroId)
+        {
+            return peer != null && playerManager.TryGetPlayer(
+                peer, out var player) && player != null &&
+                string.Equals(player.HeroId, playerHeroId,
+                    StringComparison.Ordinal);
+        }
+
+        private PendingResearch GetPending(
+            NetPeer peer,
+            string heroId,
+            string templateId)
+        {
+            if (!pending.TryGetValue(peer, out PendingResearch state) ||
+                DateTime.UtcNow > state.ExpiresUtc ||
+                !string.Equals(state.PlayerHeroId, heroId,
+                    StringComparison.Ordinal) ||
+                !string.Equals(state.TemplateId, templateId,
+                    StringComparison.Ordinal))
+            {
+                state = new PendingResearch(
+                    heroId, templateId, DateTime.UtcNow.AddSeconds(30));
+                pending[peer] = state;
+            }
+            return state;
+        }
+
+        private sealed class PendingResearch
+        {
+            internal readonly string PlayerHeroId;
+            internal readonly string TemplateId;
+            internal readonly DateTime ExpiresUtc;
+            internal readonly List<string> OpenedPieceIds = new();
+            internal bool HasXp;
+            internal float NewXp;
+
+            internal PendingResearch(
+                string playerHeroId,
+                string templateId,
+                DateTime expiresUtc)
+            {
+                PlayerHeroId = playerHeroId;
+                TemplateId = templateId;
+                ExpiresUtc = expiresUtc;
+            }
+        }
+
+        private sealed class ResearchPermit
+        {
+            internal readonly string PlayerHeroId;
+            internal readonly string TemplateId;
+            internal readonly int Gain;
+            internal readonly DateTime ExpiresUtc;
+
+            internal ResearchPermit(
+                string playerHeroId,
+                string templateId,
+                int gain,
+                DateTime expiresUtc)
+            {
+                PlayerHeroId = playerHeroId;
+                TemplateId = templateId;
+                Gain = gain;
+                ExpiresUtc = expiresUtc;
+            }
+        }
     }
 }

--- a/source/GameInterface/Services/Smithing/Handlers/CraftingCampaignBehaviorTownOrderHandler.cs
+++ b/source/GameInterface/Services/Smithing/Handlers/CraftingCampaignBehaviorTownOrderHandler.cs
@@ -3,6 +3,8 @@ using Common.Logging;
 using Common.Messaging;
 using Common.Network;
 using Common.Util;
+using System;
+using System.Linq;
 using GameInterface.Registry.Auto;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Smithing.Interfaces;
@@ -187,71 +189,165 @@ internal class CraftingCampaignBehaviorTownOrderHandler : IHandler
 
     private void CompleteOrderServer(CompleteOrderServer data)
     {
-        GameThread.RunSafe(() =>
+        if (!craftingCampaignBehaviorInterface.TryGetCraftingBehavior(
+                out var craftingBehavior))
+            throw new InvalidOperationException(
+                "Crafting behavior is unavailable during order completion.");
+
+        var craftingOrder = data.CraftingOrder;
+        var craftedItem = data.CraftedItem;
+        var town = data.Town;
+        var completerHero = data.CompleterHero;
+        if (craftingOrder == null || craftedItem == null || town == null ||
+            completerHero == null || data.MainHero == null ||
+            !craftingBehavior.CraftingOrders.TryGetValue(
+                town, out CraftingCampaignBehavior.CraftingOrderSlots slots) ||
+            slots == null ||
+            !IsActiveOrder(slots, craftingOrder))
         {
-            if (!craftingCampaignBehaviorInterface.TryGetCraftingBehavior(out var craftingBehavior)) return;
+            throw new InvalidOperationException(
+                "The crafting order is no longer active.");
+        }
 
-            var craftingOrder = data.CraftingOrder;
-            var craftedItem = data.CraftedItem;
-            var town = data.Town;
-            var completerHero = data.CompleterHero;
+        if (!objectManager.TryGetIdWithLogging(data.Town, out var townId) ||
+            !objectManager.TryGetIdWithLogging(
+                data.CraftingOrder, out var craftingOrderId) ||
+            !objectManager.TryGetIdWithLogging(
+                data.CraftedItem, out var craftedItemId) ||
+            !objectManager.TryGetIdWithLogging(
+                data.CompleterHero, out var completerHeroId))
+        {
+            throw new InvalidOperationException(
+                "Crafting order completion objects are not registered.");
+        }
 
-            // Replace TaleWorlds implementation
-            int amount = craftingBehavior.CalculateOrderPriceDifference(craftingOrder, craftedItem);
-            GiveGoldAction.ApplyBetweenCharacters(null, data.MainHero, amount, false);
-
-            Hero orderOwner = craftingOrder.OrderOwner;
-            CraftingOrder previousOrder = null;
-
-            craftingBehavior.GetOrderResult(craftingOrder, craftedItem, out var isSucceed, out _, out _, out _);
-            if (craftingBehavior._craftingOrders[town].CustomOrders.Contains(craftingOrder))
-            {
-                craftingBehavior._craftingOrders[town].RemoveCustomOrder(craftingOrder);
-            }
+        bool isCustom = slots.CustomOrders.Contains(craftingOrder);
+        craftingBehavior.GetOrderResult(
+            craftingOrder,
+            craftedItem,
+            out bool succeeded,
+            out _,
+            out _,
+            out _);
+        int goldBefore = data.MainHero.Gold;
+        int amount = craftingBehavior.CalculateOrderPriceDifference(
+            craftingOrder, craftedItem);
+        try
+        {
+            GiveGoldAction.ApplyBetweenCharacters(
+                null, data.MainHero, amount, false);
+            if (isCustom)
+                slots.RemoveCustomOrder(craftingOrder);
             else
-            {
-                if (craftingOrder.IsLordOrder)
-                {
-                    craftingBehavior.ChangeCraftedOrderWithTheNoblesWeaponIfItIsBetter(craftedItem, craftingOrder);
-                    if (orderOwner.PartyBelongedTo != null)
-                    {
-                        craftingBehavior.GiveTroopToNobleAtWeaponTier((int)craftedItem.Tier, orderOwner);
-                    }
-                    if (isSucceed && completerHero.GetPerkValue(DefaultPerks.Crafting.SteelMaker3))
-                    {
-                        ChangeRelationAction.ApplyRelationChangeBetweenHeroes(completerHero, orderOwner, (int)DefaultPerks.Crafting.SteelMaker3.SecondaryBonus, true);
-                    }
-                }
-                else
-                {
-                    orderOwner.AddPower((float)(craftedItem.Tier + 1));
-                    if (isSucceed && completerHero.GetPerkValue(DefaultPerks.Crafting.ExperiencedSmith))
-                    {
-                        ChangeRelationAction.ApplyRelationChangeBetweenHeroes(completerHero, orderOwner, (int)DefaultPerks.Crafting.ExperiencedSmith.SecondaryBonus, true);
-                    }
-                }
-                previousOrder = craftingBehavior._craftingOrders[town].Slots[craftingOrder.DifficultyLevel];
+                slots.RemoveTownOrder(craftingOrder);
+        }
+        catch
+        {
+            RestoreOrderCore(
+                data.MainHero,
+                goldBefore,
+                slots,
+                craftingOrder,
+                isCustom);
+            throw;
+        }
 
-                craftingBehavior._craftingOrders[town].RemoveTownOrder(craftingOrder);
-            }
+        Hero orderOwner = craftingOrder.OrderOwner;
+        if (!isCustom && craftingOrder.IsLordOrder)
+        {
+            TryPostOrderEffect(() => craftingBehavior
+                .ChangeCraftedOrderWithTheNoblesWeaponIfItIsBetter(
+                    craftedItem, craftingOrder), "noble weapon reward");
+            if (orderOwner?.PartyBelongedTo != null)
+                TryPostOrderEffect(() => craftingBehavior
+                    .GiveTroopToNobleAtWeaponTier(
+                        (int)craftedItem.Tier, orderOwner),
+                    "noble troop reward");
+            if (succeeded && completerHero.GetPerkValue(
+                    DefaultPerks.Crafting.SteelMaker3))
+                TryPostOrderEffect(() => ChangeRelationAction
+                    .ApplyRelationChangeBetweenHeroes(
+                        completerHero,
+                        orderOwner,
+                        (int)DefaultPerks.Crafting.SteelMaker3.SecondaryBonus,
+                        true), "noble relation reward");
+        }
+        else if (!isCustom && orderOwner != null)
+        {
+            TryPostOrderEffect(() => orderOwner.AddPower(
+                (float)(craftedItem.Tier + 1)), "notable power reward");
+            if (succeeded && completerHero.GetPerkValue(
+                    DefaultPerks.Crafting.ExperiencedSmith))
+                TryPostOrderEffect(() => ChangeRelationAction
+                    .ApplyRelationChangeBetweenHeroes(
+                        completerHero,
+                        orderOwner,
+                        (int)DefaultPerks.Crafting.ExperiencedSmith
+                            .SecondaryBonus,
+                        true), "notable relation reward");
+        }
 
-            CampaignEventDispatcher.Instance.OnCraftingOrderCompleted(town, craftingOrder, craftedItem, completerHero);
+        TryPostOrderEffect(() => CampaignEventDispatcher.Instance
+            .OnCraftingOrderCompleted(
+                town, craftingOrder, craftedItem, completerHero),
+            "crafting order event");
+        TryPostOrderEffect(() => network.SendAll(
+            new NetworkCompleteOrderClients(
+                townId,
+                craftingOrderId,
+                craftedItemId,
+                completerHeroId)), "crafting order broadcast");
+        if (!isCustom)
+            TryPostOrderEffect(() => MessageBroker.Instance.Publish(
+                null,
+                new InstanceDestroyed<CraftingOrder>(craftingOrder)),
+                "crafting order cleanup");
+    }
 
-            if (!objectManager.TryGetIdWithLogging(data.Town, out var townId)) return;
-            if (!objectManager.TryGetIdWithLogging(data.CraftingOrder, out var craftingOrderId)) return;
-            if (!objectManager.TryGetIdWithLogging(data.CraftedItem, out var craftedItemId)) return;
-            if (!objectManager.TryGetIdWithLogging(data.CompleterHero, out var completerHeroId)) return;
+    private static bool IsActiveOrder(
+        CraftingCampaignBehavior.CraftingOrderSlots slots,
+        CraftingOrder order)
+    {
+        return slots != null && order != null &&
+            (slots.CustomOrders.Contains(order) || slots.Slots.Contains(order));
+    }
 
-            network.SendAll(new NetworkCompleteOrderClients(townId, craftingOrderId, craftedItemId, completerHeroId));
+    private static void RestoreOrderCore(
+        Hero mainHero,
+        int goldBefore,
+        CraftingCampaignBehavior.CraftingOrderSlots slots,
+        CraftingOrder craftingOrder,
+        bool isCustom)
+    {
+        mainHero.Gold = goldBefore;
+        if (isCustom)
+        {
+            if (!slots.CustomOrders.Contains(craftingOrder))
+                slots.AddCustomOrder(craftingOrder);
+            return;
+        }
 
-            // Remove previous order from objectManager
-            // Queue destroying the instance after sending NetworkCompleteOrderClients message
-            // Destroying the instance before sending client message prevents clients from being able to resolve the removed crafting order by network id
-            if (previousOrder is not null)
-            {
-                MessageBroker.Instance.Publish(null, new InstanceDestroyed<CraftingOrder>(previousOrder));
-            }
-        });
+        if (!slots.Slots.Contains(craftingOrder) &&
+            craftingOrder.DifficultyLevel >= 0 &&
+            craftingOrder.DifficultyLevel < slots.Slots.Length)
+        {
+            slots.Slots[craftingOrder.DifficultyLevel] = craftingOrder;
+        }
+    }
+
+    private static void TryPostOrderEffect(Action action, string operation)
+    {
+        try
+        {
+            action?.Invoke();
+        }
+        catch (Exception exception)
+        {
+            Logger.Error(
+                exception,
+                "Crafting order committed, but {Operation} failed",
+                operation);
+        }
     }
 
     private void CompleteOrderClients(NetworkCompleteOrderClients obj)

--- a/source/GameInterface/Services/Smithing/Handlers/CraftingCampaignBehaviorWeaponNameHandler.cs
+++ b/source/GameInterface/Services/Smithing/Handlers/CraftingCampaignBehaviorWeaponNameHandler.cs
@@ -1,11 +1,15 @@
-﻿using Common;
+using Common;
 using Common.Logging;
 using Common.Messaging;
 using Common.Network;
 using Common.Util;
 using GameInterface.Services.Smithing.Interfaces;
 using GameInterface.Services.Smithing.Messages;
+using GameInterface.Services.Transactions;
+using LiteNetLib;
 using Serilog;
+using System;
+using System.Linq;
 using TaleWorlds.CampaignSystem.ViewModelCollection.WeaponCrafting.WeaponDesign;
 using TaleWorlds.Core;
 using TaleWorlds.Localization;
@@ -15,7 +19,8 @@ namespace GameInterface.Services.Smithing.Handlers;
 
 internal class CraftingCampaignBehaviorWeaponNameHandler : IHandler
 {
-    private static readonly ILogger Logger = LogManager.GetLogger<CraftingCampaignBehaviorWeaponNameHandler>();
+    private static readonly ILogger Logger =
+        LogManager.GetLogger<CraftingCampaignBehaviorWeaponNameHandler>();
 
     private readonly IMessageBroker messageBroker;
     private readonly INetwork network;
@@ -32,96 +37,132 @@ internal class CraftingCampaignBehaviorWeaponNameHandler : IHandler
         this.network = network;
         this.craftingCampaignBehaviorInterface = craftingCampaignBehaviorInterface;
 
-        messageBroker.Subscribe<WeaponDesignResultPopupVMCreated>(Handle_WeaponDesignResultPopupVMCreated);
-
-        messageBroker.Subscribe<SetBehaviorCraftedWeaponName>(Handle_SetBehaviorCraftedWeaponName);
-        messageBroker.Subscribe<NetworkBehaviorSetCraftedWeaponNameServer>(Handle_NetworkBehaviorSetCraftedWeaponNameServer);
-        messageBroker.Subscribe<NetworkBehaviorSetCraftedWeaponNameClients>(Handle_NetworkBehaviorSetCraftedWeaponNameClients);
-
+        messageBroker.Subscribe<WeaponDesignResultPopupVMCreated>(
+            Handle_WeaponDesignResultPopupVMCreated);
+        messageBroker.Subscribe<SetBehaviorCraftedWeaponName>(
+            Handle_SetBehaviorCraftedWeaponName);
+        messageBroker.Subscribe<NetworkBehaviorSetCraftedWeaponNameServer>(
+            Handle_NetworkBehaviorSetCraftedWeaponNameServer);
+        messageBroker.Subscribe<NetworkBehaviorSetCraftedWeaponNameClients>(
+            Handle_NetworkBehaviorSetCraftedWeaponNameClients);
         messageBroker.Subscribe<UpdateCraftedItem>(Handle_UpdateCraftedItem);
-
-        currentWeaponDesignResultPopupVM = null;
     }
 
     public void Dispose()
     {
-        messageBroker.Unsubscribe<WeaponDesignResultPopupVMCreated>(Handle_WeaponDesignResultPopupVMCreated);
-
-        messageBroker.Unsubscribe<SetBehaviorCraftedWeaponName>(Handle_SetBehaviorCraftedWeaponName);
-        messageBroker.Unsubscribe<NetworkBehaviorSetCraftedWeaponNameServer>(Handle_NetworkBehaviorSetCraftedWeaponNameServer);
-        messageBroker.Unsubscribe<NetworkBehaviorSetCraftedWeaponNameClients>(Handle_NetworkBehaviorSetCraftedWeaponNameClients);
-
+        messageBroker.Unsubscribe<WeaponDesignResultPopupVMCreated>(
+            Handle_WeaponDesignResultPopupVMCreated);
+        messageBroker.Unsubscribe<SetBehaviorCraftedWeaponName>(
+            Handle_SetBehaviorCraftedWeaponName);
+        messageBroker.Unsubscribe<NetworkBehaviorSetCraftedWeaponNameServer>(
+            Handle_NetworkBehaviorSetCraftedWeaponNameServer);
+        messageBroker.Unsubscribe<NetworkBehaviorSetCraftedWeaponNameClients>(
+            Handle_NetworkBehaviorSetCraftedWeaponNameClients);
         messageBroker.Unsubscribe<UpdateCraftedItem>(Handle_UpdateCraftedItem);
     }
 
-    private void Handle_WeaponDesignResultPopupVMCreated(MessagePayload<WeaponDesignResultPopupVMCreated> obj)
+    private void Handle_WeaponDesignResultPopupVMCreated(
+        MessagePayload<WeaponDesignResultPopupVMCreated> obj)
     {
         GameThread.RunSafe(() =>
-        {
-            currentWeaponDesignResultPopupVM = obj.What.WeaponDesignResultPopupVM;
-        });  
+            currentWeaponDesignResultPopupVM =
+                obj.What.WeaponDesignResultPopupVM);
     }
 
-    private void Handle_SetBehaviorCraftedWeaponName(MessagePayload<SetBehaviorCraftedWeaponName> obj)
+    private void Handle_SetBehaviorCraftedWeaponName(
+        MessagePayload<SetBehaviorCraftedWeaponName> obj)
     {
-        // Send to server from client
-        NetworkBehaviorSetCraftedWeaponNameServer message = new(
+        if (ModInformation.IsServer) return;
+        network.SendAll(new NetworkBehaviorSetCraftedWeaponNameServer(
             obj.What.CraftedWeaponId,
-            obj.What.Name
-        );
-        network.SendAll(message);
+            obj.What.Name));
     }
 
-    private void Handle_NetworkBehaviorSetCraftedWeaponNameServer(MessagePayload<NetworkBehaviorSetCraftedWeaponNameServer> obj)
+    private void Handle_NetworkBehaviorSetCraftedWeaponNameServer(
+        MessagePayload<NetworkBehaviorSetCraftedWeaponNameServer> obj)
     {
-        // obj.What.CraftedItemId
-        NetworkBehaviorSetCraftedWeaponNameClients nameChange = new(obj.What);
+        if (!ModInformation.IsServer || obj.Who is not NetPeer peer)
+            return;
 
         GameThread.RunSafe(() =>
         {
-            SetCraftedWeaponName(nameChange);
-
-            // Send from server to all clients
-            network.SendAll(nameChange);
-        });
-    }
-
-    private void Handle_NetworkBehaviorSetCraftedWeaponNameClients(MessagePayload<NetworkBehaviorSetCraftedWeaponNameClients> obj)
-    {
-        SetCraftedWeaponName(obj.What);
-    }
-
-    private void SetCraftedWeaponName(NetworkBehaviorSetCraftedWeaponNameClients obj)
-    {
-        GameThread.RunSafe(() =>
-        {
-            if (!craftingCampaignBehaviorInterface.TryGetCraftingBehavior(out var craftingBehavior)) return;
-
-            ItemObject mbCraftedWeapon = MBObjectManager.Instance.GetObject<ItemObject>(obj.CraftedWeaponId);
-            if (mbCraftedWeapon == null) return;
-
-            using (new AllowedThread())
+            try
             {
-                craftingBehavior.SetCraftedWeaponName(mbCraftedWeapon, obj.Name);
+                string safeName = new string((obj.What.Name?.ToString() ?? "")
+                    .Where(character => !char.IsControl(character))
+                    .Take(64)
+                    .ToArray()).Trim();
+                if (safeName.Length == 0 ||
+                    !ServerTransactionOutcome.TryConsumeCraftRename(
+                        peer, obj.What.CraftedWeaponId))
+                    return;
+
+                var sanitized =
+                    new NetworkBehaviorSetCraftedWeaponNameServer(
+                        obj.What.CraftedWeaponId,
+                        new TextObject("{=!}" + safeName));
+                var nameChange =
+                    new NetworkBehaviorSetCraftedWeaponNameClients(sanitized);
+                if (!TrySetCraftedWeaponName(nameChange))
+                    return;
+                network.SendAll(nameChange);
+            }
+            catch (Exception exception)
+            {
+                Logger.Error(
+                    exception,
+                    "Failed to apply crafted weapon rename");
             }
         });
     }
 
-    private void Handle_UpdateCraftedItem(MessagePayload<UpdateCraftedItem> obj)
+    private void Handle_NetworkBehaviorSetCraftedWeaponNameClients(
+        MessagePayload<NetworkBehaviorSetCraftedWeaponNameClients> obj)
+    {
+        if (ModInformation.IsServer) return;
+        GameThread.RunSafe(() => TrySetCraftedWeaponName(obj.What));
+    }
+
+    private bool TrySetCraftedWeaponName(
+        NetworkBehaviorSetCraftedWeaponNameClients obj)
+    {
+        if (!craftingCampaignBehaviorInterface.TryGetCraftingBehavior(
+                out var craftingBehavior))
+            return false;
+
+        ItemObject craftedWeapon =
+            MBObjectManager.Instance.GetObject<ItemObject>(
+                obj.CraftedWeaponId);
+        if (craftedWeapon == null)
+            return false;
+
+        using (new AllowedThread())
+        {
+            craftingBehavior.SetCraftedWeaponName(
+                craftedWeapon, obj.Name);
+        }
+        return true;
+    }
+
+    private void Handle_UpdateCraftedItem(
+        MessagePayload<UpdateCraftedItem> obj)
     {
         GameThread.RunSafe(() =>
         {
             if (currentWeaponDesignResultPopupVM == null) return;
 
-            // Unregister object used for visual in VM
-            MBObjectManager.Instance.UnregisterObject(currentWeaponDesignResultPopupVM._craftedItem);
+            MBObjectManager.Instance.UnregisterObject(
+                currentWeaponDesignResultPopupVM._craftedItem);
+            currentWeaponDesignResultPopupVM._craftedItem.StringId =
+                obj.What.CraftedItemObject.StringId;
 
-            currentWeaponDesignResultPopupVM._craftedItem.StringId = obj.What.CraftedItemObject.StringId;
-
-            // If the player finalized crafting before this point replay the rename so the crafted item keeps the generated name
-            TextObject textObject = new TextObject("{=!}" + currentWeaponDesignResultPopupVM.ItemName, null);
-            currentWeaponDesignResultPopupVM._crafting.SetCraftedWeaponName(textObject);
-            currentWeaponDesignResultPopupVM._craftingBehavior.SetCraftedWeaponName(obj.What.CraftedItemObject, textObject);
+            TextObject name = new TextObject(
+                "{=!}" + currentWeaponDesignResultPopupVM.ItemName);
+            currentWeaponDesignResultPopupVM._crafting
+                .SetCraftedWeaponName(name);
+            currentWeaponDesignResultPopupVM._craftingBehavior
+                .SetCraftedWeaponName(
+                    obj.What.CraftedItemObject, name);
         });
     }
 }

--- a/source/GameInterface/Services/Smithing/Interfaces/SessionCraftingPlayerDataInterface.cs
+++ b/source/GameInterface/Services/Smithing/Interfaces/SessionCraftingPlayerDataInterface.cs
@@ -2,7 +2,9 @@
 using GameInterface.CoopSessionData;
 using GameInterface.Services.ObjectManager;
 using Serilog;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.Core;
 
@@ -11,8 +13,13 @@ namespace GameInterface.Services.Smithing.Interfaces;
 public interface ISessionCraftingPlayerDataInterface : IGameAbstraction
 {
     void SetCraftingPieceXp(string playerHeroId, string craftingTemplateId, float xp);
+    float GetCraftingPieceXp(string playerHeroId, string craftingTemplateId);
+    IReadOnlyCollection<string> GetOpenedCraftingPieces(
+        string playerHeroId, string craftingTemplateId);
     void UnlockCraftingPiece(string playerHeroId, string craftingTemplateId, string craftingPieceId);
     void UpdateCraftingHistory(string playerHeroId, List<string> craftedItemHistoryIds);
+    IReadOnlyList<string> AppendCraftingHistory(
+        string playerHeroId, string craftedItemId);
     void AddPlayerKeys(string playerHeroId);
 }
 
@@ -37,11 +44,39 @@ public class SessionCraftingPlayerDataInterface : ISessionCraftingPlayerDataInte
         }
     }
 
+    public float GetCraftingPieceXp(
+        string playerHeroId,
+        string craftingTemplateId)
+    {
+        if (!IsPlayerHeroIdValid(playerHeroId) ||
+            !CraftingPlayerData.PlayerOpenNewPartXpDictionary
+                .TryGetValue(playerHeroId, out var templates) ||
+            !templates.TryGetValue(craftingTemplateId, out float xp))
+            return 0f;
+        return xp;
+    }
+
+    public IReadOnlyCollection<string> GetOpenedCraftingPieces(
+        string playerHeroId,
+        string craftingTemplateId)
+    {
+        if (!IsPlayerHeroIdValid(playerHeroId) ||
+            !CraftingPlayerData.PlayerOpenedPartsDictionary
+                .TryGetValue(playerHeroId, out var templates) ||
+            !templates.TryGetValue(craftingTemplateId, out var pieces) ||
+            pieces == null)
+            return Array.Empty<string>();
+        return pieces.ToArray();
+    }
+
     public void UnlockCraftingPiece(string playerHeroId, string craftingTemplateId, string craftingPieceId)
     {
         if (IsPlayerHeroIdValid(playerHeroId))
         {
-            CraftingPlayerData.PlayerOpenedPartsDictionary[playerHeroId][craftingTemplateId].Add(craftingPieceId);
+            List<string> pieces = CraftingPlayerData
+                .PlayerOpenedPartsDictionary[playerHeroId][craftingTemplateId];
+            if (!pieces.Contains(craftingPieceId))
+                pieces.Add(craftingPieceId);
         }
     }
 
@@ -49,8 +84,34 @@ public class SessionCraftingPlayerDataInterface : ISessionCraftingPlayerDataInte
     {
         if (IsPlayerHeroIdValid(playerHeroId))
         {
-            CraftingPlayerData.PlayerCraftedItemsHistory[playerHeroId] = craftedItemHistoryIds;
+            List<string> cleaned =
+                (craftedItemHistoryIds ?? new List<string>())
+                .Where(id => !string.IsNullOrEmpty(id))
+                .ToList();
+            if (cleaned.Count > 200)
+                cleaned.RemoveRange(0, cleaned.Count - 200);
+            CraftingPlayerData.PlayerCraftedItemsHistory[playerHeroId] = cleaned;
         }
+    }
+
+    public IReadOnlyList<string> AppendCraftingHistory(
+        string playerHeroId, string craftedItemId)
+    {
+        if (!IsPlayerHeroIdValid(playerHeroId) ||
+            string.IsNullOrEmpty(craftedItemId))
+            return Array.Empty<string>();
+        if (!CraftingPlayerData.PlayerCraftedItemsHistory.TryGetValue(
+                playerHeroId, out List<string> history) || history == null)
+        {
+            history = new List<string>();
+            CraftingPlayerData.PlayerCraftedItemsHistory[playerHeroId] = history;
+        }
+        history.RemoveAll(id => string.Equals(
+            id, craftedItemId, StringComparison.Ordinal));
+        history.Add(craftedItemId);
+        if (history.Count > 200)
+            history.RemoveRange(0, history.Count - 200);
+        return history.ToArray();
     }
 
     public void AddPlayerKeys(string playerHeroId)
@@ -69,6 +130,9 @@ public class SessionCraftingPlayerDataInterface : ISessionCraftingPlayerDataInte
         {
             CraftingPlayerData.PlayerOpenedPartsDictionary[playerHeroId] = new Dictionary<string, List<string>>();
         }
+        if (!CraftingPlayerData.PlayerCraftedItemsHistory.ContainsKey(playerHeroId))
+            CraftingPlayerData.PlayerCraftedItemsHistory[playerHeroId] =
+                new List<string>();
 
         foreach (CraftingTemplate craftingTemplate in CraftingTemplate.All)
         {

--- a/source/GameInterface/Services/Time/Patches/GameStateManagerPatches.cs
+++ b/source/GameInterface/Services/Time/Patches/GameStateManagerPatches.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using SandBox.View.Map;
+using TaleWorlds.CampaignSystem.Encounters;
 using TaleWorlds.CampaignSystem.GameState;
 using TaleWorlds.Core;
 using TaleWorlds.MountAndBlade;
@@ -45,21 +46,45 @@ namespace GameInterface.Services.Time.Patches
     }
 
     /// <summary>
-    /// Prevents the inactive campaign map camera from replacing a mission's global audio listener.
+    /// Prevents the inactive campaign map camera from ticking while another game
+    /// state owns the view. Apart from replacing a mission's audio listener, an
+    /// inactive camera can follow a party/map-event whose transition position is
+    /// temporarily invalid and snap the view towards the map origin.
     /// </summary>
     [HarmonyPatch(typeof(MapCameraView), nameof(MapCameraView.OnBeforeTick))]
     internal static class MapCameraViewPatches
     {
         [HarmonyPrefix]
-        private static bool OnBeforeTickPrefix()
+        private static bool OnBeforeTickPrefix(
+            MapCameraView.InputInformation inputInformation)
         {
-            return ShouldTickMapCamera(GameStateManager.Current?.ActiveState);
+            var conversation = TaleWorlds.CampaignSystem.Campaign.Current?
+                .ConversationManager;
+            return ShouldTickMapCamera(
+                GameStateManager.Current?.ActiveState,
+                inputInformation.IsInMenu,
+                conversation?.IsConversationInProgress == true ||
+                conversation?.IsConversationFlowActive == true,
+                PlayerEncounter.IsActive);
         }
 
-        internal static bool ShouldTickMapCamera(TaleWorlds.Core.GameState activeState)
+        internal static bool ShouldTickMapCamera(
+            TaleWorlds.Core.GameState activeState,
+            bool isInMenu = false,
+            bool isConversationActive = false,
+            bool isEncounterActive = false)
         {
-            // The map camera writes the global audio listener, which the active mission owns.
-            return activeState is not MissionState;
+            // Only the foreground campaign map owns this camera. Inventory,
+            // conversation, encounter and mission-transition states still run the
+            // background MapState simulation above, but must not run its camera.
+            // Map conversations keep MapState active, so the native menu flag and
+            // ConversationManager lifecycle are both required to prevent the
+            // follow target/map-event position from dragging the camera away.
+            // Conversation end and mission start are not atomic. PlayerEncounter
+            // remains active across that transition, closing the one-frame gap
+            // where a half-created MapEvent could drag the camera to the origin.
+            return activeState is MapState && !isInMenu &&
+                !isConversationActive && !isEncounterActive;
         }
     }
 }

--- a/source/GameInterface/Services/Tournaments/Handlers/TournamentSessionHandler.cs
+++ b/source/GameInterface/Services/Tournaments/Handlers/TournamentSessionHandler.cs
@@ -783,6 +783,16 @@ internal sealed partial class TournamentSessionHandler : IHandler
             "[Tournament] Completed tournament leave requested session={SessionId}, controller={ControllerId}",
             current.SessionId,
             controllerId);
+
+        // A completed tournament can fail or stall during reward/native finalization. Eject the
+        // requesting client independently first; the later global removal is idempotent and still
+        // clears every remaining participant once finalization succeeds.
+        if (peer != null)
+        {
+            network.Send(
+                peer,
+                new NetworkTournamentSessionRemoved(current.SessionId, current.TownId));
+        }
         FinalizeCompletedTournament(current);
         return true;
     }

--- a/source/GameInterface/Services/Tournaments/UI/TournamentUIController.cs
+++ b/source/GameInterface/Services/Tournaments/UI/TournamentUIController.cs
@@ -227,11 +227,13 @@ internal sealed class TournamentUIController : ITournamentUIController, IHandler
 
     private void Handle_TournamentSessionRemoved(MessagePayload<TournamentSessionRemoved> payload)
     {
-        bool removed = RemoveSession(payload.What.SessionId, payload.What.TownId);
+        RemoveSession(payload.What.SessionId, payload.What.TownId);
         GameThread.RunSafe(() =>
         {
-            if (removed)
-                SessionRemoved?.Invoke(payload.What.SessionId);
+            // Authoritative removal is also the mission-leave acknowledgement. Notify idempotently
+            // even if cache reconciliation already removed the row; otherwise a missing UI cache can
+            // strand the player inside the tournament mission.
+            SessionRemoved?.Invoke(payload.What.SessionId);
             RouteRemovedSession(payload.What.TownId);
         });
     }

--- a/source/GameInterface/Services/Transactions/ServerTransactionOutcome.cs
+++ b/source/GameInterface/Services/Transactions/ServerTransactionOutcome.cs
@@ -1,0 +1,271 @@
+using LiteNetLib;
+using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Players;
+using GameInterface.Services.Players.Data;
+using System;
+using System.Runtime.CompilerServices;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Party;
+
+namespace GameInterface.Services.Transactions;
+
+/// <summary>
+/// Server-only completion signal for authoritative campaign transactions.
+/// Action handlers publish only after their game-thread work either commits
+/// or is rejected. The additive type does not alter Coop's wire protocol or
+/// any client assembly contract.
+/// </summary>
+public static class ServerTransactionOutcome
+{
+    private static readonly object CraftGate = new();
+    private static readonly ConditionalWeakTable<NetPeer, CraftXpPermit>
+        CraftXpPermits = new();
+    private static readonly ConditionalWeakTable<NetPeer, CraftRenamePermit>
+        CraftRenamePermits = new();
+    [ThreadStatic]
+    private static ExecutionFrame CurrentExecution;
+    public const int Trade = 1;
+    public const int Party = 2;
+    public const int Smelt = 3;
+    public const int Refine = 4;
+    public const int Craft = 5;
+    public const int CraftXp = 6;
+    public const int Recruit = 7;
+    public const int ClanParty = 8;
+
+    public static event Action<NetPeer, int, bool, string> Completed;
+
+    public static void Accept(NetPeer peer, int kind)
+    {
+        MarkExecutionCompleted(peer, kind);
+        InvokeCompleted(peer, kind, true, string.Empty);
+    }
+
+    public static void Reject(NetPeer peer, int kind, string reason)
+    {
+        MarkExecutionCompleted(peer, kind);
+        InvokeCompleted(
+            peer,
+            kind,
+            false,
+            reason ?? "The server rejected this action.");
+    }
+
+    private static void InvokeCompleted(
+        NetPeer peer, int kind, bool success, string reason)
+    {
+        Delegate[] handlers = Completed?.GetInvocationList();
+        if (handlers == null)
+            return;
+        foreach (Delegate handler in handlers)
+        {
+            try
+            {
+                ((Action<NetPeer, int, bool, string>)handler)(
+                    peer, kind, success, reason);
+            }
+            catch (Exception exception)
+            {
+                Console.Error.WriteLine(
+                    "[Coop] Transaction completion listener failed: " +
+                    exception.GetBaseException().Message);
+            }
+        }
+    }
+
+    public static void Execute(NetPeer peer, int kind, Action action)
+    {
+        ExecutionFrame previous = CurrentExecution;
+        var frame = new ExecutionFrame(peer, kind);
+        CurrentExecution = frame;
+        try
+        {
+            action?.Invoke();
+            if (!frame.Completed)
+                Reject(
+                    peer,
+                    kind,
+                    "The authoritative handler did not report a result.");
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine(
+                "[Coop] Authoritative transaction failed: " +
+                exception.GetBaseException().Message);
+            Reject(
+                peer,
+                kind,
+                "The server could not safely complete this action.");
+        }
+        finally
+        {
+            CurrentExecution = previous;
+        }
+    }
+
+    private static void MarkExecutionCompleted(NetPeer peer, int kind)
+    {
+        ExecutionFrame frame = CurrentExecution;
+        if (frame != null && ReferenceEquals(frame.Peer, peer) &&
+            frame.Kind == kind)
+            frame.Completed = true;
+    }
+
+    public static bool TryResolvePlayer(
+        NetPeer peer,
+        IPlayerManager playerManager,
+        IObjectManager objectManager,
+        string requestedHeroId,
+        string requestedPartyId,
+        out Player player,
+        out Hero hero,
+        out MobileParty party,
+        out string reason)
+    {
+        player = null;
+        hero = null;
+        party = null;
+        reason = "The server could not authenticate this player.";
+        if (peer == null || playerManager == null || objectManager == null ||
+            !playerManager.TryGetPlayer(peer, out player) || player == null ||
+            !string.Equals(player.HeroId, requestedHeroId,
+                StringComparison.Ordinal) ||
+            !string.Equals(player.MobilePartyId, requestedPartyId,
+                StringComparison.Ordinal) ||
+            !objectManager.TryGetObject(player.HeroId, out hero) ||
+            !objectManager.TryGetObject(player.MobilePartyId, out party) ||
+            hero == null || party == null || hero.PartyBelongedTo != party)
+            return false;
+
+        return true;
+    }
+
+    public static bool TryResolveOwnedCraftingHero(
+        NetPeer peer,
+        IPlayerManager playerManager,
+        IObjectManager objectManager,
+        string craftingHeroId,
+        out Player player,
+        out Hero craftingHero,
+        out MobileParty playerParty,
+        out string reason)
+    {
+        craftingHero = null;
+        player = null;
+        playerParty = null;
+        reason = "The server could not authenticate this player.";
+        if (peer == null || playerManager == null || objectManager == null ||
+            !playerManager.TryGetPlayer(peer, out player) || player == null ||
+            !TryResolvePlayer(
+                peer,
+                playerManager,
+                objectManager,
+                player.HeroId,
+                player.MobilePartyId,
+                out player,
+                out Hero playerHero,
+                out playerParty,
+                out reason) ||
+            !objectManager.TryGetObject(craftingHeroId, out craftingHero) ||
+            craftingHero == null ||
+            craftingHero != playerHero &&
+            (craftingHero.Clan != playerHero.Clan ||
+             craftingHero.PartyBelongedTo != playerParty))
+        {
+            reason = "Smithing hero did not belong to the connected player.";
+            return false;
+        }
+
+        reason = string.Empty;
+        return true;
+    }
+
+    public static void AllowCraftXp(NetPeer peer, string heroId)
+    {
+        if (peer == null || string.IsNullOrEmpty(heroId)) return;
+        lock (CraftGate)
+        {
+            CraftXpPermits.Remove(peer);
+            CraftXpPermits.Add(peer, new CraftXpPermit(
+                heroId, DateTime.UtcNow.AddSeconds(30)));
+        }
+    }
+
+    public static bool TryConsumeCraftXp(NetPeer peer, string heroId)
+    {
+        if (peer == null || string.IsNullOrEmpty(heroId)) return false;
+        lock (CraftGate)
+        {
+            if (!CraftXpPermits.TryGetValue(peer, out CraftXpPermit permit))
+                return false;
+            CraftXpPermits.Remove(peer);
+            return permit.ExpiresUtc >= DateTime.UtcNow &&
+                string.Equals(permit.HeroId, heroId, StringComparison.Ordinal);
+        }
+    }
+
+    public static void AllowCraftRename(NetPeer peer, string craftedItemId)
+    {
+        if (peer == null || string.IsNullOrEmpty(craftedItemId)) return;
+        lock (CraftGate)
+        {
+            CraftRenamePermits.Remove(peer);
+            CraftRenamePermits.Add(peer, new CraftRenamePermit(
+                craftedItemId, DateTime.UtcNow.AddMinutes(2)));
+        }
+    }
+
+    public static bool TryConsumeCraftRename(
+        NetPeer peer, string craftedItemId)
+    {
+        if (peer == null || string.IsNullOrEmpty(craftedItemId)) return false;
+        lock (CraftGate)
+        {
+            if (!CraftRenamePermits.TryGetValue(
+                    peer, out CraftRenamePermit permit))
+                return false;
+            CraftRenamePermits.Remove(peer);
+            return permit.ExpiresUtc >= DateTime.UtcNow &&
+                string.Equals(permit.CraftedItemId, craftedItemId,
+                    StringComparison.Ordinal);
+        }
+    }
+
+    private sealed class CraftXpPermit
+    {
+        internal readonly string HeroId;
+        internal readonly DateTime ExpiresUtc;
+
+        internal CraftXpPermit(string heroId, DateTime expiresUtc)
+        {
+            HeroId = heroId;
+            ExpiresUtc = expiresUtc;
+        }
+    }
+
+    private sealed class ExecutionFrame
+    {
+        internal readonly NetPeer Peer;
+        internal readonly int Kind;
+        internal bool Completed;
+
+        internal ExecutionFrame(NetPeer peer, int kind)
+        {
+            Peer = peer;
+            Kind = kind;
+        }
+    }
+
+    private sealed class CraftRenamePermit
+    {
+        internal readonly string CraftedItemId;
+        internal readonly DateTime ExpiresUtc;
+
+        internal CraftRenamePermit(
+            string craftedItemId, DateTime expiresUtc)
+        {
+            CraftedItemId = craftedItemId;
+            ExpiresUtc = expiresUtc;
+        }
+    }
+}

--- a/source/GameInterface/Services/TroopRosters/Interfaces/TroopRosterInterface.cs
+++ b/source/GameInterface/Services/TroopRosters/Interfaces/TroopRosterInterface.cs
@@ -2,10 +2,12 @@
 using Common.Messaging;
 using GameInterface.Services.Heroes.Extensions;
 using GameInterface.Services.Heroes.Messages.Collections;
+using GameInterface.Services.MobileParties.Messages;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.TroopRosters.Data;
 using GameInterface.Services.TroopRosters.Logging;
 using GameInterface.Services.TroopRosters.Messages;
+using Helpers;
 using Serilog;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,6 +16,7 @@ using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Roster;
+using TaleWorlds.CampaignSystem.Settlements;
 
 namespace GameInterface.Services.TroopRosters.Interfaces;
 
@@ -55,7 +58,10 @@ public interface ITroopRosterInterface : IGameAbstraction
     /// <summary>
     /// Runs troop recruitment logic for client requests.
     /// </summary>
-    void HandleOnRecruitmentDone(string mobilePartyId, TroopInfo[] troopsInCart);
+    bool TryHandleOnRecruitmentDone(
+        string mobilePartyId,
+        TroopInfo[] troopsInCart,
+        out string rejectionReason);
 
     /// <summary>
     /// Players are able to change the order of their party roster.
@@ -232,10 +238,24 @@ internal class TroopRosterInterface : ITroopRosterInterface
             }
         }
 
-        // AddToCounts(hero, -n) nulls the hero's party linkage, so additions must be the last operation.
-        ApplyDeltaElements(elements, applyAdditions: false);
-        ApplyDeltaElements(elements, applyAdditions: true);
-        return true;
+        var snapshots = deltas
+            .Select(entry => entry.roster)
+            .Distinct()
+            .ToDictionary(roster => roster, SumByCharacter);
+        try
+        {
+            ApplyDeltaElements(elements, applyAdditions: false);
+            ApplyDeltaElements(elements, applyAdditions: true);
+            return true;
+        }
+        catch (System.Exception exception)
+        {
+            Logger.Error(
+                exception,
+                "Troop roster delta failed; restoring authoritative snapshots");
+            RestoreRosterSnapshots(snapshots);
+            return false;
+        }
     }
 
     private void ApplyDeltaElements(
@@ -266,6 +286,79 @@ internal class TroopRosterInterface : ITroopRosterInterface
         }
     }
 
+    private static bool RestoreRosterSnapshots(
+        IReadOnlyDictionary<TroopRoster, Dictionary<CharacterObject,
+            (int number, int wounded, int xp)>> snapshots)
+    {
+        bool restored = true;
+        // Remove excess units from every roster before adding missing units back.
+        // This preserves hero party linkage across a failed transfer.
+        for (int pass = 0; pass < 2; pass++)
+        {
+            foreach (var snapshot in snapshots)
+            {
+                var current = SumByCharacter(snapshot.Key);
+                var characters = new HashSet<CharacterObject>(current.Keys);
+                characters.UnionWith(snapshot.Value.Keys);
+                foreach (CharacterObject character in characters)
+                {
+                    current.TryGetValue(character, out var actual);
+                    snapshot.Value.TryGetValue(character, out var target);
+                    int numberDelta = target.number - actual.number;
+                    if ((numberDelta < 0) != (pass == 0))
+                        continue;
+                    if (!RestoreRosterElement(
+                            snapshot.Key, character, target))
+                        restored = false;
+                }
+            }
+        }
+        return restored;
+    }
+
+    private static bool RestoreRosterElement(
+        TroopRoster roster,
+        CharacterObject character,
+        (int number, int wounded, int xp) target)
+    {
+        for (int attempt = 0; attempt < 2; attempt++)
+        {
+            var current = SumByCharacter(roster);
+            current.TryGetValue(character, out var actual);
+            int numberDelta = target.number - actual.number;
+            int woundedDelta = target.wounded - actual.wounded;
+            int xpDelta = target.xp - actual.xp;
+            if (numberDelta == 0 && woundedDelta == 0 && xpDelta == 0)
+                return true;
+            try
+            {
+                roster.AddToCounts(
+                    character,
+                    numberDelta,
+                    false,
+                    woundedDelta,
+                    xpDelta,
+                    true);
+            }
+            catch (System.Exception rollbackException)
+            {
+                Logger.Error(
+                    rollbackException,
+                    "Troop roster snapshot restore threw for {Character}",
+                    character?.StringId);
+            }
+        }
+
+        var final = SumByCharacter(roster);
+        final.TryGetValue(character, out var finalValue);
+        bool matches = finalValue == target;
+        if (!matches)
+            Logger.Error(
+                "Troop roster snapshot restore did not converge for {Character}",
+                character?.StringId);
+        return matches;
+    }
+
     private static Dictionary<CharacterObject, (int number, int wounded, int xp)> SumByCharacter(TroopRoster roster)
     {
         var counts = new Dictionary<CharacterObject, (int number, int wounded, int xp)>();
@@ -280,50 +373,232 @@ internal class TroopRosterInterface : ITroopRosterInterface
         return counts;
     }
 
-    public void HandleOnRecruitmentDone(string mobilePartyId, TroopInfo[] troopsInCart)
+    public bool TryHandleOnRecruitmentDone(
+        string mobilePartyId,
+        TroopInfo[] troopsInCart,
+        out string rejectionReason)
     {
-        if (!objectManager.TryGetObjectWithLogging(mobilePartyId, out MobileParty mobileParty)) return;
+        rejectionReason = "Recruitment could not be completed.";
+        if (!objectManager.TryGetObjectWithLogging(
+                mobilePartyId, out MobileParty mobileParty) ||
+            mobileParty?.LeaderHero == null ||
+            troopsInCart == null || troopsInCart.Length == 0)
+            return false;
 
-        List<(Hero, CharacterObject, int)> herosValidated = new();
+        List<(Hero hero, CharacterObject character, int resolvedIndex, bool rebound)>
+            herosValidated = new();
+        HashSet<(Hero, int)> submittedSlots = new();
+        HashSet<(Hero, int)> claimedSlots = new();
+        Settlement currentSettlement = mobileParty.CurrentSettlement;
+        if (currentSettlement == null)
+        {
+            rejectionReason = "You are no longer in that settlement.";
+            return false;
+        }
 
         // Validate troops before committing to recruiting
         foreach (var troop in troopsInCart)
         {
-            if (!objectManager.TryGetObjectWithLogging(troop.RecruiterHeroId, out Hero hero)) continue;
-            if (!objectManager.TryGetObjectWithLogging(troop.CharacterObjectId, out CharacterObject characterObject)) continue;
+            if (!objectManager.TryGetObjectWithLogging(
+                    troop.RecruiterHeroId, out Hero hero) ||
+                !objectManager.TryGetObjectWithLogging(
+                    troop.CharacterObjectId, out CharacterObject characterObject) ||
+                troop.TroopIndex < 0 ||
+                troop.TroopIndex >= hero.VolunteerTypes.Length ||
+                !submittedSlots.Add((hero, troop.TroopIndex)) ||
+                hero.CurrentSettlement != currentSettlement ||
+                !currentSettlement.Notables.Contains(hero))
+            {
+                rejectionReason = "The requested volunteer slot is no longer valid.";
+                return false;
+            }
 
-            var volunteerTroopAtIndex = hero.VolunteerTypes[troop.TroopIndex];
+            int resolvedIndex = ResolveVolunteerSlot(
+                mobileParty.LeaderHero,
+                hero,
+                characterObject,
+                troop.TroopIndex,
+                claimedSlots);
+            if (resolvedIndex < 0)
+            {
+                rejectionReason =
+                    "That volunteer changed while the recruitment screen was open. No troops were recruited; please try again.";
+                return false;
+            }
 
-            if (volunteerTroopAtIndex is null) continue;
+            claimedSlots.Add((hero, resolvedIndex));
+            herosValidated.Add((
+                hero,
+                characterObject,
+                resolvedIndex,
+                resolvedIndex != troop.TroopIndex));
+        }
 
-            herosValidated.Add((hero, characterObject, troop.TroopIndex));
+        if ((long)mobileParty.Party.NumberOfAllMembers +
+                herosValidated.Count > mobileParty.Party.PartySizeLimit)
+        {
+            rejectionReason = "Your party no longer has room for those recruits.";
+            return false;
         }
 
         // Calculate cost before changing any data
         var cost = 0;
-        foreach ((Hero hero, CharacterObject characterObject, int index) in herosValidated)
+        foreach (var validated in herosValidated)
         {
-            cost += Campaign.Current.Models.PartyWageModel.GetTroopRecruitmentCost(characterObject, mobileParty.LeaderHero).RoundedResultNumber;
+            cost += Campaign.Current.Models.PartyWageModel.GetTroopRecruitmentCost(
+                validated.character, mobileParty.LeaderHero).RoundedResultNumber;
         }
 
         // Do not apply recruitment if the player does not have enough gold
         if (cost > mobileParty.LeaderHero.Gold)
         {
             Logger.Warning("Attempted to recruit troops that cost more than the player had");
-            return;
+            rejectionReason = "You no longer have enough denars for this recruitment.";
+            return false;
         }
 
-        // Commit recruitment
-        foreach ((Hero hero, CharacterObject characterObject, int index) in herosValidated)
+        // Commit recruitment with compensation. A native event/patch exception
+        // must not consume a volunteer, troop or denars while the transaction is
+        // reported as rejected.
+        int goldBefore = mobileParty.LeaderHero.Gold;
+        var rosterBefore = new Dictionary<TroopRoster, Dictionary<
+            CharacterObject, (int number, int wounded, int xp)>>
         {
-            hero.VolunteerTypes[index] = null;
-            MessageBroker.Instance.Publish(this, new VolunteerTypesArrayUpdated(hero, null, index));
-
-            mobileParty.MemberRoster.AddToCounts(characterObject, 1, false, 0, 0, true, -1);
-            CampaignEventDispatcher.Instance.OnUnitRecruited(characterObject, 1);
+            [mobileParty.MemberRoster] =
+                SumByCharacter(mobileParty.MemberRoster)
+        };
+        var clearedSlots = new List<(Hero hero, CharacterObject troop, int index)>();
+        try
+        {
+            GiveGoldAction.ApplyBetweenCharacters(
+                mobileParty.LeaderHero, null, cost, false);
+            foreach (var validated in herosValidated)
+            {
+                validated.hero.VolunteerTypes[validated.resolvedIndex] = null;
+                clearedSlots.Add((
+                    validated.hero,
+                    validated.character,
+                    validated.resolvedIndex));
+                mobileParty.MemberRoster.AddToCounts(
+                    validated.character, 1, false, 0, 0, true, -1);
+            }
+        }
+        catch (System.Exception exception)
+        {
+            Logger.Error(
+                exception,
+                "Recruitment failed during commit; restoring authoritative state");
+            RestoreRosterSnapshots(rosterBefore);
+            foreach (var cleared in clearedSlots)
+                cleared.hero.VolunteerTypes[cleared.index] = cleared.troop;
+            mobileParty.LeaderHero.Gold = goldBefore;
+            rejectionReason =
+                "Recruitment could not be committed safely. Please try again.";
+            return false;
         }
 
-        GiveGoldAction.ApplyBetweenCharacters(mobileParty.LeaderHero, null, cost, false);
+        // State is committed. Notifications and progression may fail, but must
+        // never turn the accepted recruitment into a retryable transaction.
+        var reboundSnapshots = new Dictionary<Hero, CharacterObject[]>();
+        foreach (var validated in herosValidated)
+        {
+            try
+            {
+                if (validated.rebound)
+                {
+                    reboundSnapshots[validated.hero] =
+                        validated.hero.VolunteerTypes.ToArray();
+                }
+                else
+                {
+                    MessageBroker.Instance.Publish(
+                        this,
+                        new VolunteerTypesArrayUpdated(
+                            validated.hero,
+                            null,
+                            validated.resolvedIndex));
+                }
+            }
+            catch (System.Exception exception)
+            {
+                Logger.Error(
+                    exception,
+                    "Recruitment committed, but volunteer broadcast failed");
+            }
+            try
+            {
+                CampaignEventDispatcher.Instance.OnUnitRecruited(
+                    validated.character, 1);
+            }
+            catch (System.Exception exception)
+            {
+                Logger.Error(
+                    exception,
+                    "Recruitment committed, but progression event failed");
+            }
+        }
+
+        if (reboundSnapshots.Count > 0)
+        {
+            try
+            {
+                MessageBroker.Instance.Publish(
+                    this,
+                    new VolunteersUpdated(reboundSnapshots));
+            }
+            catch (System.Exception exception)
+            {
+                Logger.Error(
+                    exception,
+                    "Recruitment committed, but rebound volunteer snapshot failed");
+            }
+        }
+
+        rejectionReason = string.Empty;
+        return true;
+    }
+
+    private static int ResolveVolunteerSlot(
+        Hero recruitingHero,
+        Hero notable,
+        CharacterObject requestedCharacter,
+        int requestedIndex,
+        HashSet<(Hero, int)> claimedSlots)
+    {
+        if (SlotMatches(
+                recruitingHero,
+                notable,
+                requestedCharacter,
+                requestedIndex,
+                claimedSlots))
+            return requestedIndex;
+
+        for (int index = 0; index < notable.VolunteerTypes.Length; index++)
+        {
+            if (index != requestedIndex && SlotMatches(
+                    recruitingHero,
+                    notable,
+                    requestedCharacter,
+                    index,
+                    claimedSlots))
+                return index;
+        }
+
+        return -1;
+    }
+
+    private static bool SlotMatches(
+        Hero recruitingHero,
+        Hero notable,
+        CharacterObject requestedCharacter,
+        int index,
+        HashSet<(Hero, int)> claimedSlots)
+    {
+        return index >= 0 &&
+            index < notable.VolunteerTypes.Length &&
+            !claimedSlots.Contains((notable, index)) &&
+            ReferenceEquals(notable.VolunteerTypes[index], requestedCharacter) &&
+            HeroHelper.HeroCanRecruitFromHero(recruitingHero, notable, index);
     }
 
     public TroopRosterOrderData PackTroopRosterOrderData(TroopRoster roster)


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## What is the current behavior?

Joining can trigger the normal save path, flush unrelated traffic, race player registration, or leave the campaign paused after a disconnect. Late joiners can also receive stale party state. Several party, trade, smithing, recruitment, and battle reward flows trust stale client snapshots and can duplicate or overwrite newer server state.

## What is the new behavior?

- separates cached join snapshots from disk autosaves and sends them through a phased, cancellable join queue
- reserves and commits player controllers atomically, with reconnect and transferred-party repair
- pauses only for a sustained overloaded join queue and resumes with hysteresis when the queue drains or the peer leaves
- keeps join party positions and behavior authoritative without requiring resolved navigation faces
- validates trade, party, clan-party, recruitment, prisoner, and smithing actions against the connected player's current server state
- makes battle loot and temporary party rewards single-use, reversible server grants
- fixes headless/unregistered object sync, temporary roster traffic, map-event cleanup, player release positions, and UI/tournament edge cases
- runs authoritative transactions without an external authorization hook

No module dependencies or dedicated-server launcher code are added.

Tests: Common 101, CrashReporter 10, Coop integration 139, Coop 596, GameInterface 882 passed. The complete E2E project was also started locally but exceeded the 10-minute run cap without reporting a failure.

## Bot Changelog Entry

- Improved late joining, reconnect recovery, server pause/resume, campaign actions, battle rewards, and dedicated-server compatibility.