### PR TITLE
Fix/generic handler round3 review

### DIFF
--- a/source/E2E.Tests/Services/Issues/AlternativeSolutionCompletionOwnerResolutionTests.cs
+++ b/source/E2E.Tests/Services/Issues/AlternativeSolutionCompletionOwnerResolutionTests.cs
@@ -92,7 +92,7 @@ public class AlternativeSolutionCompletionOwnerResolutionTests : IDisposable
                 Assert.True(Campaign.Current.IssueManager.CreateNewIssue(in pid, owner));
             }
 
-            IssueOwnershipRegistry.SetOwner(owner, controllerId);
+            Server.Resolve<IIssueOwnershipRegistry>().SetOwner(owner, controllerId);
         });
 
         Server.Call(() =>

--- a/source/E2E.Tests/Services/Issues/AlternativeSolutionCompletionOwnerResolutionTests.cs
+++ b/source/E2E.Tests/Services/Issues/AlternativeSolutionCompletionOwnerResolutionTests.cs
@@ -139,7 +139,7 @@ public class AlternativeSolutionCompletionOwnerResolutionTests : IDisposable
             Assert.Equal(serverMainHeroGoldBefore, Hero.MainHero.Gold);
             Assert.Equal(serverMainHeroCharacterBefore, Hero.MainHero.CharacterObject);
 
-            Assert.True(AwaitingAlternativeSolutionTroopsRegistry.TryGet(controllerId, out var deposited));
+            Assert.True(Server.Resolve<IAwaitingAlternativeSolutionTroopsRegistry>().TryGet(controllerId, out var deposited));
             Assert.True(deposited.TotalManCount >= 1);
         });
     }

--- a/source/E2E.Tests/Services/Issues/AlternativeSolutionStartOwnerResolutionTests.cs
+++ b/source/E2E.Tests/Services/Issues/AlternativeSolutionStartOwnerResolutionTests.cs
@@ -120,14 +120,14 @@ public class AlternativeSolutionStartOwnerResolutionTests : IDisposable
             Assert.True(owner.Issue.AlternativeSolutionReturnTimeForTroops.IsFuture);
             Assert.Equal(owner.Issue.AlternativeSolutionReturnTimeForTroops, state.ReturnTime);
 
-            IssueOwnershipRegistry.SetOwner(owner, controllerId);
+            Server.Resolve<IIssueOwnershipRegistry>().SetOwner(owner, controllerId);
         });
 
         Server.Call(() =>
         {
             Assert.True(Server.ObjectManager.TryGetObject<Hero>(heroId, out var owner));
 
-            Assert.True(IssueOwnershipRegistry.TryGetOwnerControllerId(owner, out var ownerControllerId));
+            Assert.True(Server.Resolve<IIssueOwnershipRegistry>().TryGetOwnerControllerId(owner, out var ownerControllerId));
             Assert.Equal(controllerId, ownerControllerId);
 
             Assert.Equal(serverMainHeroGoldBefore, Hero.MainHero.Gold);

--- a/source/E2E.Tests/Services/Issues/AlternativeSolutionStartOwnerResolutionTests.cs
+++ b/source/E2E.Tests/Services/Issues/AlternativeSolutionStartOwnerResolutionTests.cs
@@ -18,13 +18,13 @@ using Xunit.Abstractions;
 
 namespace E2E.Tests.Services.Issues;
 
-public class AlternativeSolutionCompletionOwnerResolutionTests : IDisposable
+public class AlternativeSolutionStartOwnerResolutionTests : IDisposable
 {
     private E2ETestEnvironment TestEnvironment { get; }
     private EnvironmentInstance Server => TestEnvironment.Server;
     private EnvironmentInstance ClientB => TestEnvironment.Clients.ElementAt(1);
 
-    public AlternativeSolutionCompletionOwnerResolutionTests(ITestOutputHelper output)
+    public AlternativeSolutionStartOwnerResolutionTests(ITestOutputHelper output)
     {
         TestEnvironment = new E2ETestEnvironment(output);
     }
@@ -35,7 +35,7 @@ public class AlternativeSolutionCompletionOwnerResolutionTests : IDisposable
     }
 
     [Fact]
-    public void CompleteOnServer_TrueOwnerIsRemoteClient_RewardGoldAndTroopsLandOnTrueOwnerNotServerMainHero()
+    public void StartOnServer_TrueOwnerIsRemoteClient_StateComputedUnderTrueOwnerNotServerMainHero()
     {
         var controllerId = "player-B-" + Guid.NewGuid();
 
@@ -91,8 +91,14 @@ public class AlternativeSolutionCompletionOwnerResolutionTests : IDisposable
             {
                 Assert.True(Campaign.Current.IssueManager.CreateNewIssue(in pid, owner));
             }
+        });
 
-            IssueOwnershipRegistry.SetOwner(owner, controllerId);
+        int serverMainHeroGoldBefore = 0;
+        CharacterObject serverMainHeroCharacterBefore = null;
+        Server.Call(() =>
+        {
+            serverMainHeroGoldBefore = Hero.MainHero.Gold;
+            serverMainHeroCharacterBefore = Hero.MainHero.CharacterObject;
         });
 
         Server.Call(() =>
@@ -100,47 +106,32 @@ public class AlternativeSolutionCompletionOwnerResolutionTests : IDisposable
             Assert.True(Server.ObjectManager.TryGetObject<Hero>(heroId, out var owner));
             Assert.True(Server.ObjectManager.TryGetObject<Hero>(companionHeroId, out var companion));
 
+            var playerManager = Server.Resolve<IPlayerManager>();
+            Assert.True(playerManager.TryGetPlayer(controllerId, out var truePlayer));
+
             using (new AllowedThread())
-            using (new AlternativeSolutionStartAuthorityGuard())
             {
                 owner.Issue.AlternativeSolutionSentTroops.AddToCounts(companion.CharacterObject, 1);
-                owner.Issue.StartIssueWithAlternativeSolution();
             }
-        });
 
-        int serverMainHeroGoldBefore = 0;
-        CharacterObject serverMainHeroCharacterBefore = null;
-        int trueOwnerGoldBefore = 0;
-        Server.Call(() =>
-        {
-            serverMainHeroGoldBefore = Hero.MainHero.Gold;
-            serverMainHeroCharacterBefore = Hero.MainHero.CharacterObject;
+            var state = AlternativeSolutionStartRunner.StartOnServer(owner, truePlayer);
 
-            Assert.True(Server.ObjectManager.TryGetObject<Hero>(trueOwnerHeroId, out var trueOwner));
-            trueOwnerGoldBefore = trueOwner.Gold;
+            Assert.True(owner.Issue.IsSolvingWithAlternative);
+            Assert.True(owner.Issue.AlternativeSolutionReturnTimeForTroops.IsFuture);
+            Assert.Equal(owner.Issue.AlternativeSolutionReturnTimeForTroops, state.ReturnTime);
+
+            IssueOwnershipRegistry.SetOwner(owner, controllerId);
         });
 
         Server.Call(() =>
         {
             Assert.True(Server.ObjectManager.TryGetObject<Hero>(heroId, out var owner));
-            var issue = (IssueBase)owner.Issue;
 
-            using (new AllowedThread())
-            {
-                AlternativeSolutionCompletionRunner.CompleteOnServer(owner, issue);
-            }
-        });
+            Assert.True(IssueOwnershipRegistry.TryGetOwnerControllerId(owner, out var ownerControllerId));
+            Assert.Equal(controllerId, ownerControllerId);
 
-        Server.Call(() =>
-        {
-            Assert.True(Server.ObjectManager.TryGetObject<Hero>(trueOwnerHeroId, out var trueOwner));
-
-            Assert.True(trueOwner.Gold > trueOwnerGoldBefore);
             Assert.Equal(serverMainHeroGoldBefore, Hero.MainHero.Gold);
             Assert.Equal(serverMainHeroCharacterBefore, Hero.MainHero.CharacterObject);
-
-            Assert.True(AwaitingAlternativeSolutionTroopsRegistry.TryGet(controllerId, out var deposited));
-            Assert.True(deposited.TotalManCount >= 1);
         });
     }
 }

--- a/source/E2E.Tests/Services/Issues/AwaitingAlternativeSolutionTroopsTests.cs
+++ b/source/E2E.Tests/Services/Issues/AwaitingAlternativeSolutionTroopsTests.cs
@@ -1,4 +1,5 @@
 using Common.Messaging;
+using Common.Network;
 using Common.Util;
 using E2E.Tests.Environment;
 using E2E.Tests.Environment.Instance;
@@ -169,6 +170,37 @@ public class AwaitingAlternativeSolutionTroopsTests : IDisposable
         Client.Call(() =>
         {
             Assert.True(Client.ObjectManager.TryGetObject<Hero>(fixture.HeroId, out var owner));
+            Assert.True(Client.ObjectManager.TryGetId(owner, out var clientOwnerId));
+            MessageBroker.Instance.Publish(owner, new IssueConversationOpenedLocally(owner, controllerId));
+        });
+
+        Assert.Single(Client.NetworkSentMessages.GetMessages<RequestIssueConversationOpened>());
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(fixture.HeroId, out var owner));
+            Assert.True(Server.ObjectManager.TryGetId(owner, out var ownerId));
+
+            Assert.NotNull(owner.Issue);
+            Assert.True(owner.Issue.IsOngoingWithoutQuest, $"IsOngoingWithoutQuest={owner.Issue.IsOngoingWithoutQuest}");
+            Assert.True(owner.Issue.IssueStayAliveConditions(), "IssueStayAliveConditions false");
+            Assert.True(
+                GenericAcceptMirrorIssueTypes.IsQuestSolutionMirrorEligible(owner.Issue) ||
+                GenericAcceptMirrorIssueTypes.IsAlternativeSolutionMirrorEligible(owner.Issue),
+                "not mirror eligible");
+
+            var playerManager = Server.Resolve<IPlayerManager>();
+            Assert.True(playerManager.TryGetPlayer(controllerId, out var player), "player not found by controllerId");
+
+            var conversationTracker = Server.Resolve<IIssueConversationTracker>();
+            Assert.True(conversationTracker.TryGetTrackedRequester(ownerId, out var trackedControllerId, out _),
+                $"no tracked requester for ownerId={ownerId}");
+            Assert.Equal(controllerId, trackedControllerId);
+        });
+
+        Client.Call(() =>
+        {
+            Assert.True(Client.ObjectManager.TryGetObject<Hero>(fixture.HeroId, out var owner));
             Assert.True(Client.ObjectManager.TryGetObject<Hero>(fixture.CompanionHeroId, out var companion));
             using (new AllowedThread())
             {
@@ -313,6 +345,48 @@ public class AwaitingAlternativeSolutionTroopsTests : IDisposable
 
             Assert.True(AwaitingAlternativeSolutionTroopsRegistry.TryGet(controllerId, out var deposited));
             Assert.Equal(1, deposited.TotalManCount);
+        });
+    }
+
+    [Fact]
+    public void RequestGenericIssueAcceptQuest_PeerNeverOpenedConversation_RejectedDespiteFreshGeneration()
+    {
+        var controllerId = "player-A-" + Guid.NewGuid();
+
+        var fixture = SetupVillageOwner();
+        CreateIssueOnBothPeers(fixture);
+
+        var partyId = TestEnvironment.CreateRegisteredObject<MobileParty>();
+        Server.Call(() =>
+        {
+            var playerManager = Server.Resolve<IPlayerManager>();
+            Assert.True(playerManager.AddPlayer(new Player(controllerId, fixture.HeroId, partyId, "", "")));
+        });
+        TestEnvironment.ConnectRegisteredPlayer(Client, controllerId);
+        Client.Resolve<IControllerIdProvider>().SetControllerId(controllerId);
+
+        Client.Call(() =>
+        {
+            Assert.True(Client.ObjectManager.TryGetObject<Hero>(fixture.HeroId, out var owner));
+            Assert.True(Client.ObjectManager.TryGetId(owner, out var ownerId));
+            Assert.True(IssueGenerationRegistry.TryGetGeneration(owner, out var generation));
+
+            var network = Client.Resolve<INetwork>();
+            network.SendAll(new RequestGenericIssueAcceptQuest(ownerId, generation));
+        });
+
+        var rejection = Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkGenericIssueAcceptRejected>());
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(fixture.HeroId, out var owner));
+            Assert.True(Server.ObjectManager.TryGetId(owner, out var ownerId));
+            Assert.Equal(ownerId, rejection.OwnerId);
+
+            Assert.False(IssueOwnershipRegistry.TryGetOwnerControllerId(owner, out _));
+
+            var conversationTracker = Server.Resolve<IIssueConversationTracker>();
+            Assert.False(conversationTracker.TryGetTrackedRequester(ownerId, out _, out _));
         });
     }
 

--- a/source/E2E.Tests/Services/Issues/AwaitingAlternativeSolutionTroopsTests.cs
+++ b/source/E2E.Tests/Services/Issues/AwaitingAlternativeSolutionTroopsTests.cs
@@ -234,7 +234,7 @@ public class AwaitingAlternativeSolutionTroopsTests : IDisposable
                 Hero.MainHero.ChangeState(previousState);
             }
 
-            Assert.True(AwaitingAlternativeSolutionTroopsRegistry.TryGet(controllerId, out var deposited));
+            Assert.True(Client.Resolve<IAwaitingAlternativeSolutionTroopsRegistry>().TryGet(controllerId, out var deposited));
             Assert.True(deposited.TotalManCount >= 1);
             Assert.True(deposited.TotalHeroes >= 1);
         });
@@ -242,23 +242,24 @@ public class AwaitingAlternativeSolutionTroopsTests : IDisposable
         Assert.Single(Client.NetworkSentMessages.GetMessages<RequestAwaitingAlternativeSolutionTroopsDeposit>());
         Server.Call(() =>
         {
-            Assert.True(AwaitingAlternativeSolutionTroopsRegistry.TryGet(controllerId, out var serverDeposited));
+            Assert.True(Server.Resolve<IAwaitingAlternativeSolutionTroopsRegistry>().TryGet(controllerId, out var serverDeposited));
             Assert.True(serverDeposited.TotalManCount >= 1);
             depositedManCount = serverDeposited.TotalManCount;
         });
 
         Server.Call(() =>
         {
+            var troopsRegistry = Server.Resolve<IAwaitingAlternativeSolutionTroopsRegistry>();
             var behavior = new IssuesCampaignBehavior();
             var records = new Dictionary<string, object>();
 
             behavior.SyncData(new TestDataStore(isSaving: true, records));
 
-            AwaitingAlternativeSolutionTroopsRegistry.ClearAll();
+            troopsRegistry.ClearAll();
 
             behavior.SyncData(new TestDataStore(isSaving: false, records));
 
-            Assert.True(AwaitingAlternativeSolutionTroopsRegistry.TryGet(controllerId, out var restored));
+            Assert.True(troopsRegistry.TryGet(controllerId, out var restored));
             Assert.Equal(depositedManCount, restored.TotalManCount);
         });
 
@@ -300,13 +301,13 @@ public class AwaitingAlternativeSolutionTroopsTests : IDisposable
             Assert.True(Client.ObjectManager.TryGetObject<MobileParty>(clientPartyId, out var clientParty));
             Assert.True(clientParty.MemberRoster.Contains(companion.CharacterObject));
 
-            Assert.False(AwaitingAlternativeSolutionTroopsRegistry.TryGet(controllerId, out _));
+            Assert.False(Client.Resolve<IAwaitingAlternativeSolutionTroopsRegistry>().TryGet(controllerId, out _));
         });
 
         Assert.Single(Client.NetworkSentMessages.GetMessages<RequestAwaitingAlternativeSolutionTroopsDrain>());
         Server.Call(() =>
         {
-            Assert.False(AwaitingAlternativeSolutionTroopsRegistry.TryGet(controllerId, out _));
+            Assert.False(Server.Resolve<IAwaitingAlternativeSolutionTroopsRegistry>().TryGet(controllerId, out _));
         });
     }
 
@@ -344,7 +345,7 @@ public class AwaitingAlternativeSolutionTroopsTests : IDisposable
                 Game.Current.PlayerTroop = previousPlayerTroop;
             }
 
-            Assert.True(AwaitingAlternativeSolutionTroopsRegistry.TryGet(controllerId, out var deposited));
+            Assert.True(Server.Resolve<IAwaitingAlternativeSolutionTroopsRegistry>().TryGet(controllerId, out var deposited));
             Assert.Equal(1, deposited.TotalManCount);
         });
     }

--- a/source/E2E.Tests/Services/Issues/AwaitingAlternativeSolutionTroopsTests.cs
+++ b/source/E2E.Tests/Services/Issues/AwaitingAlternativeSolutionTroopsTests.cs
@@ -109,8 +109,9 @@ public class AwaitingAlternativeSolutionTroopsTests : IDisposable
                     }
                 }
 
-                if (isServer) generation = IssueGenerationRegistry.Bump(owner);
-                else IssueGenerationRegistry.SetGeneration(owner, generation);
+                var generationRegistry = instance.Resolve<IIssueGenerationRegistry>();
+                if (isServer) generation = generationRegistry.Bump(owner);
+                else generationRegistry.SetGeneration(owner, generation);
             });
         }
     }
