### PR TITLE
Settlement Companions

### DIFF
--- a/source/Coop.Tests/Missions/Locations/LocationPartyAgentMapTests.cs
+++ b/source/Coop.Tests/Missions/Locations/LocationPartyAgentMapTests.cs
@@ -7,16 +7,16 @@ namespace Coop.Tests.Missions.Locations;
 public class LocationPartyAgentMapTests
 {
     [Fact]
-    public void RecordAndForget_TracksPartyIdentity()
+    public void Record_TracksPartyIdentityForMissionLifetime()
     {
         var map = new LocationPartyAgentMap();
         Guid agentId = Guid.NewGuid();
 
         map.Record(agentId);
-        Assert.True(map.Contains(agentId));
+        map.Record(agentId);
 
-        map.Forget(agentId);
-        Assert.False(map.Contains(agentId));
+        Assert.True(map.Contains(agentId));
+        Assert.False(map.Contains(Guid.Empty));
     }
 
     [Theory]

--- a/source/Coop.Tests/Missions/Locations/LocationPartyAgentMapTests.cs
+++ b/source/Coop.Tests/Missions/Locations/LocationPartyAgentMapTests.cs
@@ -1,0 +1,38 @@
+﻿using Missions.Locations;
+using System;
+using Xunit;
+
+namespace Coop.Tests.Missions.Locations;
+
+public class LocationPartyAgentMapTests
+{
+    [Fact]
+    public void RecordAndForget_TracksPartyIdentity()
+    {
+        var map = new LocationPartyAgentMap();
+        Guid agentId = Guid.NewGuid();
+
+        map.Record(agentId);
+        Assert.True(map.Contains(agentId));
+
+        map.Forget(agentId);
+        Assert.False(map.Contains(agentId));
+    }
+
+    [Theory]
+    [InlineData(true, false, true)]
+    [InlineData(true, true, false)]
+    [InlineData(false, false, false)]
+    [InlineData(false, true, false)]
+    public void Migration_AdoptsOnlyBoundNonPartyAgents(
+        bool hasNpcBinding,
+        bool isPartyAgent,
+        bool expected)
+    {
+        var map = new LocationPartyAgentMap();
+        Guid agentId = Guid.NewGuid();
+        if (isPartyAgent) map.Record(agentId);
+
+        Assert.Equal(expected, map.ShouldAdoptAsNpc(agentId, hasNpcBinding));
+    }
+}

--- a/source/E2E.Tests/Services/Missions/AgentEquipmentDataTests.cs
+++ b/source/E2E.Tests/Services/Missions/AgentEquipmentDataTests.cs
@@ -1,3 +1,5 @@
+using Common.Util;
+using E2E.Tests.Environment.MockEngine;
 using Missions.Agents.Packets;
 using System.Collections.Generic;
 using System.Reflection;
@@ -25,6 +27,16 @@ public class AgentEquipmentDataTests
         SetWeaponSlots(equipment, (int)EquipmentIndex.NumAllWeaponSlots);
 
         Assert.True(HasSafeWeaponSlots(equipment));
+    }
+
+    [Fact]
+    public void NonHumanAgent_IsNotCapturedAsEquipment()
+    {
+        using var fixture = new MissionEngineFixture();
+        var animal = ObjectHelper.SkipConstructor<Agent>();
+        AgentMirror.Bind(animal, new MirrorAgent { IsHuman = false });
+
+        Assert.False(AgentEquipmentData.TryCapture(animal, out _));
     }
 
     [Fact]

--- a/source/E2E.Tests/Services/Missions/MovementTrafficTests.cs
+++ b/source/E2E.Tests/Services/Missions/MovementTrafficTests.cs
@@ -85,6 +85,32 @@ public class MovementTrafficTests : MissionTestEnvironment
     }
 
     [Fact]
