### PR TITLE
[2938] Grow the mobile-party visual buffer

### DIFF
--- a/source/GameInterface.Tests/Services/PartyVisuals/MobilePartyVisualManagerPatchesTests.cs
+++ b/source/GameInterface.Tests/Services/PartyVisuals/MobilePartyVisualManagerPatchesTests.cs
@@ -1,5 +1,6 @@
 ﻿using GameInterface.Services.PartyVisuals.Patches;
 using SandBox.View.Map.Visuals;
+using System;
 using Xunit;
 
 namespace GameInterface.Tests.Services.PartyVisuals;
@@ -74,5 +75,38 @@ public class MobilePartyVisualManagerPatchesTests
 
         Assert.Equal(-1, dirtyCount);
         Assert.Same(grownBuffer, buffer);
+    }
+
+    [Fact]
+    public void PrepareDirtyPartyVisualBuffer_NavalArrayAboveBoundary_PreservesElementTypeAndValues()
+    {
+        int dirtyCount = 7;
+        Array buffer = new string[2500];
+        buffer.SetValue("retained", 2499);
+
+        Array resized = NavalMobilePartyVisualManagerPatches.PrepareDirtyPartyVisualBuffer(
+            ref dirtyCount,
+            buffer,
+            2556);
+
+        Assert.Equal(-1, dirtyCount);
+        Assert.IsType<string[]>(resized);
+        Assert.True(resized.Length >= 2556);
+        Assert.Equal("retained", resized.GetValue(2499));
+    }
+
+    [Fact]
+    public void PrepareDirtyPartyVisualBuffer_NavalArrayAlreadyLargeEnough_ReusesBuffer()
+    {
+        int dirtyCount = 3;
+        Array buffer = new object[5000];
+
+        Array result = NavalMobilePartyVisualManagerPatches.PrepareDirtyPartyVisualBuffer(
+            ref dirtyCount,
+            buffer,
+            2556);
+
+        Assert.Equal(-1, dirtyCount);
+        Assert.Same(buffer, result);
     }
 }

--- a/source/GameInterface.Tests/Services/PartyVisuals/MobilePartyVisualManagerPatchesTests.cs
+++ b/source/GameInterface.Tests/Services/PartyVisuals/MobilePartyVisualManagerPatchesTests.cs
@@ -1,0 +1,78 @@
+﻿using GameInterface.Services.PartyVisuals.Patches;
+using SandBox.View.Map.Visuals;
+using Xunit;
+
+namespace GameInterface.Tests.Services.PartyVisuals;
+
+public class MobilePartyVisualManagerPatchesTests
+{
+    [Fact]
+    public void PrepareDirtyPartyVisualBuffer_AtVanillaBoundary_ResetsCounterWithoutGrowing()
+    {
+        int dirtyCount = 12;
+        var buffer = new MobilePartyVisual[2500];
+        var originalBuffer = buffer;
+
+        MobilePartyVisualManagerPatches.PrepareDirtyPartyVisualBuffer(
+            ref dirtyCount,
+            ref buffer,
+            2500);
+
+        Assert.Equal(-1, dirtyCount);
+        Assert.Same(originalBuffer, buffer);
+    }
+
+    [Fact]
+    public void PrepareDirtyPartyVisualBuffer_AboveVanillaBoundary_GrowsForAffectedSave()
+    {
+        int dirtyCount = 0;
+        var buffer = new MobilePartyVisual[2500];
+
+        MobilePartyVisualManagerPatches.PrepareDirtyPartyVisualBuffer(
+            ref dirtyCount,
+            ref buffer,
+            2556);
+
+        Assert.Equal(-1, dirtyCount);
+        Assert.True(buffer.Length >= 2556);
+    }
+
+    [Fact]
+    public void PrepareDirtyPartyVisualBuffer_WhenAlreadyLargeEnough_DoesNotShrink()
+    {
+        int dirtyCount = 4;
+        var buffer = new MobilePartyVisual[6000];
+        var originalBuffer = buffer;
+
+        MobilePartyVisualManagerPatches.PrepareDirtyPartyVisualBuffer(
+            ref dirtyCount,
+            ref buffer,
+            1000);
+
+        Assert.Equal(-1, dirtyCount);
+        Assert.Equal(6000, buffer.Length);
+        Assert.Same(originalBuffer, buffer);
+    }
+
+    [Fact]
+    public void PrepareDirtyPartyVisualBuffer_AcrossRepeatedCalls_ReusesGrownBufferAndResetsCounter()
+    {
+        int dirtyCount = 0;
+        var buffer = new MobilePartyVisual[2500];
+
+        MobilePartyVisualManagerPatches.PrepareDirtyPartyVisualBuffer(
+            ref dirtyCount,
+            ref buffer,
+            2556);
+        var grownBuffer = buffer;
+        dirtyCount = 37;
+
+        MobilePartyVisualManagerPatches.PrepareDirtyPartyVisualBuffer(
+            ref dirtyCount,
+            ref buffer,
+            2556);
+
+        Assert.Equal(-1, dirtyCount);
+        Assert.Same(grownBuffer, buffer);
+    }
+}