@@ -369,7 +370,7 @@ public class AwaitingAlternativeSolutionTroopsTests : IDisposable
         {
             Assert.True(Client.ObjectManager.TryGetObject<Hero>(fixture.HeroId, out var owner));
             Assert.True(Client.ObjectManager.TryGetId(owner, out var ownerId));
-            Assert.True(IssueGenerationRegistry.TryGetGeneration(owner, out var generation));
+            Assert.True(Client.Resolve<IIssueGenerationRegistry>().TryGetGeneration(owner, out var generation));
 
             var network = Client.Resolve<INetwork>();
             network.SendAll(new RequestGenericIssueAcceptQuest(ownerId, generation));

--- a/source/E2E.Tests/Services/Issues/AwaitingAlternativeSolutionTroopsTests.cs
+++ b/source/E2E.Tests/Services/Issues/AwaitingAlternativeSolutionTroopsTests.cs
@@ -212,7 +212,7 @@ public class AwaitingAlternativeSolutionTroopsTests : IDisposable
         Server.Call(() =>
         {
             Assert.True(Server.ObjectManager.TryGetObject<Hero>(fixture.HeroId, out var owner));
-            Assert.True(IssueOwnershipRegistry.TryGetOwnerControllerId(owner, out var ownerControllerId));
+            Assert.True(Server.Resolve<IIssueOwnershipRegistry>().TryGetOwnerControllerId(owner, out var ownerControllerId));
             Assert.Equal(controllerId, ownerControllerId);
         });
 
@@ -321,7 +321,7 @@ public class AwaitingAlternativeSolutionTroopsTests : IDisposable
         {
             Assert.True(Server.ObjectManager.TryGetObject<Hero>(fixture.HeroId, out var owner));
             Assert.True(Server.ObjectManager.TryGetObject<Hero>(fixture.CompanionHeroId, out var companion));
-            IssueOwnershipRegistry.SetOwner(owner, controllerId);
+            Server.Resolve<IIssueOwnershipRegistry>().SetOwner(owner, controllerId);
 
             using (new AllowedThread())
             {
@@ -383,7 +383,7 @@ public class AwaitingAlternativeSolutionTroopsTests : IDisposable
             Assert.True(Server.ObjectManager.TryGetId(owner, out var ownerId));
             Assert.Equal(ownerId, rejection.OwnerId);
 
-            Assert.False(IssueOwnershipRegistry.TryGetOwnerControllerId(owner, out _));
+            Assert.False(Server.Resolve<IIssueOwnershipRegistry>().TryGetOwnerControllerId(owner, out _));
 
             var conversationTracker = Server.Resolve<IIssueConversationTracker>();
             Assert.False(conversationTracker.TryGetTrackedRequester(ownerId, out _, out _));

--- a/source/E2E.Tests/Services/Issues/GenericQuestTypeAcceptSecurityTests.cs
+++ b/source/E2E.Tests/Services/Issues/GenericQuestTypeAcceptSecurityTests.cs
@@ -1,0 +1,279 @@
+using Common.Util;
+using E2E.Tests.Environment;
+using E2E.Tests.Environment.Instance;
+using GameInterface.Services.Entity;
+using GameInterface.Services.Issues.Generic;
+using GameInterface.Services.Issues.Interfaces;
+using GameInterface.Services.Issues.Messages;
+using GameInterface.Services.Players;
+using GameInterface.Services.Players.Data;
+using HarmonyLib;
+using System;
+using System.Linq;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Encyclopedia;
+using TaleWorlds.CampaignSystem.Issues;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.Core;
+using Xunit.Abstractions;
+
+namespace E2E.Tests.Services.Issues;
+
+public class GenericQuestTypeAcceptSecurityTests : IDisposable
+{
+    private E2ETestEnvironment TestEnvironment { get; }
+    private EnvironmentInstance Server => TestEnvironment.Server;
+    private EnvironmentInstance Client => TestEnvironment.Clients.First();
+
+    private static readonly Type TestIssueType = typeof(VillageNeedsToolsIssueBehavior.VillageNeedsToolsIssue);
+
+    public GenericQuestTypeAcceptSecurityTests(ITestOutputHelper output)
+    {
+        TestEnvironment = new E2ETestEnvironment(output);
+
+        GenericAcceptMirrorIssueTypes.QuestSolutionMirrorEligible.Remove(TestIssueType);
+        GenericAcceptMirrorIssueTypes.AlternativeSolutionMirrorEligible.Remove(TestIssueType);
+
+        QuestTypeRegistry.Register(
+            QuestDescriptorBuilder.For<VillageNeedsToolsIssueBehavior.VillageNeedsToolsIssue, TaleWorlds.CampaignSystem.QuestBase>("VillageNeedsToolsTestOnly")
+                .WithQuestSolutionAccept()
+                .WithAlternativeAccept()
+                .Build());
+    }
+
+    public void Dispose()
+    {
+        QuestTypeRegistry.ClearAllForTests();
+        GenericAcceptMirrorIssueTypes.QuestSolutionMirrorEligible.Add(TestIssueType);
+        GenericAcceptMirrorIssueTypes.AlternativeSolutionMirrorEligible.Add(TestIssueType);
+        TestEnvironment.Dispose();
+    }
+
+    private record VillageFixture(string HeroId, string VillageId, string SettlementId, string ItemId, string CompanionHeroId);
+
+    private VillageFixture SetupVillageOwner()
+    {
+        var heroId = TestEnvironment.CreateRegisteredObject<Hero>();
+        var villageId = TestEnvironment.CreateRegisteredObject<Village>();
+        var settlementId = TestEnvironment.CreateRegisteredObject<Settlement>();
+        var itemId = TestEnvironment.CreateRegisteredObject<ItemObject>();
+        var companionHeroId = TestEnvironment.CreateRegisteredObject<Hero>();
+
+        foreach (var instance in new[] { Server, Client })
+        {
+            instance.Call(() =>
+            {
+                Assert.True(instance.ObjectManager.TryGetObject<Hero>(heroId, out var hero));
+                Assert.True(instance.ObjectManager.TryGetObject<Village>(villageId, out var village));
+                Assert.True(instance.ObjectManager.TryGetObject<Settlement>(settlementId, out var settlement));
+                Assert.True(instance.ObjectManager.TryGetObject<ItemObject>(itemId, out var item));
+                Assert.True(instance.ObjectManager.TryGetObject<Hero>(companionHeroId, out var companion));
+
+                using (new AllowedThread())
+                {
+                    Campaign.Current.EncyclopediaManager ??= new EncyclopediaManager();
+                    Campaign.Current.EncyclopediaManager.CreateEncyclopediaPages();
+
+                    settlement.SetSettlementComponent(village);
+                    village.Bound = settlement;
+                    village.Hearth = 650f;
+                    hero.StayingInSettlement = settlement;
+                    hero.Occupation = Occupation.RuralNotable;
+                    AccessTools.Property(typeof(ItemObject), nameof(ItemObject.Value)).SetValue(item, 40);
+                    companion.ChangeState(Hero.CharacterStates.Disabled);
+                }
+            });
+        }
+
+        return new VillageFixture(heroId, villageId, settlementId, itemId, companionHeroId);
+    }
+
+    private void CreateIssueOnBothPeers(VillageFixture fixture)
+    {
+        var generation = 0;
+        foreach (var instance in new[] { Server, Client })
+        {
+            var isServer = instance == Server;
+            instance.Call(() =>
+            {
+                Assert.True(instance.ObjectManager.TryGetObject<Hero>(fixture.HeroId, out var owner));
+                Assert.True(instance.ObjectManager.TryGetObject<ItemObject>(fixture.ItemId, out var requestedItem));
+
+                if (owner.Issue == null)
+                {
+                    var pid = new PotentialIssueData(
+                        (in PotentialIssueData _, Hero h) => new VillageNeedsToolsIssueBehavior.VillageNeedsToolsIssue(h, requestedItem),
+                        typeof(VillageNeedsToolsIssueBehavior.VillageNeedsToolsIssue),
+                        IssueBase.IssueFrequency.VeryCommon);
+
+                    using (new AllowedThread())
+                    {
+                        Assert.True(Campaign.Current.IssueManager.CreateNewIssue(in pid, owner));
+                    }
+                }
+
+                var generationRegistry = instance.Resolve<IIssueGenerationRegistry>();
+                if (isServer) generation = generationRegistry.Bump(owner);
+                else generationRegistry.SetGeneration(owner, generation);
+            });
+        }
+    }
+
+    private string ConnectPlayer(VillageFixture fixture)
+    {
+        var controllerId = "player-A-" + Guid.NewGuid();
+        var partyId = TestEnvironment.CreateRegisteredObject<MobileParty>();
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(partyId, out var party));
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(fixture.CompanionHeroId, out var companion));
+            using (new AllowedThread())
+            {
+                party.MemberRoster.AddToCounts(companion.CharacterObject, 1);
+            }
+
+            var playerManager = Server.Resolve<IPlayerManager>();
+            Assert.True(playerManager.AddPlayer(new Player(controllerId, fixture.HeroId, partyId, "", "")));
+        });
+        TestEnvironment.ConnectRegisteredPlayer(Client, controllerId);
+        Client.Resolve<IControllerIdProvider>().SetControllerId(controllerId);
+        return controllerId;
+    }
+
+    private void OpenConversation(VillageFixture fixture, string controllerId)
+    {
+        Client.Call(() =>
+        {
+            Assert.True(Client.ObjectManager.TryGetObject<Hero>(fixture.HeroId, out var owner));
+            Common.Messaging.MessageBroker.Instance.Publish(owner, new IssueConversationOpenedLocally(owner, controllerId));
+        });
+    }
+
+    [Fact]
+    public void RequestQuestTypeAcceptQuest_PeerNeverOpenedConversation_RejectedDespiteFreshGeneration()
+    {
+        var fixture = SetupVillageOwner();
+        CreateIssueOnBothPeers(fixture);
+        var controllerId = ConnectPlayer(fixture);
+
+        Client.Call(() =>
+        {
+            Assert.True(Client.ObjectManager.TryGetObject<Hero>(fixture.HeroId, out var owner));
+            Assert.True(Client.ObjectManager.TryGetId(owner, out var ownerId));
+            Assert.True(Client.Resolve<IIssueGenerationRegistry>().TryGetGeneration(owner, out var generation));
+
+            var network = Client.Resolve<Common.Network.INetwork>();
+            network.SendAll(new RequestQuestTypeAcceptQuest(ownerId, generation));
+        });
+
+        var rejection = Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkQuestTypeAcceptRejected>());
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(fixture.HeroId, out var owner));
+            Assert.True(Server.ObjectManager.TryGetId(owner, out var ownerId));
+            Assert.Equal(ownerId, rejection.OwnerId);
+            Assert.False(Server.Resolve<IIssueOwnershipRegistry>().TryGetOwnerControllerId(owner, out _));
+        });
+    }
+
+    [Fact]
+    public void RequestQuestTypeAcceptAlternative_PeerNeverOpenedConversation_RejectedDespiteFreshGeneration()
+    {
+        var fixture = SetupVillageOwner();
+        CreateIssueOnBothPeers(fixture);
+        var controllerId = ConnectPlayer(fixture);
+
+        Client.Call(() =>
+        {
+            Assert.True(Client.ObjectManager.TryGetObject<Hero>(fixture.HeroId, out var owner));
+            Assert.True(Client.ObjectManager.TryGetId(owner, out var ownerId));
+            Assert.True(Client.Resolve<IIssueGenerationRegistry>().TryGetGeneration(owner, out var generation));
+
+            var troopRosterInterface = Client.Resolve<GameInterface.Services.TroopRosters.Interfaces.ITroopRosterInterface>();
+            var packedTroops = troopRosterInterface.PackTroopRosterData(owner.Issue.AlternativeSolutionSentTroops);
+
+            var network = Client.Resolve<Common.Network.INetwork>();
+            network.SendAll(new RequestQuestTypeAcceptAlternative(ownerId, generation, packedTroops));
+        });
+
+        var rejection = Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkQuestTypeAcceptRejected>());
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(fixture.HeroId, out var owner));
+            Assert.True(Server.ObjectManager.TryGetId(owner, out var ownerId));
+            Assert.Equal(ownerId, rejection.OwnerId);
+            Assert.False(Server.Resolve<IIssueOwnershipRegistry>().TryGetOwnerControllerId(owner, out _));
+        });
+    }
+
+    [Fact]
+    public void RequestQuestTypeAcceptAlternative_GenuineAccept_BroadcastStateIsServerComputedNotClientSupplied()
+    {
+        var fixture = SetupVillageOwner();
+        CreateIssueOnBothPeers(fixture);
+        var controllerId = ConnectPlayer(fixture);
+        OpenConversation(fixture, controllerId);
+
+        Client.Call(() =>
+        {
+            Assert.True(Client.ObjectManager.TryGetObject<Hero>(fixture.HeroId, out var owner));
+            Assert.True(Client.ObjectManager.TryGetObject<Hero>(fixture.CompanionHeroId, out var companion));
+            using (new AllowedThread())
+            {
+                owner.Issue.AlternativeSolutionSentTroops.AddToCounts(companion.CharacterObject, 1);
+            }
+
+            owner.Issue.StartIssueWithAlternativeSolution();
+        });
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(fixture.HeroId, out var owner));
+
+            Assert.True(owner.Issue.IsSolvingWithAlternative);
+            Assert.True(owner.Issue.AlternativeSolutionReturnTimeForTroops.IsFuture);
+
+            Assert.True(Server.Resolve<IIssueOwnershipRegistry>().TryGetOwnerControllerId(owner, out var ownerControllerId));
+            Assert.Equal(controllerId, ownerControllerId);
+        });
+
+        var accepted = Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkQuestTypeAlternativeAccepted>());
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(fixture.HeroId, out var owner));
+            Assert.Equal(owner.Issue.AlternativeSolutionReturnTimeForTroops, accepted.State.ReturnTime);
+        });
+    }
+
+    [Fact]
+    public void RequestQuestTypeAcceptQuest_GenuineAccept_SetsOwnershipAndBroadcasts()
+    {
+        var fixture = SetupVillageOwner();
+        CreateIssueOnBothPeers(fixture);
+        var controllerId = ConnectPlayer(fixture);
+        OpenConversation(fixture, controllerId);
+
+        Client.Call(() =>
+        {
+            Assert.True(Client.ObjectManager.TryGetObject<Hero>(fixture.HeroId, out var owner));
+            Assert.True(Client.ObjectManager.TryGetId(owner, out var ownerId));
+            Assert.True(Client.Resolve<IIssueGenerationRegistry>().TryGetGeneration(owner, out var generation));
+
+            var network = Client.Resolve<Common.Network.INetwork>();
+            network.SendAll(new RequestQuestTypeAcceptQuest(ownerId, generation));
+        });
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(fixture.HeroId, out var owner));
+            Assert.True(Server.Resolve<IIssueOwnershipRegistry>().TryGetOwnerControllerId(owner, out var ownerControllerId));
+            Assert.Equal(controllerId, ownerControllerId);
+        });
+
+        Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkQuestTypeQuestAccepted>());
+    }
+}

--- a/source/GameInterface.Tests/Services/Issues/Generic/QuestTypeRegistryTests.cs
+++ b/source/GameInterface.Tests/Services/Issues/Generic/QuestTypeRegistryTests.cs
@@ -169,9 +169,14 @@ public class QuestTypeRegistryTests : IDisposable
 
     private sealed class FakeAlternativeStrategy : IAlternativeAcceptMirrorStrategy<int>
     {
+        public bool ReplayCalled;
         public int? MirroredValue;
         public bool RejectCalled;
+        public bool CaptureSucceeds = true;
+        public int CaptureValue = 99;
 
+        public void ReplayAlternativeAccepted(Hero owner) => ReplayCalled = true;
+        public bool TryCaptureAlternativeFields(Hero owner, out int payload) { payload = CaptureValue; return CaptureSucceeds; }
         public void MirrorAlternativeAccepted(Hero owner, int payload) => MirroredValue = payload;
         public void RejectAcceptance(Hero owner) => RejectCalled = true;
     }
@@ -238,13 +243,50 @@ public class QuestTypeRegistryTests : IDisposable
             .WithAlternativeAccept(strategy)
             .Build();
         var owner = ObjectHelper.SkipConstructor<Hero>();
-        var payloadBytes = GenericAcceptFieldsSerializer.Serialize(99);
 
-        descriptor.MirrorAlternativeAcceptBytes(owner, payloadBytes);
-        Assert.Equal(99, strategy.MirroredValue);
+        var (accepted, fieldsBytes) = descriptor.TryArbitrateAlternativeAcceptBytes(owner, _ => true);
+
+        Assert.True(accepted);
+        Assert.True(strategy.ReplayCalled);
+        Assert.NotNull(fieldsBytes);
+
+        descriptor.MirrorAlternativeAcceptBytes(owner, fieldsBytes);
+        Assert.Equal(strategy.CaptureValue, strategy.MirroredValue);
 
         descriptor.RejectAlternativeAccept(owner);
         Assert.True(strategy.RejectCalled);
+    }
+
+    [Fact]
+    public void TryArbitrateAlternativeAcceptBytes_CaptureFails_RejectsAndReturnsFalse()
+    {
+        var strategy = new FakeAlternativeStrategy { CaptureSucceeds = false };
+        var descriptor = QuestDescriptorBuilder.For<FakeIssueA, FakeQuestA>("FakeA")
+            .WithAlternativeAccept(strategy)
+            .Build();
+        var owner = ObjectHelper.SkipConstructor<Hero>();
+
+        var (accepted, fieldsBytes) = descriptor.TryArbitrateAlternativeAcceptBytes(owner, _ => true);
+
+        Assert.False(accepted);
+        Assert.Null(fieldsBytes);
+        Assert.True(strategy.RejectCalled);
+    }
+
+    [Fact]
+    public void TryArbitrateAlternativeAcceptBytes_CanAcceptReturnsFalse_NeverReplaysOrCaptures()
+    {
+        var strategy = new FakeAlternativeStrategy();
+        var descriptor = QuestDescriptorBuilder.For<FakeIssueA, FakeQuestA>("FakeA")
+            .WithAlternativeAccept(strategy)
+            .Build();
+        var owner = ObjectHelper.SkipConstructor<Hero>();
+
+        var (accepted, fieldsBytes) = descriptor.TryArbitrateAlternativeAcceptBytes(owner, _ => false);
+
+        Assert.False(accepted);
+        Assert.Null(fieldsBytes);
+        Assert.False(strategy.ReplayCalled);
     }
 
     [Fact]
@@ -255,8 +297,62 @@ public class QuestTypeRegistryTests : IDisposable
         Assert.Null(descriptor.TryArbitrateQuestSolutionAcceptBytes);
         Assert.Null(descriptor.MirrorQuestSolutionAcceptBytes);
         Assert.Null(descriptor.RejectQuestSolutionAccept);
+        Assert.Null(descriptor.TryArbitrateAlternativeAcceptBytes);
         Assert.Null(descriptor.MirrorAlternativeAcceptBytes);
         Assert.Null(descriptor.RejectAlternativeAccept);
+    }
+
+    [Fact]
+    public void SupportsQuestSolutionAndAlternativeAccept_AreFalse_WhenNeverWired()
+    {
+        var descriptor = QuestDescriptorBuilder.For<FakeIssueB, FakeQuestB>("FakeB").Build();
+
+        Assert.False(descriptor.SupportsQuestSolutionAccept);
+        Assert.False(descriptor.SupportsAlternativeAccept);
+    }
+
+    [Fact]
+    public void WithQuestSolutionAccept_NoArgOverload_SetsSupportFlagWithoutByteBlobDelegates()
+    {
+        var descriptor = QuestDescriptorBuilder.For<FakeIssueA, FakeQuestA>("FakeA")
+            .WithQuestSolutionAccept()
+            .Build();
+
+        Assert.True(descriptor.SupportsQuestSolutionAccept);
+        Assert.Null(descriptor.TryArbitrateQuestSolutionAcceptBytes);
+        Assert.Null(descriptor.MirrorQuestSolutionAcceptBytes);
+    }
+
+    [Fact]
+    public void WithAlternativeAccept_NoArgOverload_SetsSupportFlagWithoutByteBlobDelegates()
+    {
+        var descriptor = QuestDescriptorBuilder.For<FakeIssueA, FakeQuestA>("FakeA")
+            .WithAlternativeAccept()
+            .Build();
+
+        Assert.True(descriptor.SupportsAlternativeAccept);
+        Assert.Null(descriptor.TryArbitrateAlternativeAcceptBytes);
+        Assert.Null(descriptor.MirrorAlternativeAcceptBytes);
+    }
+
+    [Fact]
+    public void WithQuestSolutionAccept_ByteBlobOverload_AlsoSetsSupportFlag()
+    {
+        var descriptor = QuestDescriptorBuilder.For<FakeIssueA, FakeQuestA>("FakeA")
+            .WithQuestSolutionAccept(new FakeQuestSolutionStrategy())
+            .Build();
+
+        Assert.True(descriptor.SupportsQuestSolutionAccept);
+    }
+
+    [Fact]
+    public void WithAlternativeAccept_ByteBlobOverload_AlsoSetsSupportFlag()
+    {
+        var descriptor = QuestDescriptorBuilder.For<FakeIssueA, FakeQuestA>("FakeA")
+            .WithAlternativeAccept(new FakeAlternativeStrategy())
+            .Build();
+
+        Assert.True(descriptor.SupportsAlternativeAccept);
     }
 }
 

--- a/source/GameInterface.Tests/Services/Issues/VillageNeedsToolsIssueOwnershipTests.cs
+++ b/source/GameInterface.Tests/Services/Issues/VillageNeedsToolsIssueOwnershipTests.cs
@@ -15,14 +15,10 @@ namespace GameInterface.Tests.Services.Issues;
 [Collection(ModInformationRoleCollection.Name)]
 public class VillageNeedsToolsIssueOwnershipTests : IDisposable
 {
-    public VillageNeedsToolsIssueOwnershipTests()
-    {
-        IssueOwnershipRegistry.ClearAll();
-    }
+    private readonly IIssueOwnershipRegistry registry = new IssueOwnershipRegistry();
 
     public void Dispose()
     {
-        IssueOwnershipRegistry.ClearAll();
         ContainerProvider.Clear();
     }
 
@@ -42,13 +38,13 @@ public class VillageNeedsToolsIssueOwnershipTests : IDisposable
     public void IsLocalPeerOwner_TrueOnlyOnTheMachineWhoseControllerIdMatchesTheRecordedOwner()
     {
         var issueGiver = NewHero();
-        IssueOwnershipRegistry.SetOwner(issueGiver, "player-A");
+        registry.SetOwner(issueGiver, "player-A");
 
         SetLocalControllerId("player-A");
-        Assert.True(IssueOwnershipRegistry.IsLocalPeerOwner(issueGiver));
+        Assert.True(registry.IsLocalPeerOwner(issueGiver));
 
         SetLocalControllerId("player-B");
-        Assert.False(IssueOwnershipRegistry.IsLocalPeerOwner(issueGiver));
+        Assert.False(registry.IsLocalPeerOwner(issueGiver));
     }
 
     [Fact]
@@ -57,17 +53,17 @@ public class VillageNeedsToolsIssueOwnershipTests : IDisposable
         var issueGiver = NewHero();
         SetLocalControllerId("player-A");
 
-        Assert.False(IssueOwnershipRegistry.IsLocalPeerOwner(issueGiver));
+        Assert.False(registry.IsLocalPeerOwner(issueGiver));
     }
 
     [Fact]
     public void IsLocalPeerOwner_FalseWhenNoControllerIdProviderCanBeResolved()
     {
         var issueGiver = NewHero();
-        IssueOwnershipRegistry.SetOwner(issueGiver, "player-A");
+        registry.SetOwner(issueGiver, "player-A");
         ContainerProvider.Clear();
 
-        Assert.False(IssueOwnershipRegistry.IsLocalPeerOwner(issueGiver));
+        Assert.False(registry.IsLocalPeerOwner(issueGiver));
     }
 
     [Fact]
@@ -75,20 +71,20 @@ public class VillageNeedsToolsIssueOwnershipTests : IDisposable
     {
         var issueGiver = NewHero();
 
-        IssueOwnershipRegistry.SetOwner(issueGiver, null);
-        IssueOwnershipRegistry.SetOwner(issueGiver, string.Empty);
+        registry.SetOwner(issueGiver, null);
+        registry.SetOwner(issueGiver, string.Empty);
 
-        Assert.False(IssueOwnershipRegistry.TryGetOwnerControllerId(issueGiver, out _));
+        Assert.False(registry.TryGetOwnerControllerId(issueGiver, out _));
     }
 
     [Fact]
     public void SetOwner_OverwritesAPreviouslyRecordedOwnerForTheSameHero()
     {
         var issueGiver = NewHero();
-        IssueOwnershipRegistry.SetOwner(issueGiver, "player-A");
-        IssueOwnershipRegistry.SetOwner(issueGiver, "player-B");
+        registry.SetOwner(issueGiver, "player-A");
+        registry.SetOwner(issueGiver, "player-B");
 
-        Assert.True(IssueOwnershipRegistry.TryGetOwnerControllerId(issueGiver, out var controllerId));
+        Assert.True(registry.TryGetOwnerControllerId(issueGiver, out var controllerId));
         Assert.Equal("player-B", controllerId);
     }
 
@@ -97,13 +93,13 @@ public class VillageNeedsToolsIssueOwnershipTests : IDisposable
     {
         var issueGiver = NewHero();
         var otherIssueGiver = NewHero();
-        IssueOwnershipRegistry.SetOwner(issueGiver, "player-A");
-        IssueOwnershipRegistry.SetOwner(otherIssueGiver, "player-B");
+        registry.SetOwner(issueGiver, "player-A");
+        registry.SetOwner(otherIssueGiver, "player-B");
 
-        IssueOwnershipRegistry.Clear(issueGiver);
+        registry.Clear(issueGiver);
 
-        Assert.False(IssueOwnershipRegistry.TryGetOwnerControllerId(issueGiver, out _));
-        Assert.True(IssueOwnershipRegistry.TryGetOwnerControllerId(otherIssueGiver, out var otherControllerId));
+        Assert.False(registry.TryGetOwnerControllerId(issueGiver, out _));
+        Assert.True(registry.TryGetOwnerControllerId(otherIssueGiver, out var otherControllerId));
         Assert.Equal("player-B", otherControllerId);
     }
 
@@ -112,25 +108,25 @@ public class VillageNeedsToolsIssueOwnershipTests : IDisposable
     {
         var heroA = NewHero();
         var heroB = NewHero();
-        IssueOwnershipRegistry.SetOwner(heroA, "player-A");
-        IssueOwnershipRegistry.SetOwner(heroB, "player-B");
+        registry.SetOwner(heroA, "player-A");
+        registry.SetOwner(heroB, "player-B");
 
-        var snapshot = IssueOwnershipRegistry.Snapshot().ToList();
+        var snapshot = registry.Snapshot().ToList();
         Assert.Equal(2, snapshot.Count);
         Assert.Contains(snapshot, kvp => kvp.Key == heroA && kvp.Value == "player-A");
         Assert.Contains(snapshot, kvp => kvp.Key == heroB && kvp.Value == "player-B");
 
-        IssueOwnershipRegistry.ClearAll();
-        Assert.Empty(IssueOwnershipRegistry.Snapshot());
+        registry.ClearAll();
+        Assert.Empty(registry.Snapshot());
 
         foreach (var kvp in snapshot)
         {
-            IssueOwnershipRegistry.SetOwner(kvp.Key, kvp.Value);
+            registry.SetOwner(kvp.Key, kvp.Value);
         }
 
-        Assert.True(IssueOwnershipRegistry.TryGetOwnerControllerId(heroA, out var idA));
+        Assert.True(registry.TryGetOwnerControllerId(heroA, out var idA));
         Assert.Equal("player-A", idA);
-        Assert.True(IssueOwnershipRegistry.TryGetOwnerControllerId(heroB, out var idB));
+        Assert.True(registry.TryGetOwnerControllerId(heroB, out var idB));
         Assert.Equal("player-B", idB);
     }
 }