+    public void PollMovement_NonHumanNonMountSendsMovementWithoutEquipment()
+    {
+        using var fixture = new MissionEngineFixture();
+        var peer = Clients.First();
+        SetControllerId(peer, "peer");
+
+        peer.Call(() =>
+        {
+            var mock = CreateMovementMission(fixture, peer);
+            var registry = peer.Resolve<INetworkAgentRegistry>();
+            var component = peer.Resolve<ICoopMissionComponent>();
+            var network = Assert.IsType<MockBattleNetwork>(peer.Resolve<IBattleNetwork>());
+            Agent animal = SpawnRider(mock);
+            Assert.True(AgentMirror.TryGet(animal, out var mirror));
+            mirror.IsHuman = false;
+            mirror.IsMount = false;
+            Assert.True(registry.TryRegisterAgent("peer", Guid.NewGuid(), animal));
+
+            component.AgentMovementHandler.PollMovement(0f);
+
+            Assert.Single(network.NetworkSentPackets.GetPackets<MovementPacket>());
+            Assert.Empty(network.NetworkSentPackets.GetPackets<AgentEquipmentPacket>());
+        });
+    }
+
+    [Fact]
     public void PollMovement_TournamentProfileUsesSixtyHertzCadence()
     {
         using var fixture = new MissionEngineFixture();

--- a/source/E2E.Tests/Services/Missions/NetworkMissionJoinInfoSerializationTests.cs
+++ b/source/E2E.Tests/Services/Missions/NetworkMissionJoinInfoSerializationTests.cs
@@ -1,0 +1,55 @@
+﻿using Common.Messaging;
+using Common.PacketHandlers;
+using Common.Serialization;
+using GameInterface.Surrogates;
+using Missions.Data;
+using Missions.Messages;
+using Missions.Taverns;
+using System;
+using TaleWorlds.Library;
+using Xunit;
+
+namespace E2E.Tests.Services.Missions;
+
+/// <summary>
+/// Regression coverage for party-agent join data.
+/// </summary>
+public class NetworkMissionJoinInfoSerializationTests
+{
+    public NetworkMissionJoinInfoSerializationTests()
+    {
+        _ = new SurrogateCollection();
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void RemotePartyAgent_DisablesHorsesOnlyWhenOwnerIsDismounted(
+        bool hasMount,
+        bool expected)
+    {
+        Assert.Equal(expected, CoopLocationsController.ShouldDisableHorses(hasMount));
+    }
+
+    [Fact]
+    public void CompanionMountState_RoundTrips()
+    {
+        var spawn = new CoopAgentSpawnData(
+            Guid.NewGuid(),
+            "companion",
+            new Vec3(1f, 2f, 3f),
+            75f,
+            isPlayer: false,
+            hasMount: true);
+        var original = new NetworkMissionJoinInfo("owner", true, new[] { spawn });
+        var serializer = new ProtoBufSerializer(new SerializableTypeMapper());
+        MessagePacket packet = MessagePacket.Create(original, serializer);
+
+        var result = Assert.IsType<NetworkMissionJoinInfo>(
+            serializer.Deserialize<IMessage>(packet.Data));
+        CoopAgentSpawnData companion = Assert.Single(result.AiAgentData);
+
+        Assert.True(companion.HasMount);
+        Assert.False(companion.IsPlayer);
+    }
+}

--- a/source/GameInterface.Tests/Services/Locations/LocationCompanionAuthorityPatchTests.cs
+++ b/source/GameInterface.Tests/Services/Locations/LocationCompanionAuthorityPatchTests.cs
@@ -1,0 +1,81 @@
+﻿using GameInterface.Services.Locations.Patches;
+using Xunit;
+
+namespace GameInterface.Tests.Services.Locations;
+
+public class LocationCompanionAuthorityPatchTests
+{
+    [Fact]
+    public void AccompanyingCompanions_SpawnOnOwningClient()
+    {
+        Assert.True(LocationCharacterGuardPatches.ShouldSpawnAccompanyingCharacters(isClient: true));
+    }
+
+    [Fact]
+    public void AccompanyingCompanions_DoNotSpawnOnDedicatedServer()
+    {
+        Assert.False(LocationCharacterGuardPatches.ShouldSpawnAccompanyingCharacters(isClient: false));
+    }
+
+    [Theory]
+    [InlineData(true, false, false, false, 30f, 18f, true)]
+    [InlineData(false, false, false, false, 30f, 18f, false)]
+    [InlineData(true, true, false, false, 30f, 18f, false)]
+    [InlineData(true, false, true, false, 30f, 18f, false)]
+    [InlineData(true, false, false, true, 30f, 18f, false)]
+    [InlineData(true, false, false, false, 17f, 18f, false)]
+    public void VanillaFallback_UsesVanillaBodyguardEligibility(
+        bool isHero,
+        bool isMainHero,
+        bool isPrisoner,
+        bool isWounded,
+        float age,
+        float heroComesOfAge,
+        bool expected)
+    {
+        Assert.Equal(expected,
+            LocationCharacterGuardPatches.IsEligibleVanillaCompanion(
+                isHero, isMainHero, isPrisoner, isWounded, age, heroComesOfAge));
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void SpawnCapture_ExcludesPlayerOwnedPartyAgents(
+        bool isLocalPlayerPartyAgent,
+        bool expected)
+    {
+        Assert.Equal(expected,
+            LocationAgentSpawnedPatch.ShouldCaptureAsAmbientNpc(isLocalPlayerPartyAgent));
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(false, false, true)]
+    public void DefaultLocationSpawn_BypassesNpcGateOnlyForOwnedCompanions(
+        bool isOwnedCompanion,
+        bool suppressNativeSpawns,
+        bool expected)
+    {
+        Assert.Equal(expected,
+            LocationNativeSpawnSuppressionPatches.ShouldAllowDefaultLocationSpawn(
+                isOwnedCompanion,
+                suppressNativeSpawns));
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(false, false, true)]
+    public void EnteringLocationSpawn_BypassesNpcGateOnlyForOwnedCompanions(
+        bool isOwnedCompanion,
+        bool suppressNativeSpawns,
+        bool expected)
+    {
+        Assert.Equal(expected,
+            LocationNativeSpawnSuppressionPatches.ShouldAllowEnteringLocationSpawn(
+                isOwnedCompanion,
+                suppressNativeSpawns));
+    }
+}

--- a/source/GameInterface.Tests/Services/Locations/LocationCompanionAuthorityPatchTests.cs
+++ b/source/GameInterface.Tests/Services/Locations/LocationCompanionAuthorityPatchTests.cs
@@ -39,6 +39,22 @@ public class LocationCompanionAuthorityPatchTests
     }
 
     [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(true, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(false, false, false)]
+    public void VanillaFallback_RetainsOnlyEligibleMainPartyCompanion(
+        bool isInMainParty,
+        bool isEligible,
+        bool expected)
+    {
+        Assert.Equal(expected,
+            LocationCharacterGuardPatches.ShouldRetainExistingCompanion(
+                isInMainParty,
+                isEligible));
+    }
+
+    [Theory]
     [InlineData(true, false)]
     [InlineData(false, true)]
     public void SpawnCapture_ExcludesPlayerOwnedPartyAgents(

--- a/source/GameInterface/Services/Locations/LocationCharacterFactory.cs
+++ b/source/GameInterface/Services/Locations/LocationCharacterFactory.cs
@@ -24,9 +24,6 @@ internal static class LocationCharacterFactory
 {
     private static readonly ILogger Logger = LogManager.GetLogger<LocationCharacter>();
 
-    private static readonly string CompanionBehaviorsName =
-        $"{typeof(BehaviorSets).FullName}.{nameof(BehaviorSets.AddCompanionBehaviors)}";
-
     /// <summary>
     /// Extracts the synced fields of a roster entry into the internal added event.
     /// </summary>
@@ -90,24 +87,6 @@ internal static class LocationCharacterFactory
         }
 
         return locationCharacter;
-    }
-
-    /// <summary>
-    /// Builds the roster entry for a companion of a visiting player party. Vanilla never places
-    /// another party's companions, so the server creates these for every visitor itself.
-    /// </summary>
-    public static LocationCharacter CreateCompanion(Hero companion, MobileParty party, bool useCivilianEquipment)
-    {
-        return Create(
-            companion.CharacterObject,
-            party,
-            specialItem: null,
-            spawnTag: "sp_notable",
-            actionSetCode: null,
-            behaviorsMethodName: CompanionBehaviorsName,
-            characterRelation: (int)LocationCharacter.CharacterRelations.Neutral,
-            fixedLocation: true,
-            useCivilianEquipment: useCivilianEquipment);
     }
 
     /// <summary>

--- a/source/GameInterface/Services/Locations/Patches/LocationAgentSpawnedPatch.cs
+++ b/source/GameInterface/Services/Locations/Patches/LocationAgentSpawnedPatch.cs
@@ -4,6 +4,8 @@ using GameInterface.Services.Locations.Messages;
 using GameInterface.Services.ObjectManager;
 using HarmonyLib;
 using Serilog;
+using TaleWorlds.CampaignSystem.AgentOrigins;
+using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
@@ -30,9 +32,13 @@ internal class LocationAgentSpawnedPatch
         if (LocationNpcGate.SuppressCapture) return;
         if (__result == null) return;
 
-        // The player's own agent goes through Mission.SpawnAgent too (MissionHelper.SpawnPlayer) —
-        // players replicate via the join-info path, never as NPC records.
+        // The player's own agent and accompanying companions go through Mission.SpawnAgent too. The owning
+        // client replicates the whole party through mission join info; capturing a companion here would also
+        // register it as an ambient host NPC and make it eligible for host migration after its player leaves.
         if (__result.Controller == AgentControllerType.Player) return;
+        bool isLocalPlayerPartyAgent =
+            __result.Origin is PartyAgentOrigin origin && origin.Party == PartyBase.MainParty;
+        if (!ShouldCaptureAsAmbientNpc(isLocalPlayerPartyAgent)) return;
 
         // Settlement humans always spawn on foot (native passes NoHorses everywhere), so a mount here
         // is unexpected; animals arrive via SpawnMonster and are captured by LocationMonsterSpawnedPatch.
@@ -40,6 +46,9 @@ internal class LocationAgentSpawnedPatch
 
         MessageBroker.Instance.Publish(__result, new AgentSpawnedInLocation(__result));
     }
+
+    internal static bool ShouldCaptureAsAmbientNpc(bool isLocalPlayerPartyAgent)
+        => !isLocalPlayerPartyAgent;
 }
 
 /// <summary>

--- a/source/GameInterface/Services/Locations/Patches/LocationCharacterGuardPatches.cs
+++ b/source/GameInterface/Services/Locations/Patches/LocationCharacterGuardPatches.cs
@@ -1,10 +1,19 @@
 ﻿using Common;
+using Common.Logging;
 using GameInterface.Policies;
 using HarmonyLib;
+using SandBox;
 using SandBox.Missions.AgentBehaviors;
 using SandBox.Missions.MissionLogics;
 using SandBox.Objects;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.AgentOrigins;
+using TaleWorlds.CampaignSystem.Encounters;
+using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Settlements.Locations;
 using TaleWorlds.MountAndBlade;
 
@@ -17,9 +26,11 @@ namespace GameInterface.Services.Locations.Patches;
 [HarmonyPatch]
 internal class LocationCharacterGuardPatches
 {
-    // On clients, hero moves come from server broadcasts. Blocking the whole move (not just the
-    // inner add/remove) prevents the mission notification from spawning ghost agents that have no
-    // roster entry, e.g. from the in-mission passage-usage AI tick.
+    private static readonly ILogger Logger = LogManager.GetLogger<LocationCharacterGuardPatches>();
+
+    // On clients, settlement-NPC hero moves come from server broadcasts. The local player's own
+    // accompanying companions are the exception: vanilla owns their location/AI lifecycle on this client.
+    // Blocking other hero moves prevents ghost agents that have no authoritative roster entry.
     [HarmonyPatch(typeof(LocationComplex), nameof(LocationComplex.ChangeLocation))]
     [HarmonyPrefix]
     static bool ChangeLocationPrefix(LocationCharacter locationCharacter)
@@ -27,19 +38,234 @@ internal class LocationCharacterGuardPatches
         if (CallOriginalPolicy.IsOriginalAllowed()) return true;
         if (ModInformation.IsServer) return true;
 
-        return locationCharacter?.Character?.IsHero != true;
+        return locationCharacter?.Character?.IsHero != true || IsLocalPlayerPartyCharacter(locationCharacter);
     }
 
-    // Companions accompanying a player are placed by the server for every visiting party. The
-    // local spawn would duplicate them, because the mission spawn check compares agent origins by
-    // reference and cannot recognize the server-broadcast entry as the same character.
+    // Let vanilla spawn and drive this client's accompanying companions. Other clients never run this
+    // local player's LocationEncounter; they receive the companions as controller-less P2P puppets.
     [HarmonyPatch(typeof(MissionLocationLogic), nameof(MissionLocationLogic.SpawnCharactersAccompanyingPlayer))]
     [HarmonyPrefix]
-    static bool SpawnCharactersAccompanyingPlayerPrefix()
+    static bool SpawnCharactersAccompanyingPlayerPrefix(bool noHorse)
     {
-        if (CallOriginalPolicy.IsOriginalAllowed()) return true;
+        bool shouldSpawn = CallOriginalPolicy.IsOriginalAllowed() ||
+            ShouldSpawnAccompanyingCharacters(ModInformation.IsClient);
 
-        return ModInformation.IsServer;
+        if (ModInformation.IsClient)
+        {
+            EnsureVanillaAccompanyingCharacter();
+            LogVanillaCompanionSpawnInput(noHorse, shouldSpawn);
+        }
+
+        return shouldSpawn;
+    }
+
+    [HarmonyPatch(typeof(MissionLocationLogic), nameof(MissionLocationLogic.SpawnCharactersAccompanyingPlayer))]
+    [HarmonyPostfix]
+    static void SpawnCharactersAccompanyingPlayerPostfix()
+    {
+        if (ModInformation.IsClient)
+            LogVanillaCompanionSpawnResult();
+    }
+
+    internal static bool ShouldSpawnAccompanyingCharacters(bool isClient) => isClient;
+
+    /// <summary>
+    /// Vanilla normally delegates bodyguard selection to ClanMemberRolesCampaignBehavior, but that broad
+    /// campaign behavior is intentionally disabled in co-op. Reproduce only its location-mission responsibility:
+    /// add the first eligible MainParty hero when the encounter has no player-party companion entry. Other
+    /// accompanying characters (for example quest followers) are preserved.
+    /// </summary>
+    private static void EnsureVanillaAccompanyingCharacter()
+    {
+        try
+        {
+            LocationEncounter encounter = PlayerEncounter.LocationEncounter;
+            MobileParty mainParty = MobileParty.MainParty;
+            LocationComplex locationComplex = LocationComplex.Current;
+            if (encounter == null || mainParty?.MemberRoster == null || locationComplex == null) return;
+
+            foreach (AccompanyingCharacter existing in encounter.CharactersAccompanyingPlayer)
+            {
+                if (existing?.LocationCharacter?.AgentOrigin is PartyAgentOrigin origin &&
+                    origin.Party == PartyBase.MainParty)
+                {
+                    return;
+                }
+            }
+
+            foreach (var element in mainParty.MemberRoster.GetTroopRoster())
+            {
+                CharacterObject character = element.Character;
+                Hero hero = character?.HeroObject;
+                if (hero == null || !IsEligibleVanillaCompanion(
+                        character.IsHero,
+                        hero == Hero.MainHero,
+                        hero.IsPrisoner,
+                        hero.IsWounded,
+                        hero.Age,
+                        Campaign.Current.Models.AgeModel.HeroComesOfAge)) continue;
+
+                LocationCharacter entry = LocationCharacter.CreateBodyguardHero(
+                    hero,
+                    mainParty,
+                    SandBoxManager.Instance.AgentBehaviorManager.AddFirstCompanionBehavior);
+                encounter.AddAccompanyingCharacter(entry, isFollowing: true);
+
+                AccompanyingCharacter accompanying = encounter.GetAccompanyingCharacter(character);
+                accompanying?.DisallowEntranceToAllLocations();
+                accompanying?.AllowEntranceToLocations(location =>
+                    location == locationComplex.GetLocationWithId("center") ||
+                    location == locationComplex.GetLocationWithId("village_center") ||
+                    location == locationComplex.GetLocationWithId("tavern"));
+
+                Logger.Warning(
+                    "[LocationCompanion] Reconstructed vanilla bodyguard entry for {Character}; no MainParty companion had been added to this encounter",
+                    character.StringId);
+                break;
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Warning(ex, "[LocationCompanion] Failed to reconstruct vanilla accompanying entry");
+        }
+    }
+
+    internal static bool IsEligibleVanillaCompanion(
+        bool isHero,
+        bool isMainHero,
+        bool isPrisoner,
+        bool isWounded,
+        float age,
+        float heroComesOfAge)
+        => isHero && !isMainHero && !isPrisoner && !isWounded && age >= heroComesOfAge;
+
+    private static void LogVanillaCompanionSpawnInput(bool noHorse, bool shouldSpawn)
+    {
+        try
+        {
+            LocationEncounter encounter = PlayerEncounter.LocationEncounter;
+            Location currentLocation = CampaignMission.Current?.Location;
+            var partyHeroDetails = new List<string>();
+            var accompanyingDetails = new List<string>();
+
+            MobileParty mainParty = MobileParty.MainParty;
+            if (mainParty?.MemberRoster != null)
+            {
+                foreach (var element in mainParty.MemberRoster.GetTroopRoster())
+                {
+                    CharacterObject character = element.Character;
+                    if (character?.IsHero != true || character == CharacterObject.PlayerCharacter) continue;
+
+                    Hero hero = character.HeroObject;
+                    partyHeroDetails.Add($"{character.StringId}(count={element.Number},wounded={hero?.IsWounded},prisoner={hero?.IsPrisoner},alive={hero?.IsAlive})");
+                }
+            }
+
+            var accompanying = encounter?.CharactersAccompanyingPlayer;
+            if (accompanying != null)
+            {
+                foreach (AccompanyingCharacter companion in accompanying)
+                {
+                    LocationCharacter entry = companion.LocationCharacter;
+                    bool canEnter = currentLocation != null && companion.CanEnterLocation(currentLocation);
+                    bool inRoster = currentLocation?.GetCharacterList()?.Contains(entry) == true;
+                    accompanyingDetails.Add($"{entry?.Character?.StringId ?? "<null>"}(following={companion.IsFollowingPlayerAtMissionStart},canEnter={canEnter},inRoster={inRoster},wounded={entry?.Character?.HeroObject?.IsWounded})");
+                }
+            }
+
+            Logger.Information(
+                "[LocationCompanion] Vanilla accompanying spawn input: allowed={Allowed}, noHorse={NoHorse}, settlement={Settlement}, location={Location}, encounterEntries={EncounterCount} [{EncounterEntries}], mainPartyHeroes={PartyHeroCount} [{PartyHeroes}]",
+                shouldSpawn,
+                noHorse,
+                encounter?.Settlement?.StringId ?? "<null>",
+                currentLocation?.StringId ?? "<null>",
+                accompanying?.Count ?? 0,
+                string.Join(", ", accompanyingDetails),
+                partyHeroDetails.Count,
+                string.Join(", ", partyHeroDetails));
+
+            if (shouldSpawn && partyHeroDetails.Count > 0 && (accompanying == null || accompanying.Count == 0))
+            {
+                Logger.Warning(
+                    "[LocationCompanion] MainParty contains companion heroes but vanilla LocationEncounter has no accompanying entries. ClanMemberRolesCampaignBehavior likely did not populate the encounter before mission open.");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Warning(ex, "[LocationCompanion] Failed to inspect vanilla accompanying spawn input");
+        }
+    }
+
+    private static void LogVanillaCompanionSpawnResult()
+    {
+        try
+        {
+            Mission mission = Mission.Current;
+            Location currentLocation = CampaignMission.Current?.Location;
+            LocationEncounter encounter = PlayerEncounter.LocationEncounter;
+            var ownedAgentDetails = new List<string>();
+            var missingCharacters = new List<string>();
+
+            if (mission != null)
+            {
+                foreach (Agent agent in mission.Agents)
+                {
+                    if (ReferenceEquals(agent, Agent.Main)) continue;
+                    if (!(agent.Origin is PartyAgentOrigin origin) || origin.Party != PartyBase.MainParty) continue;
+
+                    ownedAgentDetails.Add($"{agent.Character?.StringId ?? "<null>"}(active={agent.IsActive()},health={agent.Health:0.##},controller={agent.Controller})");
+                }
+            }
+
+            if (encounter?.CharactersAccompanyingPlayer != null && currentLocation != null)
+            {
+                foreach (AccompanyingCharacter companion in encounter.CharactersAccompanyingPlayer)
+                {
+                    LocationCharacter entry = companion.LocationCharacter;
+                    bool woundedOutsideRoster = entry?.Character?.HeroObject?.IsWounded == true &&
+                        currentLocation.GetCharacterList()?.Contains(entry) != true;
+                    if (!companion.CanEnterLocation(currentLocation) || woundedOutsideRoster) continue;
+
+                    bool found = false;
+                    if (mission != null)
+                    {
+                        foreach (Agent agent in mission.Agents)
+                        {
+                            if (agent.Character == entry?.Character)
+                            {
+                                found = true;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (!found)
+                        missingCharacters.Add(entry?.Character?.StringId ?? "<null>");
+                }
+            }
+
+            Logger.Information(
+                "[LocationCompanion] Vanilla accompanying spawn result: location={Location}, ownedCompanionAgents={AgentCount} [{Agents}]",
+                currentLocation?.StringId ?? "<null>",
+                ownedAgentDetails.Count,
+                string.Join(", ", ownedAgentDetails));
+
+            if (missingCharacters.Count > 0)
+            {
+                Logger.Warning(
+                    "[LocationCompanion] Vanilla accompanying entries were eligible but produced no mission agent: [{Characters}]",
+                    string.Join(", ", missingCharacters));
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Warning(ex, "[LocationCompanion] Failed to inspect vanilla accompanying spawn result");
+        }
+    }
+
+    internal static bool IsLocalPlayerPartyCharacter(LocationCharacter locationCharacter)
+    {
+        return locationCharacter?.AgentOrigin is PartyAgentOrigin origin && origin.Party == PartyBase.MainParty;
     }
 
     // On clients an ambient NPC's origin isn't always in the location's character list, so vanilla's

--- a/source/GameInterface/Services/Locations/Patches/LocationCharacterGuardPatches.cs
+++ b/source/GameInterface/Services/Locations/Patches/LocationCharacterGuardPatches.cs
@@ -72,8 +72,8 @@ internal class LocationCharacterGuardPatches
     /// <summary>
     /// Vanilla normally delegates bodyguard selection to ClanMemberRolesCampaignBehavior, but that broad
     /// campaign behavior is intentionally disabled in co-op. Reproduce only its location-mission responsibility:
-    /// add the first eligible MainParty hero when the encounter has no player-party companion entry. Other
-    /// accompanying characters (for example quest followers) are preserved.
+    /// reconcile the MainParty bodyguard entry and add the first eligible hero when needed. Other accompanying
+    /// characters, such as quest followers, are preserved.
     /// </summary>
     private static void EnsureVanillaAccompanyingCharacter()
     {
@@ -84,14 +84,36 @@ internal class LocationCharacterGuardPatches
             LocationComplex locationComplex = LocationComplex.Current;
             if (encounter == null || mainParty?.MemberRoster == null || locationComplex == null) return;
 
-            foreach (AccompanyingCharacter existing in encounter.CharactersAccompanyingPlayer)
+            bool hasEligibleCompanion = false;
+            for (int index = encounter.CharactersAccompanyingPlayer.Count - 1; index >= 0; index--)
             {
-                if (existing?.LocationCharacter?.AgentOrigin is PartyAgentOrigin origin &&
-                    origin.Party == PartyBase.MainParty)
+                AccompanyingCharacter existing = encounter.CharactersAccompanyingPlayer[index];
+                LocationCharacter existingCharacter = existing?.LocationCharacter;
+                if (!(existingCharacter?.AgentOrigin is PartyAgentOrigin origin) ||
+                    origin.Party != PartyBase.MainParty) continue;
+
+                CharacterObject character = existingCharacter.Character;
+                Hero hero = character?.HeroObject;
+                bool isEligible = hero != null && IsEligibleVanillaCompanion(
+                    character.IsHero,
+                    hero == Hero.MainHero,
+                    hero.IsPrisoner,
+                    hero.IsWounded,
+                    hero.Age,
+                    Campaign.Current.Models.AgeModel.HeroComesOfAge);
+                if (ShouldRetainExistingCompanion(
+                        character != null && mainParty.MemberRoster.Contains(character), isEligible))
                 {
-                    return;
+                    hasEligibleCompanion = true;
+                    continue;
                 }
+
+                encounter.RemoveAccompanyingCharacter(existingCharacter);
+                Logger.Information("[LocationCompanion] Removed stale bodyguard entry for {Character}",
+                    character?.StringId ?? "<null>");
             }
+
+            if (hasEligibleCompanion) return;
 
             foreach (var element in mainParty.MemberRoster.GetTroopRoster())
             {
@@ -129,6 +151,9 @@ internal class LocationCharacterGuardPatches
             Logger.Warning(ex, "[LocationCompanion] Failed to reconstruct vanilla accompanying entry");
         }
     }
+
+    internal static bool ShouldRetainExistingCompanion(bool isInMainParty, bool isEligible)
+        => isInMainParty && isEligible;
 
     internal static bool IsEligibleVanillaCompanion(
         bool isHero,

--- a/source/GameInterface/Services/Locations/Patches/LocationCharacterListPatches.cs
+++ b/source/GameInterface/Services/Locations/Patches/LocationCharacterListPatches.cs
@@ -18,9 +18,9 @@ namespace GameInterface.Services.Locations.Patches;
 
 /// <summary>
 /// Patches for the methods mutating <see cref="Location"/>'s character list. The server broadcasts
-/// every mutation; clients are blocked from mutating hero entries (those are synced strictly) but
-/// keep mutating non-hero ambience locally, because the crowd-spawning behaviors are
-/// scene-dependent and can only run on the machine whose player is visiting.
+/// every mutation; clients are blocked from mutating server-owned hero entries but retain vanilla
+/// ownership of their own accompanying companions and non-hero ambience, because both lifecycles
+/// only run on the machine whose player is visiting.
 /// </summary>
 [HarmonyPatch(typeof(Location))]
 internal class LocationCharacterListPatches
@@ -36,7 +36,8 @@ internal class LocationCharacterListPatches
 
         if (ModInformation.IsClient)
         {
-            if (locationCharacter.Character.IsHero == false) return true;
+            if (locationCharacter.Character.IsHero == false ||
+                LocationCharacterGuardPatches.IsLocalPlayerPartyCharacter(locationCharacter)) return true;
 
             // Expected during normal client visits; the synced entry arrives from the server instead.
             Logger.Debug("Client add of hero {Hero} to location {Location} blocked",
@@ -67,7 +68,8 @@ internal class LocationCharacterListPatches
 
         if (ModInformation.IsClient)
         {
-            if (locationCharacter.Character.IsHero == false) return true;
+            if (locationCharacter.Character.IsHero == false ||
+                LocationCharacterGuardPatches.IsLocalPlayerPartyCharacter(locationCharacter)) return true;
 
             Logger.Debug("Client removal of hero {Hero} from location {Location} blocked",
                 locationCharacter.Character.StringId, __instance.StringId);

--- a/source/GameInterface/Services/Locations/Patches/LocationNativeSpawnSuppressionPatches.cs
+++ b/source/GameInterface/Services/Locations/Patches/LocationNativeSpawnSuppressionPatches.cs
@@ -10,12 +10,14 @@ namespace GameInterface.Services.Locations.Patches;
 /// <see cref="LocationNpcGate.ShouldSuppressNativeSpawns"/> holds (SR-012/SR-013): a coop location
 /// mission is active and this client is not (yet) the confirmed NPC host. The host's assignment
 /// lifts the gate and the population director runs the pass explicitly; non-hosts receive the
-/// host's agents as replicated puppets instead.
+/// host's agents as replicated puppets instead. The sole exception is the local player's companion
+/// roster entries: their owning client spawns those natively and replicates them as party puppets.
 /// <para>
 /// Seam inventory is decompile-verified (doc/SettlementRequirements.md V1–V3, R2). Every target is
 /// void or null-tolerated at its call sites; <c>SpawnWanderingAgentWithInitialFrame</c> is
-/// deliberately NOT skipped (callers dereference its return) — it is only reachable through the
-/// suppressed entry points anyway. Skipping <c>SpawnLocationCharacters</c> wholesale also keeps the
+/// deliberately NOT skipped because callers dereference its return and the owner-side companion path
+/// invokes it directly. Ambient access to it remains behind the gated entry points. Skipping
+/// <c>SpawnLocationCharacters</c> wholesale also keeps the
 /// <c>LocationCharactersAreReadyToSpawn</c> roster event from firing on non-hosts (R1): their
 /// ambient roster entries are reconstructed from the host's spawn records, not rolled in parallel.
 /// </para>
@@ -31,12 +33,24 @@ internal class LocationNativeSpawnSuppressionPatches
     [HarmonyPatch(nameof(MissionAgentHandler.SpawnDefaultLocationCharacter))]
     [HarmonyPrefix]
     [HarmonyPriority(Priority.High)]
-    private static bool SkipSpawnDefaultLocationCharacter() => !LocationNpcGate.ShouldSuppressNativeSpawns;
+    private static bool SkipSpawnDefaultLocationCharacter(LocationCharacter locationCharacter)
+        => ShouldAllowDefaultLocationSpawn(
+            LocationCharacterGuardPatches.IsLocalPlayerPartyCharacter(locationCharacter),
+            LocationNpcGate.ShouldSuppressNativeSpawns);
+
+    internal static bool ShouldAllowDefaultLocationSpawn(bool isOwnedCompanion, bool suppressNativeSpawns)
+        => isOwnedCompanion || !suppressNativeSpawns;
 
     [HarmonyPatch(nameof(MissionAgentHandler.SpawnEnteringLocationCharacter))]
     [HarmonyPrefix]
     [HarmonyPriority(Priority.High)]
-    private static bool SkipSpawnEnteringLocationCharacter() => !LocationNpcGate.ShouldSuppressNativeSpawns;
+    private static bool SkipSpawnEnteringLocationCharacter(LocationCharacter locationCharacter)
+        => ShouldAllowEnteringLocationSpawn(
+            LocationCharacterGuardPatches.IsLocalPlayerPartyCharacter(locationCharacter),
+            LocationNpcGate.ShouldSuppressNativeSpawns);
+
+    internal static bool ShouldAllowEnteringLocationSpawn(bool isOwnedCompanion, bool suppressNativeSpawns)
+        => isOwnedCompanion || !suppressNativeSpawns;
 
     [HarmonyPatch(nameof(MissionAgentHandler.SpawnWanderingAgentWithDelay))]
     [HarmonyPrefix]

--- a/source/GameInterface/Services/Locations/SettlementPopulationTracker.cs
+++ b/source/GameInterface/Services/Locations/SettlementPopulationTracker.cs
@@ -39,20 +39,6 @@ internal class SettlementPopulationTracker : IHandler
     // Keyed by Settlement.StringId; holds the settlement so cleanup never rescans the campaign.
     private readonly Dictionary<string, Settlement> populatedSettlements = new Dictionary<string, Settlement>();
     private readonly Dictionary<string, string> playerPartySettlements = new Dictionary<string, string>();
-    private readonly Dictionary<string, List<LocationCharacterEntry>> partyCompanionEntries =
-        new Dictionary<string, List<LocationCharacterEntry>>();
-
-    private readonly struct LocationCharacterEntry
-    {
-        public readonly Location Location;
-        public readonly LocationCharacter Entry;
-
-        public LocationCharacterEntry(Location location, LocationCharacter entry)
-        {
-            Location = location;
-            Entry = entry;
-        }
-    }
 
     public SettlementPopulationTracker(
         IMessageBroker messageBroker,
@@ -97,7 +83,9 @@ internal class SettlementPopulationTracker : IHandler
                     PopulateSettlement(settlement);
                 }
 
-                AddCompanionEntries(partyId, party, settlement);
+                // The visiting client's vanilla LocationEncounter spawns its own accompanying companions.
+                // They are deliberately absent from this server roster; their owner announces them over the
+                // mission mesh and every other client creates controller-less puppets.
                 BroadcastRosterSnapshot(settlement, settlementId);
             }
             else if (HasPlayerVisitors(settlementId) && party.LeaderHero != null)
@@ -128,7 +116,6 @@ internal class SettlementPopulationTracker : IHandler
             }
 
             playerPartySettlements.Remove(partyId);
-            RemoveCompanionEntries(partyId);
 
             if (objectManager.TryGetObjectWithLogging(settlementId, out Settlement settlement) == false) return;
 
@@ -278,51 +265,6 @@ internal class SettlementPopulationTracker : IHandler
         catch (Exception e)
         {
             Logger.Warning(e, "Failed to place {Hero} in {Settlement}", hero.StringId, settlement.StringId);
-        }
-    }
-
-    private void AddCompanionEntries(string partyId, MobileParty party, Settlement settlement)
-    {
-        var locationComplex = settlement.LocationComplex;
-        var targetLocation = locationComplex.GetLocationWithId("tavern") ?? locationComplex.GetLocationWithId("center");
-        if (targetLocation == null) return;
-
-        if (party.MemberRoster == null) return;
-
-        var entries = new List<LocationCharacterEntry>();
-
-        foreach (var rosterElement in party.MemberRoster.GetTroopRoster())
-        {
-            var character = rosterElement.Character;
-            if (character == null || character.IsHero == false) continue;
-
-            var hero = character.HeroObject;
-            if (hero == null || hero == party.LeaderHero || hero.IsAlive == false) continue;
-            if (PlayerManager.TryGetControlledObjectInfo(hero, out _)) continue;
-
-            var entry = LocationCharacterFactory.CreateCompanion(hero, party, useCivilianEquipment: settlement.IsVillage == false);
-
-            // The patched mutator publishes the broadcast for this add.
-            targetLocation.AddCharacter(entry);
-            entries.Add(new LocationCharacterEntry(targetLocation, entry));
-        }
-
-        if (entries.Count > 0)
-        {
-            partyCompanionEntries[partyId] = entries;
-        }
-    }
-
-    private void RemoveCompanionEntries(string partyId)
-    {
-        if (partyCompanionEntries.TryGetValue(partyId, out var entries) == false) return;
-
-        partyCompanionEntries.Remove(partyId);
-
-        foreach (var entry in entries)
-        {
-            // List.Remove on an absent entry is a no-op, so no containment check is needed.
-            entry.Location.RemoveLocationCharacter(entry.Entry);
         }
     }
 

--- a/source/Missions/Agents/Handlers/AgentMovementHandler.cs
+++ b/source/Missions/Agents/Handlers/AgentMovementHandler.cs
@@ -630,7 +630,11 @@ public class AgentMovementHandler : IAgentMovementHandler
                 capturedMovements.Add(
                     new CapturedMovement(agentInfo, agentData, isPriority));
 
-                var equipment = new AgentEquipmentData(agent);
+                // SpawnMonster also creates non-mountable livestock. Those agents use this movement path but
+                // have no native wield-state pointers, so equipment capture is only valid for humans.
+                if (!AgentEquipmentData.TryCapture(agent, out var equipment))
+                    continue;
+
                 if (!lastEquipment.TryGetValue(agentInfo.AgentId, out var previousEquipment))
                 {
                     lastEquipment[agentInfo.AgentId] = equipment;

--- a/source/Missions/Agents/Handlers/AgentMovementHandler.cs
+++ b/source/Missions/Agents/Handlers/AgentMovementHandler.cs
@@ -1740,7 +1740,7 @@ public class AgentMovementHandler : IAgentMovementHandler
         if (BattleSpawnGate.IsCoopBattleActive) return;
 
         // Same fork for settlement missions (SR-015): LocationAuthorityMigrator despawns only the departed
-        // controller's PLAYER agent — its host-owned NPC puppets must survive for adopt-in-place migration,
+        // controller's player and companion agents; its host-owned NPC puppets survive for migration,
         // so this all-agents sweep would fade the whole crowd out with its host.
         if (LocationNpcGate.IsCoopLocationMissionActive) return;
 

--- a/source/Missions/Agents/Packets/AgentEquipmentData.cs
+++ b/source/Missions/Agents/Packets/AgentEquipmentData.cs
@@ -10,9 +10,48 @@ namespace Missions.Agents.Packets
     {
         public AgentEquipmentData(Agent agent)
         {
-            MainHandIndex = (int)agent.GetPrimaryWieldedItemIndex();
-            OffHandIndex = (int)agent.GetOffhandWieldedItemIndex();
-            MainHandUsageIndex = GetUsageIndex(agent.Equipment, (EquipmentIndex)MainHandIndex);
+            if (!TryRead(agent, out EquipmentIndex mainHandIndex,
+                    out EquipmentIndex offHandIndex, out int mainHandUsageIndex))
+            {
+                mainHandIndex = EquipmentIndex.None;
+                offHandIndex = EquipmentIndex.None;
+                mainHandUsageIndex = 0;
+            }
+
+            MainHandIndex = (int)mainHandIndex;
+            OffHandIndex = (int)offHandIndex;
+            MainHandUsageIndex = mainHandUsageIndex;
+        }
+
+        internal static bool TryCapture(Agent agent, out AgentEquipmentData data)
+        {
+            data = default;
+            if (!TryRead(agent, out EquipmentIndex mainHandIndex,
+                    out EquipmentIndex offHandIndex, out int mainHandUsageIndex))
+            {
+                return false;
+            }
+
+            data = new AgentEquipmentData(mainHandIndex, offHandIndex, mainHandUsageIndex);
+            return true;
+        }
+
+        private static bool TryRead(
+            Agent agent,
+            out EquipmentIndex mainHandIndex,
+            out EquipmentIndex offHandIndex,
+            out int mainHandUsageIndex)
+        {
+            mainHandIndex = EquipmentIndex.None;
+            offHandIndex = EquipmentIndex.None;
+            mainHandUsageIndex = 0;
+            if (agent == null || !agent.IsHuman)
+                return false;
+
+            mainHandIndex = agent.GetPrimaryWieldedItemIndex();
+            offHandIndex = agent.GetOffhandWieldedItemIndex();
+            mainHandUsageIndex = GetUsageIndex(agent.Equipment, mainHandIndex);
+            return true;
         }
 
         internal AgentEquipmentData(
@@ -30,7 +69,7 @@ namespace Missions.Agents.Packets
             // Bannerlord's wield-change callback always reads every weapon slot. During mission teardown and the
             // next tournament match's spawn, an agent can still be active while its MissionEquipment backing array
             // is temporarily incomplete. Do not invoke the native wield path until all weapon slots are available.
-            if (!HasSafeWeaponSlots(agent?.Equipment)) return;
+            if (agent?.IsHuman != true || !HasSafeWeaponSlots(agent.Equipment)) return;
 
             // Only wield an index this agent actually has a weapon in RIGHT NOW. The sender's wielded index can point
             // to a slot that is EMPTY on this puppet — its loadout differs, its weapon depleted/broke, or this is a

--- a/source/Missions/Data/CoopAgentSpawnData.cs
+++ b/source/Missions/Data/CoopAgentSpawnData.cs
@@ -20,13 +20,22 @@ public class CoopAgentSpawnData
     public readonly float Health;
     [ProtoMember(5)]
     public readonly bool IsPlayer;
+    [ProtoMember(6)]
+    public readonly bool HasMount;
 
-    public CoopAgentSpawnData(Guid agentId, string characterObjectId, Vec3 position, float health, bool isPlayer)
+    public CoopAgentSpawnData(
+        Guid agentId,
+        string characterObjectId,
+        Vec3 position,
+        float health,
+        bool isPlayer,
+        bool hasMount = false)
     {
         AgentId = agentId;
         CharacterObjectId = characterObjectId;
         Position = position;
         Health = health;
         IsPlayer = isPlayer;
+        HasMount = hasMount;
     }
 }

--- a/source/Missions/Locations/LocationAuthorityMigrator.cs
+++ b/source/Missions/Locations/LocationAuthorityMigrator.cs
@@ -111,7 +111,6 @@ public class LocationAuthorityMigrator : ILocationAuthorityMigrator
                 var agent = info.Agent;
                 coopMissionComponent.AgentMovementHandler.Interpolator.Forget(agent);
                 registry.RemoveAgent(info.AgentId);
-                partyAgentMap.Forget(info.AgentId);
 
                 // A party id can carry a stale NPC binding when a host's ambient spawn batch raced its
                 // companion join record. It is still a departing party agent and must never be adopted.

--- a/source/Missions/Locations/LocationAuthorityMigrator.cs
+++ b/source/Missions/Locations/LocationAuthorityMigrator.cs
@@ -16,14 +16,14 @@ namespace Missions.Locations;
 
 /// <summary>
 /// Owns the departure fork of a settlement location mission (SR-014/SR-015). On ANY member's
-/// departure every remaining client despawns that controller's PLAYER puppet only — its NPC puppets
+/// departure every remaining client despawns that controller's player and companion puppets — its NPC puppets
 /// (the ones recorded in the binding map) stay on the field awaiting adoption. On promotion
 /// (<see cref="LocationHostMigrated"/>, published only on the promoted client) the new host adopts
 /// the previous host's NPCs in place: authority transfer, interpolation forget (a stale interpolation
 /// target pins an adopted agent — the battle-migration lesson), then settlement-AI re-creation from
 /// the LOCAL roster entry the puppet's origin already points at (SR-030, V5). Mirrors the generic
-/// halves of <c>BattleAuthorityMigrator</c>; there is no withdrawn-own-party split — a location
-/// "party" is just the player's body, which always despawns.
+/// halves of <c>BattleAuthorityMigrator</c>; player and companion agents always despawn, while only
+/// roster-bound ambient NPCs survive for adoption.
 /// </summary>
 public interface ILocationAuthorityMigrator : System.IDisposable
 {
@@ -45,6 +45,7 @@ public class LocationAuthorityMigrator : ILocationAuthorityMigrator
     private readonly ICoopMissionComponent coopMissionComponent;
     private readonly ILocationSession session;
     private readonly ILocationAgentBindingMap bindingMap;
+    private readonly ILocationPartyAgentMap partyAgentMap;
     private readonly IMissionContext missionContext;
     private readonly GameInterface.Services.Locations.Conversations.ILocationNpcHoldRegistry holdRegistry;
 
@@ -53,6 +54,7 @@ public class LocationAuthorityMigrator : ILocationAuthorityMigrator
         ICoopMissionComponent coopMissionComponent,
         ILocationSession session,
         ILocationAgentBindingMap bindingMap,
+        ILocationPartyAgentMap partyAgentMap,
         IMissionContext missionContext,
         GameInterface.Services.Locations.Conversations.ILocationNpcHoldRegistry holdRegistry)
     {
@@ -60,6 +62,7 @@ public class LocationAuthorityMigrator : ILocationAuthorityMigrator
         this.coopMissionComponent = coopMissionComponent;
         this.session = session;
         this.bindingMap = bindingMap;
+        this.partyAgentMap = partyAgentMap;
         this.missionContext = missionContext;
         this.holdRegistry = holdRegistry;
 
@@ -77,19 +80,19 @@ public class LocationAuthorityMigrator : ILocationAuthorityMigrator
 
     private void Handle_PeerLeft(MessagePayload<MissionPeerLeft> payload)
     {
-        DespawnPlayerPuppet(payload.What.ControllerId, payload.What.InstanceId);
+        DespawnPartyPuppets(payload.What.ControllerId, payload.What.InstanceId);
     }
 
     private void Handle_PeerDisconnected(MessagePayload<MissionPeerDisconnected> payload)
     {
-        DespawnPlayerPuppet(payload.What.ControllerId, payload.What.InstanceId);
+        DespawnPartyPuppets(payload.What.ControllerId, payload.What.InstanceId);
     }
 
-    // [All remaining clients] A member departed: despawn ITS PLAYER agent only. Its NPC puppets (every
+    // [All remaining clients] A member departed: despawn its player and companion agents. Its NPC puppets (every
     // registered agent with a binding-map record) stay — they belong to the promoted successor
     // (SR-015). This replaces the generic AgentMovementHandler.RemoveControllerParty sweep, which is
     // skipped for location missions exactly so it cannot fade the NPCs out with their departing host.
-    internal void DespawnPlayerPuppet(string controllerId, string instanceId)
+    internal void DespawnPartyPuppets(string controllerId, string instanceId)
     {
         if (string.IsNullOrEmpty(controllerId)) return;
         if (instanceId != null && instanceId != session.InstanceId) return;
@@ -102,22 +105,32 @@ public class LocationAuthorityMigrator : ILocationAuthorityMigrator
             int despawned = 0;
             foreach (var info in registry.GetAgents(controllerId))
             {
-                if (bindingMap.TryGet(info.AgentId, out _)) continue; // an NPC — awaits adoption
+                bool hasNpcBinding = bindingMap.TryGet(info.AgentId, out _);
+                if (partyAgentMap.ShouldAdoptAsNpc(info.AgentId, hasNpcBinding)) continue;
 
                 var agent = info.Agent;
-                if (agent != null && agent.IsActive() && agent.Health > 0)
+                coopMissionComponent.AgentMovementHandler.Interpolator.Forget(agent);
+                registry.RemoveAgent(info.AgentId);
+                partyAgentMap.Forget(info.AgentId);
+
+                // A party id can carry a stale NPC binding when a host's ambient spawn batch raced its
+                // companion join record. It is still a departing party agent and must never be adopted.
+                bindingMap.Forget(info.AgentId);
+
+                if (agent != null && agent.Mission == Mission.Current && agent.IsActive() && agent.Health > 0)
                 {
                     bool hideMount = agent.HasMount && agent.MountAgent != null && agent.MountAgent.IsActive();
                     agent.FadeOut(false, hideMount);
                 }
 
-                registry.RemoveAgent(info.AgentId);
+                Logger.Information("[LocationSync] Despawned departed party agent {AgentId} ({Character}) from {Controller}",
+                    info.AgentId, agent?.Character?.StringId ?? "<null>", controllerId);
                 despawned++;
             }
 
             if (despawned > 0)
                 Logger.Information("[LocationSync] Despawned {Count} player agent(s) of departed {Controller}", despawned, controllerId);
-        }, context: nameof(DespawnPlayerPuppet));
+        }, context: nameof(DespawnPartyPuppets));
     }
 
     // [Promoted host] The previous host departed and the server promoted us — adopt its NPCs in place
@@ -172,9 +185,18 @@ public class LocationAuthorityMigrator : ILocationAuthorityMigrator
             {
                 foreach (var info in registry.GetAgents(controllerId))
                 {
-                    // A lingering non-NPC entry (the departed player's own body whose despawn we
-                    // somehow missed) is not ours to adopt; DespawnPlayerPuppet owns it.
-                    if (!bindingMap.TryGet(info.AgentId, out _)) continue;
+                    // Party identity wins over a binding produced by any racing ambient spawn record.
+                    // Player and companion puppets always despawn with their controller and are never adopted.
+                    bool hasNpcBinding = bindingMap.TryGet(info.AgentId, out _);
+                    if (!partyAgentMap.ShouldAdoptAsNpc(info.AgentId, hasNpcBinding))
+                    {
+                        if (hasNpcBinding && partyAgentMap.Contains(info.AgentId))
+                        {
+                            Logger.Warning("[LocationSync] Refused host-migration adoption for party agent {AgentId}",
+                                info.AgentId);
+                        }
+                        continue;
+                    }
                     adopted.Add(info);
                 }
             }
@@ -223,6 +245,11 @@ public class LocationAuthorityMigrator : ILocationAuthorityMigrator
     public void AdoptSpawnedPuppet(Agent agent, System.Guid agentId)
     {
         if (agent == null || agentId == System.Guid.Empty) return;
+        if (partyAgentMap.Contains(agentId))
+        {
+            Logger.Warning("[LocationSync] Refused late NPC adoption for party agent {AgentId}", agentId);
+            return;
+        }
 
         var registry = coopMissionComponent.AgentRegistry;
         registry.TryTransferAuthority(session.OwnControllerId, agentId);

--- a/source/Missions/Locations/LocationOwnedAgentReplicator.cs
+++ b/source/Missions/Locations/LocationOwnedAgentReplicator.cs
@@ -10,6 +10,8 @@ using Serilog;
 using System;
 using System.Collections.Generic;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.AgentOrigins;
+using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Settlements.Locations;
 using TaleWorlds.Core;
 using TaleWorlds.MountAndBlade;
@@ -298,6 +300,15 @@ public class LocationOwnedAgentReplicator : ILocationOwnedAgentReplicator
     {
         var agent = payload.What.Agent;
         if (agent == null || !(agent.Character is CharacterObject)) return;
+
+        // Defense in depth: player-owned companions use the party join-info path even when this client is
+        // also the elected NPC host. Never give them an ambient binding or migration eligibility.
+        if (agent.Origin is PartyAgentOrigin origin && origin.Party == PartyBase.MainParty)
+        {
+            Logger.Warning("[LocationSync] Ignored ambient capture event for local party agent {Character}",
+                agent.Character.StringId);
+            return;
+        }
 
         // The roster identity is extracted at capture time — the entry is resolvable via the agent's
         // origin right now, and any FUTURE host needs it to re-bind (SR-022).

--- a/source/Missions/Locations/LocationPartyAgentMap.cs
+++ b/source/Missions/Locations/LocationPartyAgentMap.cs
@@ -5,15 +5,14 @@ namespace Missions.Locations;
 
 /// <summary>
 /// Per-mission identity set for player and companion agents received through party join info.
-/// Party identity is tracked independently from NPC roster bindings so a duplicate/racing ambient
-/// spawn record can never make a departing companion eligible for settlement-host adoption.
+/// Identities remain until mission disposal so a delayed ambient spawn can never make a departed
+/// companion eligible for settlement-host adoption.
 /// </summary>
 public interface ILocationPartyAgentMap
 {
     void Record(Guid agentId);
     bool Contains(Guid agentId);
     bool ShouldAdoptAsNpc(Guid agentId, bool hasNpcBinding);
-    void Forget(Guid agentId);
 }
 
 /// <inheritdoc cref="ILocationPartyAgentMap"/>
@@ -32,10 +31,4 @@ public class LocationPartyAgentMap : ILocationPartyAgentMap
 
     public bool ShouldAdoptAsNpc(Guid agentId, bool hasNpcBinding)
         => hasNpcBinding && !Contains(agentId);
-
-    public void Forget(Guid agentId)
-    {
-        if (agentId != Guid.Empty)
-            agentIds.TryRemove(agentId, out _);
-    }
 }

--- a/source/Missions/Locations/LocationPartyAgentMap.cs
+++ b/source/Missions/Locations/LocationPartyAgentMap.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Concurrent;
+
+namespace Missions.Locations;
+
+/// <summary>
+/// Per-mission identity set for player and companion agents received through party join info.
+/// Party identity is tracked independently from NPC roster bindings so a duplicate/racing ambient
+/// spawn record can never make a departing companion eligible for settlement-host adoption.
+/// </summary>
+public interface ILocationPartyAgentMap
+{
+    void Record(Guid agentId);
+    bool Contains(Guid agentId);
+    bool ShouldAdoptAsNpc(Guid agentId, bool hasNpcBinding);
+    void Forget(Guid agentId);
+}
+
+/// <inheritdoc cref="ILocationPartyAgentMap"/>
+public class LocationPartyAgentMap : ILocationPartyAgentMap
+{
+    private readonly ConcurrentDictionary<Guid, byte> agentIds = new ConcurrentDictionary<Guid, byte>();
+
+    public void Record(Guid agentId)
+    {
+        if (agentId != Guid.Empty)
+            agentIds[agentId] = 0;
+    }
+
+    public bool Contains(Guid agentId)
+        => agentId != Guid.Empty && agentIds.ContainsKey(agentId);
+
+    public bool ShouldAdoptAsNpc(Guid agentId, bool hasNpcBinding)
+        => hasNpcBinding && !Contains(agentId);
+
+    public void Forget(Guid agentId)
+    {
+        if (agentId != Guid.Empty)
+            agentIds.TryRemove(agentId, out _);
+    }
+}

--- a/source/Missions/Locations/LocationPuppetSpawner.cs
+++ b/source/Missions/Locations/LocationPuppetSpawner.cs
@@ -176,7 +176,6 @@ public class LocationPuppetSpawner : ILocationPuppetSpawner
                 coopMissionComponent.AgentMovementHandler.Interpolator.Forget(agent);
                 registry.RemoveAgent(id);
                 bindingMap.Forget(id);
-                partyAgentMap.Forget(id);
                 pendingPointUses.Remove(id);
                 removed++;
             }

--- a/source/Missions/Locations/LocationPuppetSpawner.cs
+++ b/source/Missions/Locations/LocationPuppetSpawner.cs
@@ -55,6 +55,7 @@ public class LocationPuppetSpawner : ILocationPuppetSpawner
     private readonly ICoopMissionComponent coopMissionComponent;
     private readonly ILocationSession session;
     private readonly ILocationAgentBindingMap bindingMap;
+    private readonly ILocationPartyAgentMap partyAgentMap;
     private readonly ILocationPuppetRosterBinder rosterBinder;
     private readonly IBattleAgentBudget agentBudget;
     private readonly ILocationAgentSpawnBatchCodec spawnBatchCodec;
@@ -88,6 +89,7 @@ public class LocationPuppetSpawner : ILocationPuppetSpawner
         ICoopMissionComponent coopMissionComponent,
         ILocationSession session,
         ILocationAgentBindingMap bindingMap,
+        ILocationPartyAgentMap partyAgentMap,
         ILocationPuppetRosterBinder rosterBinder,
         IBattleAgentBudget agentBudget,
         ILocationAgentSpawnBatchCodec spawnBatchCodec,
@@ -98,6 +100,7 @@ public class LocationPuppetSpawner : ILocationPuppetSpawner
         this.coopMissionComponent = coopMissionComponent;
         this.session = session;
         this.bindingMap = bindingMap;
+        this.partyAgentMap = partyAgentMap;
         this.rosterBinder = rosterBinder;
         this.agentBudget = agentBudget;
         this.spawnBatchCodec = spawnBatchCodec;
@@ -173,6 +176,7 @@ public class LocationPuppetSpawner : ILocationPuppetSpawner
                 coopMissionComponent.AgentMovementHandler.Interpolator.Forget(agent);
                 registry.RemoveAgent(id);
                 bindingMap.Forget(id);
+                partyAgentMap.Forget(id);
                 pendingPointUses.Remove(id);
                 removed++;
             }
@@ -336,6 +340,7 @@ public class LocationPuppetSpawner : ILocationPuppetSpawner
         if (IsWithdrawn(data.OwnerControllerId, out ownerIsWithdrawnHost) && !ownerIsWithdrawnHost)
             return true;                                                // stale player record — drop
         if (IsTombstoned(data.AgentId)) return true;                    // already despawned by the host — drop
+        if (partyAgentMap.Contains(data.AgentId)) return true;          // party join info owns this id — never bind it as an NPC
         if (registry.TryGetAgentInfo(data.AgentId, out _)) return true; // already spawned (incl. our own natives) — dedupe
 
         int slotsNeeded = 1;

--- a/source/Missions/Taverns/CoopLocationsController.cs
+++ b/source/Missions/Taverns/CoopLocationsController.cs
@@ -349,7 +349,6 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
         if (agent == null || !_ownedCompanionIds.TryGetValue(agent, out Guid agentId)) return false;
 
         _ownedCompanionIds.Remove(agent);
-        partyAgentMap.Forget(agentId);
         coopMissionComponent.AgentRegistry.RemoveAgent(agentId);
         network.SendAll(new NetworkDespawnLocationAgents(
             new[] { agentId },
@@ -541,7 +540,6 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
         if (newAgent == null)
         {
             Logger.Error("[LocationSync] Failed to spawn remote agent {AgentID} — removing agent.", agentData.AgentId);
-            partyAgentMap.Forget(agentData.AgentId);
             agentRegistry.RemoveAgent(agentData.AgentId);
             return;
         }

--- a/source/Missions/Taverns/CoopLocationsController.cs
+++ b/source/Missions/Taverns/CoopLocationsController.cs
@@ -439,7 +439,8 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
                 characterObjectId,
                 agent.Position,
                 agent.Health,
-                isPlayer: ReferenceEquals(agent, mainAgent)));
+                isPlayer: ReferenceEquals(agent, mainAgent),
+                hasMount: agent.HasMount));
         }
 
         return new NetworkMissionJoinInfo(
@@ -535,7 +536,7 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
             agentData.IsPlayer == true ? "Player" : "Agent",
             characterObject?.Name?.ToString() ?? "<unresolved>", agentData.AgentId, controllerId);
 
-        Agent newAgent = SpawnAgent(agentData.Position, characterObject, agentData.IsPlayer, agentData.Health);
+        Agent newAgent = SpawnAgent(agentData.Position, characterObject, agentData.HasMount, agentData.Health);
 
         if (newAgent == null)
         {
@@ -549,7 +550,7 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
             agentData.AgentId, newAgent.Position, Mission.Current?.SceneName);
     }
 
-    public Agent SpawnAgent(Vec3 startingPos, CharacterObject character, bool isPlayer = false, float health = -1f)
+    public Agent SpawnAgent(Vec3 startingPos, CharacterObject character, bool hasMount = false, float health = -1f)
     {
         // A remote player's hero CharacterObject often does not resolve to a fully-initialized
         // object on this client (live campaign: each player has a distinct, not-yet-synced hero),
@@ -576,9 +577,7 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
                 // The player may have left between receiving the join info and this running.
                 if (Mission.Current == null) return;
 
-                // The player rides in villages, but companions are roster-spawned on foot even there. Preserve
-                // that distinction so a remote companion puppet does not gain a horse its authoritative AI does
-                // not have. Towns, taverns and castle courtyards use civilian equipment and are always on-foot.
+                // The owner sends the live mount state because companions can spawn mounted in village centers.
                 bool isVillage = Settlement.CurrentSettlement?.IsVillage == true;
 
                 AgentBuildData agentBuildData = new AgentBuildData(character);
@@ -586,7 +585,7 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
                 agentBuildData.InitialPosition(startingPos);
                 agentBuildData.Team(Mission.Current.PlayerAllyTeam);
                 agentBuildData.InitialDirection(Vec2.Forward);
-                agentBuildData.NoHorses(!isPlayer || !isVillage);
+                agentBuildData.NoHorses(ShouldDisableHorses(hasMount));
                 agentBuildData.Equipment(isVillage ? character.FirstBattleEquipment : character.FirstCivilianEquipment);
                 agentBuildData.TroopOrigin(new SimpleAgentOrigin(character, -1, null, default));
                 agentBuildData.Controller(AgentControllerType.None);
@@ -619,6 +618,8 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
 
         return agent;
     }
+
+    internal static bool ShouldDisableHorses(bool hasMount) => !hasMount;
 
     // Cheap, non-throwing pre-filter for the common "unresolved remote hero" case, so the normal
     // path does not rely on a thrown exception (which trips first-chance break in the debugger).

--- a/source/Missions/Taverns/CoopLocationsController.cs
+++ b/source/Missions/Taverns/CoopLocationsController.cs
@@ -14,12 +14,16 @@ using LiteNetLib;
 using Missions.Data;
 using Missions.Locations;
 using Missions.Services.Network;
+using SandBox.Missions.MissionLogics;
 using Serilog;
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.AgentOrigins;
+using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.CampaignSystem.Settlements.Locations;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
@@ -37,6 +41,7 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
     private readonly ILocationPuppetSpawner npcPuppetSpawner;
     private readonly ILocationPopulationDirector populationDirector;
     private readonly ILocationAuthorityMigrator authorityMigrator;
+    private readonly ILocationPartyAgentMap partyAgentMap;
     //private readonly BoardGameManager boardGameManager;
 
     private string instanceId;
@@ -71,13 +76,15 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
         // instances instead of DI-resolving them (transient injection would give each its own).
         session = new LocationSession(controllerIdProvider, hostRegistry);
         var bindingMap = new LocationAgentBindingMap();
+        partyAgentMap = new LocationPartyAgentMap();
 
         npcReplicator = new LocationOwnedAgentReplicator(
             network, messageBroker, objectManager, coopMissionComponent, session, bindingMap, rosterBinder, spawnBatchCodec);
         authorityMigrator = new LocationAuthorityMigrator(
-            messageBroker, coopMissionComponent, session, bindingMap, missionContext, npcHoldRegistry);
+            messageBroker, coopMissionComponent, session, bindingMap, partyAgentMap, missionContext, npcHoldRegistry);
         npcPuppetSpawner = new LocationPuppetSpawner(
-            messageBroker, objectManager, coopMissionComponent, session, bindingMap, rosterBinder, agentBudget, spawnBatchCodec, authorityMigrator);
+            messageBroker, objectManager, coopMissionComponent, session, bindingMap, partyAgentMap,
+            rosterBinder, agentBudget, spawnBatchCodec, authorityMigrator);
         populationDirector = new LocationPopulationDirector(messageBroker, session, bindingMap, npcPuppetSpawner);
 
         messageBroker.Subscribe<PlayerEnteredLocation>(Handle_PlayerEnteredLocation);