--- a/source/GameInterface.Tests/Services/PartyVisuals/PartyVisualDebugCommandsTests.cs
+++ b/source/GameInterface.Tests/Services/PartyVisuals/PartyVisualDebugCommandsTests.cs
@@ -1,0 +1,43 @@
+﻿#if DEBUG
+using Common.Util;
+using GameInterface.Services.PartyVisuals.Commands;
+using System.Linq;
+using TaleWorlds.CampaignSystem.Party;
+using Xunit;
+
+namespace GameInterface.Tests.Services.PartyVisuals;
+
+public class PartyVisualDebugCommandsTests
+{
+    [Fact]
+    public void GetFixturePartiesForRestore_RetainsPartyAfterRegistryRenamesStringId()
+    {
+        MobileParty renamedParty = ObjectHelper.SkipConstructor<MobileParty>();
+        renamedParty.StringId = "Created_123";
+        renamedParty.IsActive = true;
+
+        MobileParty[] result = PartyVisualDebugCommands.GetFixturePartiesForRestore(
+            new[] { renamedParty },
+            new[] { renamedParty }).ToArray();
+        int liveCount = PartyVisualDebugCommands.GetLiveFixturePartyCount(
+            new[] { renamedParty },
+            new[] { renamedParty });
+
+        Assert.Equal(new[] { renamedParty }, result);
+        Assert.Equal(1, liveCount);
+    }
+
+    [Fact]
+    public void GetFixturePartiesForRestore_FindsUnretainedPartyWithFixtureId()
+    {
+        MobileParty fixtureParty = ObjectHelper.SkipConstructor<MobileParty>();
+        fixtureParty.StringId = "issue2938_visual_fixture_1";
+
+        MobileParty[] result = PartyVisualDebugCommands.GetFixturePartiesForRestore(
+            Enumerable.Empty<MobileParty>(),
+            new[] { fixtureParty }).ToArray();
+
+        Assert.Equal(new[] { fixtureParty }, result);
+    }
+}
+#endif