--- a/source/GameInterface/GameInterfaceModule.cs
+++ b/source/GameInterface/GameInterfaceModule.cs
@@ -15,6 +15,7 @@ using GameInterface.Services.Chat;
 using GameInterface.Services.Entity;
 using GameInterface.Services.GameDebug.Metrics;
 using GameInterface.Services.Issues.Generic;
+using GameInterface.Services.Issues.Interfaces;
 using GameInterface.Services.Kingdoms;
 using GameInterface.Services.LiveTesting;
 using GameInterface.Services.Locations;
@@ -70,6 +71,7 @@ public class GameInterfaceModule : Module
         builder.RegisterType<IssueConversationTracker>().As<IIssueConversationTracker>().InstancePerLifetimeScope();
         builder.RegisterType<IssueOwnershipRegistry>().As<IIssueOwnershipRegistry>().InstancePerLifetimeScope();
         builder.RegisterType<IssueGenerationRegistry>().As<IIssueGenerationRegistry>().InstancePerLifetimeScope();
+        builder.RegisterType<AwaitingAlternativeSolutionTroopsRegistry>().As<IAwaitingAlternativeSolutionTroopsRegistry>().InstancePerLifetimeScope();
         builder.RegisterType<BattleHostRegistry>().As<IBattleHostRegistry>().InstancePerLifetimeScope();
         builder.RegisterType<LocationHostRegistry>().As<ILocationHostRegistry>().InstancePerLifetimeScope();
         builder.RegisterType<BattleAgentBudget>().As<IBattleAgentBudget>().InstancePerDependency();

--- a/source/GameInterface/GameInterfaceModule.cs
+++ b/source/GameInterface/GameInterfaceModule.cs
@@ -67,6 +67,7 @@ public class GameInterfaceModule : Module
         builder.RegisterType<PeacePursuitCleaner>().As<IPeacePursuitCleaner>().InstancePerDependency();
         builder.RegisterType<PartyVisibilitySweep>().As<IPartyVisibilitySweep>().InstancePerDependency();
         builder.RegisterType<ConversationRestartContextTracker>().As<IConversationRestartContextTracker>().InstancePerLifetimeScope();
+        builder.RegisterType<IssueConversationTracker>().As<IIssueConversationTracker>().InstancePerLifetimeScope();
         builder.RegisterType<BattleHostRegistry>().As<IBattleHostRegistry>().InstancePerLifetimeScope();
         builder.RegisterType<LocationHostRegistry>().As<ILocationHostRegistry>().InstancePerLifetimeScope();
         builder.RegisterType<BattleAgentBudget>().As<IBattleAgentBudget>().InstancePerDependency();

--- a/source/GameInterface/GameInterfaceModule.cs
+++ b/source/GameInterface/GameInterfaceModule.cs
@@ -68,6 +68,7 @@ public class GameInterfaceModule : Module
         builder.RegisterType<PartyVisibilitySweep>().As<IPartyVisibilitySweep>().InstancePerDependency();
         builder.RegisterType<ConversationRestartContextTracker>().As<IConversationRestartContextTracker>().InstancePerLifetimeScope();
         builder.RegisterType<IssueConversationTracker>().As<IIssueConversationTracker>().InstancePerLifetimeScope();
+        builder.RegisterType<IssueOwnershipRegistry>().As<IIssueOwnershipRegistry>().InstancePerLifetimeScope();
         builder.RegisterType<BattleHostRegistry>().As<IBattleHostRegistry>().InstancePerLifetimeScope();
         builder.RegisterType<LocationHostRegistry>().As<ILocationHostRegistry>().InstancePerLifetimeScope();
         builder.RegisterType<BattleAgentBudget>().As<IBattleAgentBudget>().InstancePerDependency();

--- a/source/GameInterface/GameInterfaceModule.cs
+++ b/source/GameInterface/GameInterfaceModule.cs
@@ -69,6 +69,7 @@ public class GameInterfaceModule : Module
         builder.RegisterType<ConversationRestartContextTracker>().As<IConversationRestartContextTracker>().InstancePerLifetimeScope();
         builder.RegisterType<IssueConversationTracker>().As<IIssueConversationTracker>().InstancePerLifetimeScope();
         builder.RegisterType<IssueOwnershipRegistry>().As<IIssueOwnershipRegistry>().InstancePerLifetimeScope();
+        builder.RegisterType<IssueGenerationRegistry>().As<IIssueGenerationRegistry>().InstancePerLifetimeScope();
         builder.RegisterType<BattleHostRegistry>().As<IBattleHostRegistry>().InstancePerLifetimeScope();
         builder.RegisterType<LocationHostRegistry>().As<ILocationHostRegistry>().InstancePerLifetimeScope();
         builder.RegisterType<BattleAgentBudget>().As<IBattleAgentBudget>().InstancePerDependency();

--- a/source/GameInterface/Services/Issues/Generic/AcceptMirror/AcceptMirrorSupport.cs
+++ b/source/GameInterface/Services/Issues/Generic/AcceptMirror/AcceptMirrorSupport.cs
@@ -10,7 +10,7 @@ internal static class AcceptMirrorSupport
     {
         if (owner?.Issue == null || owner.Issue.IsOngoingWithoutQuest) return;
         if (owner.Issue.IssueQuest == null) return;
-        if (IssueOwnershipRegistry.IsLocalPeerOwner(owner)) return;
+        if (ContainerProvider.TryResolve<IIssueOwnershipRegistry>(out var ownershipRegistry) && ownershipRegistry.IsLocalPeerOwner(owner)) return;
 
         using (new AllowedThread())
         {

--- a/source/GameInterface/Services/Issues/Generic/AcceptMirror/IAlternativeAcceptMirrorStrategy.cs
+++ b/source/GameInterface/Services/Issues/Generic/AcceptMirror/IAlternativeAcceptMirrorStrategy.cs
@@ -11,6 +11,10 @@ namespace GameInterface.Services.Issues.Generic.AcceptMirror;
 
 public interface IAlternativeAcceptMirrorStrategy<TPayload>
 {
+    void ReplayAlternativeAccepted(Hero owner);
+
+    bool TryCaptureAlternativeFields(Hero owner, out TPayload payload);
+
     void MirrorAlternativeAccepted(Hero owner, TPayload payload);
 
     void RejectAcceptance(Hero owner);
@@ -89,6 +93,18 @@ public sealed class AlternativeAcceptMirrorHandler<TPayload>
     public AlternativeAcceptMirrorHandler(IAlternativeAcceptMirrorStrategy<TPayload> strategy)
     {
         _strategy = strategy;
+    }
+
+    public bool TryArbitrate(Hero owner, System.Func<Hero, bool> canAccept, out TPayload payload)
+    {
+        payload = default;
+        if (owner == null || canAccept == null || !canAccept(owner)) return false;
+
+        _strategy.ReplayAlternativeAccepted(owner);
+        if (_strategy.TryCaptureAlternativeFields(owner, out payload)) return true;
+
+        _strategy.RejectAcceptance(owner);
+        return false;
     }
 
     public void Mirror(Hero owner, TPayload payload) => _strategy.MirrorAlternativeAccepted(owner, payload);

--- a/source/GameInterface/Services/Issues/Generic/AlternativeSolutionCompletion.cs
+++ b/source/GameInterface/Services/Issues/Generic/AlternativeSolutionCompletion.cs
@@ -30,7 +30,7 @@ public static class AlternativeSolutionCompletionRunner
     {
         if (owner?.Issue is not IssueBase issue) return false;
         if (!issue.IsSolvingWithAlternative || !issue.AlternativeSolutionReturnTimeForTroops.IsPast) return false;
-        if (!IssueOwnershipRegistry.IsLocalPeerOwner(owner)) return false;
+        if (!ContainerProvider.TryResolve<IIssueOwnershipRegistry>(out var ownershipRegistry) || !ownershipRegistry.IsLocalPeerOwner(owner)) return false;
 
         if (ModInformation.IsServer)
         {
@@ -57,7 +57,7 @@ public static class AlternativeSolutionCompletionRunner
 
     private static IDisposable ResolveTrueOwnerScope(Hero issueOwner)
     {
-        if (!IssueOwnershipRegistry.TryGetOwnerControllerId(issueOwner, out var controllerId)) return NullScope.Instance;
+        if (!ContainerProvider.TryResolve<IIssueOwnershipRegistry>(out var ownershipRegistry) || !ownershipRegistry.TryGetOwnerControllerId(issueOwner, out var controllerId)) return NullScope.Instance;
         if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager)) return NullScope.Instance;
         if (!playerManager.TryGetPlayer(controllerId, out var player)) return NullScope.Instance;
         if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)) return NullScope.Instance;

--- a/source/GameInterface/Services/Issues/Generic/AlternativeSolutionStart.cs
+++ b/source/GameInterface/Services/Issues/Generic/AlternativeSolutionStart.cs
@@ -1,0 +1,52 @@
+using System;
+using GameInterface.Services.Heroes.Patches;
+using GameInterface.Services.Issues.Generic.AcceptMirror;
+using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Players.Data;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Issues;
+using TaleWorlds.CampaignSystem.Party;
+
+namespace GameInterface.Services.Issues.Generic;
+
+public sealed class AlternativeSolutionStartAuthorityGuard : IDisposable
+{
+    [ThreadStatic]
+    private static int _count;
+
+    public AlternativeSolutionStartAuthorityGuard() => _count++;
+
+    public void Dispose() => _count = _count > 0 ? _count - 1 : 0;
+
+    public static bool IsActive => _count > 0;
+}
+
+public static class AlternativeSolutionStartRunner
+{
+    public static AlternativeSolutionVanillaState StartOnServer(Hero owner, Player truePlayer)
+    {
+        using (new AlternativeSolutionStartAuthorityGuard())
+        using (ResolveOwnerScope(truePlayer))
+        {
+            owner.Issue.StartIssueWithAlternativeSolution();
+            return AlternativeSolutionVanillaStateSync.Capture(owner.Issue);
+        }
+    }
+
+    private static IDisposable ResolveOwnerScope(Player truePlayer)
+    {
+        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)) return NullScope.Instance;
+        if (!objectManager.TryGetObjectWithLogging<Hero>(truePlayer.HeroId, out var trueOwnerHero)) return NullScope.Instance;
+
+        objectManager.TryGetObjectWithLogging<MobileParty>(truePlayer.MobilePartyId, out var trueOwnerParty);
+
+        return new MainHeroSubstitutionScope(trueOwnerHero, trueOwnerParty);
+    }
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+
+        public void Dispose() { }
+    }
+}

--- a/source/GameInterface/Services/Issues/Generic/Dispatch/GenericQuestTypeDispatchPatches.cs
+++ b/source/GameInterface/Services/Issues/Generic/Dispatch/GenericQuestTypeDispatchPatches.cs
@@ -69,7 +69,7 @@ internal class GenericQuestTypeAlternativeSolutionOwnershipGatePatch
     {
         if (!QuestTypeRegistry.IsRegistered(__instance?.GetType())) return true;
 
-        return IssueOwnershipRegistry.IsLocalPeerOwner(__instance.IssueOwner)
+        return (ContainerProvider.TryResolve<IIssueOwnershipRegistry>(out var ownershipRegistry) && ownershipRegistry.IsLocalPeerOwner(__instance.IssueOwner))
             || AlternativeSolutionCompletionAuthorityGuard.IsActive;
     }
 }

--- a/source/GameInterface/Services/Issues/Generic/Dispatch/GenericQuestTypeDispatchPatches.cs
+++ b/source/GameInterface/Services/Issues/Generic/Dispatch/GenericQuestTypeDispatchPatches.cs
@@ -1,7 +1,9 @@
 using Common;
+using Common.Messaging;
 using GameInterface.Policies;
 using GameInterface.Services.Entity;
 using GameInterface.Services.Issues.Interfaces;
+using GameInterface.Services.Issues.Messages;
 using HarmonyLib;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Issues;
@@ -36,10 +38,11 @@ internal class GenericQuestTypeQuestSolutionAcceptTriggerPatch
         if (!__result) return;
 
         var descriptor = QuestTypeRegistry.Get(issueOwner?.Issue);
-        if (descriptor?.OnGenuineQuestSolutionAccept == null) return;
+        if (descriptor?.SupportsQuestSolutionAccept != true) return;
 
         ContainerProvider.TryResolve<IControllerIdProvider>(out var controllerIdProvider);
-        descriptor.OnGenuineQuestSolutionAccept(issueOwner, controllerIdProvider?.ControllerId);
+        descriptor.OnGenuineQuestSolutionAccept?.Invoke(issueOwner, controllerIdProvider?.ControllerId);
+        MessageBroker.Instance.Publish(issueOwner, new QuestTypeQuestSolutionAcceptTriggered(issueOwner, controllerIdProvider?.ControllerId));
     }
 }
 
@@ -52,12 +55,14 @@ internal class GenericQuestTypeAlternativeAcceptTriggerPatch
     private static void Postfix(IssueBase __instance)
     {
         if (CallOriginalPolicy.IsOriginalAllowed() || IssueDispatchReplayGuard.IsActive) return;
+        if (AlternativeSolutionStartAuthorityGuard.IsActive) return;
 
         var descriptor = QuestTypeRegistry.Get(__instance);
-        if (descriptor?.OnGenuineAlternativeAccept == null) return;
+        if (descriptor?.SupportsAlternativeAccept != true) return;
 
         ContainerProvider.TryResolve<IControllerIdProvider>(out var controllerIdProvider);
-        descriptor.OnGenuineAlternativeAccept(__instance.IssueOwner, controllerIdProvider?.ControllerId);
+        descriptor.OnGenuineAlternativeAccept?.Invoke(__instance.IssueOwner, controllerIdProvider?.ControllerId);
+        MessageBroker.Instance.Publish(__instance, new QuestTypeAlternativeAcceptTriggered(__instance.IssueOwner, controllerIdProvider?.ControllerId));
     }
 }
 
@@ -67,9 +72,21 @@ internal class GenericQuestTypeAlternativeSolutionOwnershipGatePatch
     [HarmonyPrefix]
     private static bool Prefix(IssueBase __instance)
     {
-        if (!QuestTypeRegistry.IsRegistered(__instance?.GetType())) return true;
+        if (QuestTypeRegistry.Get(__instance)?.SupportsAlternativeAccept != true) return true;
 
         return (ContainerProvider.TryResolve<IIssueOwnershipRegistry>(out var ownershipRegistry) && ownershipRegistry.IsLocalPeerOwner(__instance.IssueOwner))
             || AlternativeSolutionCompletionAuthorityGuard.IsActive;
+    }
+}
+
+[HarmonyPatch(typeof(IssueBase), nameof(IssueBase.StartIssueWithAlternativeSolution))]
+internal class GenericQuestTypeAlternativeSolutionStartOwnershipGatePatch
+{
+    [HarmonyPrefix]
+    private static bool Prefix(IssueBase __instance)
+    {
+        if (QuestTypeRegistry.Get(__instance)?.SupportsAlternativeAccept != true) return true;
+
+        return AlternativeSolutionStartAuthorityGuard.IsActive;
     }
 }

--- a/source/GameInterface/Services/Issues/Generic/IssueConversationTracker.cs
+++ b/source/GameInterface/Services/Issues/Generic/IssueConversationTracker.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+
+namespace GameInterface.Services.Issues.Generic;
+
+public interface IIssueConversationTracker
+{
+    void Register(string issueGiverId, string controllerId, int generation);
+    bool TryGetTrackedRequester(string issueGiverId, out string controllerId, out int generation);
+}
+
+internal sealed class IssueConversationTracker : IIssueConversationTracker
+{
+    private readonly Dictionary<string, (string ControllerId, int Generation)> tracked = new();
+
+    public void Register(string issueGiverId, string controllerId, int generation)
+    {
+        if (issueGiverId == null || controllerId == null) return;
+
+        tracked[issueGiverId] = (controllerId, generation);
+    }
+
+    public bool TryGetTrackedRequester(string issueGiverId, out string controllerId, out int generation)
+    {
+        if (issueGiverId != null && tracked.TryGetValue(issueGiverId, out var entry))
+        {
+            controllerId = entry.ControllerId;
+            generation = entry.Generation;
+            return true;
+        }
+
+        controllerId = null;
+        generation = 0;
+        return false;
+    }
+}

--- a/source/GameInterface/Services/Issues/Generic/IssueGenerationRegistry.cs
+++ b/source/GameInterface/Services/Issues/Generic/IssueGenerationRegistry.cs
@@ -3,23 +3,32 @@ using TaleWorlds.CampaignSystem;
 
 namespace GameInterface.Services.Issues.Generic;
 
-internal static class IssueGenerationRegistry
+public interface IIssueGenerationRegistry
 {
-    private static readonly PendingRegistry<int> Registry = new();
+    int Bump(Hero owner);
+    void SetGeneration(Hero owner, int generation);
+    bool TryGetGeneration(Hero owner, out int generation);
+    IReadOnlyCollection<KeyValuePair<Hero, int>> Snapshot();
+    void RestoreAll(IEnumerable<KeyValuePair<Hero, int>> entries);
+}
 
-    public static int Bump(Hero owner)
+internal sealed class IssueGenerationRegistry : IIssueGenerationRegistry
+{
+    private readonly PendingRegistry<int> registry = new();
+
+    public int Bump(Hero owner)
     {
-        Registry.TryGet(owner, out var current);
+        registry.TryGet(owner, out var current);
         var next = current + 1;
-        Registry.Set(owner, next);
+        registry.Set(owner, next);
         return next;
     }
 
-    public static void SetGeneration(Hero owner, int generation) => Registry.Set(owner, generation);
+    public void SetGeneration(Hero owner, int generation) => registry.Set(owner, generation);
 
-    public static bool TryGetGeneration(Hero owner, out int generation) => Registry.TryGet(owner, out generation);
+    public bool TryGetGeneration(Hero owner, out int generation) => registry.TryGet(owner, out generation);
 
-    public static IReadOnlyCollection<KeyValuePair<Hero, int>> Snapshot() => Registry.Snapshot();
+    public IReadOnlyCollection<KeyValuePair<Hero, int>> Snapshot() => registry.Snapshot();
 
-    public static void RestoreAll(IEnumerable<KeyValuePair<Hero, int>> entries) => Registry.RestoreAll(entries);
+    public void RestoreAll(IEnumerable<KeyValuePair<Hero, int>> entries) => registry.RestoreAll(entries);
 }

--- a/source/GameInterface/Services/Issues/Generic/IssueOwnershipRegistry.cs
+++ b/source/GameInterface/Services/Issues/Generic/IssueOwnershipRegistry.cs
@@ -4,33 +4,44 @@ using TaleWorlds.CampaignSystem;
 
 namespace GameInterface.Services.Issues.Generic;
 
-internal static class IssueOwnershipRegistry
+public interface IIssueOwnershipRegistry
 {
-    private static readonly PendingRegistry<string> Registry = new();
+    void SetOwner(Hero issueGiver, string controllerId);
+    void Clear(Hero issueGiver);
+    void ClearAll();
+    bool TryGetOwnerControllerId(Hero issueGiver, out string controllerId);
+    bool IsLocalPeerOwner(Hero issueGiver);
+    IReadOnlyCollection<KeyValuePair<Hero, string>> Snapshot();
+    void RestoreAll(IEnumerable<KeyValuePair<Hero, string>> entries);
+}
 
-    public static void SetOwner(Hero issueGiver, string controllerId)
+internal sealed class IssueOwnershipRegistry : IIssueOwnershipRegistry
+{
+    private readonly PendingRegistry<string> registry = new();
+
+    public void SetOwner(Hero issueGiver, string controllerId)
     {
         if (issueGiver == null || string.IsNullOrEmpty(controllerId)) return;
 
-        Registry.Set(issueGiver, controllerId);
+        registry.Set(issueGiver, controllerId);
     }
 
-    public static void Clear(Hero issueGiver)
+    public void Clear(Hero issueGiver)
     {
-        Registry.Clear(issueGiver);
+        registry.Clear(issueGiver);
     }
 
-    public static void ClearAll()
+    public void ClearAll()
     {
-        Registry.ClearAll();
+        registry.ClearAll();
     }
 
-    public static bool TryGetOwnerControllerId(Hero issueGiver, out string controllerId)
+    public bool TryGetOwnerControllerId(Hero issueGiver, out string controllerId)
     {
-        return Registry.TryGet(issueGiver, out controllerId);
+        return registry.TryGet(issueGiver, out controllerId);
     }
 
-    public static bool IsLocalPeerOwner(Hero issueGiver)
+    public bool IsLocalPeerOwner(Hero issueGiver)
     {
         if (!TryGetOwnerControllerId(issueGiver, out var ownerControllerId)) return false;
         if (!ContainerProvider.TryResolve<IControllerIdProvider>(out var controllerIdProvider)) return false;
@@ -38,13 +49,13 @@ internal static class IssueOwnershipRegistry
         return controllerIdProvider.ControllerId == ownerControllerId;
     }
 
-    public static IReadOnlyCollection<KeyValuePair<Hero, string>> Snapshot()
+    public IReadOnlyCollection<KeyValuePair<Hero, string>> Snapshot()
     {
-        return Registry.Snapshot();
+        return registry.Snapshot();
     }
 
-    public static void RestoreAll(IEnumerable<KeyValuePair<Hero, string>> entries)
+    public void RestoreAll(IEnumerable<KeyValuePair<Hero, string>> entries)
     {
-        Registry.RestoreAll(entries);
+        registry.RestoreAll(entries);
     }
 }

