### PR TITLE
[2785] Restore player parties after campaign synchronization

### DIFF
--- a/source/Coop.Core/Server/Connections/Messages/PlayerCampaignSynchronized.cs
+++ b/source/Coop.Core/Server/Connections/Messages/PlayerCampaignSynchronized.cs
@@ -1,0 +1,17 @@
+﻿using Common.Messaging;
+using LiteNetLib;
+
+namespace Coop.Core.Server.Connections.Messages;
+
+/// <summary>
+/// A player applied the ordered campaign join tail and can receive normal world state.
+/// </summary>
+internal record PlayerCampaignSynchronized : IEvent
+{
+    public NetPeer PlayerId { get; }
+
+    public PlayerCampaignSynchronized(NetPeer playerId)
+    {
+        PlayerId = playerId;
+    }
+}

--- a/source/Coop.Core/Server/Connections/States/LoadingState.cs
+++ b/source/Coop.Core/Server/Connections/States/LoadingState.cs
@@ -168,6 +168,7 @@ public class LoadingState : ConnectionStateBase
             if (!IsCurrent(JoinPhase.CatchUpAppliedQueued)) return;
 
             connectionMessageQueue.CompleteCatchUp(peer);
+            messageBroker.Publish(this, new PlayerCampaignSynchronized(peer));
             ConnectionLogic.EnterCampaign();
         }, context: nameof(JoinSyncSignal.CatchUpApplied));
     }

--- a/source/Coop.Core/Server/Services/Players/Handlers/PlayerPartyVisibilityHandler.cs
+++ b/source/Coop.Core/Server/Services/Players/Handlers/PlayerPartyVisibilityHandler.cs
@@ -29,7 +29,7 @@ using TaleWorlds.CampaignSystem.Party;
 namespace Coop.Core.Server.Services.Players.Handlers;
 /// <summary>
 /// Server-side: hides a disconnected player's party from the map and stops it being simulated, then
-/// restores it once the peer is back in the campaign. Parties in a MapEvent remain active so reconnect
+/// restores it once the peer has synchronized the campaign. Parties in a MapEvent remain active so reconnect
 /// saves preserve their battle membership.
 /// <see cref="MobileParty.IsActive"/> gates spotting/interaction/ticking (see
 /// PartyVisibilityServerPatches, MobilePartyVisualManagerPatches) and is an AutoSync property, so
@@ -63,7 +63,7 @@ internal class PlayerPartyVisibilityHandler : IHandler
         this.siegeEventInterface = siegeEventInterface;
 
         messageBroker.Subscribe<PlayerDisconnected>(Handle_PlayerDisconnected);
-        messageBroker.Subscribe<PlayerCampaignEntered>(Handle_PlayerCampaignEntered);
+        messageBroker.Subscribe<PlayerCampaignSynchronized>(Handle_PlayerCampaignSynchronized);
         messageBroker.Subscribe<MapEventFinalized>(Handle_MapEventFinalized);
         messageBroker.Subscribe<SavedPlayerRegistrationsRestored>(Handle_SavedPlayerRegistrationsRestored);
     }
@@ -71,7 +71,7 @@ internal class PlayerPartyVisibilityHandler : IHandler
     public void Dispose()
     {
         messageBroker.Unsubscribe<PlayerDisconnected>(Handle_PlayerDisconnected);
-        messageBroker.Unsubscribe<PlayerCampaignEntered>(Handle_PlayerCampaignEntered);
+        messageBroker.Unsubscribe<PlayerCampaignSynchronized>(Handle_PlayerCampaignSynchronized);
         messageBroker.Unsubscribe<MapEventFinalized>(Handle_MapEventFinalized);
         messageBroker.Unsubscribe<SavedPlayerRegistrationsRestored>(Handle_SavedPlayerRegistrationsRestored);
         deferredMapEventParking.Clear();
@@ -147,14 +147,16 @@ internal class PlayerPartyVisibilityHandler : IHandler
         Logger.Information("Parked party {PartyId} because {Reason}", party.StringId, reason);
     }
 
