### PR TITLE
Fix AutoSync interception during parallel client save loads

### DIFF
--- a/source/GameInterface.Tests/Policies/CallOriginalPolicyTests.cs
+++ b/source/GameInterface.Tests/Policies/CallOriginalPolicyTests.cs
@@ -1,0 +1,53 @@
+using GameInterface.Policies;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GameInterface.Tests.Policies;
+
+public class CallOriginalPolicyTests
+{
+    [Fact]
+    public async Task AllThreadsScope_IsVisibleOnWorkerThreadUntilDisposed()
+    {
+        Assert.False(CallOriginalPolicy.AreOriginalsAllowedOnAllThreads);
+
+        using (CallOriginalPolicy.AllowOriginalsOnAllThreads())
+        {
+            Assert.True(CallOriginalPolicy.AreOriginalsAllowedOnAllThreads);
+            Assert.True(await Task.Run(CallOriginalPolicy.IsOriginalAllowed));
+        }
+
+        Assert.False(CallOriginalPolicy.AreOriginalsAllowedOnAllThreads);
+    }
+
+    [Fact]
+    public void NestedAllThreadsScope_DoesNotRevokeOuterScope()
+    {
+        using (CallOriginalPolicy.AllowOriginalsOnAllThreads())
+        {
+            using (CallOriginalPolicy.AllowOriginalsOnAllThreads())
+            {
+                Assert.True(CallOriginalPolicy.AreOriginalsAllowedOnAllThreads);
+            }
+
+            Assert.True(CallOriginalPolicy.AreOriginalsAllowedOnAllThreads);
+        }
+
+        Assert.False(CallOriginalPolicy.AreOriginalsAllowedOnAllThreads);
+    }
+
+    [Fact]
+    public void AllThreadsScope_DoubleDispose_DoesNotRevokeAnotherScope()
+    {
+        using (CallOriginalPolicy.AllowOriginalsOnAllThreads())
+        {
+            var scope = CallOriginalPolicy.AllowOriginalsOnAllThreads();
+            scope.Dispose();
+            scope.Dispose();
+
+            Assert.True(CallOriginalPolicy.AreOriginalsAllowedOnAllThreads);
+        }
+
+        Assert.False(CallOriginalPolicy.AreOriginalsAllowedOnAllThreads);
+    }
+}

--- a/source/GameInterface/Policies/CallOriginalPolicy.cs
+++ b/source/GameInterface/Policies/CallOriginalPolicy.cs
@@ -1,6 +1,8 @@
 ﻿using Common.Logging;
 using Common.Util;
 using Serilog;
+using System;
+using System.Threading;
 
 namespace GameInterface.Policies;
 
@@ -8,10 +10,15 @@ public class CallOriginalPolicy
 {
     private static readonly ILogger Logger = LogManager.GetLogger<CallOriginalPolicy>();
 
+    private static int _allThreadsAllowedCount;
+
+    internal static bool AreOriginalsAllowedOnAllThreads =>
+        Volatile.Read(ref _allThreadsAllowedCount) > 0;
+
     public static bool IsOriginalAllowed()
     {
-        // While using allowed thread, allow original call
-        if (AllowedThread.IsThisThreadAllowed()) return true;
+        // While using an allowed thread or operation, allow original call
+        if (AllowedThread.IsThisThreadAllowed() || AreOriginalsAllowedOnAllThreads) return true;
 
         if (ContainerProvider.TryResolve<ISyncPolicy>(out var syncPolicy) == false)
         {
@@ -22,5 +29,30 @@ public class CallOriginalPolicy
         if (syncPolicy.AllowOriginal()) return true;
 
         return false;
+    }
+
+    /// <summary>
+    /// Allows original calls on every thread for the returned scope's lifetime. Use only around
+    /// operations, such as the native save loader, that synchronously dispatch patched work to
+    /// engine-owned threads and wait for all of it to finish before the scope is disposed.
+    /// </summary>
+    public static IDisposable AllowOriginalsOnAllThreads() => new AllThreadsScope();
+
+    private sealed class AllThreadsScope : IDisposable
+    {
+        private int _disposed;
+
+        public AllThreadsScope()
+        {
+            Interlocked.Increment(ref _allThreadsAllowedCount);
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
+            {
+                Interlocked.Decrement(ref _allThreadsAllowedCount);
+            }
+        }
     }
 }

--- a/source/GameInterface/Services/GameState/Interfaces/GameStateInterface.cs
+++ b/source/GameInterface/Services/GameState/Interfaces/GameStateInterface.cs
@@ -1,6 +1,7 @@
 ﻿using Common;
 using Common.Logging;
 using Common.Messaging;
+using GameInterface.Policies;
 using GameInterface.Services.GameState.Messages;
 using GameInterface.Services.Heroes;
 using SandBox;
@@ -67,7 +68,16 @@ internal class GameStateInterface : IGameStateInterface
         }
 
         ISaveDriver driver = new CoopInMemSaveDriver(saveData);
-        LoadResult loadResult = SaveManager.Load("", driver, loadAsLateInitialize: true);
+        LoadResult loadResult;
+
+        // SaveManager fills objects on NativeParallelDriver workers. A normal AllowedThread scope only
+        // affects this game thread, leaving AutoSync patches active on those workers. Keep every
+        // CallOriginalPolicy-gated patch on its original path until the synchronous load joins its workers.
+        using (CallOriginalPolicy.AllowOriginalsOnAllThreads())
+        {
+            loadResult = SaveManager.Load("", driver, loadAsLateInitialize: true);
+        }
+
         var loadedGame = (Game)loadResult.Root;
         var loadedCampaign = (Campaign)loadedGame.GameType;
         ClearTransferredMapNotices(loadedCampaign.CampaignInformationManager);


### PR DESCRIPTION
## Summary

- add a narrowly scoped, process-wide override to `CallOriginalPolicy`
- enable it only while the client synchronously runs `SaveManager.Load`
- make the override thread-safe, reference-counted, and safe against repeated disposal
- cover worker-thread visibility, nested scopes, and disposal behavior with tests

## Root cause

`AllowedThread` is intentionally thread-local, but Bannerlord's save system fills loaded objects through `NativeParallelDriver` worker callbacks. Those workers do not inherit the game thread's allowance, so AutoSync Harmony prefixes remain active while `PropertyLoadData.FillObject` invokes saveable property setters. On the reported Linux/Mono client, that path throws inside patched setters, `LoadContext` returns a failed load, and the join never leaves the loading screen.

The new scope bypasses `ISyncPolicy`/AutoSync interception across those workers only for the synchronous `SaveManager.Load` window. It is disposed before normal campaign startup continues.

## Validation

- `dotnet test source/GameInterface.Tests/GameInterface.Tests.csproj --configuration Debug --verbosity minimal -p:NuGetAudit=false`
- 928 tests passed

A default restore is currently blocked by the repository's existing warnings-as-errors treatment of known Scriban 7.2.0 advisories, so validation disabled NuGet audit rather than changing dependencies in this fix.

## Remaining validation

I could not run the original Steam/Proton join flow locally. This targets the confirmed parallel setter crash. The separate missing-object/repeated registry log noise reported after successful loading is not changed here.

Fixes #2999
