### PR TITLE
Potential Fix to the WhoAmI Command

### DIFF
--- a/source/GameInterface.Tests/Services/Party/PartyCommandsTests.cs
+++ b/source/GameInterface.Tests/Services/Party/PartyCommandsTests.cs
@@ -1,0 +1,32 @@
+﻿using Common;
+using GameInterface.Services.Party.Commands;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace GameInterface.Tests.Services.Party;
+
+/// <summary>
+/// Added a regression test to check first if the instance is a server and
+/// if that is true, to return the message.
+/// </summary>
+[Collection(ModInformationRoleCollection.Name)]
+public class PartyCommandsTests : IDisposable
+{
+    private readonly bool wasServer = ModInformation.IsServer;
+
+    public void Dispose()
+    {
+        ModInformation.IsServer = wasServer;
+    }
+
+    [Fact]
+    public void WhoAmI_WhenServer_ReturnsClientOnlyError()
+    {
+        ModInformation.IsServer = true;
+
+        var result = PartyCommands.WhoAmICommand(new List<string>());
+        
+        Assert.Equal("Command can only be run on a client.", result);
+    }
+}

--- a/source/GameInterface/Services/Party/Commands/PartyCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/PartyCommands.cs
@@ -76,7 +76,6 @@ internal class PartyCommands
     [CommandLineArgumentFunction("whoami", "coop.debug.mobileparty")]
     public static string WhoAmICommand(List<string> strings)
     {
-        
         if(!ModInformation.IsClient) return "Command can only be run on a client.";
         
         var me = Hero.MainHero;

--- a/source/GameInterface/Services/Party/Commands/PartyCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/PartyCommands.cs
@@ -76,8 +76,11 @@ internal class PartyCommands
     [CommandLineArgumentFunction("whoami", "coop.debug.mobileparty")]
     public static string WhoAmICommand(List<string> strings)
     {
+        
+        if(!ModInformation.IsClient) return "Command can only be run on a client.";
+        
         var me = Hero.MainHero;
-        if (me == null) return "No main hero on this instance (the host has none; run this on a client).";
+        if (me == null) return "No main hero on this instance";
 
         return me.PartyBelongedTo != null
             ? "You are " + me.Name + " | hero id: " + me.StringId + " | party id: " + me.PartyBelongedTo.StringId


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Running `coop.debug.mobileparty.whoami` on a dedicated server reads `Hero.MainHero`. Although the dedicated server has no local co-op player, Bannerlord may retain a native main hero from the loaded campaign. So, the command can incorrectly identify that hero `pacarios` as the user running the command.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->

Resolves #2871

`coop.debug.mobileparty.whoami` now reports that it can only be run on a client when invoked on the server. On a client, it continues to report the local player's hero and party identifiers.

A regression test verifies that server-side execution returns the client-only message without attempting to resolve `Hero.MainHero`.

## Bot Changelog Entry

- Fixed the dedicated server incorrectly identifying a campaign hero as the local player when using the WhoAmI command.

## Other information