-    /// <summary> A peer (re)entered the campaign, un-park its party and rebuild its map figure.
-    private void Handle_PlayerCampaignEntered(MessagePayload<PlayerCampaignEntered> payload)
+    /// <summary> A peer finished campaign synchronization, un-park its party and rebuild its map figure.
+    private void Handle_PlayerCampaignSynchronized(MessagePayload<PlayerCampaignSynchronized> payload)
     {
         if (ModInformation.IsClient) return;
 
-        var peer = payload.What.playerId;
+        var peer = payload.What.PlayerId;
 
         if (!playerManager.TryGetPlayer(peer, out var player) ||
+            !playerManager.TryGetPeer(player.ControllerId, out var currentPeer) ||
+            !ReferenceEquals(currentPeer, peer) ||
             !objectManager.TryGetObjectWithLogging<MobileParty>(player.MobilePartyId, out var party))
         {
             Logger.Error("Could not resolve party for peer {Peer} on campaign entry", peer.Id);

--- a/source/Coop.Tests/Server/Connections/States/LoadingStateTests.cs
+++ b/source/Coop.Tests/Server/Connections/States/LoadingStateTests.cs
@@ -103,8 +103,12 @@ namespace Coop.Tests.Server.Connections.States
             Assert.Equal(0, SignalCount(JoinSyncSignal.WorldReady));
             SendAndDrain(state, JoinSyncSignal.FinalBaselineApplied);
             Assert.Equal(1, SignalCount(JoinSyncSignal.WorldReady));
+            Assert.Empty(serverComponent.TestMessageBroker.GetMessagesFromType<PlayerCampaignSynchronized>());
             Assert.IsType<LoadingState>(connectionLogic.State);
             SendAndDrain(state, JoinSyncSignal.CatchUpApplied);
+            var synchronized = Assert.Single(
+                serverComponent.TestMessageBroker.GetMessagesFromType<PlayerCampaignSynchronized>());
+            Assert.Same(playerPeer, synchronized.PlayerId);
             Assert.IsType<CampaignState>(connectionLogic.State);
         }
 
@@ -281,6 +285,8 @@ namespace Coop.Tests.Server.Connections.States
                 connectionLogic.Dispose();
             });
 
+            Assert.Empty(
+                serverComponent.TestMessageBroker.GetMessagesFromType<PlayerCampaignSynchronized>());
             Assert.Null(connectionLogic.State);
         }
 

--- a/source/Coop.Tests/Server/Services/Players/PlayerPartyVisibilityHandlerTests.cs
+++ b/source/Coop.Tests/Server/Services/Players/PlayerPartyVisibilityHandlerTests.cs
@@ -2,6 +2,7 @@
 using Common.Network;
 using Common.Network.Messages;
 using Common.Tests.Utils;
+using Coop.Core.Server.Connections.Messages;
 using Coop.Core.Server.Services.Players.Handlers;
 using Coop.Core.Server.Services.Save.Messages;
 using GameInterface.Services.ObjectManager;
@@ -15,6 +16,7 @@ using System;
 using System.Runtime.Serialization;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.CampaignSystem.Siege;
 using Xunit;
 
@@ -143,6 +145,77 @@ public class PlayerPartyVisibilityHandlerTests : IDisposable
 
         siegeEventInterface.Verify(value => value.BreakSiegeForPartyOnly(party), Times.Once);
         Assert.False(party.IsActive);
