### PR TITLE
Fix for static log access before configuration was completed

### DIFF
--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -108,12 +108,6 @@ namespace Coop
             }
 
             isAutoConnect = args.Any(a => a.Equals("/autoconnect", StringComparison.OrdinalIgnoreCase));
-#if DEBUG
-            isDeferredClientJoin = args.Any(a =>
-                    a.Equals("/cooptestmanualjoin", StringComparison.OrdinalIgnoreCase)) &&
-                LiveTestControlServer.IsEnabled(Environment.GetCommandLineArgs());
-            isLiveTestRun = LiveTestControlServer.IsEnabled(Environment.GetCommandLineArgs());
-#endif
 
             // GetFullCommandLineString splits on spaces, which would cut a quoted save
             // name apart; the managed-server arguments need real Windows arg parsing.
@@ -128,6 +122,13 @@ namespace Coop
 
             SetupLogging();
             InitializeCrashReporting();
+            
+#if DEBUG
+            isDeferredClientJoin = args.Any(a =>
+                                       a.Equals("/cooptestmanualjoin", StringComparison.OrdinalIgnoreCase)) &&
+                                   LiveTestControlServer.IsEnabled(Environment.GetCommandLineArgs());
+            isLiveTestRun = LiveTestControlServer.IsEnabled(Environment.GetCommandLineArgs());
+#endif
 
             // Creates the handler during launch
             if (!isServer)

--- a/source/Coop/LiveTesting/LiveTestControlServer.cs
+++ b/source/Coop/LiveTesting/LiveTestControlServer.cs
@@ -29,7 +29,7 @@ namespace Coop.LiveTesting
     {
         private const string EndpointDirectoryName = "BannerlordCoop.LiveTest.v1";
 
-        private static readonly ILogger Logger = LogManager.GetLogger<LiveTestControlServer>();
+        private static readonly ILogger Logger;
 
         private readonly string logFilePath;
         private readonly bool isServer;
@@ -45,6 +45,11 @@ namespace Coop.LiveTesting
         private readonly string endpointRegistrationPath;
         private int shutdownScheduled;
         private int deferredClientJoinAttempted;
+        
+        static LiveTestControlServer()
+        {
+            Logger = LogManager.GetLogger<LiveTestControlServer>();
+        }
 
         public LiveTestControlServer(
             bool isServer,


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
A static method LiveTestControlServer.IsEnabled was called, triggering static initialization of the Logger field in LiveTestControlServer, which got the logger from LogManager before the logger configuration was completely setup. 

## What is the new behavior?
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
The Coop_client.log and Coop_server.log fill out correctly (tested on both Windows and Linux). Since it works for most people in the first place, this seems to be a niche bug due to differences in sdk versions used, or some other unknown factor.

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->


## Other information