--- a/source/GameInterface/Services/PartyVisuals/Commands/PartyVisualDebugCommands.cs
+++ b/source/GameInterface/Services/PartyVisuals/Commands/PartyVisualDebugCommands.cs
@@ -1,0 +1,42 @@
+﻿using Common;
+using SandBox.View.Map.Managers;
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using TaleWorlds.CampaignSystem;
+using static TaleWorlds.Library.CommandLineFunctionality;
+
+namespace GameInterface.Services.PartyVisuals.Commands;
+
+internal class PartyVisualDebugCommands
+{
+    [CommandLineArgumentFunction("buffer_state", "coop.debug.partyvisuals")]
+    public static string BufferState(List<string> args)
+    {
+        if (ModInformation.IsServer)
+            return "Run this command on a client.";
+
+        if (args.Count != 0)
+            return "Usage: coop.debug.partyvisuals.buffer_state";
+
+        var manager = MobilePartyVisualManager.Current;
+        if (manager == null)
+            return "Mobile party visual manager is unavailable.";
+
+        int visualCount = manager._visualsFlattened.Count;
+        int bufferCapacity = manager._dirtyPartiesList.Length;
+        int dirtyCount = manager._dirtyPartyVisualCount;
+        int campaignPartyCount = Campaign.Current?.MobileParties?.Count ?? 0;
+        string structuredState = JsonSerializer.Serialize(new
+        {
+            visualCount,
+            bufferCapacity,
+            dirtyCount,
+            campaignPartyCount,
+        });
+
+        return $"visualCount={visualCount} bufferCapacity={bufferCapacity} dirtyCount={dirtyCount} " +
+               $"campaignPartyCount={campaignPartyCount}" + Environment.NewLine +
+               $"LIVE_TEST_JSON={structuredState}";
+    }
+}

--- a/source/GameInterface/Services/PartyVisuals/Commands/PartyVisualDebugCommands.cs
+++ b/source/GameInterface/Services/PartyVisuals/Commands/PartyVisualDebugCommands.cs
@@ -58,7 +58,7 @@ internal class PartyVisualDebugCommands
         if (args.Count != 0)
             return "Usage: coop.debug.partyvisuals.fixture_state";
 
-        return GetFixtureState();
+        return GetFixtureState(includeBaseline: true);
     }
 
     [CommandLineArgumentFunction("stage_over_limit_fixture", "coop.debug.partyvisuals")]
@@ -88,7 +88,7 @@ internal class PartyVisualDebugCommands
         fixtureBaselineEligiblePartyCount = GetEligiblePartyCount();
         int partiesToCreate = targetEligiblePartyCount - fixtureBaselineEligiblePartyCount;
         if (partiesToCreate <= 0)
-            return GetFixtureState();
+            return GetFixtureState(includeBaseline: true);
 
         try
         {
@@ -113,7 +113,7 @@ internal class PartyVisualDebugCommands
             throw;
         }
 
-        return GetFixtureState();
+        return GetFixtureState(includeBaseline: true);
     }
 
     [CommandLineArgumentFunction("restore_over_limit_fixture", "coop.debug.partyvisuals")]
@@ -126,7 +126,7 @@ internal class PartyVisualDebugCommands
             return "Usage: coop.debug.partyvisuals.restore_over_limit_fixture";
 
         int removedPartyCount = RestoreFixtureParties();
-        string state = GetFixtureState();
+        string state = GetFixtureState(includeBaseline: false);
         return $"removedPartyCount={removedPartyCount}{Environment.NewLine}{state}";
     }
 
@@ -150,7 +150,7 @@ internal class PartyVisualDebugCommands
         return removedPartyCount;
     }
 
-    private static string GetFixtureState()
+    private static string GetFixtureState(bool includeBaseline)
     {
         int eligiblePartyCount = GetEligiblePartyCount();
         int liveFixturePartyCount = GetLiveFixturePartyCount();
@@ -158,12 +158,12 @@ internal class PartyVisualDebugCommands
         {
             eligiblePartyCount,
             liveFixturePartyCount,
-            fixtureBaselineEligiblePartyCount,
+            fixtureBaselineEligiblePartyCount = includeBaseline ? fixtureBaselineEligiblePartyCount : -1,
             campaignPartyCount = Campaign.Current?.MobileParties?.Count ?? 0,
         });
 
         return $"eligiblePartyCount={eligiblePartyCount} liveFixturePartyCount={liveFixturePartyCount} " +
-               $"fixtureBaselineEligiblePartyCount={fixtureBaselineEligiblePartyCount}" + Environment.NewLine +
+               $"fixtureBaselineEligiblePartyCount={(includeBaseline ? fixtureBaselineEligiblePartyCount : -1)}" + Environment.NewLine +
                $"LIVE_TEST_JSON={structuredState}";
     }
 