+    }
+
+    [Fact]
+    public void CampaignEntry_LeavesSettlementPartyParkedUntilSynchronizationCompletes()
+    {
+        var peer = (NetPeer)FormatterServices.GetUninitializedObject(typeof(NetPeer));
+        var player = CreatePlayer();
+        var party = CreateParty(isActive: false);
+        var settlement = (Settlement)FormatterServices.GetUninitializedObject(typeof(Settlement));
+        party._currentSettlement = settlement;
+        var playerManager = new Mock<IPlayerManager>();
+        playerManager
+            .Setup(manager => manager.TryGetPlayer(peer, out player))
+            .Returns(true);
+        playerManager
+            .Setup(manager => manager.TryGetPeer(player.ControllerId, out peer))
+            .Returns(true);
+
+        var objectManager = new Mock<IObjectManager>();
+        objectManager
+            .Setup(manager => manager.TryGetObjectWithLogging(player.MobilePartyId, out party))
+            .Returns(true);
+
+        var broker = new TestMessageBroker();
+        using var handler = new PlayerPartyVisibilityHandler(
+            broker,
+            playerManager.Object,
+            objectManager.Object,
+            Mock.Of<INetwork>(),
+            Mock.Of<ISiegeEventInterface>());
+
+        broker.Publish(this, new PlayerCampaignEntered(peer));
+        Assert.False(party.IsActive);
+
+        broker.Publish(this, new PlayerCampaignSynchronized(peer));
+        GameThread.Run(() => { }, blocking: true);
+
+        Assert.True(party.IsActive);
+        Assert.Same(settlement, party.CurrentSettlement);
+    }
+
+    [Fact]
+    public void SynchronizationFromSupersededPeer_LeavesPartyParked()
+    {
+        var supersededPeer = (NetPeer)FormatterServices.GetUninitializedObject(typeof(NetPeer));
+        var currentPeer = (NetPeer)FormatterServices.GetUninitializedObject(typeof(NetPeer));
+        var player = CreatePlayer();
+        var party = CreateParty(isActive: false);
+
+        var playerManager = new Mock<IPlayerManager>();
+        playerManager
+            .Setup(manager => manager.TryGetPlayer(supersededPeer, out player))
+            .Returns(true);
+        playerManager
+            .Setup(manager => manager.TryGetPeer(player.ControllerId, out currentPeer))
+            .Returns(true);
+
+        var objectManager = new Mock<IObjectManager>();
+        var broker = new TestMessageBroker();
+        using var handler = new PlayerPartyVisibilityHandler(
+            broker,
+            playerManager.Object,
+            objectManager.Object,
+            Mock.Of<INetwork>(),
+            Mock.Of<ISiegeEventInterface>());
+
+        broker.Publish(this, new PlayerCampaignSynchronized(supersededPeer));
+        GameThread.Run(() => { }, blocking: true);
+
+        Assert.False(party.IsActive);
+        objectManager.VerifyNoOtherCalls();
     }
 
     [Fact]

--- a/source/E2E.Tests/Services/Missions/BattleAbandonmentTests.cs
+++ b/source/E2E.Tests/Services/Missions/BattleAbandonmentTests.cs
@@ -74,7 +74,7 @@ public class BattleAbandonmentTests : MissionTestEnvironment
             var playerManager = Server.Resolve<IPlayerManager>();
             playerManager.SetPeer("connected-ctrl", connected.NetPeer);
             Server.Resolve<ITimeControlInterface>().ServerSetTimeControl(TimeControlEnum.Play_2x);
-            Server.Resolve<IMessageBroker>().Publish(this, new PlayerCampaignEntered(connected.NetPeer));
+            Server.Resolve<IMessageBroker>().Publish(this, new PlayerCampaignSynchronized(connected.NetPeer));
         });
 
         Assert.Equal(1, Server.NetworkSentMessages.GetMessages<NetworkMapEventLockChanged>().Last().PlayersInMapEvent);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Players reconnecting while their party is parked inside a settlement can remain stuck on Finishing Synchronization until an administrator forces the party to leave the settlement.

## What is the new behavior?

Resolves #2785

Reconnects now keep the player's party parked until campaign synchronization is complete, allowing the player to finish loading while preserving the party's current settlement.

## Bot Changelog Entry

- Fixed an issue where players would get stuck on Finishing Synchronization when they try to rejoin after quitting while being in a settlement.