--- a/source/GameInterface/Services/Issues/Generic/ModuleRescanCompletion.cs
+++ b/source/GameInterface/Services/Issues/Generic/ModuleRescanCompletion.cs
@@ -15,6 +15,13 @@ public interface IModuleRescanCompletionRunner
 
 internal sealed class ModuleRescanCompletionRunner : IModuleRescanCompletionRunner
 {
+    private readonly IIssueOwnershipRegistry ownershipRegistry;
+
+    public ModuleRescanCompletionRunner(IIssueOwnershipRegistry ownershipRegistry)
+    {
+        this.ownershipRegistry = ownershipRegistry;
+    }
+
     public void Run<TIssue>(ModuleRescanCompletion<TIssue> spec) where TIssue : IssueBase
     {
         if (spec?.TryTriggerOwnedCompletion == null) return;
@@ -28,7 +35,7 @@ internal sealed class ModuleRescanCompletionRunner : IModuleRescanCompletionRunn
 
         foreach (var kvp in snapshot)
         {
-            if (kvp.Value is TIssue && IssueOwnershipRegistry.IsLocalPeerOwner(kvp.Key))
+            if (kvp.Value is TIssue && ownershipRegistry.IsLocalPeerOwner(kvp.Key))
             {
                 spec.TryTriggerOwnedCompletion(kvp.Key);
             }

--- a/source/GameInterface/Services/Issues/Generic/QuestTypeDescriptor.cs
+++ b/source/GameInterface/Services/Issues/Generic/QuestTypeDescriptor.cs
@@ -13,6 +13,10 @@ public abstract class QuestTypeDescriptor
     public Type QuestType { get; }
     public string DisplayName { get; }
 
+    public bool SupportsQuestSolutionAccept { get; }
+
+    public bool SupportsAlternativeAccept { get; }
+
     public Action<IssueBase> OnGenuineCreation { get; }
 
     public Action<Hero, string> OnGenuineQuestSolutionAccept { get; }
@@ -27,6 +31,8 @@ public abstract class QuestTypeDescriptor
 
     public Action<Hero> RejectQuestSolutionAccept { get; }
 
+    public Func<Hero, Func<Hero, bool>, (bool Accepted, byte[] FieldsBytes)> TryArbitrateAlternativeAcceptBytes { get; }
+
     public Action<Hero, byte[]> MirrorAlternativeAcceptBytes { get; }
 
     public Action<Hero> RejectAlternativeAccept { get; }
@@ -35,6 +41,8 @@ public abstract class QuestTypeDescriptor
         Type issueType,
         Type questType,
         string displayName,
+        bool supportsQuestSolutionAccept,
+        bool supportsAlternativeAccept,
         Action<IssueBase> onGenuineCreation,
         Action<Hero, string> onGenuineQuestSolutionAccept,
         Action<Hero, string> onGenuineAlternativeAccept,
@@ -42,12 +50,15 @@ public abstract class QuestTypeDescriptor
         Func<Hero, Func<Hero, bool>, (bool, byte[])> tryArbitrateQuestSolutionAcceptBytes,
         Action<Hero, byte[]> mirrorQuestSolutionAcceptBytes,
         Action<Hero> rejectQuestSolutionAccept,
+        Func<Hero, Func<Hero, bool>, (bool, byte[])> tryArbitrateAlternativeAcceptBytes,
         Action<Hero, byte[]> mirrorAlternativeAcceptBytes,
         Action<Hero> rejectAlternativeAccept)
     {
         IssueType = issueType ?? throw new ArgumentNullException(nameof(issueType));
         QuestType = questType ?? throw new ArgumentNullException(nameof(questType));
         DisplayName = displayName;
+        SupportsQuestSolutionAccept = supportsQuestSolutionAccept;
+        SupportsAlternativeAccept = supportsAlternativeAccept;
         OnGenuineCreation = onGenuineCreation;
         OnGenuineQuestSolutionAccept = onGenuineQuestSolutionAccept;
         OnGenuineAlternativeAccept = onGenuineAlternativeAccept;
@@ -55,6 +66,7 @@ public abstract class QuestTypeDescriptor
         TryArbitrateQuestSolutionAcceptBytes = tryArbitrateQuestSolutionAcceptBytes;
         MirrorQuestSolutionAcceptBytes = mirrorQuestSolutionAcceptBytes;
         RejectQuestSolutionAccept = rejectQuestSolutionAccept;
+        TryArbitrateAlternativeAcceptBytes = tryArbitrateAlternativeAcceptBytes;
         MirrorAlternativeAcceptBytes = mirrorAlternativeAcceptBytes;
         RejectAlternativeAccept = rejectAlternativeAccept;
     }
@@ -73,6 +85,8 @@ public sealed class QuestTypeDescriptor<TIssue, TQuest> : QuestTypeDescriptor
         object creationCaptureStrategy,
         object questSolutionAcceptMirrorStrategy,
         object alternativeAcceptMirrorStrategy,
+        bool supportsQuestSolutionAccept,
+        bool supportsAlternativeAccept,
         Action<TIssue> onGenuineCreation,
         Action<Hero, string> onGenuineQuestSolutionAccept,
         Action<Hero, string> onGenuineAlternativeAccept,
@@ -80,12 +94,15 @@ public sealed class QuestTypeDescriptor<TIssue, TQuest> : QuestTypeDescriptor
         Func<Hero, Func<Hero, bool>, (bool, byte[])> tryArbitrateQuestSolutionAcceptBytes,
         Action<Hero, byte[]> mirrorQuestSolutionAcceptBytes,
         Action<Hero> rejectQuestSolutionAccept,
+        Func<Hero, Func<Hero, bool>, (bool, byte[])> tryArbitrateAlternativeAcceptBytes,
         Action<Hero, byte[]> mirrorAlternativeAcceptBytes,
         Action<Hero> rejectAlternativeAccept)
         : base(
             typeof(TIssue),
             typeof(TQuest),
             displayName,
+            supportsQuestSolutionAccept,
+            supportsAlternativeAccept,
             onGenuineCreation == null ? (Action<IssueBase>)null : issue => { if (issue is TIssue typed) onGenuineCreation(typed); },
             onGenuineQuestSolutionAccept,
             onGenuineAlternativeAccept,
@@ -93,6 +110,7 @@ public sealed class QuestTypeDescriptor<TIssue, TQuest> : QuestTypeDescriptor
             tryArbitrateQuestSolutionAcceptBytes,
             mirrorQuestSolutionAcceptBytes,
             rejectQuestSolutionAccept,
+            tryArbitrateAlternativeAcceptBytes,
             mirrorAlternativeAcceptBytes,
             rejectAlternativeAccept)
     {
@@ -126,6 +144,8 @@ public static class QuestDescriptorBuilder
         private object _creationCapture;
         private object _questSolutionAccept;
         private object _alternativeAccept;
+        private bool _supportsQuestSolutionAccept;
+        private bool _supportsAlternativeAccept;
         private Action<TIssue> _onGenuineCreation;
         private Action<Hero, string> _onGenuineQuestSolutionAccept;
         private Action<Hero, string> _onGenuineAlternativeAccept;
@@ -133,6 +153,7 @@ public static class QuestDescriptorBuilder
         private Func<Hero, Func<Hero, bool>, (bool, byte[])> _tryArbitrateQuestSolutionAcceptBytes;
         private Action<Hero, byte[]> _mirrorQuestSolutionAcceptBytes;
         private Action<Hero> _rejectQuestSolutionAccept;
+        private Func<Hero, Func<Hero, bool>, (bool, byte[])> _tryArbitrateAlternativeAcceptBytes;
         private Action<Hero, byte[]> _mirrorAlternativeAcceptBytes;
         private Action<Hero> _rejectAlternativeAccept;
 
@@ -147,8 +168,15 @@ public static class QuestDescriptorBuilder
             return this;
         }
 
+        public Builder<TIssue, TQuest> WithQuestSolutionAccept()
+        {
+            _supportsQuestSolutionAccept = true;
+            return this;
+        }
+
         public Builder<TIssue, TQuest> WithQuestSolutionAccept<TFields>(IRaceArbitratedAcceptMirrorStrategy<TFields> strategy)
         {
+            _supportsQuestSolutionAccept = true;
             _questSolutionAccept = strategy;
 
             var handler = new RaceArbitratedAcceptMirrorHandler<TFields>(strategy);
@@ -164,11 +192,23 @@ public static class QuestDescriptorBuilder
             return this;
         }
 
+        public Builder<TIssue, TQuest> WithAlternativeAccept()
+        {
+            _supportsAlternativeAccept = true;
+            return this;
+        }
+
         public Builder<TIssue, TQuest> WithAlternativeAccept<TPayload>(IAlternativeAcceptMirrorStrategy<TPayload> strategy)
         {
+            _supportsAlternativeAccept = true;
             _alternativeAccept = strategy;
 
             var handler = new AlternativeAcceptMirrorHandler<TPayload>(strategy);
+            _tryArbitrateAlternativeAcceptBytes = (owner, canAccept) =>
+            {
+                if (!handler.TryArbitrate(owner, canAccept, out var payload)) return (false, null);
+                return (true, GenericAcceptFieldsSerializer.Serialize(payload));
+            };
             _mirrorAlternativeAcceptBytes = (owner, bytes) =>
                 handler.Mirror(owner, GenericAcceptFieldsSerializer.Deserialize<TPayload>(bytes));
             _rejectAlternativeAccept = owner => handler.Reject(owner);
@@ -202,8 +242,9 @@ public static class QuestDescriptorBuilder
 
         public QuestTypeDescriptor<TIssue, TQuest> Build()
             => new(_displayName, _creationCapture, _questSolutionAccept, _alternativeAccept,
+                _supportsQuestSolutionAccept, _supportsAlternativeAccept,
                 _onGenuineCreation, _onGenuineQuestSolutionAccept, _onGenuineAlternativeAccept, _validateQuestSuccess,
                 _tryArbitrateQuestSolutionAcceptBytes, _mirrorQuestSolutionAcceptBytes, _rejectQuestSolutionAccept,
-                _mirrorAlternativeAcceptBytes, _rejectAlternativeAccept);
+                _tryArbitrateAlternativeAcceptBytes, _mirrorAlternativeAcceptBytes, _rejectAlternativeAccept);
     }
 }

--- a/source/GameInterface/Services/Issues/Handlers/AlternativeSolutionCompletionHandler.cs
+++ b/source/GameInterface/Services/Issues/Handlers/AlternativeSolutionCompletionHandler.cs
@@ -15,15 +15,18 @@ internal class AlternativeSolutionCompletionHandler : IHandler
     private readonly IMessageBroker messageBroker;
     private readonly IObjectManager objectManager;
     private readonly IPlayerManager playerManager;
+    private readonly IIssueOwnershipRegistry ownershipRegistry;
 
     public AlternativeSolutionCompletionHandler(
         IMessageBroker messageBroker,
         IObjectManager objectManager,
-        IPlayerManager playerManager)
+        IPlayerManager playerManager,
+        IIssueOwnershipRegistry ownershipRegistry)
     {
         this.messageBroker = messageBroker;
         this.objectManager = objectManager;
         this.playerManager = playerManager;
+        this.ownershipRegistry = ownershipRegistry;
 
         messageBroker.Subscribe<RequestAlternativeSolutionCompletion>(Handle_RequestAlternativeSolutionCompletion);
     }
@@ -54,7 +57,7 @@ internal class AlternativeSolutionCompletionHandler : IHandler
 
         if (requester == null || !playerManager.TryGetPlayer(requester, out var player)) return false;
         if (!objectManager.TryGetObjectWithLogging(ownerId, out owner)) return false;
-        if (!IssueOwnershipRegistry.TryGetOwnerControllerId(owner, out var recordedOwner)) return false;
+        if (!ownershipRegistry.TryGetOwnerControllerId(owner, out var recordedOwner)) return false;
         if (recordedOwner != player.ControllerId) return false;
         if (owner.Issue is not IssueBase resolvedIssue) return false;
         if (!resolvedIssue.IsSolvingWithAlternative || !resolvedIssue.AlternativeSolutionReturnTimeForTroops.IsPast) return false;

--- a/source/GameInterface/Services/Issues/Handlers/AwaitingAlternativeSolutionTroopsHandler.cs
+++ b/source/GameInterface/Services/Issues/Handlers/AwaitingAlternativeSolutionTroopsHandler.cs
@@ -20,17 +20,20 @@ internal class AwaitingAlternativeSolutionTroopsHandler : IHandler
     private readonly INetwork network;
     private readonly ITroopRosterInterface troopRosterInterface;
     private readonly IPlayerManager playerManager;
+    private readonly IAwaitingAlternativeSolutionTroopsRegistry troopsRegistry;
 
     public AwaitingAlternativeSolutionTroopsHandler(
         IMessageBroker messageBroker,
         INetwork network,
         ITroopRosterInterface troopRosterInterface,
-        IPlayerManager playerManager)
+        IPlayerManager playerManager,
+        IAwaitingAlternativeSolutionTroopsRegistry troopsRegistry)
     {
         this.messageBroker = messageBroker;
         this.network = network;
         this.troopRosterInterface = troopRosterInterface;
         this.playerManager = playerManager;
+        this.troopsRegistry = troopsRegistry;
 
         messageBroker.Subscribe<AwaitingAlternativeSolutionTroopsDepositedLocally>(Handle_AwaitingAlternativeSolutionTroopsDepositedLocally);
         messageBroker.Subscribe<RequestAwaitingAlternativeSolutionTroopsDeposit>(Handle_RequestAwaitingAlternativeSolutionTroopsDeposit);
@@ -72,7 +75,7 @@ internal class AwaitingAlternativeSolutionTroopsHandler : IHandler
             roster.AddToCounts(element.Character, element.Number, false, element.WoundedNumber, element.Xp, false);
         }
 
-        AwaitingAlternativeSolutionTroopsRegistry.Deposit(player.ControllerId, roster);
+        troopsRegistry.Deposit(player.ControllerId, roster);
     }
 
     private void Handle_AwaitingAlternativeSolutionTroopsDrainedLocally(MessagePayload<AwaitingAlternativeSolutionTroopsDrainedLocally> payload)
@@ -92,6 +95,6 @@ internal class AwaitingAlternativeSolutionTroopsHandler : IHandler
             return;
         }
 
-        AwaitingAlternativeSolutionTroopsRegistry.Clear(player.ControllerId);
+        troopsRegistry.Clear(player.ControllerId);
     }
 }

--- a/source/GameInterface/Services/Issues/Handlers/GenericAcceptMirrorHandler.cs
+++ b/source/GameInterface/Services/Issues/Handlers/GenericAcceptMirrorHandler.cs
@@ -70,10 +70,6 @@ internal class GenericAcceptMirrorHandler : IHandler
         messageBroker.Subscribe<NetworkGenericIssueAlternativeAccepted>(Handle_NetworkGenericIssueAlternativeAccepted);
 
         messageBroker.Subscribe<NetworkGenericIssueAcceptRejected>(Handle_NetworkGenericIssueAcceptRejected);
-
-        messageBroker.Subscribe<IssueConversationOpenedLocally>(Handle_IssueConversationOpenedLocally);
-        messageBroker.Subscribe<RequestIssueConversationOpened>(Handle_RequestIssueConversationOpened);
-        messageBroker.Subscribe<NetworkIssueConversationAllowed>(Handle_NetworkIssueConversationAllowed);
     }
 
     public void Dispose()
@@ -87,71 +83,6 @@ internal class GenericAcceptMirrorHandler : IHandler
         messageBroker.Unsubscribe<NetworkGenericIssueAlternativeAccepted>(Handle_NetworkGenericIssueAlternativeAccepted);
 
         messageBroker.Unsubscribe<NetworkGenericIssueAcceptRejected>(Handle_NetworkGenericIssueAcceptRejected);
-
-        messageBroker.Unsubscribe<IssueConversationOpenedLocally>(Handle_IssueConversationOpenedLocally);
-        messageBroker.Unsubscribe<RequestIssueConversationOpened>(Handle_RequestIssueConversationOpened);
-        messageBroker.Unsubscribe<NetworkIssueConversationAllowed>(Handle_NetworkIssueConversationAllowed);
-    }
-
-    private void Handle_IssueConversationOpenedLocally(MessagePayload<IssueConversationOpenedLocally> payload)
-    {
-        var issueGiver = payload.What.IssueGiver;
-        if (issueGiver == null || !objectManager.TryGetIdWithLogging(issueGiver, out var issueGiverId)) return;
-
-        if (ModInformation.IsServer)
-        {
-            TryRegisterConversation(issueGiverId, payload.What.ControllerId);
-        }
-        else
-        {
-            network.SendAll(new RequestIssueConversationOpened(issueGiverId));
-        }
-    }
-
-    private void Handle_RequestIssueConversationOpened(MessagePayload<RequestIssueConversationOpened> payload)
-    {
-        if (ModInformation.IsClient) return;
-
-        var issueGiverId = payload.What.IssueGiverId;
-        var requester = payload.Who as NetPeer;
-        GameThread.RunSafe(() =>
-        {
-            if (requester == null || !playerManager.TryGetPlayer(requester, out var player)) return;
-
-            if (TryRegisterConversation(issueGiverId, player.ControllerId) &&
-                conversationTracker.TryGetTrackedRequester(issueGiverId, out _, out var generation))
-            {
-                network.Send(requester, new NetworkIssueConversationAllowed(issueGiverId, generation));
-            }
-            else
-            {
-                network.Send(requester, new NetworkIssueConversationDenied(issueGiverId));
-            }
-        });
-    }
-
-    private void Handle_NetworkIssueConversationAllowed(MessagePayload<NetworkIssueConversationAllowed> payload)
-    {
-        var data = payload.What;
-        GameThread.RunSafe(() =>
-        {
-            if (!ContainerProvider.TryResolve<IControllerIdProvider>(out var controllerIdProvider)) return;
-
-            conversationTracker.Register(data.IssueGiverId, controllerIdProvider.ControllerId, data.Generation);
-        });
-    }
-
-    private bool TryRegisterConversation(string issueGiverId, string controllerId)
-    {
-        if (controllerId == null) return false;
-        if (!objectManager.TryGetObjectWithLogging<Hero>(issueGiverId, out var issueGiver)) return false;
-        if (issueGiver.Issue == null || !issueGiver.Issue.IsOngoingWithoutQuest || !issueGiver.Issue.IssueStayAliveConditions()) return false;
-        if (!GenericAcceptMirrorIssueTypes.IsQuestSolutionMirrorEligible(issueGiver.Issue) &&
-            !GenericAcceptMirrorIssueTypes.IsAlternativeSolutionMirrorEligible(issueGiver.Issue)) return false;
-
-        generationRegistry.TryGetGeneration(issueGiver, out var generation);
-        conversationTracker.Register(issueGiverId, controllerId, generation);
-        return true;
     }
 
     private void Handle_GenericIssueQuestAcceptTriggered(MessagePayload<GenericIssueQuestAcceptTriggered> payload)

--- a/source/GameInterface/Services/Issues/Handlers/GenericAcceptMirrorHandler.cs
+++ b/source/GameInterface/Services/Issues/Handlers/GenericAcceptMirrorHandler.cs
@@ -3,6 +3,7 @@ using Common.Logging;
 using Common.Messaging;
 using Common.Network;
 using Common.Util;
+using GameInterface.Services.Entity;
 using GameInterface.Services.Issues.Generic;
 using GameInterface.Services.Issues.Generic.AcceptMirror;
 using GameInterface.Services.Issues.Interfaces;
@@ -33,6 +34,7 @@ internal class GenericAcceptMirrorHandler : IHandler
     private readonly IPlayerManager playerManager;
     private readonly ITroopRosterInterface troopRosterInterface;
     private readonly IPrisonerSaleValidator troopValidator;
+    private readonly IIssueConversationTracker conversationTracker;
 
     public GenericAcceptMirrorHandler(
         IMessageBroker messageBroker,
@@ -41,7 +43,8 @@ internal class GenericAcceptMirrorHandler : IHandler
         IGenericAcceptMirrorInterface issueInterface,
         IPlayerManager playerManager,
         ITroopRosterInterface troopRosterInterface,
-        IPrisonerSaleValidator troopValidator)
+        IPrisonerSaleValidator troopValidator,
+        IIssueConversationTracker conversationTracker)
     {
         this.messageBroker = messageBroker;
         this.objectManager = objectManager;
@@ -50,6 +53,7 @@ internal class GenericAcceptMirrorHandler : IHandler
         this.playerManager = playerManager;
         this.troopRosterInterface = troopRosterInterface;
         this.troopValidator = troopValidator;
+        this.conversationTracker = conversationTracker;
 
         messageBroker.Subscribe<GenericIssueQuestAcceptTriggered>(Handle_GenericIssueQuestAcceptTriggered);
         messageBroker.Subscribe<RequestGenericIssueAcceptQuest>(Handle_RequestGenericIssueAcceptQuest);
@@ -60,6 +64,10 @@ internal class GenericAcceptMirrorHandler : IHandler
         messageBroker.Subscribe<NetworkGenericIssueAlternativeAccepted>(Handle_NetworkGenericIssueAlternativeAccepted);
 
         messageBroker.Subscribe<NetworkGenericIssueAcceptRejected>(Handle_NetworkGenericIssueAcceptRejected);
+
+        messageBroker.Subscribe<IssueConversationOpenedLocally>(Handle_IssueConversationOpenedLocally);
+        messageBroker.Subscribe<RequestIssueConversationOpened>(Handle_RequestIssueConversationOpened);
+        messageBroker.Subscribe<NetworkIssueConversationAllowed>(Handle_NetworkIssueConversationAllowed);
     }
 
     public void Dispose()
@@ -73,6 +81,71 @@ internal class GenericAcceptMirrorHandler : IHandler
         messageBroker.Unsubscribe<NetworkGenericIssueAlternativeAccepted>(Handle_NetworkGenericIssueAlternativeAccepted);
 
         messageBroker.Unsubscribe<NetworkGenericIssueAcceptRejected>(Handle_NetworkGenericIssueAcceptRejected);