--- a/source/GameInterface/Services/PartyVisuals/Commands/PartyVisualDebugCommands.cs
+++ b/source/GameInterface/Services/PartyVisuals/Commands/PartyVisualDebugCommands.cs
@@ -2,14 +2,25 @@
 using SandBox.View.Map.Managers;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Actions;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Party.PartyComponents;
+using TaleWorlds.CampaignSystem.Settlements;
 using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.PartyVisuals.Commands;
 
 internal class PartyVisualDebugCommands
 {
+#if DEBUG
+    private const string FixturePartyIdPrefix = "issue2938_visual_fixture_";
+    private static readonly List<MobileParty> stagedParties = new();
+    private static int fixtureBaselineEligiblePartyCount = -1;
+#endif
+
     [CommandLineArgumentFunction("buffer_state", "coop.debug.partyvisuals")]
     public static string BufferState(List<string> args)
     {
@@ -39,4 +50,136 @@ internal class PartyVisualDebugCommands
                $"campaignPartyCount={campaignPartyCount}" + Environment.NewLine +
                $"LIVE_TEST_JSON={structuredState}";
     }
+
+#if DEBUG
+    [CommandLineArgumentFunction("fixture_state", "coop.debug.partyvisuals")]
+    public static string FixtureState(List<string> args)
+    {
+        if (args.Count != 0)
+            return "Usage: coop.debug.partyvisuals.fixture_state";
+
+        return GetFixtureState();
+    }
+
+    [CommandLineArgumentFunction("stage_over_limit_fixture", "coop.debug.partyvisuals")]
+    public static string StageOverLimitFixture(List<string> args)
+    {
+        if (ModInformation.IsClient)
+            return "stage_over_limit_fixture must be run on the server.";
+
+        if (args.Count != 2 ||
+            !int.TryParse(args[0], out int targetEligiblePartyCount) ||
+            targetEligiblePartyCount < 2500)
+        {
+            return "Usage: coop.debug.partyvisuals.stage_over_limit_fixture <targetEligiblePartyCount>=2500+ <settlementId>";
+        }
+
+        if (stagedParties.Count != 0 || GetLiveFixturePartyCount() != 0)
+            return "The party-visual fixture is already staged.";
+
+        Settlement settlement = Settlement.All.FirstOrDefault(candidate => candidate.StringId == args[1]);
+        if (settlement == null)
+            return $"Settlement '{args[1]}' was not found.";
+
+        Clan looterClan = Clan.BanditFactions.FirstOrDefault(candidate => candidate.StringId == "looters");
+        if (looterClan == null)
+            return "The looter clan was not found.";
+
+        fixtureBaselineEligiblePartyCount = GetEligiblePartyCount();
+        int partiesToCreate = targetEligiblePartyCount - fixtureBaselineEligiblePartyCount;
+        if (partiesToCreate <= 0)
+            return GetFixtureState();
+
+        try
+        {
+            for (int index = 0; index < partiesToCreate; index++)
+            {
+                MobileParty party = BanditPartyComponent.CreateLooterParty(
+                    $"{FixturePartyIdPrefix}{index + 1}",
+                    looterClan,
+                    settlement,
+                    isBossParty: false,
+                    pt: null,
+                    settlement.GatePosition);
+                party.IsVisible = true;
+                party.IsInspected = true;
+                party.SetMoveModeHold();
+                stagedParties.Add(party);
+            }
+        }
+        catch
+        {
+            RestoreFixtureParties();
+            throw;
+        }
+
+        return GetFixtureState();
+    }
+
+    [CommandLineArgumentFunction("restore_over_limit_fixture", "coop.debug.partyvisuals")]
+    public static string RestoreOverLimitFixture(List<string> args)
+    {
+        if (ModInformation.IsClient)
+            return "restore_over_limit_fixture must be run on the server.";
+
+        if (args.Count != 0)
+            return "Usage: coop.debug.partyvisuals.restore_over_limit_fixture";
+
+        int removedPartyCount = RestoreFixtureParties();
+        string state = GetFixtureState();
+        return $"removedPartyCount={removedPartyCount}{Environment.NewLine}{state}";
+    }
+
+    private static int RestoreFixtureParties()
+    {
+        int removedPartyCount = 0;
+        List<MobileParty> fixtureParties = MobileParty.All
+            .Where(party => party?.StringId?.StartsWith(FixturePartyIdPrefix, StringComparison.Ordinal) == true)
+            .ToList();
+        for (int index = fixtureParties.Count - 1; index >= 0; index--)
+        {
+            MobileParty party = fixtureParties[index];
+            if (party?.IsActive != true) continue;
+
+            DestroyPartyAction.Apply(null, party);
+            removedPartyCount++;
+        }
+
+        stagedParties.Clear();
+        fixtureBaselineEligiblePartyCount = -1;
+        return removedPartyCount;
+    }
+
+    private static string GetFixtureState()
+    {
+        int eligiblePartyCount = GetEligiblePartyCount();
+        int liveFixturePartyCount = GetLiveFixturePartyCount();
+        string structuredState = JsonSerializer.Serialize(new
+        {
+            eligiblePartyCount,
+            liveFixturePartyCount,
+            fixtureBaselineEligiblePartyCount,
+            campaignPartyCount = Campaign.Current?.MobileParties?.Count ?? 0,
+        });
+
+        return $"eligiblePartyCount={eligiblePartyCount} liveFixturePartyCount={liveFixturePartyCount} " +
+               $"fixtureBaselineEligiblePartyCount={fixtureBaselineEligiblePartyCount}" + Environment.NewLine +
+               $"LIVE_TEST_JSON={structuredState}";
+    }
+
+    private static int GetEligiblePartyCount()
+    {
+        return MobileParty.All.Count(party =>
+            party?.IsActive == true &&
+            !party.IsGarrison &&
+            !party.IsMilitia);
+    }
+
+    private static int GetLiveFixturePartyCount()
+    {
+        return MobileParty.All.Count(party =>
+            party?.IsActive == true &&
+            party.StringId?.StartsWith(FixturePartyIdPrefix, StringComparison.Ordinal) == true);
+    }
+#endif
 }

