### PR TITLE
Hide server IP from loading screen

### DIFF
--- a/source/Coop.Core/Client/ClientModule.cs
+++ b/source/Coop.Core/Client/ClientModule.cs
@@ -55,11 +55,9 @@ public class ClientModule : CommonModule
         builder.RegisterType<SessionAdvertisementConfig>().AsSelf().InstancePerLifetimeScope();
 
         // Keeps the module resolvable on its own; a session container registers the real intent.
-        builder.Register(c =>
-        {
-            var config = c.Resolve<INetworkConfig>();
-            return JoinAttemptPresentation.For(JoinIntent.PlayerDirect, config.Address, config.Port);
-        }).AsSelf().InstancePerLifetimeScope();
+        builder.Register(_ => JoinAttemptPresentation.For(JoinIntent.PlayerDirect))
+            .AsSelf()
+            .InstancePerLifetimeScope();
 
         RegisterAllTypesWithInterface<ClientModule, IHandler>(builder, autoInstantiate: true);
         RegisterAllTypesWithInterface<ClientModule, IPacketHandler>(builder, autoInstantiate: true);

--- a/source/Coop.Core/Common/Session/JoinAttemptPresentation.cs
+++ b/source/Coop.Core/Common/Session/JoinAttemptPresentation.cs
@@ -29,10 +29,10 @@ public sealed class JoinAttemptPresentation
     public string CancelLabel { get; }
     public string CancelledNotice { get; }
 
-    public static JoinAttemptPresentation For(JoinIntent intent, string address, int port) => intent switch
+    public static JoinAttemptPresentation For(JoinIntent intent) => intent switch
     {
         JoinIntent.PlayerDirect => new JoinAttemptPresentation(intent, JoiningTitle,
-            $"Contacting {address}:{port}...", PlayerCancelLabel, PlayerCancelledNotice),
+            "Contacting the server...", PlayerCancelLabel, PlayerCancelledNotice),
 
         // A tunnelled Steam join dials a local pump, so the host is named by route not by address.
         JoinIntent.PlayerSteam => new JoinAttemptPresentation(intent, JoiningTitle,

--- a/source/Coop.Core/CoopartiveMultiplayerExperience.cs
+++ b/source/Coop.Core/CoopartiveMultiplayerExperience.cs
@@ -619,9 +619,7 @@ namespace Coop.Core
                 builder.RegisterInstance(advertisementConfig).AsSelf().SingleInstance();
             }
 
-            // Null config is the debug auto-connect entry point.
-            var joinConfig = configuration ?? this.configuration;
-            var presentation = JoinAttemptPresentation.For(intent, joinConfig.Address, joinConfig.Port);
+            var presentation = JoinAttemptPresentation.For(intent);
             builder.RegisterInstance(presentation).AsSelf().SingleInstance();
 
             container = builder.Build();

--- a/source/Coop.Tests/ClientTestComponent.cs
+++ b/source/Coop.Tests/ClientTestComponent.cs
@@ -1,5 +1,4 @@
 ﻿using Autofac;
-using Common.Network;
 using Coop.Core.Client;
 using Coop.Core.Common.Session;
 using GameInterface.Registry;
@@ -17,11 +16,9 @@ internal class ClientTestComponent : TestComponentBase
         builder.RegisterModule<RegistryModule>();
 
         // Overrides ClientModule's registration, which is pinned to one intent.
-        builder.Register(c =>
-        {
-            var config = c.Resolve<INetworkConfig>();
-            return JoinAttemptPresentation.For(intent, config.Address, config.Port);
-        }).AsSelf().InstancePerLifetimeScope();
+        builder.Register(_ => JoinAttemptPresentation.For(intent))
+            .AsSelf()
+            .InstancePerLifetimeScope();
 
         Container = BuildContainer(builder);
     }

--- a/source/Coop.Tests/Session/JoinAttemptPresentationTests.cs
+++ b/source/Coop.Tests/Session/JoinAttemptPresentationTests.cs
@@ -7,27 +7,26 @@ namespace Coop.Tests.Session;
 public class JoinAttemptPresentationTests
 {
     [Fact]
-    public void For_DirectJoin_NamesTheEndpointBeingDialled()
+    public void For_DirectJoin_DoesNotExposeTheServerEndpoint()
     {
-        var presentation = JoinAttemptPresentation.For(JoinIntent.PlayerDirect, "203.0.113.7", 4200);
+        var presentation = JoinAttemptPresentation.For(JoinIntent.PlayerDirect);
 
-        Assert.Equal("Contacting 203.0.113.7:4200...", presentation.Description);
+        Assert.Equal("Contacting the server...", presentation.Description);
         Assert.Equal("Cancel", presentation.CancelLabel);
     }
 
     [Fact]
-    public void For_SteamJoin_KeepsTheTunnelEndpointOutOfTheDescription()
+    public void For_SteamJoin_DescribesTheSteamRoute()
     {
-        var presentation = JoinAttemptPresentation.For(JoinIntent.PlayerSteam, "127.0.0.1", 27015);
+        var presentation = JoinAttemptPresentation.For(JoinIntent.PlayerSteam);
 
-        Assert.DoesNotContain("127.0.0.1", presentation.Description);
-        Assert.DoesNotContain("27015", presentation.Description);
+        Assert.Equal("Contacting the host through Steam...", presentation.Description);
     }
 
     [Fact]
     public void For_HostLoopback_SaysTheServerOutlivesTheCancelledWait()
     {
-        var presentation = JoinAttemptPresentation.For(JoinIntent.HostLoopback, "127.0.0.1", 4200);
+        var presentation = JoinAttemptPresentation.For(JoinIntent.HostLoopback);
 
         Assert.Contains("stays open", presentation.CancelledNotice);
         Assert.NotEqual("Cancel", presentation.CancelLabel);
@@ -39,9 +38,9 @@ public class JoinAttemptPresentationTests
         // MainMenuState shows this title once connected; matching it means the heading does not
         // change under the player when the handshake lands.
         Assert.Equal("Connecting to Coop Server",
-            JoinAttemptPresentation.For(JoinIntent.PlayerDirect, "localhost", 4200).Title);
+            JoinAttemptPresentation.For(JoinIntent.PlayerDirect).Title);
         Assert.Equal("Connecting to Coop Server",
-            JoinAttemptPresentation.For(JoinIntent.PlayerSteam, "localhost", 4200).Title);
+            JoinAttemptPresentation.For(JoinIntent.PlayerSteam).Title);
     }
 
     [Fact]
@@ -49,7 +48,7 @@ public class JoinAttemptPresentationTests
     {
         foreach (JoinIntent intent in Enum.GetValues(typeof(JoinIntent)))
         {
-            var presentation = JoinAttemptPresentation.For(intent, "localhost", 4200);
+            var presentation = JoinAttemptPresentation.For(intent);
 
             Assert.False(string.IsNullOrWhiteSpace(presentation.Title), $"{intent} title");
             Assert.False(string.IsNullOrWhiteSpace(presentation.Description), $"{intent} description");


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

Direct joins show the server address and port on the connecting loading screen.

## What is the new behavior?

Direct joins show `Contacting the server...` without exposing the endpoint.

Resolves #3049

## Bot Changelog Entry

- Server IP addresses are no longer shown on the connecting loading screen.