+
+        messageBroker.Unsubscribe<IssueConversationOpenedLocally>(Handle_IssueConversationOpenedLocally);
+        messageBroker.Unsubscribe<RequestIssueConversationOpened>(Handle_RequestIssueConversationOpened);
+        messageBroker.Unsubscribe<NetworkIssueConversationAllowed>(Handle_NetworkIssueConversationAllowed);
+    }
+
+    private void Handle_IssueConversationOpenedLocally(MessagePayload<IssueConversationOpenedLocally> payload)
+    {
+        var issueGiver = payload.What.IssueGiver;
+        if (issueGiver == null || !objectManager.TryGetIdWithLogging(issueGiver, out var issueGiverId)) return;
+
+        if (ModInformation.IsServer)
+        {
+            TryRegisterConversation(issueGiverId, payload.What.ControllerId);
+        }
+        else
+        {
+            network.SendAll(new RequestIssueConversationOpened(issueGiverId));
+        }
+    }
+
+    private void Handle_RequestIssueConversationOpened(MessagePayload<RequestIssueConversationOpened> payload)
+    {
+        if (ModInformation.IsClient) return;
+
+        var issueGiverId = payload.What.IssueGiverId;
+        var requester = payload.Who as NetPeer;
+        GameThread.RunSafe(() =>
+        {
+            if (requester == null || !playerManager.TryGetPlayer(requester, out var player)) return;
+
+            if (TryRegisterConversation(issueGiverId, player.ControllerId) &&
+                conversationTracker.TryGetTrackedRequester(issueGiverId, out _, out var generation))
+            {
+                network.Send(requester, new NetworkIssueConversationAllowed(issueGiverId, generation));
+            }
+            else
+            {
+                network.Send(requester, new NetworkIssueConversationDenied(issueGiverId));
+            }
+        });
+    }
+
+    private void Handle_NetworkIssueConversationAllowed(MessagePayload<NetworkIssueConversationAllowed> payload)
+    {
+        var data = payload.What;
+        GameThread.RunSafe(() =>
+        {
+            if (!ContainerProvider.TryResolve<IControllerIdProvider>(out var controllerIdProvider)) return;
+
+            conversationTracker.Register(data.IssueGiverId, controllerIdProvider.ControllerId, data.Generation);
+        });
+    }
+
+    private bool TryRegisterConversation(string issueGiverId, string controllerId)
+    {
+        if (controllerId == null) return false;
+        if (!objectManager.TryGetObjectWithLogging<Hero>(issueGiverId, out var issueGiver)) return false;
+        if (issueGiver.Issue == null || !issueGiver.Issue.IsOngoingWithoutQuest || !issueGiver.Issue.IssueStayAliveConditions()) return false;
+        if (!GenericAcceptMirrorIssueTypes.IsQuestSolutionMirrorEligible(issueGiver.Issue) &&
+            !GenericAcceptMirrorIssueTypes.IsAlternativeSolutionMirrorEligible(issueGiver.Issue)) return false;
+
+        IssueGenerationRegistry.TryGetGeneration(issueGiver, out var generation);
+        conversationTracker.Register(issueGiverId, controllerId, generation);
+        return true;
     }
 
     private void Handle_GenericIssueQuestAcceptTriggered(MessagePayload<GenericIssueQuestAcceptTriggered> payload)
@@ -115,6 +188,15 @@ internal class GenericAcceptMirrorHandler : IHandler
             if (!IssueGenerationRegistry.TryGetGeneration(owner, out var currentGeneration) || currentGeneration != requestedGeneration)
             {
                 Logger.Error("Rejecting {Message} for a stale/superseded issue generation for owner {Owner}",
+                    nameof(RequestGenericIssueAcceptQuest), ownerId);
+                network.Send(requester, new NetworkGenericIssueAcceptRejected(ownerId));
+                return;
+            }
+
+            if (!conversationTracker.TryGetTrackedRequester(ownerId, out var trackedControllerId, out var trackedGeneration) ||
+                trackedControllerId != player.ControllerId || trackedGeneration != requestedGeneration)
+            {
+                Logger.Error("Rejecting {Message} for a requester with no tracked conversation with owner {Owner}",
                     nameof(RequestGenericIssueAcceptQuest), ownerId);
                 network.Send(requester, new NetworkGenericIssueAcceptRejected(ownerId));
                 return;
@@ -191,6 +273,15 @@ internal class GenericAcceptMirrorHandler : IHandler
             if (!IssueGenerationRegistry.TryGetGeneration(owner, out var currentGeneration) || currentGeneration != requestedGeneration)
             {
                 Logger.Error("Rejecting {Message} for a stale/superseded issue generation for owner {Owner}",
+                    nameof(RequestGenericIssueAcceptAlternative), ownerId);
+                network.Send(requester, new NetworkGenericIssueAcceptRejected(ownerId));
+                return;
+            }
+
+            if (!conversationTracker.TryGetTrackedRequester(ownerId, out var trackedControllerId, out var trackedGeneration) ||
+                trackedControllerId != player.ControllerId || trackedGeneration != requestedGeneration)
+            {
+                Logger.Error("Rejecting {Message} for a requester with no tracked conversation with owner {Owner}",
                     nameof(RequestGenericIssueAcceptAlternative), ownerId);
                 network.Send(requester, new NetworkGenericIssueAcceptRejected(ownerId));
                 return;

--- a/source/GameInterface/Services/Issues/Handlers/GenericAcceptMirrorHandler.cs
+++ b/source/GameInterface/Services/Issues/Handlers/GenericAcceptMirrorHandler.cs
@@ -36,6 +36,7 @@ internal class GenericAcceptMirrorHandler : IHandler
     private readonly IPrisonerSaleValidator troopValidator;
     private readonly IIssueConversationTracker conversationTracker;
     private readonly IIssueOwnershipRegistry ownershipRegistry;
+    private readonly IIssueGenerationRegistry generationRegistry;
 
     public GenericAcceptMirrorHandler(
         IMessageBroker messageBroker,
@@ -46,7 +47,8 @@ internal class GenericAcceptMirrorHandler : IHandler
         ITroopRosterInterface troopRosterInterface,
         IPrisonerSaleValidator troopValidator,
         IIssueConversationTracker conversationTracker,
-        IIssueOwnershipRegistry ownershipRegistry)
+        IIssueOwnershipRegistry ownershipRegistry,
+        IIssueGenerationRegistry generationRegistry)
     {
         this.messageBroker = messageBroker;
         this.objectManager = objectManager;
@@ -57,6 +59,7 @@ internal class GenericAcceptMirrorHandler : IHandler
         this.troopValidator = troopValidator;
         this.conversationTracker = conversationTracker;
         this.ownershipRegistry = ownershipRegistry;
+        this.generationRegistry = generationRegistry;
 
         messageBroker.Subscribe<GenericIssueQuestAcceptTriggered>(Handle_GenericIssueQuestAcceptTriggered);
         messageBroker.Subscribe<RequestGenericIssueAcceptQuest>(Handle_RequestGenericIssueAcceptQuest);
@@ -146,7 +149,7 @@ internal class GenericAcceptMirrorHandler : IHandler
         if (!GenericAcceptMirrorIssueTypes.IsQuestSolutionMirrorEligible(issueGiver.Issue) &&
             !GenericAcceptMirrorIssueTypes.IsAlternativeSolutionMirrorEligible(issueGiver.Issue)) return false;
 
-        IssueGenerationRegistry.TryGetGeneration(issueGiver, out var generation);
+        generationRegistry.TryGetGeneration(issueGiver, out var generation);
         conversationTracker.Register(issueGiverId, controllerId, generation);
         return true;
     }
@@ -164,7 +167,7 @@ internal class GenericAcceptMirrorHandler : IHandler
         }
         else
         {
-            IssueGenerationRegistry.TryGetGeneration(owner, out var generation);
+            generationRegistry.TryGetGeneration(owner, out var generation);
             network.SendAll(new RequestGenericIssueAcceptQuest(ownerId, generation));
         }
     }
@@ -188,7 +191,7 @@ internal class GenericAcceptMirrorHandler : IHandler
                 return;
             }
 
-            if (!IssueGenerationRegistry.TryGetGeneration(owner, out var currentGeneration) || currentGeneration != requestedGeneration)
+            if (!generationRegistry.TryGetGeneration(owner, out var currentGeneration) || currentGeneration != requestedGeneration)
             {
                 Logger.Error("Rejecting {Message} for a stale/superseded issue generation for owner {Owner}",
                     nameof(RequestGenericIssueAcceptQuest), ownerId);
@@ -248,7 +251,7 @@ internal class GenericAcceptMirrorHandler : IHandler
         }
         else
         {
-            IssueGenerationRegistry.TryGetGeneration(owner, out var generation);
+            generationRegistry.TryGetGeneration(owner, out var generation);
             var packedTroops = troopRosterInterface.PackTroopRosterData(owner.Issue.AlternativeSolutionSentTroops);
             network.SendAll(new RequestGenericIssueAcceptAlternative(ownerId, generation, packedTroops));
         }
@@ -273,7 +276,7 @@ internal class GenericAcceptMirrorHandler : IHandler
                 return;
             }
 
-            if (!IssueGenerationRegistry.TryGetGeneration(owner, out var currentGeneration) || currentGeneration != requestedGeneration)
+            if (!generationRegistry.TryGetGeneration(owner, out var currentGeneration) || currentGeneration != requestedGeneration)
             {
                 Logger.Error("Rejecting {Message} for a stale/superseded issue generation for owner {Owner}",
                     nameof(RequestGenericIssueAcceptAlternative), ownerId);

--- a/source/GameInterface/Services/Issues/Handlers/GenericAcceptMirrorHandler.cs
+++ b/source/GameInterface/Services/Issues/Handlers/GenericAcceptMirrorHandler.cs
@@ -35,6 +35,7 @@ internal class GenericAcceptMirrorHandler : IHandler
     private readonly ITroopRosterInterface troopRosterInterface;
     private readonly IPrisonerSaleValidator troopValidator;
     private readonly IIssueConversationTracker conversationTracker;
+    private readonly IIssueOwnershipRegistry ownershipRegistry;
 
     public GenericAcceptMirrorHandler(
         IMessageBroker messageBroker,
@@ -44,7 +45,8 @@ internal class GenericAcceptMirrorHandler : IHandler
         IPlayerManager playerManager,
         ITroopRosterInterface troopRosterInterface,
         IPrisonerSaleValidator troopValidator,
-        IIssueConversationTracker conversationTracker)
+        IIssueConversationTracker conversationTracker,
+        IIssueOwnershipRegistry ownershipRegistry)
     {
         this.messageBroker = messageBroker;
         this.objectManager = objectManager;
@@ -54,6 +56,7 @@ internal class GenericAcceptMirrorHandler : IHandler
         this.troopRosterInterface = troopRosterInterface;
         this.troopValidator = troopValidator;
         this.conversationTracker = conversationTracker;
+        this.ownershipRegistry = ownershipRegistry;
 
         messageBroker.Subscribe<GenericIssueQuestAcceptTriggered>(Handle_GenericIssueQuestAcceptTriggered);
         messageBroker.Subscribe<RequestGenericIssueAcceptQuest>(Handle_RequestGenericIssueAcceptQuest);
@@ -156,7 +159,7 @@ internal class GenericAcceptMirrorHandler : IHandler
         if (ModInformation.IsServer)
         {
             var hostControllerId = payload.What.ControllerId;
-            IssueOwnershipRegistry.SetOwner(owner, hostControllerId);
+            ownershipRegistry.SetOwner(owner, hostControllerId);
             network.SendAll(new NetworkGenericIssueQuestAccepted(ownerId, hostControllerId));
         }
         else
@@ -206,7 +209,7 @@ internal class GenericAcceptMirrorHandler : IHandler
                 owner.Issue.IssueStayAliveConditions())
             {
                 issueInterface.EnsureServerQuestMirror(owner);
-                IssueOwnershipRegistry.SetOwner(owner, player.ControllerId);
+                ownershipRegistry.SetOwner(owner, player.ControllerId);
                 network.SendAll(new NetworkGenericIssueQuestAccepted(ownerId, player.ControllerId));
             }
             else
@@ -224,7 +227,7 @@ internal class GenericAcceptMirrorHandler : IHandler
         {
             if (!objectManager.TryGetObjectWithLogging<Hero>(ownerId, out var owner)) return;
             issueInterface.MirrorQuestAccepted(owner);
-            IssueOwnershipRegistry.SetOwner(owner, ownerControllerId);
+            ownershipRegistry.SetOwner(owner, ownerControllerId);
         });
     }
 
@@ -239,7 +242,7 @@ internal class GenericAcceptMirrorHandler : IHandler
             if (hostControllerId == null || !playerManager.TryGetPlayer(hostControllerId, out var player)) return;
 
             var state = AlternativeSolutionStartRunner.StartOnServer(owner, player);
-            IssueOwnershipRegistry.SetOwner(owner, hostControllerId);
+            ownershipRegistry.SetOwner(owner, hostControllerId);
             var hostTroops = troopRosterInterface.PackTroopRosterData(owner.Issue.AlternativeSolutionSentTroops);
             network.SendAll(new NetworkGenericIssueAlternativeAccepted(ownerId, hostControllerId, state, hostTroops));
         }
@@ -304,7 +307,7 @@ internal class GenericAcceptMirrorHandler : IHandler
                     return;
                 }
 
-                IssueOwnershipRegistry.SetOwner(owner, player.ControllerId);
+                ownershipRegistry.SetOwner(owner, player.ControllerId);
                 var validatedTroops = troopRosterInterface.PackTroopRosterData(owner.Issue.AlternativeSolutionSentTroops);
                 network.SendAll(new NetworkGenericIssueAlternativeAccepted(ownerId, player.ControllerId, state, validatedTroops));
             }
@@ -358,7 +361,7 @@ internal class GenericAcceptMirrorHandler : IHandler
                 return;
             }
 
-            IssueOwnershipRegistry.SetOwner(owner, data.OwnerControllerId);
+            ownershipRegistry.SetOwner(owner, data.OwnerControllerId);
         });
     }
 

--- a/source/GameInterface/Services/Issues/Handlers/GenericAcceptMirrorHandler.cs
+++ b/source/GameInterface/Services/Issues/Handlers/GenericAcceptMirrorHandler.cs
@@ -154,15 +154,18 @@ internal class GenericAcceptMirrorHandler : IHandler
         if (ModInformation.IsServer)
         {
             var hostControllerId = payload.What.ControllerId;
+            if (hostControllerId == null || !playerManager.TryGetPlayer(hostControllerId, out var player)) return;
+
+            var state = AlternativeSolutionStartRunner.StartOnServer(owner, player);
             IssueOwnershipRegistry.SetOwner(owner, hostControllerId);
             var hostTroops = troopRosterInterface.PackTroopRosterData(owner.Issue.AlternativeSolutionSentTroops);
-            network.SendAll(new NetworkGenericIssueAlternativeAccepted(ownerId, hostControllerId, payload.What.State, hostTroops));
+            network.SendAll(new NetworkGenericIssueAlternativeAccepted(ownerId, hostControllerId, state, hostTroops));
         }
         else
         {
             IssueGenerationRegistry.TryGetGeneration(owner, out var generation);
             var packedTroops = troopRosterInterface.PackTroopRosterData(owner.Issue.AlternativeSolutionSentTroops);
-            network.SendAll(new RequestGenericIssueAcceptAlternative(ownerId, generation, packedTroops, payload.What.State));
+            network.SendAll(new RequestGenericIssueAcceptAlternative(ownerId, generation, packedTroops));
         }
     }
 
@@ -196,10 +199,11 @@ internal class GenericAcceptMirrorHandler : IHandler
             if (GenericAcceptMirrorIssueTypes.IsAlternativeSolutionMirrorEligible(owner.Issue) && owner.Issue.IsOngoingWithoutQuest &&
                 owner.Issue.IssueStayAliveConditions())
             {
+                AlternativeSolutionVanillaState state;
                 try
                 {
                     ApplyValidatedSentTroops(owner, player, payload.What.SentTroops);
-                    issueInterface.MirrorAlternativeAccepted(owner, payload.What.State);
+                    state = AlternativeSolutionStartRunner.StartOnServer(owner, player);
                 }
                 catch (Exception e)
                 {
@@ -211,7 +215,7 @@ internal class GenericAcceptMirrorHandler : IHandler
 
                 IssueOwnershipRegistry.SetOwner(owner, player.ControllerId);
                 var validatedTroops = troopRosterInterface.PackTroopRosterData(owner.Issue.AlternativeSolutionSentTroops);
-                network.SendAll(new NetworkGenericIssueAlternativeAccepted(ownerId, player.ControllerId, payload.What.State, validatedTroops));
+                network.SendAll(new NetworkGenericIssueAlternativeAccepted(ownerId, player.ControllerId, state, validatedTroops));
             }
             else
             {

--- a/source/GameInterface/Services/Issues/Handlers/GenericQuestTypeAcceptHandler.cs
+++ b/source/GameInterface/Services/Issues/Handlers/GenericQuestTypeAcceptHandler.cs
@@ -4,7 +4,9 @@ using Common.Messaging;
 using Common.Network;
 using Common.Util;
 using System;
+using GameInterface.Services.Entity;
 using GameInterface.Services.Issues.Generic;
+using GameInterface.Services.Issues.Generic.AcceptMirror;
 using GameInterface.Services.Issues.Interfaces;
 using GameInterface.Services.Issues.Messages;
 using GameInterface.Services.ObjectManager;
@@ -16,6 +18,7 @@ using GameInterface.Services.TroopRosters.Interfaces;
 using LiteNetLib;
 using Serilog;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Issues;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Roster;
 
@@ -33,6 +36,7 @@ internal class GenericQuestTypeAcceptHandler : IHandler
     private readonly IPrisonerSaleValidator troopValidator;
     private readonly IIssueOwnershipRegistry ownershipRegistry;
     private readonly IIssueGenerationRegistry generationRegistry;
+    private readonly IIssueConversationTracker conversationTracker;
 
     public GenericQuestTypeAcceptHandler(
         IMessageBroker messageBroker,
@@ -42,7 +46,8 @@ internal class GenericQuestTypeAcceptHandler : IHandler
         ITroopRosterInterface troopRosterInterface,
         IPrisonerSaleValidator troopValidator,
         IIssueOwnershipRegistry ownershipRegistry,
-        IIssueGenerationRegistry generationRegistry)
+        IIssueGenerationRegistry generationRegistry,
+        IIssueConversationTracker conversationTracker)
     {
         this.messageBroker = messageBroker;
         this.objectManager = objectManager;
@@ -52,6 +57,7 @@ internal class GenericQuestTypeAcceptHandler : IHandler
         this.troopValidator = troopValidator;
         this.ownershipRegistry = ownershipRegistry;
         this.generationRegistry = generationRegistry;
+        this.conversationTracker = conversationTracker;
 
         messageBroker.Subscribe<QuestTypeQuestSolutionAcceptTriggered>(Handle_QuestTypeQuestSolutionAcceptTriggered);
         messageBroker.Subscribe<RequestQuestTypeAcceptQuest>(Handle_RequestQuestTypeAcceptQuest);
@@ -82,11 +88,22 @@ internal class GenericQuestTypeAcceptHandler : IHandler
         var owner = payload.What.Owner;
         if (owner == null || !objectManager.TryGetIdWithLogging(owner, out var ownerId)) return;
 
+        var descriptor = QuestTypeRegistry.Get(owner.Issue);
+        if (descriptor?.SupportsQuestSolutionAccept != true) return;
+
         if (ModInformation.IsServer)
         {
             var hostControllerId = payload.What.ControllerId;
+            byte[] fieldsBytes = null;
+            if (descriptor.TryArbitrateQuestSolutionAcceptBytes != null)
+            {
+                var (accepted, bytes) = descriptor.TryArbitrateQuestSolutionAcceptBytes(owner, _ => true);
+                if (!accepted) return;
+                fieldsBytes = bytes;
+            }
+
             ownershipRegistry.SetOwner(owner, hostControllerId);
-            network.SendAll(new NetworkQuestTypeQuestAccepted(ownerId, hostControllerId, payload.What.FieldsBytes));
+            network.SendAll(new NetworkQuestTypeQuestAccepted(ownerId, hostControllerId, fieldsBytes));
         }
         else
         {
@@ -122,28 +139,43 @@ internal class GenericQuestTypeAcceptHandler : IHandler
                 return;
             }
 
+            if (!conversationTracker.TryGetTrackedRequester(ownerId, out var trackedControllerId, out var trackedGeneration) ||
+                trackedControllerId != player.ControllerId || trackedGeneration != requestedGeneration)
+            {
+                Logger.Error("Rejecting {Message} for a requester with no tracked conversation with owner {Owner}",
+                    nameof(RequestQuestTypeAcceptQuest), ownerId);
+                network.Send(requester, new NetworkQuestTypeAcceptRejected(ownerId));
+                return;
+            }
+
             var descriptor = QuestTypeRegistry.Get(owner.Issue);
-            if (descriptor?.TryArbitrateQuestSolutionAcceptBytes == null)
+            var canAccept = descriptor?.SupportsQuestSolutionAccept == true &&
+                owner.Issue.IsOngoingWithoutQuest && owner.Issue.IssueStayAliveConditions();
+            if (!canAccept)
             {
                 network.Send(requester, new NetworkQuestTypeAcceptRejected(ownerId));
                 return;
             }
 
-            var canAccept = owner.Issue.IsOngoingWithoutQuest && owner.Issue.IssueStayAliveConditions();
-            var (accepted, fieldsBytes) = descriptor.TryArbitrateQuestSolutionAcceptBytes(owner, _ => canAccept);
-            if (accepted)
+            byte[] fieldsBytes = null;
+            if (descriptor.TryArbitrateQuestSolutionAcceptBytes != null)
             {
-                ownershipRegistry.SetOwner(owner, player.ControllerId);
-                network.SendAll(new NetworkQuestTypeQuestAccepted(ownerId, player.ControllerId, fieldsBytes));
+                var (accepted, bytes) = descriptor.TryArbitrateQuestSolutionAcceptBytes(owner, _ => canAccept);
+                if (!accepted)
+                {
+                    Logger.Error("Replayed accept for owner {Owner} but could not read back its quest fields - rolled back and rejecting", ownerId);
+                    network.Send(requester, new NetworkQuestTypeAcceptRejected(ownerId));
+                    return;
+                }
+                fieldsBytes = bytes;
             }
             else
             {
-                if (canAccept)
-                {
-                    Logger.Error("Replayed accept for owner {Owner} but could not read back its quest fields - rolled back and rejecting", ownerId);
-                }
-                network.Send(requester, new NetworkQuestTypeAcceptRejected(ownerId));
+                owner.Issue.StartIssueWithQuest();
             }
+
+            ownershipRegistry.SetOwner(owner, player.ControllerId);
+            network.SendAll(new NetworkQuestTypeQuestAccepted(ownerId, player.ControllerId, fieldsBytes));
         });
     }
 
