### PR TITLE
Enable PrisonerCaptureCampaignBehavior

### DIFF
--- a/source/GameInterface/Services/Towns/Patches/Disabled/DisablePrisonerCaptureCampaignBehavior.cs
+++ b/source/GameInterface/Services/Towns/Patches/Disabled/DisablePrisonerCaptureCampaignBehavior.cs
@@ -1,5 +1,12 @@
-﻿using HarmonyLib;
+﻿using Common;
+using GameInterface.Services.Armies.Extensions;
+using GameInterface.Services.Heroes.Extensions;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Settlements;
 
 namespace GameInterface.Services.Towns.Patches.Disabled;
 
@@ -7,5 +14,51 @@ namespace GameInterface.Services.Towns.Patches.Disabled;
 internal class DisablePrisonerCaptureCampaignBehavior
 {
     [HarmonyPatch(nameof(PrisonerCaptureCampaignBehavior.RegisterEvents))]
-    static bool Prefix() => false;
+    static bool Prefix() => ModInformation.IsServer;
+}
+
+[HarmonyPatch(typeof(PrisonerCaptureCampaignBehavior))]
+internal class PrisonerCaptureCampaignBehaviorPatches
+{
+    [HarmonyPatch(nameof(PrisonerCaptureCampaignBehavior.HandleSettlementHeroes))]
+    [HarmonyPrefix]
+    public static bool HandleSettlementHeroesPrefix(PrisonerCaptureCampaignBehavior __instance, Settlement settlement)
+    {
+        for (int i = settlement.HeroesWithoutParty.Count - 1; i >= 0; i--)
+        {
+            Hero hero = settlement.HeroesWithoutParty[i];
+            if (__instance.SettlementHeroCaptureCommonCondition(hero))
+            {
+                TakePrisonerAction.Apply(hero.CurrentSettlement.Party, hero);
+            }
+        }
+        for (int j = settlement.Parties.Count - 1; j >= 0; j--)
+        {
+            MobileParty mobileParty = settlement.Parties[j];
+
+            // Replace MobileParty.MainParty usage
+            if (mobileParty.IsLordParty
+                && (mobileParty.Army == null || (mobileParty.Army != null && mobileParty.Army.LeaderParty == mobileParty && !mobileParty.Army.IsPlayerArmy())
+                && mobileParty.MapEvent == null
+                && __instance.SettlementHeroCaptureCommonCondition(mobileParty.LeaderHero)))
+            {
+                LeaveSettlementAction.ApplyForParty(mobileParty);
+            }
+        }
+
+        return false;
+    }
+
+    [HarmonyPatch(nameof(PrisonerCaptureCampaignBehavior.SettlementHeroCaptureCommonCondition))]
+    [HarmonyPrefix]
+    public static bool HandleSettlementHeroesPrefix(ref bool __result, Hero hero)
+    {
+        if (hero.IsPlayerHero())
+        {
+            __result = false;
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/source/GameInterface/Services/Towns/Patches/Disabled/DisablePrisonerCaptureCampaignBehavior.cs
+++ b/source/GameInterface/Services/Towns/Patches/Disabled/DisablePrisonerCaptureCampaignBehavior.cs
@@ -38,9 +38,9 @@ internal class PrisonerCaptureCampaignBehaviorPatches
 
             // Replace MobileParty.MainParty usage
             if (mobileParty.IsLordParty
-                && (mobileParty.Army == null || (mobileParty.Army != null && mobileParty.Army.LeaderParty == mobileParty && !mobileParty.Army.IsPlayerArmy())
+                && (mobileParty.Army == null || (mobileParty.Army != null && mobileParty.Army.LeaderParty == mobileParty && !mobileParty.Army.IsPlayerArmy()))
                 && mobileParty.MapEvent == null
-                && __instance.SettlementHeroCaptureCommonCondition(mobileParty.LeaderHero)))
+                && __instance.SettlementHeroCaptureCommonCondition(mobileParty.LeaderHero))
             {
                 LeaveSettlementAction.ApplyForParty(mobileParty);
             }


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`PrisonerCaptureCampaignBehavior` is currently disabled. This behavior controls capturing heroes in settlements. e.g. Capturing a hero in a now hostile settlement when war is declared or making a lord party leave a now hostile settlement.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Enabled and patched `PrisonerCaptureCampaignBehavior` to work for coop.

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Fixed an issue where heroes were not captured when the settlement they are in becomes hostile.
