### PR TITLE
Update mod config descriptions

### DIFF
--- a/deploy/mod-config.default.json
+++ b/deploy/mod-config.default.json
@@ -12,8 +12,8 @@
   // Levels: "VeryEasy" | "Easy" | "Realistic".
   "difficulty": {
     // Damage players take. VeryEasy is Bannerlord's new-campaign default.
-    // VeryEasy: -50% Damage
-    // Easy: -25% Damage
+    // VeryEasy: -75% Damage
+    // Easy: -50% Damage
     // Realistic: No change
     "playerReceivedDamage": "VeryEasy",
 

--- a/deploy/mod-config.default.json
+++ b/deploy/mod-config.default.json
@@ -12,19 +12,66 @@
   // Levels: "VeryEasy" | "Easy" | "Realistic".
   "difficulty": {
     // Damage players take. VeryEasy is Bannerlord's new-campaign default.
+    // VeryEasy: -50% Damage
+    // Easy: -25% Damage
+    // Realistic: No change
     "playerReceivedDamage": "VeryEasy",
 
+    // Determine the damage received by your troops.
+    // VeryEasy: -50% Damage
+    // Easy: -25% Damage
+    // Realistic: No change
     "playerTroopsReceivedDamage": "VeryEasy",
+
+    // Determine the difficulty of the combat AI.
+    // VeryEasy: Normal
+    // Easy: Veteran
+    // Realistic: Challenging
     "combatAIDifficulty": "VeryEasy",
+
+    // Determine the amount of troops available from notables.
+    // VeryEasy: +2 Troops
+    // Easy: +1 Troops
+    // Realistic: No change
     "recruitmentDifficulty": "VeryEasy",
+
+    // Determine player party movement speed while travelling.
+    // VeryEasy: +10% Speed
+    // Easy: +5% Speed
+    // Realistic: No change
     "playerMapMovementSpeed": "VeryEasy",
+
+    // Determine the difficulty of stealth and disguise gameplay.
+    // VeryEasy: Normal
+    // Easy: Veteran
+    // Realistic: Challenging
     "stealthAndDisguiseDifficulty": "VeryEasy",
+
+    // Determine persuasion success chance.
+    // VeryEasy: +10% Success chance
+    // Easy: +5% Success chance
+    // Realistic: No change
     "persuasionSuccessChance": "VeryEasy",
+
+    // Determine the possibility of player clan members dying in battle.
+    // VeryEasy: Disabled battle death for clan members
+    // Easy: Reduced by 50%
+    // Realistic: No change
     "clanMemberDeathChance": "VeryEasy",
+
+    // Determine if players and/or other heroes can die in battle.
+    // VeryEasy: Disable battle death for all heroes
+    // Easy: Disable battle death for player heroes
+    // Realistic: Enable battle death for all heroes
     "battleDeath": "VeryEasy",
 
-    "birthAndDeath": true,                 // aging, births, natural deaths
-    "autoAllocateClanMemberPerks": false,
+    // (Not currently supported) Toggle aging, births and natural deaths.
+    // NOTE: Having this off doesn't necessarily disable battle deaths
+    // To disable battle deaths change "battleDeath" and "clanMemberDeathChance" instead
+    "birthAndDeath": false,
+
+    // Toggle auto allocation of perks for members of player clans.
+    "autoAllocateClanMemberPerks": false
   },
   "modOptions": {
     // Toggle fast forward (2x speed) being enabled

--- a/source/GameInterface.Tests/Configuration/ModConfigTests.cs
+++ b/source/GameInterface.Tests/Configuration/ModConfigTests.cs
@@ -137,7 +137,7 @@ public class ModConfigTests : IDisposable
         _ = NewModConfig().Data;
 
         Assert.Equal(DifficultyLevel.Easy, config.Difficulty.BattleDeath);
-        Assert.True(config.Difficulty.BirthAndDeath);
+        Assert.False(config.Difficulty.BirthAndDeath);
         Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.PlayerReceivedDamage);
         Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.CombatAIDifficulty);
         Assert.True(config.ModOptions.ClientsCanUseCheats);
@@ -157,7 +157,7 @@ public class ModConfigTests : IDisposable
         _ = NewModConfig().Data;
 
         Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.BattleDeath);
-        Assert.True(config.Difficulty.BirthAndDeath);
+        Assert.False(config.Difficulty.BirthAndDeath);
         Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.PlayerReceivedDamage);
         Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.CombatAIDifficulty);
         Assert.True(config.ModOptions.ClientsCanUseCheats);

--- a/source/GameInterface.Tests/Configuration/ModConfigTests.cs
+++ b/source/GameInterface.Tests/Configuration/ModConfigTests.cs
@@ -47,7 +47,7 @@ public class ModConfigTests : IDisposable
         Assert.True(File.Exists(ConfigPath), "first load should create mod-config.json");
         Assert.Equal(File.ReadAllText(ShippedTemplatePath), File.ReadAllText(ConfigPath));
         Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.PlayerReceivedDamage);
-        Assert.True(config.Difficulty.BirthAndDeath);
+        Assert.False(config.Difficulty.BirthAndDeath);
     }
 
     [Fact]
@@ -66,7 +66,7 @@ public class ModConfigTests : IDisposable
         Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.PersuasionSuccessChance);
         Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.ClanMemberDeathChance);
         Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.BattleDeath);
-        Assert.True(config.Difficulty.BirthAndDeath);
+        Assert.False(config.Difficulty.BirthAndDeath);
         Assert.False(config.Difficulty.AutoAllocateClanMemberPerks);
         Assert.True(config.UnknownKeys == null || config.UnknownKeys.Count == 0);
         Assert.True(config.Difficulty.UnknownKeys == null || config.Difficulty.UnknownKeys.Count == 0);

--- a/source/GameInterface/Configuration/ModConfig.cs
+++ b/source/GameInterface/Configuration/ModConfig.cs
@@ -61,7 +61,7 @@ internal sealed class ModConfig : IModConfig
             ["persuasionSuccessChance"] = "VeryEasy",
             ["clanMemberDeathChance"] = "VeryEasy",
             ["battleDeath"] = "VeryEasy",
-            ["birthAndDeath"] = true,
+            ["birthAndDeath"] = false,
             ["autoAllocateClanMemberPerks"] = false,
         };
 


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The mod config includes the campaign options but currently lacks descriptions for each of them.

This has led to some confusion about what each of these options does as they are all labelled with the same "VeryEasy", "Easy" and "Realistic" difficulties. A specific example of this is in the linked issue about heroes dying in battle despite deaths supposedly being disabled. The reporter had `battleDeaths` set to realistic, an option that is independent of `birthAndDeath` which only controls the natural life & death cycle.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #2956
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Updated `mod-config.default.json` to include descriptions for each campaign option matching the vanilla campaign options menu with an additional note about `birthAndDeath` not disabling battle deaths.

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Added descriptions for campaign options in mod config.
