### PR TITLE
fix activepolicies sync on kingdom creation

### DIFF
--- a/source/GameInterface/Services/Kingdoms/Handlers/KingdomHandler.cs
+++ b/source/GameInterface/Services/Kingdoms/Handlers/KingdomHandler.cs
@@ -438,20 +438,22 @@ public class KingdomHandler : IHandler
     private void HandleChangeKingdomPolicy(MessagePayload<ChangeKingdomPolicy> obj)
     {
         var payload = obj.What;
-
-        if (!objectManager.TryGetObject(payload.KingdomId, out Kingdom kingdom))
+        GameThread.RunSafe(() =>
         {
-            Logger.Debug("Kingdom not found in KingdomHandler with KingdomId: {id}", payload.KingdomId);
-            return;
-        }
+            if (!objectManager.TryGetObject(payload.KingdomId, out Kingdom kingdom))
+            {
+                Logger.Debug("Kingdom not found in KingdomHandler with KingdomId: {id}", payload.KingdomId);
+                return;
+            }
 
-        if (!objectManager.TryGetObject(payload.PolicyId, out PolicyObject policy))
-        {
-            Logger.Debug("PolicyObject not found in KingdomHandler with PolicyId: {id}", payload.PolicyId);
-            return;
-        }
+            if (!objectManager.TryGetObject(payload.PolicyId, out PolicyObject policy))
+            {
+                Logger.Debug("PolicyObject not found in KingdomHandler with PolicyId: {id}", payload.PolicyId);
+                return;
+            }
 
-        kingdomInterface.ChangeKingdomPolicy(kingdom, policy, payload.IsAdd);
+            kingdomInterface.ChangeKingdomPolicy(kingdom, policy, payload.IsAdd);
+        });
     }
 
     private void HandleRemoveDecision(MessagePayload<RemoveDecision> obj)

--- a/source/GameInterface/Services/Kingdoms/Patches/KingdomDecisionVMPatches.cs
+++ b/source/GameInterface/Services/Kingdoms/Patches/KingdomDecisionVMPatches.cs
@@ -72,8 +72,8 @@ namespace GameInterface.Services.Kingdoms.Patches
             if (!KingdomDecisionsVMPatches.TryGetVoteManager(out var voteManager)) return true;
             if (!voteManager.ShouldBlockLocalResolution(__instance)) return true;
 
-            bool published = voteManager.TryPublishFinalVote(__instance);
-            return !published; // fall back to native if we couldn't route it
+            voteManager.TryPublishFinalVote(__instance);
+            return false;
         }
 
         [HarmonyPatch("OnFinalize")]

--- a/source/GameInterface/Services/Kingdoms/Patches/KingdomDecisionVMPatches.cs
+++ b/source/GameInterface/Services/Kingdoms/Patches/KingdomDecisionVMPatches.cs
@@ -72,8 +72,8 @@ namespace GameInterface.Services.Kingdoms.Patches
             if (!KingdomDecisionsVMPatches.TryGetVoteManager(out var voteManager)) return true;
             if (!voteManager.ShouldBlockLocalResolution(__instance)) return true;
 
-            voteManager.TryPublishFinalVote(__instance);
-            return false;
+            bool published = voteManager.TryPublishFinalVote(__instance);
+            return !published; // fall back to native if we couldn't route it
         }
 
         [HarmonyPatch("OnFinalize")]


### PR DESCRIPTION
Activepolicies not being properly synced at kingdomcreation

## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ x ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ x ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
1: Policies were not properly synced at the start of a kingdom. Clients would have a empty list of activepolicies while the server was populated.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #2794 
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
1: Policies are properly synced on kingdom creation.

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. --> Policies are synced on kingdom creation.