### PR TITLE
Reject incompatible co-op builds during validation

### DIFF
--- a/source/Coop.Core/Client/States/ValidateModuleState.cs
+++ b/source/Coop.Core/Client/States/ValidateModuleState.cs
@@ -127,6 +127,12 @@ public class ValidateModuleState : ClientStateBase
 
     internal void Handle_NetworkModuleVersionsValidated(MessagePayload<NetworkModuleVersionsValidated> obj)
     {
+        if (!ModInformation.MatchesBuildVersion(obj.What.CoopBuildVersion))
+        {
+            RejectModuleValidation(GetIncompatibleBuildReason(obj.What.CoopBuildVersion));
+            return;
+        }
+
         // Reaching this handshake proves both sides run Coop; only a version mismatch should block it.
         if (obj.What.Matches || string.Equals(obj.What.Reason, UnsupportedCoopModuleReason, StringComparison.Ordinal))
         {
@@ -134,14 +140,31 @@ public class ValidateModuleState : ClientStateBase
         }
         else
         {
-            var reason = "Module validation failed!\nReason: " + obj.What.Reason;
-            messageBroker.Publish(this, new SendInformationMessage(reason));
-
-            // Carry the reason into the teardown pop-up: the information message above lands in the
-            // chat log, which is invisible behind the forced loading screen the player is watching.
-            disconnectReason = reason;
-            Logic.Disconnect();
+            RejectModuleValidation(obj.What.Reason);
         }
+    }
+
+    private static string GetIncompatibleBuildReason(string? serverBuildVersion)
+    {
+        if (string.IsNullOrEmpty(serverBuildVersion))
+        {
+            return $"Incompatible co-op mod build. This client uses '{ModInformation.BuildVersion}', " +
+                   "but the server did not report an exact build. Update the co-op mod on both sides.";
+        }
+
+        return $"Incompatible co-op mod build. This client uses '{ModInformation.BuildVersion}', " +
+               $"but the server uses '{serverBuildVersion}'. Update the co-op mod on both sides.";
+    }
+
+    private void RejectModuleValidation(string? reason)
+    {
+        var message = "Module validation failed!\nReason: " + reason;
+        messageBroker.Publish(this, new SendInformationMessage(message));
+
+        // Carry the reason into the teardown pop-up: the information message above lands in the
+        // chat log, which is invisible behind the forced loading screen the player is watching.
+        disconnectReason = message;
+        Logic.Disconnect();
     }
 
     internal void Handle_NetworkClientValidated(MessagePayload<NetworkClientValidated> obj)

--- a/source/Coop.Core/Server/Connections/Messages/NetworkModuleVersionsValidate.cs
+++ b/source/Coop.Core/Server/Connections/Messages/NetworkModuleVersionsValidate.cs
@@ -1,4 +1,5 @@
-﻿using Common.Messaging;
+﻿using Common;
+using Common.Messaging;
 using GameInterface.Services.Modules;
 using ProtoBuf;
 using System;