@@ -154,9 +186,17 @@ internal class GenericQuestTypeAcceptHandler : IHandler
         {
             if (!objectManager.TryGetObjectWithLogging<Hero>(data.OwnerId, out var owner)) return;
 
+            var descriptor = QuestTypeRegistry.Get(owner.Issue);
             try
             {
-                QuestTypeRegistry.Get(owner.Issue)?.MirrorQuestSolutionAcceptBytes?.Invoke(owner, data.FieldsBytes);
+                if (descriptor?.MirrorQuestSolutionAcceptBytes != null)
+                {
+                    descriptor.MirrorQuestSolutionAcceptBytes(owner, data.FieldsBytes);
+                }
+                else
+                {
+                    MirrorQuestAccepted(owner);
+                }
             }
             catch (Exception e)
             {
@@ -174,18 +214,33 @@ internal class GenericQuestTypeAcceptHandler : IHandler
         var owner = payload.What.Owner;
         if (owner == null || !objectManager.TryGetIdWithLogging(owner, out var ownerId)) return;
 
+        var descriptor = QuestTypeRegistry.Get(owner.Issue);
+        if (descriptor?.SupportsAlternativeAccept != true) return;
+
         if (ModInformation.IsServer)
         {
             var hostControllerId = payload.What.ControllerId;
+            if (hostControllerId == null || !playerManager.TryGetPlayer(hostControllerId, out var player)) return;
+
+            var state = AlternativeSolutionStartRunner.StartOnServer(owner, player);
+
+            byte[] fieldsBytes = null;
+            if (descriptor.TryArbitrateAlternativeAcceptBytes != null)
+            {
+                var (accepted, bytes) = descriptor.TryArbitrateAlternativeAcceptBytes(owner, _ => true);
+                if (!accepted) return;
+                fieldsBytes = bytes;
+            }
+
             ownershipRegistry.SetOwner(owner, hostControllerId);
             var hostTroops = troopRosterInterface.PackTroopRosterData(owner.Issue.AlternativeSolutionSentTroops);
-            network.SendAll(new NetworkQuestTypeAlternativeAccepted(ownerId, hostControllerId, payload.What.FieldsBytes, hostTroops));
+            network.SendAll(new NetworkQuestTypeAlternativeAccepted(ownerId, hostControllerId, state, fieldsBytes, hostTroops));
         }
         else
         {
             generationRegistry.TryGetGeneration(owner, out var generation);
             var packedTroops = troopRosterInterface.PackTroopRosterData(owner.Issue.AlternativeSolutionSentTroops);
-            network.SendAll(new RequestQuestTypeAcceptAlternative(ownerId, generation, packedTroops, payload.What.FieldsBytes));
+            network.SendAll(new RequestQuestTypeAcceptAlternative(ownerId, generation, packedTroops));
         }
     }
 
@@ -216,36 +271,53 @@ internal class GenericQuestTypeAcceptHandler : IHandler
                 return;
             }
 
+            if (!conversationTracker.TryGetTrackedRequester(ownerId, out var trackedControllerId, out var trackedGeneration) ||
+                trackedControllerId != player.ControllerId || trackedGeneration != requestedGeneration)
+            {
+                Logger.Error("Rejecting {Message} for a requester with no tracked conversation with owner {Owner}",
+                    nameof(RequestQuestTypeAcceptAlternative), ownerId);
+                network.Send(requester, new NetworkQuestTypeAcceptRejected(ownerId));
+                return;
+            }
+
             var descriptor = QuestTypeRegistry.Get(owner.Issue);
-            if (descriptor?.MirrorAlternativeAcceptBytes == null)
+            var canAccept = descriptor?.SupportsAlternativeAccept == true &&
+                owner.Issue.IsOngoingWithoutQuest && owner.Issue.IssueStayAliveConditions();
+            if (!canAccept)
             {
                 network.Send(requester, new NetworkQuestTypeAcceptRejected(ownerId));
                 return;
             }
 
-            if (owner.Issue.IsOngoingWithoutQuest && owner.Issue.IssueStayAliveConditions())
+            AlternativeSolutionVanillaState state;
+            byte[] fieldsBytes = null;
+            try
             {
-                try
-                {
-                    ApplyValidatedSentTroops(owner, player, payload.What.SentTroops);
-                    descriptor.MirrorAlternativeAcceptBytes(owner, payload.What.FieldsBytes);
-                }
-                catch (Exception e)
-                {
-                    Logger.Error(e, "Failed to apply {Message} for owner {Owner} - malformed or version-mismatched payload",
-                        nameof(RequestQuestTypeAcceptAlternative), ownerId);
-                    network.Send(requester, new NetworkQuestTypeAcceptRejected(ownerId));
-                    return;
-                }
+                ApplyValidatedSentTroops(owner, player, payload.What.SentTroops);
+                state = AlternativeSolutionStartRunner.StartOnServer(owner, player);
 
-                ownershipRegistry.SetOwner(owner, player.ControllerId);
-                var validatedTroops = troopRosterInterface.PackTroopRosterData(owner.Issue.AlternativeSolutionSentTroops);
-                network.SendAll(new NetworkQuestTypeAlternativeAccepted(ownerId, player.ControllerId, payload.What.FieldsBytes, validatedTroops));
+                if (descriptor.TryArbitrateAlternativeAcceptBytes != null)
+                {
+                    var (accepted, bytes) = descriptor.TryArbitrateAlternativeAcceptBytes(owner, _ => true);
+                    if (!accepted)
+                    {
+                        network.Send(requester, new NetworkQuestTypeAcceptRejected(ownerId));
+                        return;
+                    }
+                    fieldsBytes = bytes;
+                }
             }
-            else
+            catch (Exception e)
             {
+                Logger.Error(e, "Failed to apply {Message} for owner {Owner} - malformed or version-mismatched payload",
+                    nameof(RequestQuestTypeAcceptAlternative), ownerId);
                 network.Send(requester, new NetworkQuestTypeAcceptRejected(ownerId));
+                return;
             }
+
+            ownershipRegistry.SetOwner(owner, player.ControllerId);
+            var validatedTroops = troopRosterInterface.PackTroopRosterData(owner.Issue.AlternativeSolutionSentTroops);
+            network.SendAll(new NetworkQuestTypeAlternativeAccepted(ownerId, player.ControllerId, state, fieldsBytes, validatedTroops));
         });
     }
 
@@ -280,10 +352,12 @@ internal class GenericQuestTypeAcceptHandler : IHandler
         {
             if (!objectManager.TryGetObjectWithLogging<Hero>(data.OwnerId, out var owner) || owner.Issue == null) return;
 
+            var descriptor = QuestTypeRegistry.Get(owner.Issue);
             try
             {
                 ApplyReceivedTroops(owner, data.SentTroops);
-                QuestTypeRegistry.Get(owner.Issue)?.MirrorAlternativeAcceptBytes?.Invoke(owner, data.FieldsBytes);
+                MirrorAlternativeAccepted(owner, data.State);
+                descriptor?.MirrorAlternativeAcceptBytes?.Invoke(owner, data.FieldsBytes);
             }
             catch (Exception e)
             {
@@ -315,7 +389,42 @@ internal class GenericQuestTypeAcceptHandler : IHandler
         GameThread.RunSafe(() =>
         {
             if (!objectManager.TryGetObjectWithLogging<Hero>(ownerId, out var owner)) return;
-            QuestTypeRegistry.Get(owner.Issue)?.RejectQuestSolutionAccept?.Invoke(owner);
+
+            var descriptor = QuestTypeRegistry.Get(owner.Issue);
+            if (descriptor?.RejectQuestSolutionAccept != null)
+            {
+                descriptor.RejectQuestSolutionAccept(owner);
+            }
+            else
+            {
+                AcceptMirrorSupport.RejectAcceptance(owner);
+            }
         });
+    }
+
+    private static void MirrorQuestAccepted(Hero owner)
+    {
+        if (owner?.Issue == null || !owner.Issue.IsOngoingWithoutQuest) return;
+
+        var issue = owner.Issue;
+        using (new AllowedThread())
+        {
+            issue._issueState = IssueBase.IssueState.SolvingWithQuestSolution;
+            issue.IsTriedToSolveBefore = true;
+            issue.IssueDueTime = CampaignTime.Never;
+        }
+    }
+
+    private static void MirrorAlternativeAccepted(Hero owner, AlternativeSolutionVanillaState state)
+    {
+        if (owner?.Issue == null || !owner.Issue.IsOngoingWithoutQuest) return;
+
+        var issue = owner.Issue;
+        using (new AllowedThread())
+        {
+            issue._issueState = IssueBase.IssueState.SolvingWithAlternativeSolution;
+            issue.IsTriedToSolveBefore = true;
+            AlternativeSolutionVanillaStateSync.Apply(issue, state);
+        }
     }
 }

--- a/source/GameInterface/Services/Issues/Handlers/GenericQuestTypeAcceptHandler.cs
+++ b/source/GameInterface/Services/Issues/Handlers/GenericQuestTypeAcceptHandler.cs
@@ -32,6 +32,7 @@ internal class GenericQuestTypeAcceptHandler : IHandler
     private readonly ITroopRosterInterface troopRosterInterface;
     private readonly IPrisonerSaleValidator troopValidator;
     private readonly IIssueOwnershipRegistry ownershipRegistry;
+    private readonly IIssueGenerationRegistry generationRegistry;
 
     public GenericQuestTypeAcceptHandler(
         IMessageBroker messageBroker,
@@ -40,7 +41,8 @@ internal class GenericQuestTypeAcceptHandler : IHandler
         IPlayerManager playerManager,
         ITroopRosterInterface troopRosterInterface,
         IPrisonerSaleValidator troopValidator,
-        IIssueOwnershipRegistry ownershipRegistry)
+        IIssueOwnershipRegistry ownershipRegistry,
+        IIssueGenerationRegistry generationRegistry)
     {
         this.messageBroker = messageBroker;
         this.objectManager = objectManager;
@@ -49,6 +51,7 @@ internal class GenericQuestTypeAcceptHandler : IHandler
         this.troopRosterInterface = troopRosterInterface;
         this.troopValidator = troopValidator;
         this.ownershipRegistry = ownershipRegistry;
+        this.generationRegistry = generationRegistry;
 
         messageBroker.Subscribe<QuestTypeQuestSolutionAcceptTriggered>(Handle_QuestTypeQuestSolutionAcceptTriggered);
         messageBroker.Subscribe<RequestQuestTypeAcceptQuest>(Handle_RequestQuestTypeAcceptQuest);
@@ -87,7 +90,7 @@ internal class GenericQuestTypeAcceptHandler : IHandler
         }
         else
         {
-            IssueGenerationRegistry.TryGetGeneration(owner, out var generation);
+            generationRegistry.TryGetGeneration(owner, out var generation);
             network.SendAll(new RequestQuestTypeAcceptQuest(ownerId, generation));
         }
     }
@@ -111,7 +114,7 @@ internal class GenericQuestTypeAcceptHandler : IHandler
                 return;
             }
 
-            if (!IssueGenerationRegistry.TryGetGeneration(owner, out var currentGeneration) || currentGeneration != requestedGeneration)
+            if (!generationRegistry.TryGetGeneration(owner, out var currentGeneration) || currentGeneration != requestedGeneration)
             {
                 Logger.Error("Rejecting {Message} for a stale/superseded issue generation for owner {Owner}",
                     nameof(RequestQuestTypeAcceptQuest), ownerId);
@@ -180,7 +183,7 @@ internal class GenericQuestTypeAcceptHandler : IHandler
         }
         else
         {
-            IssueGenerationRegistry.TryGetGeneration(owner, out var generation);
+            generationRegistry.TryGetGeneration(owner, out var generation);
             var packedTroops = troopRosterInterface.PackTroopRosterData(owner.Issue.AlternativeSolutionSentTroops);
             network.SendAll(new RequestQuestTypeAcceptAlternative(ownerId, generation, packedTroops, payload.What.FieldsBytes));
         }
@@ -205,7 +208,7 @@ internal class GenericQuestTypeAcceptHandler : IHandler
                 return;
             }
 
-            if (!IssueGenerationRegistry.TryGetGeneration(owner, out var currentGeneration) || currentGeneration != requestedGeneration)
+            if (!generationRegistry.TryGetGeneration(owner, out var currentGeneration) || currentGeneration != requestedGeneration)
             {
                 Logger.Error("Rejecting {Message} for a stale/superseded issue generation for owner {Owner}",
                     nameof(RequestQuestTypeAcceptAlternative), ownerId);

--- a/source/GameInterface/Services/Issues/Handlers/GenericQuestTypeAcceptHandler.cs
+++ b/source/GameInterface/Services/Issues/Handlers/GenericQuestTypeAcceptHandler.cs
@@ -31,6 +31,7 @@ internal class GenericQuestTypeAcceptHandler : IHandler
     private readonly IPlayerManager playerManager;
     private readonly ITroopRosterInterface troopRosterInterface;
     private readonly IPrisonerSaleValidator troopValidator;
+    private readonly IIssueOwnershipRegistry ownershipRegistry;
 
     public GenericQuestTypeAcceptHandler(
         IMessageBroker messageBroker,
@@ -38,7 +39,8 @@ internal class GenericQuestTypeAcceptHandler : IHandler
         INetwork network,
         IPlayerManager playerManager,
         ITroopRosterInterface troopRosterInterface,
-        IPrisonerSaleValidator troopValidator)
+        IPrisonerSaleValidator troopValidator,
+        IIssueOwnershipRegistry ownershipRegistry)
     {
         this.messageBroker = messageBroker;
         this.objectManager = objectManager;
@@ -46,6 +48,7 @@ internal class GenericQuestTypeAcceptHandler : IHandler
         this.playerManager = playerManager;
         this.troopRosterInterface = troopRosterInterface;
         this.troopValidator = troopValidator;
+        this.ownershipRegistry = ownershipRegistry;
 
         messageBroker.Subscribe<QuestTypeQuestSolutionAcceptTriggered>(Handle_QuestTypeQuestSolutionAcceptTriggered);
         messageBroker.Subscribe<RequestQuestTypeAcceptQuest>(Handle_RequestQuestTypeAcceptQuest);
@@ -79,7 +82,7 @@ internal class GenericQuestTypeAcceptHandler : IHandler
         if (ModInformation.IsServer)
         {
             var hostControllerId = payload.What.ControllerId;
-            IssueOwnershipRegistry.SetOwner(owner, hostControllerId);
+            ownershipRegistry.SetOwner(owner, hostControllerId);
             network.SendAll(new NetworkQuestTypeQuestAccepted(ownerId, hostControllerId, payload.What.FieldsBytes));
         }
         else
@@ -127,7 +130,7 @@ internal class GenericQuestTypeAcceptHandler : IHandler
             var (accepted, fieldsBytes) = descriptor.TryArbitrateQuestSolutionAcceptBytes(owner, _ => canAccept);
             if (accepted)
             {
-                IssueOwnershipRegistry.SetOwner(owner, player.ControllerId);
+                ownershipRegistry.SetOwner(owner, player.ControllerId);
                 network.SendAll(new NetworkQuestTypeQuestAccepted(ownerId, player.ControllerId, fieldsBytes));
             }
             else
@@ -159,7 +162,7 @@ internal class GenericQuestTypeAcceptHandler : IHandler
                 return;
             }
 
-            IssueOwnershipRegistry.SetOwner(owner, data.OwnerControllerId);
+            ownershipRegistry.SetOwner(owner, data.OwnerControllerId);
         });
     }
 
@@ -171,7 +174,7 @@ internal class GenericQuestTypeAcceptHandler : IHandler
         if (ModInformation.IsServer)
         {
             var hostControllerId = payload.What.ControllerId;
-            IssueOwnershipRegistry.SetOwner(owner, hostControllerId);
+            ownershipRegistry.SetOwner(owner, hostControllerId);
             var hostTroops = troopRosterInterface.PackTroopRosterData(owner.Issue.AlternativeSolutionSentTroops);
             network.SendAll(new NetworkQuestTypeAlternativeAccepted(ownerId, hostControllerId, payload.What.FieldsBytes, hostTroops));
         }
@@ -232,7 +235,7 @@ internal class GenericQuestTypeAcceptHandler : IHandler
                     return;
                 }
 
-                IssueOwnershipRegistry.SetOwner(owner, player.ControllerId);
+                ownershipRegistry.SetOwner(owner, player.ControllerId);
                 var validatedTroops = troopRosterInterface.PackTroopRosterData(owner.Issue.AlternativeSolutionSentTroops);
                 network.SendAll(new NetworkQuestTypeAlternativeAccepted(ownerId, player.ControllerId, payload.What.FieldsBytes, validatedTroops));
             }
@@ -286,7 +289,7 @@ internal class GenericQuestTypeAcceptHandler : IHandler
                 return;
             }
 
-            IssueOwnershipRegistry.SetOwner(owner, data.OwnerControllerId);
+            ownershipRegistry.SetOwner(owner, data.OwnerControllerId);
         });
     }
 

--- a/source/GameInterface/Services/Issues/Handlers/IssueConversationHandler.cs
+++ b/source/GameInterface/Services/Issues/Handlers/IssueConversationHandler.cs
@@ -1,0 +1,122 @@
+using Common;
+using Common.Messaging;
+using Common.Network;
+using GameInterface.Services.Entity;
+using GameInterface.Services.Issues.Generic;
+using GameInterface.Services.Issues.Interfaces;
+using GameInterface.Services.Issues.Messages;
+using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Players;
+using LiteNetLib;
+using TaleWorlds.CampaignSystem;
+
+namespace GameInterface.Services.Issues.Handlers;
+
+internal class IssueConversationHandler : IHandler
+{
+    private readonly IMessageBroker messageBroker;
+    private readonly IObjectManager objectManager;
+    private readonly INetwork network;
+    private readonly IPlayerManager playerManager;
+    private readonly IIssueGenerationRegistry generationRegistry;
+    private readonly IIssueConversationTracker conversationTracker;
+
+    public IssueConversationHandler(
+        IMessageBroker messageBroker,
+        IObjectManager objectManager,
+        INetwork network,
+        IPlayerManager playerManager,
+        IIssueGenerationRegistry generationRegistry,
+        IIssueConversationTracker conversationTracker)
+    {
+        this.messageBroker = messageBroker;
+        this.objectManager = objectManager;
+        this.network = network;
+        this.playerManager = playerManager;
+        this.generationRegistry = generationRegistry;
+        this.conversationTracker = conversationTracker;
+
+        messageBroker.Subscribe<IssueConversationOpenedLocally>(Handle_IssueConversationOpenedLocally);
+        messageBroker.Subscribe<RequestIssueConversationOpened>(Handle_RequestIssueConversationOpened);
+        messageBroker.Subscribe<NetworkIssueConversationAllowed>(Handle_NetworkIssueConversationAllowed);
+    }
+
+    public void Dispose()
+    {
+        messageBroker.Unsubscribe<IssueConversationOpenedLocally>(Handle_IssueConversationOpenedLocally);
+        messageBroker.Unsubscribe<RequestIssueConversationOpened>(Handle_RequestIssueConversationOpened);
+        messageBroker.Unsubscribe<NetworkIssueConversationAllowed>(Handle_NetworkIssueConversationAllowed);
+    }
+
+    private void Handle_IssueConversationOpenedLocally(MessagePayload<IssueConversationOpenedLocally> payload)
+    {
+        var issueGiver = payload.What.IssueGiver;
+        if (issueGiver == null || !objectManager.TryGetIdWithLogging(issueGiver, out var issueGiverId)) return;
+        if (!IsMirrorEligible(issueGiver.Issue)) return;
+
+        if (ModInformation.IsServer)
+        {
+            TryRegisterConversation(issueGiverId, payload.What.ControllerId);
+        }
+        else
+        {
+            network.SendAll(new RequestIssueConversationOpened(issueGiverId));
+        }
+    }
+
+    private void Handle_RequestIssueConversationOpened(MessagePayload<RequestIssueConversationOpened> payload)
+    {
+        if (ModInformation.IsClient) return;
+
+        var issueGiverId = payload.What.IssueGiverId;
+        var requester = payload.Who as NetPeer;
+        GameThread.RunSafe(() =>
+        {
+            if (requester == null || !playerManager.TryGetPlayer(requester, out var player)) return;
+
+            if (TryRegisterConversation(issueGiverId, player.ControllerId) &&
+                conversationTracker.TryGetTrackedRequester(issueGiverId, out _, out var generation))
+            {
+                network.Send(requester, new NetworkIssueConversationAllowed(issueGiverId, generation));
+            }
+            else
+            {
+                network.Send(requester, new NetworkIssueConversationDenied(issueGiverId));
+            }
+        });
+    }
+
+    private void Handle_NetworkIssueConversationAllowed(MessagePayload<NetworkIssueConversationAllowed> payload)
+    {
+        var data = payload.What;
+        GameThread.RunSafe(() =>
+        {
+            if (!ContainerProvider.TryResolve<IControllerIdProvider>(out var controllerIdProvider)) return;
+
+            conversationTracker.Register(data.IssueGiverId, controllerIdProvider.ControllerId, data.Generation);
+        });
+    }
+
+    private bool TryRegisterConversation(string issueGiverId, string controllerId)
+    {
+        if (controllerId == null) return false;
+        if (!objectManager.TryGetObjectWithLogging<Hero>(issueGiverId, out var issueGiver)) return false;
+        if (issueGiver.Issue == null || !issueGiver.Issue.IsOngoingWithoutQuest || !issueGiver.Issue.IssueStayAliveConditions()) return false;
+        if (!IsMirrorEligible(issueGiver.Issue)) return false;
+
+        generationRegistry.TryGetGeneration(issueGiver, out var generation);
+        conversationTracker.Register(issueGiverId, controllerId, generation);
+        return true;
+    }
+
+    private static bool IsMirrorEligible(TaleWorlds.CampaignSystem.Issues.IssueBase issue)
+    {
+        if (issue == null) return false;
+
+        var descriptor = QuestTypeRegistry.Get(issue);
+        if (descriptor != null && (descriptor.SupportsQuestSolutionAccept || descriptor.SupportsAlternativeAccept)) return true;
+
+        return GenericAcceptMirrorIssueTypes.IsQuestSolutionMirrorEligible(issue) ||
+            GenericAcceptMirrorIssueTypes.IsAlternativeSolutionMirrorEligible(issue);
+    }
+}

--- a/source/GameInterface/Services/Issues/Handlers/IssueFinalizationHandler.cs
+++ b/source/GameInterface/Services/Issues/Handlers/IssueFinalizationHandler.cs
@@ -21,17 +21,20 @@ internal class IssueFinalizationHandler : IHandler
     private readonly IObjectManager objectManager;
     private readonly INetwork network;
     private readonly IPlayerManager playerManager;
