### PR TITLE
[3005] Fix nightly client crash on connect

### DIFF
--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -529,7 +529,8 @@ namespace Coop
 
             if (gameStarterObject is CampaignGameStarter campaignGameStarter)
             {
-                campaignGameStarter.AddBehavior(new FixedTownNpcConversationBehavior());
+                if (ContainerProvider.TryResolve<ICoopModulePathResolver>(out var modulePathResolver))
+                    campaignGameStarter.AddBehavior(new FixedTownNpcConversationBehavior(modulePathResolver));
                 campaignGameStarter.AddBehavior(new PlayerPartyInteractionCampaignBehavior());
                 campaignGameStarter.AddBehavior(new CoopTournamentCampaignBehavior());
             }

--- a/source/GameInterface.Tests/Services/Modules/CoopModulePathResolverTests.cs
+++ b/source/GameInterface.Tests/Services/Modules/CoopModulePathResolverTests.cs
@@ -1,0 +1,34 @@
+﻿using GameInterface.Services.Modules;
+using System;
+using Xunit;
+
+namespace GameInterface.Tests.Services.Modules;
+
+public sealed class CoopModulePathResolverTests
+{
+    private const string XmlName = "coop_fixed_town_npcs";
+
+    [Theory]
+    [InlineData(CoopModulePathResolver.StableModuleId)]
+    [InlineData(CoopModulePathResolver.NightlyModuleId)]
+    public void GetXmlPath_UsesActiveModuleVariant(string activeModuleId)
+    {
+        var resolver = new CoopModulePathResolver(
+            moduleId => string.Equals(moduleId, activeModuleId, StringComparison.Ordinal),
+            (moduleId, xmlName) => moduleId + "/ModuleData/" + xmlName + ".xml");
+
+        string path = resolver.GetXmlPath(XmlName);
+
+        Assert.Equal(activeModuleId + "/ModuleData/" + XmlName + ".xml", path);
+    }
+
+    [Fact]
+    public void GetXmlPath_ReturnsNullWithoutActiveCoopVariant()
+    {
+        var resolver = new CoopModulePathResolver(
+            _ => false,
+            (_, _) => throw new InvalidOperationException("Path lookup should not run"));
+
+        Assert.Null(resolver.GetXmlPath(XmlName));
+    }
+}

--- a/source/GameInterface/GameInterfaceModule.cs
+++ b/source/GameInterface/GameInterfaceModule.cs
@@ -26,6 +26,7 @@ using GameInterface.Services.MapEvents.Initialization;
 using GameInterface.Services.MapEvents.Logging;
 using GameInterface.Services.MobileParties;
 using GameInterface.Services.MobileParties.Data;
+using GameInterface.Services.Modules;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Party;
 using GameInterface.Services.Players;
@@ -92,6 +93,7 @@ public class GameInterfaceModule : Module
         builder.RegisterType<PartySyncPerformanceFileWriter>().As<IPartySyncPerformanceFileWriter>().InstancePerLifetimeScope();
         builder.RegisterType<PartySyncPerformancePartyProvider>().As<IPartySyncPerformancePartyProvider>().InstancePerLifetimeScope();
         builder.RegisterType<LiveTestCommandDispatcher>().As<ILiveTestCommandDispatcher>().InstancePerDependency();
+        builder.RegisterType<CoopModulePathResolver>().As<ICoopModulePathResolver>().InstancePerDependency();
         builder.RegisterType<FixedTownNpcService>().AsSelf().InstancePerLifetimeScope();
         builder.RegisterType<KingdomCreationSettlementTracker>().AsSelf().As<IKingdomCreationSettlementTracker>().InstancePerLifetimeScope();
         builder.RegisterType<KingdomCreator>().AsSelf().As<IKingdomCreator>().InstancePerLifetimeScope();

--- a/source/GameInterface/Services/Locations/FixedTownNpcConversationBehavior.cs
+++ b/source/GameInterface/Services/Locations/FixedTownNpcConversationBehavior.cs
@@ -1,9 +1,9 @@
 using Common.Logging;
+using GameInterface.Services.Modules;
 using Serilog;
 using System;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.Core;
-using TaleWorlds.ModuleManager;
 
 namespace GameInterface.Services.Locations;
 
@@ -14,6 +14,14 @@ public sealed class FixedTownNpcConversationBehavior : CampaignBehaviorBase
     private const int DialoguePriority = 10000;
 
     private static readonly ILogger Logger = LogManager.GetLogger<FixedTownNpcConversationBehavior>();
