### PR TITLE
Accept CRLF in nightly module checks

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -182,10 +182,13 @@ jobs:
             -e "s/\${version}/v$coop_version/g" \
             -e "s/\${game_version}/$game_version/g" \
             deploy/SubModule.xml > "$module/SubModule.xml"
-          test "$(grep -Fc "<Name value=\"$nightly_module_name\"/>" "$module/SubModule.xml")" -eq 2
-          grep -Fqx "    <Id value=\"$nightly_module_id\"/>" "$module/SubModule.xml"
-          grep -Fqx '        <Module Id="Coop"/>' "$module/SubModule.xml"
-          ! grep -Fq '<Module Id="CoopNightly"/>' "$module/SubModule.xml"
+          normalized_submodule=$(mktemp)
+          trap 'rm -f "$normalized_submodule"' EXIT
+          tr -d '\r' < "$module/SubModule.xml" > "$normalized_submodule"
+          test "$(grep -Fc "<Name value=\"$nightly_module_name\"/>" "$normalized_submodule")" -eq 2
+          grep -Fqx "    <Id value=\"$nightly_module_id\"/>" "$normalized_submodule"
+          grep -Fqx '        <Module Id="Coop"/>' "$normalized_submodule"
+          ! grep -Fq '<Module Id="CoopNightly"/>' "$normalized_submodule"
 
       - name: Upload unsigned module
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

The nightly release stops while staging a valid module because the identity checks reject the repository’s Windows line endings. The release artifacts are never produced, so Bot_UP cannot publish the nightly posts.

## What is the new behavior?

Nightly staging validates the module identity independently of line endings while preserving the packaged module file unchanged. The release can continue and Bot_UP can publish the dated nightly posts.

## Bot Changelog Entry