--- a/source/GameInterface/Services/PartyVisuals/Commands/PartyVisualDebugCommands.cs
+++ b/source/GameInterface/Services/PartyVisuals/Commands/PartyVisualDebugCommands.cs
@@ -1,4 +1,5 @@
 ﻿using Common;
+using GameInterface.Services.PartyVisuals.Patches;
 using SandBox.View.Map.Managers;
 using System;
 using System.Collections.Generic;
@@ -37,16 +38,26 @@ internal class PartyVisualDebugCommands
         int visualCount = manager._visualsFlattened.Count;
         int bufferCapacity = manager._dirtyPartiesList.Length;
         int dirtyCount = manager._dirtyPartyVisualCount;
+        bool navalManagerActive = NavalMobilePartyVisualManagerPatches.TryGetBufferState(
+            out int navalVisualCount,
+            out int navalBufferCapacity,
+            out int navalDirtyCount);
         int campaignPartyCount = Campaign.Current?.MobileParties?.Count ?? 0;
         string structuredState = JsonSerializer.Serialize(new
         {
             visualCount,
             bufferCapacity,
             dirtyCount,
+            navalManagerActive,
+            navalVisualCount,
+            navalBufferCapacity,
+            navalDirtyCount,
             campaignPartyCount,
         });
 
         return $"visualCount={visualCount} bufferCapacity={bufferCapacity} dirtyCount={dirtyCount} " +
+               $"navalManagerActive={navalManagerActive} navalVisualCount={navalVisualCount} " +
+               $"navalBufferCapacity={navalBufferCapacity} navalDirtyCount={navalDirtyCount} " +
                $"campaignPartyCount={campaignPartyCount}" + Environment.NewLine +
                $"LIVE_TEST_JSON={structuredState}";
     }