@@ -103,6 +110,13 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
         npcReplicator.FlushPendingSpawns();
         npcReplicator.PollPointUsage();
         base.OnMissionTick(dt);
+
+        // Mission.OnAgentCreated fires before the engine assigns Agent.Origin. Re-scan after the native tick so
+        // companions spawned dynamically (for example by a passage transition) are registered once their
+        // PartyAgentOrigin is available.
+        if (_localAgentRegistered)
+            TryRegisterLocalPartyAgents();
+
         npcPuppetSpawner.DrainPendingPuppets();
     }
 
@@ -119,6 +133,8 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
         var reason = agentState == AgentState.Killed || agentState == AgentState.Unconscious
             ? LocationDespawnReason.Died
             : LocationDespawnReason.Removed;
+        if (TryDespawnOwnedCompanion(affectedAgent, reason)) return;
+
         npcReplicator.NotifyAgentRemoved(affectedAgent, reason);
     }
 
@@ -126,6 +142,7 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
     {
         base.OnAgentDeleted(affectedAgent);
         if (IsMissionEnding()) return;
+        if (TryDespawnOwnedCompanion(affectedAgent, LocationDespawnReason.Removed)) return;
 
         npcReplicator.NotifyAgentRemoved(affectedAgent, LocationDespawnReason.Removed);
     }
