### PR TITLE
Cap town trade tax for disconnected players

### DIFF
--- a/source/GameInterface/Services/Towns/Patches/TownTradeTaxAccumulatedCapPatch.cs
+++ b/source/GameInterface/Services/Towns/Patches/TownTradeTaxAccumulatedCapPatch.cs
@@ -1,0 +1,40 @@
+﻿using Common;
+using GameInterface.Configuration;
+using GameInterface.Services.Heroes.Extensions;
+using GameInterface.Services.Players;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem.Settlements;
+
+namespace GameInterface.Services.Towns.Patches;
+
+[HarmonyPatch(typeof(Town))]
+internal class TownTradeTaxAccumulatedCapPatch
+{
+    // Artificial cap. Players always receive 1/5 of the trade tax acculumated normally so there is no available vanilla threshold.
+    // At 25000, a player would only receive 5000 when coming back online after being gone a while instead of a huge stack.
+    // This also applies to recently conquered settlements from another disconnected player.
+    private static readonly int TradeTaxAccumulatedCap = 25000;
+
+    [HarmonyPatch(nameof(Town.TradeTaxAccumulated), MethodType.Setter)]
+    [HarmonyPostfix]
+    public static void TradeTaxAccumulatedSetterPostfix(Town __instance)
+    {
+        if (__instance.TradeTaxAccumulated <= TradeTaxAccumulatedCap) return;
+
+        if (ModInformation.IsClient) return;
+
+        // Cap trade tax acculumulated for disconnected players based on config
+        // When capped at TradeTaxAccumulatedCap (25000), rejoining players and recent conquerers won't see a spike in town trade tariffs
+        if (ModConfigProvider.ModOptions.GoldFoodInfluenceChangeForDisconnectedPlayers) return;
+
+        if (ContainerProvider.TryResolve<IPlayerManager>(out IPlayerManager playerManager) == false) return;
+
+        var owner = __instance.Settlement?.Owner;
+        if (owner == null || !owner.IsPlayerHero()) return;
+
+        if (playerManager.IsOwnerOfHeroDisconnected(owner))
+        {
+            __instance.TradeTaxAccumulated = TradeTaxAccumulatedCap;
+        }
+    }
+}


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When players own a town trade tax (tariffs) accumulates and a part of this is paid out to the settlement owner everyday. When disconnected and the config to turn this off, the trade tax continues to stockpile without a limit. This is the same as the previous issue with caravans & workshops stockpiling capital.

The problem is that when players return to a game after a while or conquer a settlement belonging to someone who hasn't been on in a while, all of that trade tax accumulated now gets paid out at 1/5 per day until it settles back down.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #2942
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Added an artificial cap of 25000 for disconnected players. This can be adjusted based on recommendation, but 25000 should mean the tariff income starts at 5000 without surging to insane profits. This doesn't affect conquering AI owned settlements or settlements of players who are in the game.

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Fixed a problem where tariff income would surge for a few days after conquering a settlement from another inactive player.