+    private readonly IIssueOwnershipRegistry ownershipRegistry;
 
     public IssueFinalizationHandler(
         IMessageBroker messageBroker,
         IObjectManager objectManager,
         INetwork network,
-        IPlayerManager playerManager)
+        IPlayerManager playerManager,
+        IIssueOwnershipRegistry ownershipRegistry)
     {
         this.messageBroker = messageBroker;
         this.objectManager = objectManager;
         this.network = network;
         this.playerManager = playerManager;
+        this.ownershipRegistry = ownershipRegistry;
 
         messageBroker.Subscribe<IssueFinalizedTriggered>(Handle_IssueFinalizedTriggered);
         messageBroker.Subscribe<RequestIssueRemoved>(Handle_RequestIssueRemoved);
@@ -79,7 +82,7 @@ internal class IssueFinalizationHandler : IHandler
                 return;
             }
 
-            if (!IssueOwnershipRegistry.TryGetOwnerControllerId(owner, out var recordedOwner) || recordedOwner != player.ControllerId)
+            if (!ownershipRegistry.TryGetOwnerControllerId(owner, out var recordedOwner) || recordedOwner != player.ControllerId)
             {
                 Logger.Error("Rejecting {Message} from {Requester}, who is not the recorded owner of {Owner}",
                     nameof(RequestIssueRemoved), player.ControllerId, ownerId);

--- a/source/GameInterface/Services/Issues/Handlers/SimpleIssueCreationHandler.cs
+++ b/source/GameInterface/Services/Issues/Handlers/SimpleIssueCreationHandler.cs
@@ -18,12 +18,18 @@ internal class SimpleIssueCreationHandler : IHandler
     private readonly IMessageBroker messageBroker;
     private readonly IObjectManager objectManager;
     private readonly INetwork network;
+    private readonly IIssueGenerationRegistry generationRegistry;
 
-    public SimpleIssueCreationHandler(IMessageBroker messageBroker, IObjectManager objectManager, INetwork network)
+    public SimpleIssueCreationHandler(
+        IMessageBroker messageBroker,
+        IObjectManager objectManager,
+        INetwork network,
+        IIssueGenerationRegistry generationRegistry)
     {
         this.messageBroker = messageBroker;
         this.objectManager = objectManager;
         this.network = network;
+        this.generationRegistry = generationRegistry;
 
         messageBroker.Subscribe<SimpleIssueCreated>(Handle_SimpleIssueCreated);
         messageBroker.Subscribe<NetworkSimpleIssueCreated>(Handle_NetworkSimpleIssueCreated);
@@ -48,7 +54,7 @@ internal class SimpleIssueCreationHandler : IHandler
             return;
         }
 
-        var generation = IssueGenerationRegistry.Bump(issue.IssueOwner);
+        var generation = generationRegistry.Bump(issue.IssueOwner);
 
         network.SendAll(new NetworkSimpleIssueCreated(ownerId, key, generation));
     }
@@ -62,7 +68,7 @@ internal class SimpleIssueCreationHandler : IHandler
         {
             if (!objectManager.TryGetObjectWithLogging<Hero>(data.OwnerId, out var owner)) return;
 
-            IssueGenerationRegistry.SetGeneration(owner, data.Generation);
+            generationRegistry.SetGeneration(owner, data.Generation);
 
             if (owner.Issue != null) return;
 

--- a/source/GameInterface/Services/Issues/Interfaces/AwaitingAlternativeSolutionTroopsRegistry.cs
+++ b/source/GameInterface/Services/Issues/Interfaces/AwaitingAlternativeSolutionTroopsRegistry.cs
@@ -3,52 +3,62 @@ using TaleWorlds.CampaignSystem.Roster;
 
 namespace GameInterface.Services.Issues.Interfaces;
 
-internal static class AwaitingAlternativeSolutionTroopsRegistry
+public interface IAwaitingAlternativeSolutionTroopsRegistry
 {
-    private static readonly Dictionary<string, TroopRoster> TroopsByOwnerControllerId = new();
+    void Deposit(string ownerControllerId, TroopRoster troops);
+    bool TryGet(string ownerControllerId, out TroopRoster troops);
+    void Clear(string ownerControllerId);
+    void ClearAll();
+    void Restore(string ownerControllerId, TroopRoster troops);
+    IReadOnlyCollection<(string OwnerControllerId, TroopRoster Troops)> Snapshot();
+}
 
-    public static void Deposit(string ownerControllerId, TroopRoster troops)
+internal sealed class AwaitingAlternativeSolutionTroopsRegistry : IAwaitingAlternativeSolutionTroopsRegistry
+{
+    private readonly Dictionary<string, TroopRoster> troopsByOwnerControllerId = new();
+
+    public void Deposit(string ownerControllerId, TroopRoster troops)
     {
         if (string.IsNullOrEmpty(ownerControllerId) || troops == null || troops.Count == 0) return;
 
-        if (!TroopsByOwnerControllerId.TryGetValue(ownerControllerId, out var existing))
+        if (!troopsByOwnerControllerId.TryGetValue(ownerControllerId, out var existing))
         {
             existing = TroopRoster.CreateDummyTroopRoster();
-            TroopsByOwnerControllerId[ownerControllerId] = existing;
+            troopsByOwnerControllerId[ownerControllerId] = existing;
         }
 
         existing.Add(troops);
     }
 
-    public static bool TryGet(string ownerControllerId, out TroopRoster troops)
+    public bool TryGet(string ownerControllerId, out TroopRoster troops)
     {
         troops = null;
         if (string.IsNullOrEmpty(ownerControllerId)) return false;
 
-        return TroopsByOwnerControllerId.TryGetValue(ownerControllerId, out troops) && troops.Count > 0;
+        return troopsByOwnerControllerId.TryGetValue(ownerControllerId, out troops) && troops.Count > 0;
     }
 
-    public static void Clear(string ownerControllerId)
+    public void Clear(string ownerControllerId)
     {
         if (string.IsNullOrEmpty(ownerControllerId)) return;
-        TroopsByOwnerControllerId.Remove(ownerControllerId);
+        troopsByOwnerControllerId.Remove(ownerControllerId);
     }
 
-    public static void ClearAll()
+    public void ClearAll()
     {
-        TroopsByOwnerControllerId.Clear();
+        troopsByOwnerControllerId.Clear();
     }
 
-    public static void Restore(string ownerControllerId, TroopRoster troops)
+    public void Restore(string ownerControllerId, TroopRoster troops)
     {
         if (string.IsNullOrEmpty(ownerControllerId) || troops == null || troops.Count == 0) return;
-        TroopsByOwnerControllerId[ownerControllerId] = troops;
+        troopsByOwnerControllerId[ownerControllerId] = troops;
     }
 
-    public static IReadOnlyCollection<(string OwnerControllerId, TroopRoster Troops)> Snapshot()
+    public IReadOnlyCollection<(string OwnerControllerId, TroopRoster Troops)> Snapshot()
     {
-        var snapshot = new List<(string, TroopRoster)>(TroopsByOwnerControllerId.Count);
-        foreach (var kvp in TroopsByOwnerControllerId)
+        var snapshot = new List<(string, TroopRoster)>(troopsByOwnerControllerId.Count);
+        foreach (var kvp in troopsByOwnerControllerId)
         {
             snapshot.Add((kvp.Key, kvp.Value));
         }

--- a/source/GameInterface/Services/Issues/Messages/GenericAcceptMirrorIssueMessages.cs
+++ b/source/GameInterface/Services/Issues/Messages/GenericAcceptMirrorIssueMessages.cs
@@ -22,13 +22,11 @@ public readonly struct GenericIssueAlternativeAcceptTriggered : IEvent
 {
     public readonly Hero Owner;
     public readonly string ControllerId;
-    public readonly AlternativeSolutionVanillaState State;
 
-    public GenericIssueAlternativeAcceptTriggered(Hero owner, string controllerId, AlternativeSolutionVanillaState state)
+    public GenericIssueAlternativeAcceptTriggered(Hero owner, string controllerId)
     {
         Owner = owner;
         ControllerId = controllerId;
-        State = state;
     }
 }
 
@@ -71,15 +69,12 @@ public readonly struct RequestGenericIssueAcceptAlternative : ICommand
     public readonly int Generation;
     [ProtoMember(3)]
     public readonly TroopRosterData SentTroops;
-    [ProtoMember(4)]
-    public readonly AlternativeSolutionVanillaState State;
 
-    public RequestGenericIssueAcceptAlternative(string ownerId, int generation, TroopRosterData sentTroops, AlternativeSolutionVanillaState state)
+    public RequestGenericIssueAcceptAlternative(string ownerId, int generation, TroopRosterData sentTroops)
     {
         OwnerId = ownerId;
         Generation = generation;
         SentTroops = sentTroops;
-        State = state;
     }
 }
 

--- a/source/GameInterface/Services/Issues/Messages/GenericQuestTypeAcceptMessages.cs
+++ b/source/GameInterface/Services/Issues/Messages/GenericQuestTypeAcceptMessages.cs
@@ -1,4 +1,5 @@
 using Common.Messaging;
+using GameInterface.Services.Issues.Generic.AcceptMirror;
 using GameInterface.Services.TroopRosters.Data;
 using ProtoBuf;
 using TaleWorlds.CampaignSystem;
@@ -9,13 +10,11 @@ public readonly struct QuestTypeQuestSolutionAcceptTriggered : IEvent
 {
     public readonly Hero Owner;
     public readonly string ControllerId;
-    public readonly byte[] FieldsBytes;
 
-    public QuestTypeQuestSolutionAcceptTriggered(Hero owner, string controllerId, byte[] fieldsBytes)
+    public QuestTypeQuestSolutionAcceptTriggered(Hero owner, string controllerId)
     {
         Owner = owner;
         ControllerId = controllerId;
-        FieldsBytes = fieldsBytes;
     }
 }
 
@@ -23,13 +22,11 @@ public readonly struct QuestTypeAlternativeAcceptTriggered : IEvent
 {
     public readonly Hero Owner;
     public readonly string ControllerId;
-    public readonly byte[] FieldsBytes;
 
-    public QuestTypeAlternativeAcceptTriggered(Hero owner, string controllerId, byte[] fieldsBytes)
+    public QuestTypeAlternativeAcceptTriggered(Hero owner, string controllerId)
     {
         Owner = owner;
         ControllerId = controllerId;
-        FieldsBytes = fieldsBytes;
     }
 }
 
@@ -75,15 +72,12 @@ public readonly struct RequestQuestTypeAcceptAlternative : ICommand
     public readonly int Generation;
     [ProtoMember(3)]
     public readonly TroopRosterData SentTroops;
-    [ProtoMember(4)]
-    public readonly byte[] FieldsBytes;
 
-    public RequestQuestTypeAcceptAlternative(string ownerId, int generation, TroopRosterData sentTroops, byte[] fieldsBytes)
+    public RequestQuestTypeAcceptAlternative(string ownerId, int generation, TroopRosterData sentTroops)
     {
         OwnerId = ownerId;
         Generation = generation;
         SentTroops = sentTroops;
-        FieldsBytes = fieldsBytes;
     }
 }
 
@@ -95,14 +89,17 @@ public readonly struct NetworkQuestTypeAlternativeAccepted : IServerToClientComm
     [ProtoMember(2)]
     public readonly string OwnerControllerId;
     [ProtoMember(3)]
-    public readonly byte[] FieldsBytes;
+    public readonly AlternativeSolutionVanillaState State;
     [ProtoMember(4)]
+    public readonly byte[] FieldsBytes;
+    [ProtoMember(5)]
     public readonly TroopRosterData SentTroops;
 
-    public NetworkQuestTypeAlternativeAccepted(string ownerId, string ownerControllerId, byte[] fieldsBytes, TroopRosterData sentTroops)
+    public NetworkQuestTypeAlternativeAccepted(string ownerId, string ownerControllerId, AlternativeSolutionVanillaState state, byte[] fieldsBytes, TroopRosterData sentTroops)
     {
         OwnerId = ownerId;
         OwnerControllerId = ownerControllerId;
+        State = state;
         FieldsBytes = fieldsBytes;
         SentTroops = sentTroops;
     }

--- a/source/GameInterface/Services/Issues/Messages/IssueConversationMessages.cs
+++ b/source/GameInterface/Services/Issues/Messages/IssueConversationMessages.cs
@@ -1,0 +1,56 @@
+using Common.Messaging;
+using ProtoBuf;
+using TaleWorlds.CampaignSystem;
+
+namespace GameInterface.Services.Issues.Messages;
+
+public readonly struct IssueConversationOpenedLocally : IEvent
+{
+    public readonly Hero IssueGiver;
+    public readonly string ControllerId;
+
+    public IssueConversationOpenedLocally(Hero issueGiver, string controllerId)
+    {
+        IssueGiver = issueGiver;
+        ControllerId = controllerId;
+    }
+}
+
+[ProtoContract(SkipConstructor = true)]
+public readonly struct RequestIssueConversationOpened : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string IssueGiverId;
+
+    public RequestIssueConversationOpened(string issueGiverId)
+    {
+        IssueGiverId = issueGiverId;
+    }
+}
+
+[ProtoContract(SkipConstructor = true)]
+public readonly struct NetworkIssueConversationAllowed : IServerToClientCommand
+{
+    [ProtoMember(1)]
+    public readonly string IssueGiverId;
+    [ProtoMember(2)]
+    public readonly int Generation;
+
+    public NetworkIssueConversationAllowed(string issueGiverId, int generation)
+    {
+        IssueGiverId = issueGiverId;
+        Generation = generation;
+    }
+}
+
+[ProtoContract(SkipConstructor = true)]
+public readonly struct NetworkIssueConversationDenied : IServerToClientCommand
+{
+    [ProtoMember(1)]
+    public readonly string IssueGiverId;
+
+    public NetworkIssueConversationDenied(string issueGiverId)
+    {
+        IssueGiverId = issueGiverId;
+    }
+}

--- a/source/GameInterface/Services/Issues/Patches/AwaitingAlternativeSolutionTroopsSaveData.cs
+++ b/source/GameInterface/Services/Issues/Patches/AwaitingAlternativeSolutionTroopsSaveData.cs
@@ -66,10 +66,12 @@ internal class AwaitingAlternativeSolutionTroopsPersistencePatches
     [HarmonyPostfix]
     private static void SyncDataPostfix(IDataStore dataStore)
     {
+        if (!ContainerProvider.TryResolve<IAwaitingAlternativeSolutionTroopsRegistry>(out var troopsRegistry)) return;
+
         List<AwaitingAlternativeSolutionTroopsSaveData> saveData = null;
         if (dataStore.IsSaving)
         {
-            saveData = AwaitingAlternativeSolutionTroopsRegistry.Snapshot()
+            saveData = troopsRegistry.Snapshot()
                 .Select(e => new AwaitingAlternativeSolutionTroopsSaveData(e.OwnerControllerId, e.Troops))
                 .ToList();
         }
@@ -77,20 +79,20 @@ internal class AwaitingAlternativeSolutionTroopsPersistencePatches
         dataStore.SyncData(SaveKey, ref saveData);
         if (!dataStore.IsLoading) return;
 
-        AwaitingAlternativeSolutionTroopsRegistry.ClearAll();
+        troopsRegistry.ClearAll();
         if (saveData != null)
         {
             foreach (var entry in saveData)
             {
                 if (entry?.OwnerControllerId == null || entry.Troops == null) continue;
-                AwaitingAlternativeSolutionTroopsRegistry.Restore(entry.OwnerControllerId, entry.Troops);
+                troopsRegistry.Restore(entry.OwnerControllerId, entry.Troops);
             }
         }
 
-        MigrateLegacyField();
+        MigrateLegacyField(troopsRegistry);
     }
 
-    private static void MigrateLegacyField()
+    private static void MigrateLegacyField(IAwaitingAlternativeSolutionTroopsRegistry troopsRegistry)
     {
         if (ModInformation.IsClient) return;
         if (Campaign.Current?.IssueManager == null) return;
@@ -106,7 +108,7 @@ internal class AwaitingAlternativeSolutionTroopsPersistencePatches
                 "(no per-owner attribution - likely a single-player-imported or pre-fix save) onto the " +
                 "server's own ControllerId {ControllerId}.", legacyRoster.Count, controllerIdProvider.ControllerId);
 
-            AwaitingAlternativeSolutionTroopsRegistry.Deposit(controllerIdProvider.ControllerId, legacyRoster);
+            troopsRegistry.Deposit(controllerIdProvider.ControllerId, legacyRoster);
         }
         else
         {

--- a/source/GameInterface/Services/Issues/Patches/IssueAcceptancePatches.cs
+++ b/source/GameInterface/Services/Issues/Patches/IssueAcceptancePatches.cs
@@ -1,6 +1,7 @@
 using Common.Messaging;
 using GameInterface.Policies;
 using GameInterface.Services.Entity;
+using GameInterface.Services.Issues.Generic;
 using GameInterface.Services.Issues.Generic.AcceptMirror;
 using GameInterface.Services.Issues.Interfaces;
 using GameInterface.Services.Issues.Messages;
@@ -34,10 +35,10 @@ internal class IssueWithAlternativeSolutionAcceptancePatch
     private static void Postfix(IssueBase __instance)
     {
         if (CallOriginalPolicy.IsOriginalAllowed()) return;
+        if (AlternativeSolutionStartAuthorityGuard.IsActive) return;
         if (!GenericAcceptMirrorIssueTypes.IsAlternativeSolutionMirrorEligible(__instance)) return;
 
         ContainerProvider.TryResolve<IControllerIdProvider>(out var controllerIdProvider);
-        var state = AlternativeSolutionVanillaStateSync.Capture(__instance);
-        MessageBroker.Instance.Publish(__instance, new GenericIssueAlternativeAcceptTriggered(__instance.IssueOwner, controllerIdProvider?.ControllerId, state));
+        MessageBroker.Instance.Publish(__instance, new GenericIssueAlternativeAcceptTriggered(__instance.IssueOwner, controllerIdProvider?.ControllerId));
     }
 }

--- a/source/GameInterface/Services/Issues/Patches/IssueConversationOpenedPatch.cs
+++ b/source/GameInterface/Services/Issues/Patches/IssueConversationOpenedPatch.cs
@@ -1,0 +1,25 @@
+using Common.Messaging;
+using GameInterface.Services.Entity;
+using GameInterface.Services.Issues.Interfaces;
+using GameInterface.Services.Issues.Messages;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Conversation;
+
+namespace GameInterface.Services.Issues.Patches;
+
+[HarmonyPatch(typeof(ConversationManager), nameof(ConversationManager.BeginConversation))]
+internal class IssueConversationOpenedPatch
+{
+    [HarmonyPostfix]
+    private static void Postfix()
+    {
+        var issueGiver = Hero.OneToOneConversationHero;
+        if (issueGiver?.Issue == null) return;
+        if (!GenericAcceptMirrorIssueTypes.IsQuestSolutionMirrorEligible(issueGiver.Issue) &&
+            !GenericAcceptMirrorIssueTypes.IsAlternativeSolutionMirrorEligible(issueGiver.Issue)) return;
+
+        ContainerProvider.TryResolve<IControllerIdProvider>(out var controllerIdProvider);
+        MessageBroker.Instance.Publish(issueGiver, new IssueConversationOpenedLocally(issueGiver, controllerIdProvider?.ControllerId));
+    }
+}

--- a/source/GameInterface/Services/Issues/Patches/IssueFinalizedPatches.cs
+++ b/source/GameInterface/Services/Issues/Patches/IssueFinalizedPatches.cs
@@ -48,7 +48,7 @@ internal class IssueFinalizedPatches
             IssueManagerQuestCompletedReasonCapture.PendingReasons.Remove(owner);
         }
 
-        IssueOwnershipRegistry.Clear(owner);
+        if (ContainerProvider.TryResolve<IIssueOwnershipRegistry>(out var ownershipRegistry)) ownershipRegistry.Clear(owner);
 
         if (CallOriginalPolicy.IsOriginalAllowed()) return;
         if (!DisableAllIssueBehaviorsExceptAllowlist.IsAllowlisted(__instance)) return;

--- a/source/GameInterface/Services/Issues/Patches/IssueManagerAlternativeSolutionTroopsPatches.cs
+++ b/source/GameInterface/Services/Issues/Patches/IssueManagerAlternativeSolutionTroopsPatches.cs
@@ -52,7 +52,9 @@ internal class IssueManagerAlternativeSolutionTroopsPatches
             return false;
         }
 
-        AwaitingAlternativeSolutionTroopsRegistry.Deposit(ownerControllerId, troops);
+        if (!ContainerProvider.TryResolve<IAwaitingAlternativeSolutionTroopsRegistry>(out var troopsRegistry)) return false;
+
+        troopsRegistry.Deposit(ownerControllerId, troops);
         MessageBroker.Instance.Publish(issue, new AwaitingAlternativeSolutionTroopsDepositedLocally(ownerControllerId, troops));
 
         return false;
@@ -69,7 +71,8 @@ internal class IssueManagerAlternativeSolutionTroopsPatches
         var localControllerId = controllerIdProvider.ControllerId;
         if (string.IsNullOrEmpty(localControllerId)) return false;
 
-        if (!AwaitingAlternativeSolutionTroopsRegistry.TryGet(localControllerId, out var troops)) return false;
+        if (!ContainerProvider.TryResolve<IAwaitingAlternativeSolutionTroopsRegistry>(out var troopsRegistry)) return false;
+        if (!troopsRegistry.TryGet(localControllerId, out var troops)) return false;
         if (!Campaign.Current.Models.IssueModel.CanTroopsReturnFromAlternativeSolution()) return false;
 
         TextObject textObject = BuildReturnedTroopsInquiryText(troops);
@@ -79,7 +82,10 @@ internal class IssueManagerAlternativeSolutionTroopsPatches
             isNegativeOptionShown: false, GameTexts.FindText("str_ok").ToString(), null, delegate
             {
                 MakeAlternativeTroopsReturn(troops);
-                AwaitingAlternativeSolutionTroopsRegistry.Clear(localControllerId);
+                if (ContainerProvider.TryResolve<IAwaitingAlternativeSolutionTroopsRegistry>(out var registryAtDrainTime))
+                {
+                    registryAtDrainTime.Clear(localControllerId);
+                }
                 _inquiryInFlight = false;
                 MessageBroker.Instance.Publish(null, new AwaitingAlternativeSolutionTroopsDrainedLocally(localControllerId));
             }, null), pauseGameActiveState: true);