@@ -17,9 +18,17 @@ public record NetworkModuleVersionsValidate : ICommand
 {
     [ProtoMember(1)]
     public NetworkModuleInfo[] Modules { get; }
+    [ProtoMember(2)]
+    public string? CoopBuildVersion { get; }
 
     public NetworkModuleVersionsValidate(IEnumerable<ModuleInfo> modules)
+        : this(modules, ModInformation.BuildVersion)
     {
+    }
+
+    public NetworkModuleVersionsValidate(IEnumerable<ModuleInfo> modules, string? coopBuildVersion)
+    {
+        CoopBuildVersion = coopBuildVersion;
         if (modules is null)
         {
             Modules = Array.Empty<NetworkModuleInfo>();

--- a/source/Coop.Core/Server/Connections/Messages/NetworkModuleVersionsValidated.cs
+++ b/source/Coop.Core/Server/Connections/Messages/NetworkModuleVersionsValidated.cs
@@ -1,4 +1,5 @@
-﻿using Common.Messaging;
+﻿using Common;
+using Common.Messaging;
 using ProtoBuf;
 
 namespace Coop.Core.Server.Connections.Messages;
@@ -12,11 +13,19 @@ public record NetworkModuleVersionsValidated : IEvent
     [ProtoMember(1)]
     public bool Matches { get; }
     [ProtoMember(2)]
-    public string Reason { get; }
+    public string? Reason { get; }
+    [ProtoMember(3)]
+    public string? CoopBuildVersion { get; }
 
-    public NetworkModuleVersionsValidated(bool matches, string reason)
+    public NetworkModuleVersionsValidated(bool matches, string? reason)
+        : this(matches, reason, ModInformation.BuildVersion)
+    {
+    }
+
+    public NetworkModuleVersionsValidated(bool matches, string? reason, string? coopBuildVersion)
     {
         Matches = matches;
         Reason = reason;
+        CoopBuildVersion = coopBuildVersion;
     }
 }

--- a/source/Coop.Core/Server/Connections/States/ResolveCharacterState.cs
+++ b/source/Coop.Core/Server/Connections/States/ResolveCharacterState.cs
@@ -79,7 +79,18 @@ public class ResolveCharacterState : ConnectionStateBase
             var clientModules = obj.What.Modules;
             var serverModules = moduleInfoProvider.GetModuleInfos();
 
-            result = moduleValidator.Validate(serverModules, clientModules.Select(ConvertToModuleInfo), out error);
+            if (!ModInformation.MatchesBuildVersion(obj.What.CoopBuildVersion))
+            {
+                result = false;
+                error = GetIncompatibleBuildReason(obj.What.CoopBuildVersion);
+            }
+            else
+            {
+                result = moduleValidator.Validate(
+                    serverModules,
+                    clientModules.Select(ConvertToModuleInfo),
+                    out error);
+            }
         }
         catch (Exception e)
         {
@@ -92,8 +103,23 @@ public class ResolveCharacterState : ConnectionStateBase
                     "Check that the client and server run the same game and mod versions.";
         }
 
-        var validateMessage = new NetworkModuleVersionsValidated(result, error);
+        var validateMessage = new NetworkModuleVersionsValidated(
+            result,
+            error,
+            ModInformation.BuildVersion);
         network.SendImmediate(ConnectionLogic.Peer, validateMessage);
+    }
+
+    private static string GetIncompatibleBuildReason(string? clientBuildVersion)
+    {
+        if (string.IsNullOrEmpty(clientBuildVersion))
+        {
+            return $"Incompatible co-op mod build. The server uses '{ModInformation.BuildVersion}', " +
+                   "but the client did not report an exact build. Update the co-op mod on both sides.";
+        }
+
+        return $"Incompatible co-op mod build. The server uses '{ModInformation.BuildVersion}', " +
+               $"but the client uses '{clientBuildVersion}'. Update the co-op mod on both sides.";
     }
 
     internal void Handle_ClientValidate(MessagePayload<NetworkClientValidate> obj)

--- a/source/Coop.Tests/Client/States/ValidateModuleStateTests.cs
+++ b/source/Coop.Tests/Client/States/ValidateModuleStateTests.cs
@@ -50,7 +50,8 @@ namespace Coop.Tests.Client.States
             Assert.NotEmpty(clientComponent.TestNetwork.Peers);
 
             var message = Assert.Single(clientComponent.TestNetwork.GetPeerMessages(serverPeer));
-            Assert.IsType<NetworkModuleVersionsValidate>(message);
+            var validateMessage = Assert.IsType<NetworkModuleVersionsValidate>(message);
+            Assert.Equal(Common.ModInformation.BuildVersion, validateMessage.CoopBuildVersion);
         }
 
         [Fact]
@@ -84,6 +85,29 @@ namespace Coop.Tests.Client.States
             // Assert
             Assert.Single(clientComponent.TestNetwork.GetPeerMessages(serverPeer).OfType<NetworkClientValidate>());
             Assert.Empty(clientComponent.TestMessageBroker.GetMessagesFromType<EndCoopMode>());
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("different-build")]
+        public void NetworkModuleVersionsValidated_IncompatibleBuild_ShowsReasonAndDisconnects(
+            string? serverBuildVersion)
+        {
+            var validateState = clientLogic.SetState<ValidateModuleState>();
+            var payload = new MessagePayload<NetworkModuleVersionsValidated>(
+                this,
+                new NetworkModuleVersionsValidated(true, null, serverBuildVersion));
+
+            validateState.Handle_NetworkModuleVersionsValidated(payload);
+
+            Assert.Empty(
+                clientComponent.TestNetwork.GetPeerMessages(serverPeer).OfType<NetworkClientValidate>());
+            Assert.Single(clientComponent.TestMessageBroker.GetMessagesFromType<EndCoopMode>());
+            var popup = Assert.Single(
+                clientComponent.TestMessageBroker.GetMessagesFromType<SendPopupMessage>());
+            Assert.Contains("Incompatible co-op mod build", popup.Text);
+            Assert.Contains("Update the co-op mod on both sides", popup.Text);
         }
 
         [Fact]

