### PR TITLE
Pass the nightly date into staging

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -145,6 +145,8 @@ jobs:
             "$release_date" "$file_name" "$head_sha" "$base_sha" >> "$GITHUB_OUTPUT"
 
       - name: Stage module
+        env:
+          RELEASE_DATE: ${{ steps.release.outputs.release_date }}
         run: |
           set -eu
           module=release-stage/Coop


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Backfilled nightly builds stop during module staging, so no download or changelog can be published.

## What is the new behavior?

Backfilled and scheduled nightly builds carry their selected release date through packaging and can finish publishing.

## Bot Changelog Entry