--- a/source/GameInterface/Services/PartyVisuals/Commands/PartyVisualDebugCommands.cs
+++ b/source/GameInterface/Services/PartyVisuals/Commands/PartyVisualDebugCommands.cs
@@ -101,10 +101,10 @@ internal class PartyVisualDebugCommands
                     isBossParty: false,
                     pt: null,
                     settlement.GatePosition);
+                stagedParties.Add(party);
                 party.IsVisible = true;
                 party.IsInspected = true;
                 party.SetMoveModeHold();
-                stagedParties.Add(party);
             }
         }
         catch
@@ -133,9 +133,7 @@ internal class PartyVisualDebugCommands
     private static int RestoreFixtureParties()
     {
         int removedPartyCount = 0;
-        List<MobileParty> fixtureParties = MobileParty.All
-            .Where(party => party?.StringId?.StartsWith(FixturePartyIdPrefix, StringComparison.Ordinal) == true)
-            .ToList();
+        List<MobileParty> fixtureParties = GetFixturePartiesForRestore(stagedParties, MobileParty.All);
         for (int index = fixtureParties.Count - 1; index >= 0; index--)
         {
             MobileParty party = fixtureParties[index];
@@ -148,6 +146,17 @@ internal class PartyVisualDebugCommands
         stagedParties.Clear();
         fixtureBaselineEligiblePartyCount = -1;
         return removedPartyCount;
+    }
+
+    internal static List<MobileParty> GetFixturePartiesForRestore(
+        IEnumerable<MobileParty> retainedParties,
+        IEnumerable<MobileParty> campaignParties)
+    {
+        return retainedParties
+            .Concat(campaignParties.Where(party =>
+                party?.StringId?.StartsWith(FixturePartyIdPrefix, StringComparison.Ordinal) == true))
+            .Distinct()
+            .ToList();
     }
 
     private static string GetFixtureState(bool includeBaseline)
@@ -177,9 +186,15 @@ internal class PartyVisualDebugCommands
 
     private static int GetLiveFixturePartyCount()
     {
-        return MobileParty.All.Count(party =>
-            party?.IsActive == true &&
-            party.StringId?.StartsWith(FixturePartyIdPrefix, StringComparison.Ordinal) == true);
+        return GetLiveFixturePartyCount(stagedParties, MobileParty.All);
+    }
+
+    internal static int GetLiveFixturePartyCount(
+        IEnumerable<MobileParty> retainedParties,
+        IEnumerable<MobileParty> campaignParties)
+    {
+        return GetFixturePartiesForRestore(retainedParties, campaignParties)
+            .Count(party => party?.IsActive == true);
     }
 #endif
 }

--- a/source/GameInterface/Services/PartyVisuals/Patches/MobilePartyVisualManagerPatches.cs
+++ b/source/GameInterface/Services/PartyVisuals/Patches/MobilePartyVisualManagerPatches.cs
@@ -4,6 +4,9 @@ using SandBox.View.Map.Managers;
 using SandBox.View.Map.Visuals;
 using Serilog;
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
@@ -102,6 +105,128 @@ namespace GameInterface.Services.PartyVisuals.Patches
                 : dirtyPartiesList.Length * 2;
             int newCapacity = Math.Max(requiredCapacity, Math.Max(1, doubledCapacity));
             Array.Resize(ref dirtyPartiesList, newCapacity);