@@ -139,61 +156,215 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
     }
 
     // Read on the network thread (HandleJoinInfo gate) and written on the main thread
-    // (TryRegisterLocalAgent), so volatile to ensure the gate sees the flip promptly.
+    // (TryRegisterLocalPartyAgents), so volatile to ensure the gate sees the flip promptly.
     private volatile bool _localAgentRegistered;
     private bool _instanceRequested;
+    private bool _spawningOwnedCompanions;
+    // AgentDeathHandler may remove a killed agent from the shared registry before Mission.OnAgentRemoved.
+    // Retain companion ids here so passage exits and deaths can still be announced exactly once.
+    private readonly Dictionary<Agent, Guid> _ownedCompanionIds = new Dictionary<Agent, Guid>();
 
     // Join info can arrive before the local interior mission has finished setting up (teams/player
     // agent) — notably on a rejoin, where the kept-alive socket reconnects and delivers the peer's
     // join info almost immediately. Spawning a remote agent into a not-yet-initialized mission corrupts
-    // team setup, so buffer early join info and drain it once we are ready (see TryRegisterLocalAgent).
+    // team setup, so buffer early join info and drain it once we are ready (see TryRegisterLocalPartyAgents).
     private readonly ConcurrentQueue<(NetPeer peer, NetworkMissionJoinInfo info)> _pendingJoinInfos
         = new ConcurrentQueue<(NetPeer, NetworkMissionJoinInfo)>();
 
     public override void OnRenderingStarted()
     {
-        TryRegisterLocalAgent();
+        // The elected NPC host owns the ambient population, but each player always owns their party companions.
+        // Recover any companion roster entry that vanilla's initial accompanying-character pass did not materialize;
+        // agents it already spawned are deduped by their shared PartyAgentOrigin.
+        SpawnOwnedCompanionRosterAgents();
+        TryRegisterLocalPartyAgents();
     }
 