--- a/source/GameInterface/Services/Issues/Patches/IssueManagerAlternativeSolutionTroopsPatches.cs
+++ b/source/GameInterface/Services/Issues/Patches/IssueManagerAlternativeSolutionTroopsPatches.cs
@@ -34,13 +34,15 @@ internal class IssueManagerAlternativeSolutionTroopsPatches
         bool modelGatePasses = IsLocalMainHeroSafelyAvailable() && MobileParty.MainParty != null
             && Campaign.Current.Models.IssueModel.CanTroopsReturnFromAlternativeSolution();
 
-        if (IssueOwnershipRegistry.IsLocalPeerOwner(issue.IssueOwner) && modelGatePasses)
+        if (!ContainerProvider.TryResolve<IIssueOwnershipRegistry>(out var ownershipRegistry)) return false;
+
+        if (ownershipRegistry.IsLocalPeerOwner(issue.IssueOwner) && modelGatePasses)
         {
             MakeAlternativeTroopsReturn(troops);
             return false;
         }
 
-        if (!IssueOwnershipRegistry.TryGetOwnerControllerId(issue.IssueOwner, out var ownerControllerId))
+        if (!ownershipRegistry.TryGetOwnerControllerId(issue.IssueOwner, out var ownerControllerId))
         {
             Logger.Error(
                 "TryToMakeTroopsReturn: no recorded owner ControllerId for issue owner {IssueOwner} - these " +

--- a/source/GameInterface/Services/Issues/Patches/IssueOwnershipPersistencePatches.cs
+++ b/source/GameInterface/Services/Issues/Patches/IssueOwnershipPersistencePatches.cs
@@ -17,10 +17,12 @@ internal class IssueOwnershipPersistencePatches
     [HarmonyPostfix]
     private static void SyncDataPostfix(IDataStore dataStore)
     {
+        if (!ContainerProvider.TryResolve<IIssueOwnershipRegistry>(out var ownershipRegistry)) return;
+
         List<IssueOwnershipSaveData> saveData = null;
         if (dataStore.IsSaving)
         {
-            saveData = IssueOwnershipRegistry.Snapshot()
+            saveData = ownershipRegistry.Snapshot()
                 .Select(kvp => new IssueOwnershipSaveData(kvp.Key, kvp.Value))
                 .ToList();
         }
@@ -30,11 +32,11 @@ internal class IssueOwnershipPersistencePatches
         {
             if (saveData == null)
             {
-                IssueOwnershipRegistry.ClearAll();
+                ownershipRegistry.ClearAll();
             }
             else
             {
-                IssueOwnershipRegistry.RestoreAll(saveData
+                ownershipRegistry.RestoreAll(saveData
                     .Where(entry => entry?.IssueGiverHero != null && !string.IsNullOrEmpty(entry.OwnerControllerId))
                     .Select(entry => new KeyValuePair<Hero, string>(entry.IssueGiverHero, entry.OwnerControllerId)));
             }

--- a/source/GameInterface/Services/Issues/Patches/IssueOwnershipPersistencePatches.cs
+++ b/source/GameInterface/Services/Issues/Patches/IssueOwnershipPersistencePatches.cs
@@ -18,6 +18,7 @@ internal class IssueOwnershipPersistencePatches
     private static void SyncDataPostfix(IDataStore dataStore)
     {
         if (!ContainerProvider.TryResolve<IIssueOwnershipRegistry>(out var ownershipRegistry)) return;
+        if (!ContainerProvider.TryResolve<IIssueGenerationRegistry>(out var generationRegistry)) return;
 
         List<IssueOwnershipSaveData> saveData = null;
         if (dataStore.IsSaving)
@@ -45,7 +46,7 @@ internal class IssueOwnershipPersistencePatches
         List<IssueGenerationSaveData> generationSaveData = null;
         if (dataStore.IsSaving)
         {
-            generationSaveData = IssueGenerationRegistry.Snapshot()
+            generationSaveData = generationRegistry.Snapshot()
                 .Select(kvp => new IssueGenerationSaveData(kvp.Key, kvp.Value))
                 .ToList();
         }
@@ -53,7 +54,7 @@ internal class IssueOwnershipPersistencePatches
         dataStore.SyncData(GenerationSaveKey, ref generationSaveData);
         if (!dataStore.IsLoading) return;
 
-        IssueGenerationRegistry.RestoreAll((generationSaveData ?? new List<IssueGenerationSaveData>())
+        generationRegistry.RestoreAll((generationSaveData ?? new List<IssueGenerationSaveData>())
             .Where(entry => entry?.IssueGiverHero != null)
             .Select(entry => new KeyValuePair<Hero, int>(entry.IssueGiverHero, entry.Generation)));
     }

--- a/source/GameInterface/Services/Issues/Patches/NewIssueTypesAlternativeSolutionPatches.cs
+++ b/source/GameInterface/Services/Issues/Patches/NewIssueTypesAlternativeSolutionPatches.cs
@@ -21,7 +21,7 @@ internal class NewIssueTypesAlternativeSolutionOwnershipGatePatch
     {
         if (!GenericAcceptMirrorIssueTypes.AlternativeSolutionMirrorEligible.Contains(__instance.GetType())) return true;
 
-        return IssueOwnershipRegistry.IsLocalPeerOwner(__instance.IssueOwner)
+        return (ContainerProvider.TryResolve<IIssueOwnershipRegistry>(out var ownershipRegistry) && ownershipRegistry.IsLocalPeerOwner(__instance.IssueOwner))
             || AlternativeSolutionCompletionAuthorityGuard.IsActive;
     }
 }
@@ -159,6 +159,7 @@ internal class NewIssueTypesAlternativeSolutionCompletionPatches
     private static void OnHourlyTick()
     {
         if (Campaign.Current?.IssueManager == null) return;
+        if (!ContainerProvider.TryResolve<IIssueOwnershipRegistry>(out var ownershipRegistry)) return;
 
         var snapshot = new List<KeyValuePair<Hero, IssueBase>>();
         foreach (var kvp in Campaign.Current.IssueManager.Issues)
@@ -169,7 +170,7 @@ internal class NewIssueTypesAlternativeSolutionCompletionPatches
         foreach (var kvp in snapshot)
         {
             if (!GenericAcceptMirrorIssueTypes.AlternativeSolutionMirrorEligible.Contains(kvp.Value.GetType())) continue;
-            if (!IssueOwnershipRegistry.IsLocalPeerOwner(kvp.Key)) continue;
+            if (!ownershipRegistry.IsLocalPeerOwner(kvp.Key)) continue;
 
             TryTriggerOwnedAlternativeSolutionCompletion(kvp.Value);
         }

--- a/source/GameInterface/Services/Issues/Patches/NewIssueTypesAlternativeSolutionPatches.cs
+++ b/source/GameInterface/Services/Issues/Patches/NewIssueTypesAlternativeSolutionPatches.cs
@@ -26,6 +26,18 @@ internal class NewIssueTypesAlternativeSolutionOwnershipGatePatch
     }
 }
 
+[HarmonyPatch(typeof(IssueBase), nameof(IssueBase.StartIssueWithAlternativeSolution))]
+internal class NewIssueTypesAlternativeSolutionStartOwnershipGatePatch
+{
+    [HarmonyPrefix]
+    private static bool Prefix(IssueBase __instance)
+    {
+        if (!GenericAcceptMirrorIssueTypes.AlternativeSolutionMirrorEligible.Contains(__instance.GetType())) return true;
+
+        return AlternativeSolutionStartAuthorityGuard.IsActive;
+    }
+}
+
 [HarmonyPatch]
 internal class NewIssueTypesAlternativeSolutionCompletionPatches
 {

--- a/source/GameInterface/Services/Issues/Patches/NewIssueTypesAlternativeSolutionPatches.cs
+++ b/source/GameInterface/Services/Issues/Patches/NewIssueTypesAlternativeSolutionPatches.cs
@@ -8,7 +8,9 @@ using GameInterface.Services.ObjectManager;
 using HarmonyLib;
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.CampaignBehaviors;
 using TaleWorlds.CampaignSystem.Issues;
 
 namespace GameInterface.Services.Issues.Patches;
@@ -38,123 +40,19 @@ internal class NewIssueTypesAlternativeSolutionStartOwnershipGatePatch
     }
 }
 
-[HarmonyPatch]
+[HarmonyPatch(typeof(IssuesCampaignBehavior), nameof(IssuesCampaignBehavior.RegisterEvents))]
 internal class NewIssueTypesAlternativeSolutionCompletionPatches
 {
-    [HarmonyPatch(typeof(LordNeedsHorsesIssueBehavior), nameof(LordNeedsHorsesIssueBehavior.RegisterEvents))]
-    [HarmonyPostfix]
-    private static void LordNeedsHorsesRegisterEventsPostfix(LordNeedsHorsesIssueBehavior __instance) =>
-        CampaignEvents.HourlyTickEvent.AddNonSerializedListener(__instance, OnHourlyTick);
+    private static readonly ConditionalWeakTable<IssuesCampaignBehavior, object> listenerRegistered = new();
 
-    [HarmonyPatch(typeof(CapturedByBountyHuntersIssueBehavior), nameof(CapturedByBountyHuntersIssueBehavior.RegisterEvents))]
     [HarmonyPostfix]
-    private static void CapturedByBountyHuntersRegisterEventsPostfix(CapturedByBountyHuntersIssueBehavior __instance) =>
-        CampaignEvents.HourlyTickEvent.AddNonSerializedListener(__instance, OnHourlyTick);
+    private static void RegisterEventsPostfix(IssuesCampaignBehavior __instance)
+    {
+        if (listenerRegistered.TryGetValue(__instance, out _)) return;
+        listenerRegistered.Add(__instance, null);
 
-    [HarmonyPatch(typeof(LandlordTrainingForRetainersIssueBehavior), nameof(LandlordTrainingForRetainersIssueBehavior.RegisterEvents))]
-    [HarmonyPostfix]
-    private static void LandlordTrainingForRetainersRegisterEventsPostfix(LandlordTrainingForRetainersIssueBehavior __instance) =>
         CampaignEvents.HourlyTickEvent.AddNonSerializedListener(__instance, OnHourlyTick);
-
-    [HarmonyPatch(typeof(GangLeaderNeedsRecruitsIssueBehavior), nameof(GangLeaderNeedsRecruitsIssueBehavior.RegisterEvents))]
-    [HarmonyPostfix]
-    private static void GangLeaderNeedsRecruitsRegisterEventsPostfix(GangLeaderNeedsRecruitsIssueBehavior __instance) =>
-        CampaignEvents.HourlyTickEvent.AddNonSerializedListener(__instance, OnHourlyTick);
-
-    [HarmonyPatch(typeof(LandLordNeedsManualLaborersIssueBehavior), nameof(LandLordNeedsManualLaborersIssueBehavior.RegisterEvents))]
-    [HarmonyPostfix]
-    private static void LandLordNeedsManualLaborersRegisterEventsPostfix(LandLordNeedsManualLaborersIssueBehavior __instance) =>
-        CampaignEvents.HourlyTickEvent.AddNonSerializedListener(__instance, OnHourlyTick);
-
-    [HarmonyPatch(typeof(HeadmanVillageNeedsDraughtAnimalsIssueBehavior), nameof(HeadmanVillageNeedsDraughtAnimalsIssueBehavior.RegisterEvents))]
-    [HarmonyPostfix]
-    private static void HeadmanVillageNeedsDraughtAnimalsRegisterEventsPostfix(HeadmanVillageNeedsDraughtAnimalsIssueBehavior __instance) =>
-        CampaignEvents.HourlyTickEvent.AddNonSerializedListener(__instance, OnHourlyTick);
-
-    [HarmonyPatch(typeof(LordNeedsGarrisonTroopsIssueQuestBehavior), nameof(LordNeedsGarrisonTroopsIssueQuestBehavior.RegisterEvents))]
-    [HarmonyPostfix]
-    private static void LordNeedsGarrisonTroopsRegisterEventsPostfix(LordNeedsGarrisonTroopsIssueQuestBehavior __instance) =>
-        CampaignEvents.HourlyTickEvent.AddNonSerializedListener(__instance, OnHourlyTick);
-
-    [HarmonyPatch(typeof(NearbyBanditBaseIssueBehavior), nameof(NearbyBanditBaseIssueBehavior.RegisterEvents))]
-    [HarmonyPostfix]
-    private static void NearbyBanditBaseRegisterEventsPostfix(NearbyBanditBaseIssueBehavior __instance) =>
-        CampaignEvents.HourlyTickEvent.AddNonSerializedListener(__instance, OnHourlyTick);
-
-    [HarmonyPatch(typeof(LandLordTheArtOfTheTradeIssueBehavior), nameof(LandLordTheArtOfTheTradeIssueBehavior.RegisterEvents))]
-    [HarmonyPostfix]
-    private static void LandLordTheArtOfTheTradeRegisterEventsPostfix(LandLordTheArtOfTheTradeIssueBehavior __instance) =>
-        CampaignEvents.HourlyTickEvent.AddNonSerializedListener(__instance, OnHourlyTick);
-
-    [HarmonyPatch(typeof(SandBox.Issues.RuralNotableInnAndOutIssueBehavior), nameof(SandBox.Issues.RuralNotableInnAndOutIssueBehavior.RegisterEvents))]
-    [HarmonyPostfix]
-    private static void RuralNotableInnAndOutRegisterEventsPostfix(SandBox.Issues.RuralNotableInnAndOutIssueBehavior __instance) =>
-        CampaignEvents.HourlyTickEvent.AddNonSerializedListener(__instance, OnHourlyTick);
-
-    [HarmonyPatch(typeof(SandBox.Issues.ProdigalSonIssueBehavior), nameof(SandBox.Issues.ProdigalSonIssueBehavior.RegisterEvents))]
-    [HarmonyPostfix]
-    private static void ProdigalSonRegisterEventsPostfix(SandBox.Issues.ProdigalSonIssueBehavior __instance) =>
-        CampaignEvents.HourlyTickEvent.AddNonSerializedListener(__instance, OnHourlyTick);
-
-    [HarmonyPatch(typeof(SandBox.Issues.TheSpyPartyIssueQuestBehavior), nameof(SandBox.Issues.TheSpyPartyIssueQuestBehavior.RegisterEvents))]
-    [HarmonyPostfix]
-    private static void TheSpyPartyRegisterEventsPostfix(SandBox.Issues.TheSpyPartyIssueQuestBehavior __instance) =>
-        CampaignEvents.HourlyTickEvent.AddNonSerializedListener(__instance, OnHourlyTick);
-
-    [HarmonyPatch(typeof(HeadmanNeedsGrainIssueBehavior), nameof(HeadmanNeedsGrainIssueBehavior.RegisterEvents))]
-    [HarmonyPostfix]
-    private static void HeadmanNeedsGrainRegisterEventsPostfix(HeadmanNeedsGrainIssueBehavior __instance) =>
-        CampaignEvents.HourlyTickEvent.AddNonSerializedListener(__instance, OnHourlyTick);
-
-    [HarmonyPatch(typeof(HeadmanNeedsToDeliverAHerdIssueBehavior), nameof(HeadmanNeedsToDeliverAHerdIssueBehavior.RegisterEvents))]
-    [HarmonyPostfix]
-    private static void HeadmanNeedsToDeliverAHerdRegisterEventsPostfix(HeadmanNeedsToDeliverAHerdIssueBehavior __instance) =>
-        CampaignEvents.HourlyTickEvent.AddNonSerializedListener(__instance, OnHourlyTick);
-
-    [HarmonyPatch(typeof(ArtisanCantSellProductsAtAFairPriceIssueBehavior), nameof(ArtisanCantSellProductsAtAFairPriceIssueBehavior.RegisterEvents))]
-    [HarmonyPostfix]
-    private static void ArtisanCantSellProductsAtAFairPriceRegisterEventsPostfix(ArtisanCantSellProductsAtAFairPriceIssueBehavior __instance) =>
-        CampaignEvents.HourlyTickEvent.AddNonSerializedListener(__instance, OnHourlyTick);
-
-    [HarmonyPatch(typeof(SmugglersIssueBehavior), nameof(SmugglersIssueBehavior.RegisterEvents))]
-    [HarmonyPostfix]
-    private static void SmugglersRegisterEventsPostfix(SmugglersIssueBehavior __instance) =>
-        CampaignEvents.HourlyTickEvent.AddNonSerializedListener(__instance, OnHourlyTick);
-
-    [HarmonyPatch(typeof(ArtisanOverpricedGoodsIssueBehavior), nameof(ArtisanOverpricedGoodsIssueBehavior.RegisterEvents))]
-    [HarmonyPostfix]
-    private static void ArtisanOverpricedGoodsRegisterEventsPostfix(ArtisanOverpricedGoodsIssueBehavior __instance) =>
-        CampaignEvents.HourlyTickEvent.AddNonSerializedListener(__instance, OnHourlyTick);
-
-    [HarmonyPatch(typeof(CaravanAmbushIssueBehavior), nameof(CaravanAmbushIssueBehavior.RegisterEvents))]
-    [HarmonyPostfix]
-    private static void CaravanAmbushRegisterEventsPostfix(CaravanAmbushIssueBehavior __instance) =>
-        CampaignEvents.HourlyTickEvent.AddNonSerializedListener(__instance, OnHourlyTick);
-
-    [HarmonyPatch(typeof(GangLeaderNeedsWeaponsIssueQuestBehavior), nameof(GangLeaderNeedsWeaponsIssueQuestBehavior.RegisterEvents))]
-    [HarmonyPostfix]
-    private static void GangLeaderNeedsWeaponsRegisterEventsPostfix(GangLeaderNeedsWeaponsIssueQuestBehavior __instance) =>
-        CampaignEvents.HourlyTickEvent.AddNonSerializedListener(__instance, OnHourlyTick);
-
-    [HarmonyPatch(typeof(MerchantArmyOfPoachersIssueBehavior), nameof(MerchantArmyOfPoachersIssueBehavior.RegisterEvents))]
-    [HarmonyPostfix]
-    private static void MerchantArmyOfPoachersRegisterEventsPostfix(MerchantArmyOfPoachersIssueBehavior __instance) =>
-        CampaignEvents.HourlyTickEvent.AddNonSerializedListener(__instance, OnHourlyTick);
-
-    [HarmonyPatch(typeof(EscortMerchantCaravanIssueBehavior), nameof(EscortMerchantCaravanIssueBehavior.RegisterEvents))]
-    [HarmonyPostfix]
-    private static void EscortMerchantCaravanRegisterEventsPostfix(EscortMerchantCaravanIssueBehavior __instance) =>
-        CampaignEvents.HourlyTickEvent.AddNonSerializedListener(__instance, OnHourlyTick);
-
-    [HarmonyPatch(typeof(SandBox.Issues.RivalGangMovingInIssueBehavior), nameof(SandBox.Issues.RivalGangMovingInIssueBehavior.RegisterEvents))]
-    [HarmonyPostfix]
-    private static void RivalGangMovingInRegisterEventsPostfix(SandBox.Issues.RivalGangMovingInIssueBehavior __instance) =>
-        CampaignEvents.HourlyTickEvent.AddNonSerializedListener(__instance, OnHourlyTick);
-
-    [HarmonyPatch(typeof(SandBox.Issues.SnareTheWealthyIssueBehavior), nameof(SandBox.Issues.SnareTheWealthyIssueBehavior.RegisterEvents))]
-    [HarmonyPostfix]
-    private static void SnareTheWealthyRegisterEventsPostfix(SandBox.Issues.SnareTheWealthyIssueBehavior __instance) =>
-        CampaignEvents.HourlyTickEvent.AddNonSerializedListener(__instance, OnHourlyTick);
+    }
 
     private static void OnHourlyTick()
     {


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
3rd review on #2763 found two remaining client-authority gaps in the generic issue-accept pipeline:

1. Alternative-solution accept still trusted client-computed state. The accepting client's own local
   `StartIssueWithAlternativeSolution()` call already ran the real RNG (casualty count, failure chance,
   return duration, reward skill) and the server just relayed whatever the client reported, unchanged.
2. Accept authorization only checked that the issue's generation stamp was fresh — not that the requester
   had actually talked to the issue-giver. Since an issue's generation is broadcast to every connected peer
   the instant it's created, any connected client could send an accept request for someone else's issue
   without ever opening a conversation with them.
   
   Additionally, `IssueOwnershipRegistry`/`IssueGenerationRegistry`/`AwaitingAlternativeSolutionTroopsRegistry`
were bare process-wide statics rather than lifetime-scoped services, 23 quest-type behaviors each registered
their own duplicate hourly-tick listener triggering the same full-issue-collection rescan redundantly every
hour, and the (currently unused) `QuestTypeDescriptor`-based dispatch pipeline had silently regressed both of
the above fixes relative to the pipeline actually in production.

## What is the new behavior?
- Alternative-solution accept now always re-derives its result server-side (`AlternativeSolutionStartRunner`),
  under the true owner's resolved hero/party context, regardless of which peer requested it.
- Accept requests are now rejected unless the requester has a live tracked conversation with that specific
  issue-giver at that exact generation (`IssueConversationTracker`/`IssueConversationHandler`), closing the
  authorization gap above.
- `IssueOwnershipRegistry`, `IssueGenerationRegistry`, and `AwaitingAlternativeSolutionTroopsRegistry` are now
  DI-scoped instances (`InstancePerLifetimeScope`) instead of static globals, resolved via constructor
  injection where possible and `ContainerProvider` at the call site for static Harmony patches.
- The 23 duplicate hourly-tick listener registrations collapse into a single listener on
  `IssuesCampaignBehavior.RegisterEvents`.
- The `QuestTypeDescriptor` pipeline (`GenericQuestTypeAcceptHandler`) is hardened to the same security
  properties as the pipeline currently in production, and its alternative-solution byte-blob strategy
  interface gained the server-authoritative capture step it was missing, so it can't regress either fix
  once quest types start migrating onto it.

## Bot Changelog Entry
Fixed two ways a client could manipulate issue-quest acceptance outcomes without server validation.


## Other information
Server-side/security hardening only — no player-facing UI or gameplay changes beyond the exploit fixes noted
above. Full build + Issues test suite (unit + E2E, including new adversarial coverage for both fixes) green
throughout. Diff is scoped to `feature/generic-quest-handler` (#2763) as base, not `development` — this is a
stacked PR carrying only the round-3 review commits.
One note on the doc-comments checkbox: I left it unchecked becau