+        }
+    }
+
+    /// <summary>
+    /// Grows the optional Naval DLC manager's independent dirty-visual buffer.
+    /// </summary>
+    [HarmonyPatch]
+    public class NavalMobilePartyVisualManagerPatches
+    {
+        private const string ManagerTypeName = "NavalDLC.View.Map.Managers.NavalMobilePartyVisualManager";
+        private static Type managerType;
+        private static FieldInfo dirtyPartyVisualCountField;
+        private static FieldInfo dirtyPartiesListField;
+        private static FieldInfo visualsFlattenedField;
+        private static PropertyInfo currentProperty;
+        private static MethodInfo onInitializeMethod;
+        private static MethodInfo onTickMethod;
+
+        [HarmonyPrepare]
+        public static bool Prepare() => TryResolveManagerType();
+
+        public static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return onInitializeMethod;
+            yield return onTickMethod;
+        }
+
+        [HarmonyPrefix]
+        private static void Prefix(object __instance, MethodBase __originalMethod)
+        {
+            int requiredCapacity = __originalMethod.Name == "OnInitialize"
+                ? MobileParty.All.Count
+                : ((ICollection)visualsFlattenedField.GetValue(__instance)).Count;
+            PrepareDirtyPartyVisualBuffer(__instance, requiredCapacity);
+        }
+
+        internal static bool TryGetBufferState(
+            out int visualCount,
+            out int bufferCapacity,
+            out int dirtyCount)
+        {
+            visualCount = 0;
+            bufferCapacity = 0;
+            dirtyCount = -1;
+            if (!TryResolveManagerType())
+                return false;
+
+            object manager = currentProperty.GetValue(null);
+            if (manager == null)
+                return false;
+
+            visualCount = ((ICollection)visualsFlattenedField.GetValue(manager)).Count;
+            bufferCapacity = ((Array)dirtyPartiesListField.GetValue(manager)).Length;
+            dirtyCount = (int)dirtyPartyVisualCountField.GetValue(manager);
+            return true;
+        }
+
+        internal static Array PrepareDirtyPartyVisualBuffer(
+            ref int dirtyPartyVisualCount,
+            Array dirtyPartiesList,
+            int requiredCapacity)
+        {
+            dirtyPartyVisualCount = -1;
+            if (dirtyPartiesList.Length >= requiredCapacity)
+                return dirtyPartiesList;
+
+            int doubledCapacity = dirtyPartiesList.Length > int.MaxValue / 2
+                ? requiredCapacity
+                : dirtyPartiesList.Length * 2;
+            int newCapacity = Math.Max(requiredCapacity, Math.Max(1, doubledCapacity));
+            Array resizedBuffer = Array.CreateInstance(
+                dirtyPartiesList.GetType().GetElementType(),
+                newCapacity);
+            Array.Copy(dirtyPartiesList, resizedBuffer, dirtyPartiesList.Length);
+            return resizedBuffer;
+        }
+
+        private static void PrepareDirtyPartyVisualBuffer(object manager, int requiredCapacity)
+        {
+            int dirtyCount = (int)dirtyPartyVisualCountField.GetValue(manager);
+            Array dirtyPartiesList = (Array)dirtyPartiesListField.GetValue(manager);
+            dirtyPartiesList = PrepareDirtyPartyVisualBuffer(
+                ref dirtyCount,
+                dirtyPartiesList,
+                requiredCapacity);
+            dirtyPartyVisualCountField.SetValue(manager, dirtyCount);
+            dirtyPartiesListField.SetValue(manager, dirtyPartiesList);
+        }
+
+        private static bool TryResolveManagerType()
+        {
+            if (managerType != null)
+                return true;
+
+            Type resolvedManagerType = AccessTools.TypeByName(ManagerTypeName);
+            if (resolvedManagerType == null)
+                return false;
+
+            FieldInfo resolvedDirtyPartyVisualCountField = AccessTools.Field(resolvedManagerType, "_dirtyPartyVisualCount");
+            FieldInfo resolvedDirtyPartiesListField = AccessTools.Field(resolvedManagerType, "_dirtyPartiesList");
+            FieldInfo resolvedVisualsFlattenedField = AccessTools.Field(resolvedManagerType, "_visualsFlattened");
+            PropertyInfo resolvedCurrentProperty = AccessTools.Property(resolvedManagerType, "Current");
+            MethodInfo resolvedOnInitializeMethod = AccessTools.Method(resolvedManagerType, "OnInitialize");
+            MethodInfo resolvedOnTickMethod = AccessTools.Method(resolvedManagerType, "OnTick");
+            if (resolvedDirtyPartyVisualCountField == null ||
+                resolvedDirtyPartiesListField == null ||
+                resolvedVisualsFlattenedField == null ||
+                resolvedCurrentProperty == null ||
+                resolvedOnInitializeMethod == null ||
+                resolvedOnTickMethod == null)
+            {
+                return false;
+            }
+
+            dirtyPartyVisualCountField = resolvedDirtyPartyVisualCountField;
+            dirtyPartiesListField = resolvedDirtyPartiesListField;
+            visualsFlattenedField = resolvedVisualsFlattenedField;
+            currentProperty = resolvedCurrentProperty;
+            onInitializeMethod = resolvedOnInitializeMethod;
+            onTickMethod = resolvedOnTickMethod;
+            managerType = resolvedManagerType;
+            return true;
         }
     }
 }