-    private void TryRegisterLocalAgent()
+    public override void OnAgentCreated(Agent agent)
     {
-        if (_localAgentRegistered) return;
-        if (Agent.Main == null) return;
+        base.OnAgentCreated(agent);
+
+        // The explicit owner-side roster pass finishes the agent's native location behaviors before registering
+        // and announcing it. Avoid re-entering registration from Mission.SpawnAgent midway through that pass.
+        if (_spawningOwnedCompanions) return;
+
+        // Some spawn paths already expose the PartyAgentOrigin here; register those immediately. The post-native
+        // tick scan is the backstop for the usual engine order where Origin is assigned after this callback.
+        if (IsOwnPartyAgent(agent))
+        {
+            TryRegisterLocalPartyAgents(agent);
+        }
+    }
+
+    private void SpawnOwnedCompanionRosterAgents()
+    {
+        Mission mission = Mission.Current;
+        Location location = CampaignMission.Current?.Location;
+        MissionAgentHandler agentHandler = mission?.GetMissionBehavior<MissionAgentHandler>();
+        if (mission == null || location == null || agentHandler == null) return;
+
+        _spawningOwnedCompanions = true;
+        bool previousSuppressCapture = LocationNpcGate.SuppressCapture;
+        LocationNpcGate.SuppressCapture = true;
+        int ownedRosterEntries = 0;
+        int recoverySpawns = 0;
+        try
+        {
+            foreach (LocationCharacter locationCharacter in location.GetCharacterList())
+            {
+                if (!IsOwnPartyCompanion(locationCharacter)) continue;
+                ownedRosterEntries++;
+
+                bool alreadySpawned = false;
+                foreach (Agent agent in mission.Agents)
+                {
+                    if (ReferenceEquals(agent.Origin, locationCharacter.AgentOrigin))
+                    {
+                        alreadySpawned = true;
+                        break;
+                    }
+                }
+
+                if (alreadySpawned)
+                {
+                    Logger.Information("[LocationCompanion] Roster entry {Character} already has a native mission agent",
+                        locationCharacter.Character?.StringId ?? "<null>");
+                    continue;
+                }
+
+                Logger.Warning("[LocationCompanion] Vanilla did not materialize roster entry {Character}; attempting owner-side recovery spawn in {Location}",
+                    locationCharacter.Character?.StringId ?? "<null>", location.StringId);
+                Agent companion = agentHandler.SpawnDefaultLocationCharacter(locationCharacter);
+                if (companion == null)
+                {
+                    Logger.Warning("[LocationCompanion] Recovery spawn failed for local companion {Character} in {Location}",
+                        locationCharacter.Character?.StringId ?? "<null>", location.StringId);
+                }
+                else
+                {
+                    recoverySpawns++;
+                    Logger.Information("[LocationCompanion] Recovery spawn created {Character} at {Position}",
+                        locationCharacter.Character?.StringId ?? "<null>", companion.Position);
+                }
+            }
+        }
+        finally
+        {
+            LocationNpcGate.SuppressCapture = previousSuppressCapture;
+            _spawningOwnedCompanions = false;
+            Logger.Information("[LocationCompanion] Owner roster reconciliation complete for {Location}: ownedRosterEntries={RosterCount}, recoverySpawns={RecoveryCount}",
+                location.StringId, ownedRosterEntries, recoverySpawns);
+        }
+    }
+
+    private static bool IsOwnPartyCompanion(LocationCharacter locationCharacter)
+    {
+        if (!(locationCharacter?.AgentOrigin is PartyAgentOrigin origin)) return false;
+        return origin.Party == PartyBase.MainParty && locationCharacter.Character != CharacterObject.PlayerCharacter;
+    }
+
+    private void TryRegisterLocalPartyAgents(Agent newlyCreatedAgent = null)
+    {
+        Agent mainAgent = Agent.Main;
+        Mission mission = Mission.Current;
+        if (mainAgent == null || mission == null) return;
 
         string controllerId = controllerIdProvider.ControllerId;
+        var agentRegistry = coopMissionComponent.AgentRegistry;
+        bool registryChanged = TryRegisterOwnedAgent(controllerId, mainAgent, "player");
+
+        // Vanilla's LocationEncounter materializes the local player's accompanying companions only on this
+        // client. Their native controllers stay AI; registering them here makes the shared movement/action
+        // paths treat this node as authoritative while peers keep controller-less puppets.
+        foreach (Agent agent in mission.Agents)
+        {
+            if (ReferenceEquals(agent, mainAgent) || !IsOwnPartyAgent(agent) ||
+                !agent.IsActive() || agent.Health <= 0) continue;
+            registryChanged |= TryRegisterOwnedAgent(controllerId, agent, "companion");
+        }
+
+        // Mission.OnAgentCreated can run before the new agent appears in Mission.Agents on some engine paths.
+        // Include the callback argument explicitly; registry deduplication makes this harmless when it is listed.
+        if (newlyCreatedAgent != null &&
+            !ReferenceEquals(newlyCreatedAgent, mainAgent) &&
+            IsOwnPartyAgent(newlyCreatedAgent) &&
+            newlyCreatedAgent.IsActive() && newlyCreatedAgent.Health > 0)
+        {
+            registryChanged |= TryRegisterOwnedAgent(controllerId, newlyCreatedAgent, "companion");
+        }
+
+        if (!agentRegistry.TryGetAgentInfo(mainAgent, out _)) return;
+
+        bool becameReady = !_localAgentRegistered;
+        _localAgentRegistered = true;
+
+        if (registryChanged)
+        {
+            // Announce the complete locally-owned party. The receiver dedupes existing ids, so this also handles
+            // companions that spawn after the initial player announcement.
+            network.SendAll(BuildJoinInfo());
+        }
+
+        if (becameReady)
+        {
+            // NPC puppet spawns wait until the local player agent and mission teams are ready.
+            npcPuppetSpawner.NotifyMissionReady();
+
+            // The mission is now set up (player agent + teams exist). Spawn any join info that arrived early.
+            DrainPendingJoinInfos();
+
+            if (instanceId != null)
+                messageBroker.Publish(this, new LocationMissionReady(instanceId));
+        }
+    }
+
+    private bool TryRegisterOwnedAgent(string controllerId, Agent agent, string agentType)
+    {
+        var agentRegistry = coopMissionComponent.AgentRegistry;
+        if (agentRegistry.TryGetAgentInfo(agent, out var existingInfo))
+        {
+            partyAgentMap.Record(existingInfo.AgentId);
+            RememberOwnedCompanion(agent, existingInfo.AgentId);
+            return false;
+        }
 
         Guid agentId = Guid.NewGuid();
+        if (!agentRegistry.TryRegisterAgent(controllerId, agentId, agent)) return false;
 
-        var agentRegistry = coopMissionComponent.AgentRegistry;
+        partyAgentMap.Record(agentId);
+        RememberOwnedCompanion(agent, agentId);
+        Logger.Information("[LocationSync] Registered local {AgentType} {AgentId} for {ControllerId}",
+            agentType, agentId, controllerId);
+        return true;
+    }
 