--- a/source/Coop.Tests/Server/Connections/States/ResolveCharacterStateTests.cs
+++ b/source/Coop.Tests/Server/Connections/States/ResolveCharacterStateTests.cs
@@ -11,8 +11,10 @@ using GameInterface.Services.Players;
 using GameInterface.Services.Players.Data;
 using LiteNetLib;
 using Moq;
+using ProtoBuf;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
 using TaleWorlds.CampaignSystem;
@@ -110,6 +112,56 @@ namespace Coop.Tests.Server.Connections.States
 
             var castedMessage = (NetworkModuleVersionsValidated)message;
             Assert.True(castedMessage.Matches);
+            Assert.Equal(Common.ModInformation.BuildVersion, castedMessage.CoopBuildVersion);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("different-build")]
+        public void NetworkModuleVersionsValidate_IncompatibleBuild_Denied(string? clientBuildVersion)
+        {
+            var currentState = connectionLogic.SetState<ResolveCharacterState>();
+            var modules = new List<ModuleInfo>
+            {
+                new ModuleInfo("1", false, false, new ApplicationVersion()),
+            };
+            serverComponent.Container
+                .Resolve<Mock<IModuleInfoProvider>>()
+                .Setup(mip => mip.GetModuleInfos())
+                .Returns(modules);
+
+            var payload = new MessagePayload<NetworkModuleVersionsValidate>(
+                playerPeer,
+                new NetworkModuleVersionsValidate(modules, clientBuildVersion));
+            currentState.Handle_ModuleVersionsValidate(payload);
+
+            var message = Assert.Single(serverComponent.TestNetwork.GetPeerMessages(playerPeer));
+            var validated = Assert.IsType<NetworkModuleVersionsValidated>(message);
+            Assert.False(validated.Matches);
+            Assert.Contains("Incompatible co-op mod build", validated.Reason);
+            Assert.Contains("Update the co-op mod on both sides", validated.Reason);
+            Assert.Equal(Common.ModInformation.BuildVersion, validated.CoopBuildVersion);
+        }
+
+        [Fact]
+        public void NetworkModuleVersionsValidate_ProtobufRoundTrip_PreservesBuildVersion()
+        {
+            var message = new NetworkModuleVersionsValidate(Array.Empty<ModuleInfo>(), "client-build");
+
+            var deserialized = ProtobufRoundTrip(message);
+
+            Assert.Equal("client-build", deserialized.CoopBuildVersion);
+        }
+
+        [Fact]
+        public void NetworkModuleVersionsValidated_ProtobufRoundTrip_PreservesBuildVersion()
+        {
+            var message = new NetworkModuleVersionsValidated(false, "reason", "server-build");
+
+            var deserialized = ProtobufRoundTrip(message);
+
+            Assert.Equal("server-build", deserialized.CoopBuildVersion);
         }
 
         [Fact]
@@ -369,6 +421,14 @@ namespace Coop.Tests.Server.Connections.States
                 .GetValueOrDefault(playerPeer.Id) ?? Enumerable.Empty<IMessage>();
 
             Assert.Empty(messages.OfType<NetworkClientValidated>());
+        }
+
+        private static T ProtobufRoundTrip<T>(T message)
+        {
+            using var stream = new MemoryStream();
+            Serializer.Serialize(stream, message);
+            stream.Position = 0;
+            return Serializer.Deserialize<T>(stream);
         }
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Different client and server builds can be accepted when they share the same displayed Coop version, then fail campaign loading and leave the player on an infinite loading screen.

## What is the new behavior?

Client and server builds must now match exactly. Different or older builds are rejected while joining, and the player sees an incompatible co-op build message instructing them to update both sides.

## Bot Changelog Entry

- Fixed an issue where old clients could connect to newer servers