--- a/source/GameInterface/Services/PartyVisuals/Patches/MobilePartyVisualManagerPatches.cs
+++ b/source/GameInterface/Services/PartyVisuals/Patches/MobilePartyVisualManagerPatches.cs
@@ -1,8 +1,10 @@
 ﻿using Common.Logging;
 using HarmonyLib;
 using SandBox.View.Map.Managers;
+using SandBox.View.Map.Visuals;
 using Serilog;
 using System;
+using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
 
@@ -13,13 +15,26 @@ namespace GameInterface.Services.PartyVisuals.Patches
     {
         private static ILogger Logger = LogManager.GetLogger<MobilePartyVisualManagerPatches>();
 
+        [HarmonyPatch(nameof(MobilePartyVisualManager.OnInitialize))]
+        [HarmonyPrefix]
+        private static void OnInitializePrefix(MobilePartyVisualManager __instance)
+        {
+            PrepareDirtyPartyVisualBuffer(
+                ref __instance._dirtyPartyVisualCount,
+                ref __instance._dirtyPartiesList,
+                MobileParty.All.Count);
+        }
+
         [HarmonyPatch(nameof(MobilePartyVisualManager.OnTick))]
         [HarmonyPrefix]
-        private static bool Prefix(MobilePartyVisualManager __instance, float realDt, float dt)
+        private static bool OnTickPrefix(MobilePartyVisualManager __instance, float realDt, float dt)
         {
             if (Mission.Current != null) return false;
 
-            __instance._dirtyPartyVisualCount = -1;
+            PrepareDirtyPartyVisualBuffer(
+                ref __instance._dirtyPartyVisualCount,
+                ref __instance._dirtyPartiesList,
+                __instance._visualsFlattened.Count);
             TWParallel.For(0, __instance._visualsFlattened.Count, delegate (int startInclusive, int endExclusive)
             {
                 for (int i = startInclusive; i < endExclusive; i++)
@@ -71,6 +86,22 @@ namespace GameInterface.Services.PartyVisuals.Patches
             }
 
             return false;
+        }
+
+        internal static void PrepareDirtyPartyVisualBuffer(
+            ref int dirtyPartyVisualCount,
+            ref MobilePartyVisual[] dirtyPartiesList,
+            int requiredCapacity)
+        {
+            dirtyPartyVisualCount = -1;
+            if (dirtyPartiesList.Length >= requiredCapacity)
+                return;
+
+            int doubledCapacity = dirtyPartiesList.Length > int.MaxValue / 2
+                ? requiredCapacity
+                : dirtyPartiesList.Length * 2;
+            int newCapacity = Math.Max(requiredCapacity, Math.Max(1, doubledCapacity));
+            Array.Resize(ref dirtyPartiesList, newCapacity);
         }
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Loading a long-running campaign with at least 2,500 visible mobile parties crashes the graphical client before the campaign map opens.

## What is the new behavior?

Resolves #2938

Large campaigns now load into the campaign map without overflowing the mobile-party visual buffer, and the buffer remains large enough as party counts change.

## Bot Changelog Entry

- Fixed a crash when loading campaigns with very large numbers of mobile parties.