-        if (!agentRegistry.TryRegisterAgent(controllerId, agentId, Agent.Main))
-            return;
+    private void RememberOwnedCompanion(Agent agent, Guid agentId)
+    {
+        if (!ReferenceEquals(agent, Agent.Main))
+            _ownedCompanionIds[agent] = agentId;
+    }
 
-        if (!agentRegistry.TryGetAgentInfo(Agent.Main, out var agentInfo))
-            return;
+    private bool TryDespawnOwnedCompanion(Agent agent, LocationDespawnReason reason)
+    {
+        if (agent == null || !_ownedCompanionIds.TryGetValue(agent, out Guid agentId)) return false;
 
-        _localAgentRegistered = true;
-        Logger.Information("[LocationSync] Registered local agent (hero {AgentId}) for {PlayerID}; broadcasting join info",
-            agentId, controllerId);
+        _ownedCompanionIds.Remove(agent);
+        partyAgentMap.Forget(agentId);
+        coopMissionComponent.AgentRegistry.RemoveAgent(agentId);
+        network.SendAll(new NetworkDespawnLocationAgents(
+            new[] { agentId },
+            new[] { (byte)reason },
+            new[] { string.Empty }));
+        Logger.Information("[LocationSync] Despawned local companion {AgentId} ({Reason})", agentId, reason);
+        return true;
+    }
 