+    private readonly ICoopModulePathResolver modulePathResolver;
+
+    public FixedTownNpcConversationBehavior(ICoopModulePathResolver modulePathResolver)
+    {
+        if (modulePathResolver == null) throw new ArgumentNullException(nameof(modulePathResolver));
+
+        this.modulePathResolver = modulePathResolver;
+    }
 
     public override void RegisterEvents()
     {
@@ -24,9 +32,9 @@ public sealed class FixedTownNpcConversationBehavior : CampaignBehaviorBase
     {
     }
 
-    private static void AddDialogs(CampaignGameStarter starter)
+    private void AddDialogs(CampaignGameStarter starter)
     {
-        string path = ModuleHelper.GetXmlPath("Coop", FixedTownNpcService.XmlName);
+        string path = modulePathResolver.GetXmlPath(FixedTownNpcService.XmlName);
         foreach (var definition in FixedTownNpcService.ReadDefinitions(path, Logger))
         {
             if (string.IsNullOrWhiteSpace(definition.Dialogue)) continue;

--- a/source/GameInterface/Services/Locations/FixedTownNpcService.cs
+++ b/source/GameInterface/Services/Locations/FixedTownNpcService.cs
@@ -1,3 +1,4 @@
+using GameInterface.Services.Modules;
 using GameInterface.Services.ObjectManager;
 using Serilog;
 using System;
@@ -8,7 +9,6 @@ using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.CampaignSystem.Settlements.Locations;
 using TaleWorlds.Core;
-using TaleWorlds.ModuleManager;
 
 namespace GameInterface.Services.Locations;
 
@@ -28,8 +28,11 @@ internal sealed class FixedTownNpcService
     private readonly IObjectManager objectManager;
     private readonly Lazy<IReadOnlyList<FixedTownNpcDefinition>> definitions;
 
-    public FixedTownNpcService(ILogger logger, IObjectManager objectManager)
-        : this(logger, objectManager, () => ModuleHelper.GetXmlPath("Coop", XmlName))
+    public FixedTownNpcService(
+        ILogger logger,
+        IObjectManager objectManager,
+        ICoopModulePathResolver modulePathResolver)
+        : this(logger, objectManager, GetPathProvider(modulePathResolver))
     {
     }
 
@@ -39,6 +42,13 @@ internal sealed class FixedTownNpcService
         this.objectManager = objectManager;
         definitions = new Lazy<IReadOnlyList<FixedTownNpcDefinition>>(
             () => ReadDefinitions(pathProvider(), logger));
+    }
+
+    private static Func<string> GetPathProvider(ICoopModulePathResolver modulePathResolver)
+    {
+        if (modulePathResolver == null) throw new ArgumentNullException(nameof(modulePathResolver));
+
+        return () => modulePathResolver.GetXmlPath(XmlName);
     }
 
     public void Populate(Settlement settlement)

--- a/source/GameInterface/Services/Modules/CoopModulePathResolver.cs
+++ b/source/GameInterface/Services/Modules/CoopModulePathResolver.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using TaleWorlds.ModuleManager;
+
+namespace GameInterface.Services.Modules;
+
+public interface ICoopModulePathResolver
+{
+    string GetXmlPath(string xmlName);
+}
+
+internal sealed class CoopModulePathResolver : ICoopModulePathResolver
+{
+    internal const string StableModuleId = "Coop";
+    internal const string NightlyModuleId = "CoopNightly";
+
+    private readonly Func<string, bool> isModuleActive;
+    private readonly Func<string, string, string> getXmlPath;
+
+    public CoopModulePathResolver()
+        : this(ModuleHelper.IsModuleActive, ModuleHelper.GetXmlPath)
+    {
+    }
+
+    internal CoopModulePathResolver(
+        Func<string, bool> isModuleActive,
+        Func<string, string, string> getXmlPath)
+    {
+        if (isModuleActive == null) throw new ArgumentNullException(nameof(isModuleActive));
+        if (getXmlPath == null) throw new ArgumentNullException(nameof(getXmlPath));
+
+        this.isModuleActive = isModuleActive;
+        this.getXmlPath = getXmlPath;
+    }
+
+    public string GetXmlPath(string xmlName)
+    {
+        if (isModuleActive(StableModuleId))
+            return getXmlPath(StableModuleId, xmlName);
+
+        if (isModuleActive(NightlyModuleId))
+            return getXmlPath(NightlyModuleId, xmlName);
+
+        return null;
+    }
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Nightly clients crash during campaign loading after connecting.

## What is the new behavior?

Resolves #3005

Nightly clients finish campaign loading, and fixed-town NPC data and dialogue remain available.
<img width="703" height="119" alt="image" src="https://github.com/user-attachments/assets/c9d385b5-2631-4f27-a54f-000d909a1d97" />
<img width="368" height="138" alt="image" src="https://github.com/user-attachments/assets/ac5c799b-19b4-4bf8-9965-bb57203084bf" />


## Bot Changelog Entry