-        // NPC puppet spawns wait on the same readiness as join info: the mission is provably set up now.
-        npcPuppetSpawner.NotifyMissionReady();
+    internal static bool IsOwnPartyAgent(Agent agent)
+    {
+        if (agent == null) return false;
+        if (ReferenceEquals(agent, Agent.Main)) return true;
 
-        if (!objectManager.TryGetIdWithLogging(CharacterObject.PlayerCharacter, out var characterObjectId))
-            return;
-
-        // Announce to peers that connected before this controller was attached/subscribed
-        // (their PeerConnected was missed). Remote side dedupes by the party/agent id.
-        network.SendAll(BuildJoinInfo(agentInfo, characterObjectId));
-
-        // The mission is now set up (player agent + teams exist). Spawn any join info that arrived
-        // before we were ready.
-        DrainPendingJoinInfos();
-
-        // Mission-ready (SR-010): the local player agent exists, so the mission has provably finished
-        // loading — ask the server to elect (or report) this instance's NPC host.
-        if (instanceId != null)
-            messageBroker.Publish(this, new LocationMissionReady(instanceId));
+        return agent.Origin is PartyAgentOrigin origin && origin.Party == PartyBase.MainParty;
     }
 
     private void DrainPendingJoinInfos()
@@ -249,21 +420,33 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
         Logger.Information("[Relay] Announced MissionEntered for instance {Instance}", instanceId);
     }
 
-    private NetworkMissionJoinInfo BuildJoinInfo(CoopAgentInfo agentInfo, string characterObjectId)
+    private NetworkMissionJoinInfo BuildJoinInfo()
     {
-        bool isPlayerAlive = Agent.Main.Health > 0;
-        Vec3 position = Agent.Main.Position;
-        float health = Agent.Main.Health;
+        Agent mainAgent = Agent.Main;
+        bool isPlayerAlive = mainAgent != null && mainAgent.Health > 0;
+        var agents = new List<CoopAgentSpawnData>();
 
-        var agents = new CoopAgentSpawnData[]
+        foreach (var agentInfo in coopMissionComponent.AgentRegistry.GetAgents(controllerIdProvider.ControllerId))
         {
-            new CoopAgentSpawnData(agentInfo.AgentId, characterObjectId, position, health, isPlayer: true),
-        };
+            Agent agent = agentInfo.Agent;
+            // The local controller may also be the elected ambient-NPC host. Those agents have their own
+            // NetworkSpawnLocationAgents catch-up path with roster bindings; never leak them into party join info.
+            if (agent == null || !IsOwnPartyAgent(agent) || !(agent.Character is CharacterObject character)) continue;
+            if (!ReferenceEquals(agent, mainAgent) && (!agent.IsActive() || agent.Health <= 0)) continue;
+            if (!objectManager.TryGetIdWithLogging(character, out var characterObjectId)) continue;
+
+            agents.Add(new CoopAgentSpawnData(
+                agentInfo.AgentId,
+                characterObjectId,
+                agent.Position,
+                agent.Health,
+                isPlayer: ReferenceEquals(agent, mainAgent)));
+        }
 
         return new NetworkMissionJoinInfo(
             controllerIdProvider.ControllerId,
             isPlayerAlive,
-            agents
+            agents.ToArray()
         );
     }
 
@@ -277,15 +460,9 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
             return;
         }
 
-        if (!objectManager.TryGetIdWithLogging(CharacterObject.PlayerCharacter, out var characterObjectId))
-            return;
-
-        var agentRegistry = coopMissionComponent.AgentRegistry;
-
-        if (!agentRegistry.TryGetAgentInfo(Agent.Main, out var agentInfo))
-            return;
-
-        NetworkMissionJoinInfo request = BuildJoinInfo(agentInfo, characterObjectId);
+        NetworkMissionJoinInfo request = null;
+        GameThread.RunSafe(() => request = BuildJoinInfo(), blocking: true);
+        if (request == null) return;
 
         network.Send(controllerId, request);
         Logger.Information("Sent Join Request for {PlayerID} to {Controller}", request.ControllerId, controllerId);
@@ -306,7 +483,7 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
     protected override void HandleJoinInfo(NetPeer netPeer, NetworkMissionJoinInfo joinInfo)
     {
         // Spawning needs the interior mission fully set up (player agent + teams). On a rejoin the join
-        // info beats the mission setup, so buffer it and drain once we are ready (TryRegisterLocalAgent).
+        // info beats the mission setup, so buffer it and drain once we are ready (TryRegisterLocalPartyAgents).
         // Re-check readiness after enqueuing to close the race with the main thread flipping it.
         if (_localAgentRegistered == false)
         {
@@ -337,6 +514,11 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
 
         var agentRegistry = coopMissionComponent.AgentRegistry;
 
+        // Record party identity before dedupe. An ambient spawn batch from the elected host can race this
+        // join record; even if that batch won and attached an NPC binding, migration must still despawn this
+        // player/companion instead of adopting it as settlement population.
+        partyAgentMap.Record(agentData.AgentId);
+
         // Dedupe across all peers: NAT punch can yield more than one connection to the same remote
         // client, delivering its join info multiple times. Only spawn one agent per id.
         if (agentRegistry.TryGetAgentInfo(agentData.AgentId, out _))
@@ -354,11 +536,12 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
             agentData.IsPlayer == true ? "Player" : "Agent",
             characterObject?.Name?.ToString() ?? "<unresolved>", agentData.AgentId, controllerId);
 
-        Agent newAgent = SpawnAgent(agentData.Position, characterObject);
+        Agent newAgent = SpawnAgent(agentData.Position, characterObject, agentData.IsPlayer, agentData.Health);
 
         if (newAgent == null)
         {
             Logger.Error("[LocationSync] Failed to spawn remote agent {AgentID} — removing agent.", agentData.AgentId);
+            partyAgentMap.Forget(agentData.AgentId);
             agentRegistry.RemoveAgent(agentData.AgentId);
             return;
         }
@@ -368,7 +551,7 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
             agentData.AgentId, newAgent.Position, Mission.Current?.SceneName);
     }
 
-    public Agent SpawnAgent(Vec3 startingPos, CharacterObject character)
+    public Agent SpawnAgent(Vec3 startingPos, CharacterObject character, bool isPlayer = false, float health = -1f)
     {
         // A remote player's hero CharacterObject often does not resolve to a fully-initialized
         // object on this client (live campaign: each player has a distinct, not-yet-synced hero),
@@ -395,11 +578,9 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
                 // The player may have left between receiving the join info and this running.
                 if (Mission.Current == null) return;
 
-                // In a village the hero rides in on their battle mount; towns, taverns and castle courtyards
-                // are civilian and on-foot. Mirror that split (the same IsVillage test the server uses when it
-                // spawns notables/companions in SettlementPopulationTracker) so a remote player's puppet matches
-                // how its owner spawned. Forcing NoHorses + civilian equipment here is what left every village
-                // puppet dismounted; once it has a mount, AgentMovementHandler keeps the mount pose in sync.
+                // The player rides in villages, but companions are roster-spawned on foot even there. Preserve
+                // that distinction so a remote companion puppet does not gain a horse its authoritative AI does
+                // not have. Towns, taverns and castle courtyards use civilian equipment and are always on-foot.
                 bool isVillage = Settlement.CurrentSettlement?.IsVillage == true;
 
                 AgentBuildData agentBuildData = new AgentBuildData(character);
@@ -407,15 +588,14 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
                 agentBuildData.InitialPosition(startingPos);
                 agentBuildData.Team(Mission.Current.PlayerAllyTeam);
                 agentBuildData.InitialDirection(Vec2.Forward);
-                agentBuildData.NoHorses(!isVillage);
+                agentBuildData.NoHorses(!isPlayer || !isVillage);
                 agentBuildData.Equipment(isVillage ? character.FirstBattleEquipment : character.FirstCivilianEquipment);
                 agentBuildData.TroopOrigin(new SimpleAgentOrigin(character, -1, null, default));
                 agentBuildData.Controller(AgentControllerType.None);
                 agentBuildData.ClothingColor1(character.HeroObject.MapFaction.Color);
                 agentBuildData.ClothingColor2(character.HeroObject.MapFaction.Color2);
 
-                // A remote PLAYER puppet is not a host-owned NPC — a promoted host's capture patch
-                // must not re-capture and re-broadcast it.
+                // Remote party puppets are not host-owned NPCs and must not be captured for replication.
                 LocationNpcGate.SuppressCapture = true;
                 try
                 {
@@ -424,6 +604,11 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
                 finally
                 {
                     LocationNpcGate.SuppressCapture = false;
+                }
+
+                if (health > 0)
+                {
+                    agent.Health = health;
                 }
                 agent.FadeIn();
             }


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

Settlement companions are not spawned and controlled by their owning client. During location host migration, a companion can also be mistaken for an ambient NPC and adopted instead of despawned with its player.

The elected settlement host also polls wielded equipment from non-humanoid livestock. These agents have no native wield-state pointer, so entering a populated city can throw from `AgentEquipmentData` and freeze `Game.OnTick`.

## What is the new behavior?

The owning client uses the vanilla accompanying-character flow to spawn and AI-control its companion, while other clients receive a location puppet. Player-party identities are tracked separately from ambient NPC bindings so companions despawn with their owner and are never adopted during host migration.

Livestock continue sending movement, but equipment capture and apply are restricted to human agents.

Resolves #3045
Resolves #2974

## Bot Changelog Entry

- Companions now spawn with you in settlements
- Fixed the settlement host freezing when a populated location contains livestock.
