### PR TITLE
Fix max level building getting stuck in queue

### DIFF
--- a/source/GameInterface/Services/Buildings/Handlers/BuildingHelperHandler.cs
+++ b/source/GameInterface/Services/Buildings/Handlers/BuildingHelperHandler.cs
@@ -2,18 +2,20 @@
 using Common.Logging;
 using Common.Messaging;
 using Common.Network;
+using Common.Util;
 using GameInterface.Services.Buildings.Messages;
+using GameInterface.Services.Buildings.Patches;
 using GameInterface.Services.ObjectManager;
-using GameInterface.Services.UI.Notifications.Messages;
 using Helpers;
-using LiteNetLib;
+using SandBox.GauntletUI;
+using SandBox.GauntletUI.Menu;
 using Serilog;
-using System;
 using System.Collections.Generic;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.CampaignSystem.Settlements.Buildings;
+using TaleWorlds.ScreenSystem;
 
 namespace GameInterface.Services.Buildings.Handlers;
 
@@ -36,20 +38,30 @@ internal class BuildingHelperHandler : IHandler
 
         messageBroker.Subscribe<DefaultBuildingChanged>(Handle_DefaultBuildingChanged);
         messageBroker.Subscribe<ChangeDefaultBuilding>(Handle_ChangeDefaultBuilding);
+
         messageBroker.Subscribe<CurrentBuildingQueueChanged>(Handle_CurrentBuildingQueueChanged);
         messageBroker.Subscribe<ChangeCurrentBuildingQueue>(Handle_ChangeCurrentBuildingQueue);
+
         messageBroker.Subscribe<BuildingProcessBoostedWithGold>(Handle_BuildingProcessBoostedWithGold);
         messageBroker.Subscribe<BoostBuildingProcessWithGold>(Handle_BoostBuildingProcessWithGold);
+
+        messageBroker.Subscribe<RefreshPlayerSettlementManagementVM>(Handle_RefreshPlayerSettlementManagementVM);
+        messageBroker.Subscribe<NetworkRefreshPlayerSettlementManagementVM>(Handle_NetworkRefreshPlayerSettlementManagementVM);
     }
 
     public void Dispose()
     {
         messageBroker.Unsubscribe<DefaultBuildingChanged>(Handle_DefaultBuildingChanged);
         messageBroker.Unsubscribe<ChangeDefaultBuilding>(Handle_ChangeDefaultBuilding);
+
         messageBroker.Unsubscribe<CurrentBuildingQueueChanged>(Handle_CurrentBuildingQueueChanged);
         messageBroker.Unsubscribe<ChangeCurrentBuildingQueue>(Handle_ChangeCurrentBuildingQueue);
+
         messageBroker.Unsubscribe<BuildingProcessBoostedWithGold>(Handle_BuildingProcessBoostedWithGold);
         messageBroker.Unsubscribe<BoostBuildingProcessWithGold>(Handle_BoostBuildingProcessWithGold);
+
+        messageBroker.Unsubscribe<RefreshPlayerSettlementManagementVM>(Handle_RefreshPlayerSettlementManagementVM);
+        messageBroker.Unsubscribe<NetworkRefreshPlayerSettlementManagementVM>(Handle_NetworkRefreshPlayerSettlementManagementVM);
     }
 
     private void Handle_DefaultBuildingChanged(MessagePayload<DefaultBuildingChanged> obj)
@@ -65,19 +77,12 @@ internal class BuildingHelperHandler : IHandler
     {
         var data = obj.What;
 
-        GameThread.Run(() =>
+        GameThread.RunSafe(() =>
         {
-            try
-            {
-                if (!objectManager.TryGetObjectWithLogging<Building>(data.NewDefaultId, out var newDefault)) return;
-                if (!objectManager.TryGetObjectWithLogging<Town>(data.TownId, out var town)) return;
+            if (!objectManager.TryGetObjectWithLogging<Building>(data.NewDefaultId, out var newDefault)) return;
+            if (!objectManager.TryGetObjectWithLogging<Town>(data.TownId, out var town)) return;
 
-                BuildingHelper.ChangeDefaultBuilding(newDefault, town);
-            }
-            catch (Exception e)
-            {
-                Logger.Error(e, "Failed to apply {Message}", nameof(ChangeDefaultBuilding));
-            }
+            BuildingHelper.ChangeDefaultBuilding(newDefault, town);
         });
     }
 
@@ -101,28 +106,27 @@ internal class BuildingHelperHandler : IHandler
     {
         var data = obj.What;
 
-        GameThread.Run(() =>
+        GameThread.RunSafe(() =>
         {
-            try
+            if (!objectManager.TryGetObjectWithLogging<Town>(data.TownId, out var town)) return;
+
+            var buildings = new List<Building>();
+            if (data.BuildingIds != null)
             {
-                var buildings = new List<Building>();
-                if (data.BuildingIds != null)
+                foreach (var buildingId in data.BuildingIds)
                 {
-                    foreach (var buildingId in data.BuildingIds)
-                    {
-                        if (!objectManager.TryGetObjectWithLogging<Building>(buildingId, out var currentBuilding)) continue;
+                    if (!objectManager.TryGetObjectWithLogging<Building>(buildingId, out var currentBuilding)) continue;
 
-                        buildings.Add(currentBuilding);
-                    }
+                    buildings.Add(currentBuilding);
                 }
-
-                if (!objectManager.TryGetObjectWithLogging<Town>(data.TownId, out var town)) return;
-
-                BuildingHelper.ChangeCurrentBuildingQueue(buildings, town);
             }
-            catch (Exception e)
+
+            BuildingHelper.ChangeCurrentBuildingQueue(buildings, town);
+
+            // Reject new buildings in queue if they have already been constructed
+            foreach (var building in buildings)
             {
-                Logger.Error(e, "Failed to apply {Message}", nameof(ChangeCurrentBuildingQueue));
+                BuildingHelper.CheckIfBuildingIsComplete(building);
             }
         });
     }
@@ -139,32 +143,53 @@ internal class BuildingHelperHandler : IHandler
     private void Handle_BoostBuildingProcessWithGold(MessagePayload<BoostBuildingProcessWithGold> obj)
     {
         var data = obj.What;
-        var peer = obj.Who as NetPeer;
 
-        GameThread.Run(() =>
+        GameThread.RunSafe(() =>
         {
-            try
-            {
-                if (!objectManager.TryGetObjectWithLogging<Town>(data.TownId, out var town)) return;
-                if (!objectManager.TryGetObjectWithLogging<Hero>(data.HeroId, out var hero)) return;
+            if (!objectManager.TryGetObjectWithLogging<Town>(data.TownId, out var town)) return;
+            if (!objectManager.TryGetObjectWithLogging<Hero>(data.HeroId, out var hero)) return;
 
-                int difference = 0;
-                if (data.Gold < town.BoostBuildingProcess)
-                {
-                    difference = town.BoostBuildingProcess - data.Gold;
-                    GiveGoldAction.ApplyBetweenCharacters(null, hero, difference, false);
-                }
-                else if (data.Gold > town.BoostBuildingProcess)
-                {
-                    difference = data.Gold - town.BoostBuildingProcess;
-                    GiveGoldAction.ApplyBetweenCharacters(hero, null, difference, false);
-                }
-                town.BoostBuildingProcess = data.Gold;
-            }
-            catch (Exception e)
+            int difference = 0;
+            if (data.Gold < town.BoostBuildingProcess)
             {
-                Logger.Error(e, "Failed to apply {Message}", nameof(BoostBuildingProcessWithGold));
+                difference = town.BoostBuildingProcess - data.Gold;
+                GiveGoldAction.ApplyBetweenCharacters(null, hero, difference, false);
             }
+            else if (data.Gold > town.BoostBuildingProcess)
+            {
+                difference = data.Gold - town.BoostBuildingProcess;
+                GiveGoldAction.ApplyBetweenCharacters(hero, null, difference, false);
+            }
+            town.BoostBuildingProcess = data.Gold;
+        });
+    }
+
+    private void Handle_RefreshPlayerSettlementManagementVM(MessagePayload<RefreshPlayerSettlementManagementVM> obj)
+    {
+        if (!objectManager.TryGetIdWithLogging(obj.What.Town, out var townId)) return;
+
+        var message = new NetworkRefreshPlayerSettlementManagementVM(townId);
+        network.SendAll(message);
+    }
+
+    private void Handle_NetworkRefreshPlayerSettlementManagementVM(MessagePayload<NetworkRefreshPlayerSettlementManagementVM> obj)
+    {
+        var data = obj.What;
+
+        GameThread.RunSafe(() =>
+        {
+            if (!objectManager.TryGetObjectWithLogging<Town>(data.TownId, out var town)) return;
+
+            // Client isn't in the settlement management screen
+            if (TownManagementViewPatches.Current?._dataSource == null) return;
+
+            // Client is in the settlement management screen but not looking at the updated town
+            if (TownManagementViewPatches.Current._dataSource._settlement != town.Settlement) return;
+
+            TownManagementViewPatches.Current._dataSource.RefreshCurrentDevelopment();
+            TownManagementViewPatches.Current._dataSource.RefreshTownManagementStats();
+
+            TownManagementViewPatches.Current._dataSource._projectSelection?.Refresh();
         });
     }
 }

--- a/source/GameInterface/Services/Buildings/Handlers/BuildingHelperHandler.cs
+++ b/source/GameInterface/Services/Buildings/Handlers/BuildingHelperHandler.cs
@@ -2,20 +2,16 @@
 using Common.Logging;
 using Common.Messaging;
 using Common.Network;
-using Common.Util;
 using GameInterface.Services.Buildings.Messages;
 using GameInterface.Services.Buildings.Patches;
 using GameInterface.Services.ObjectManager;
 using Helpers;
-using SandBox.GauntletUI;
-using SandBox.GauntletUI.Menu;
 using Serilog;
 using System.Collections.Generic;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.CampaignSystem.Settlements.Buildings;
-using TaleWorlds.ScreenSystem;
 
 namespace GameInterface.Services.Buildings.Handlers;
 
@@ -117,17 +113,16 @@ internal class BuildingHelperHandler : IHandler
                 {
                     if (!objectManager.TryGetObjectWithLogging<Building>(buildingId, out var currentBuilding)) continue;
 
+                    // Reject adding buildings to queue that are already max level
+                    if (currentBuilding.CurrentLevel == 3) continue;
+
                     buildings.Add(currentBuilding);
                 }
             }
 
             BuildingHelper.ChangeCurrentBuildingQueue(buildings, town);
 
-            // Reject new buildings in queue if they have already been constructed
-            foreach (var building in buildings)
-            {
-                BuildingHelper.CheckIfBuildingIsComplete(building);
-            }
+            messageBroker.Publish(this, new RefreshPlayerSettlementManagementVM(town));
         });
     }
 
@@ -186,10 +181,10 @@ internal class BuildingHelperHandler : IHandler
             // Client is in the settlement management screen but not looking at the updated town
             if (TownManagementViewPatches.Current._dataSource._settlement != town.Settlement) return;
 
+            TownManagementViewPatches.Current._dataSource._projectSelection?.Refresh();
+
             TownManagementViewPatches.Current._dataSource.RefreshCurrentDevelopment();
             TownManagementViewPatches.Current._dataSource.RefreshTownManagementStats();
-
-            TownManagementViewPatches.Current._dataSource._projectSelection?.Refresh();
         });
     }
 }

--- a/source/GameInterface/Services/Buildings/Messages/NetworkRefreshPlayerSettlementManagementVM.cs
+++ b/source/GameInterface/Services/Buildings/Messages/NetworkRefreshPlayerSettlementManagementVM.cs
@@ -1,0 +1,16 @@
+﻿using Common.Messaging;
+using ProtoBuf;
+
+namespace GameInterface.Services.Buildings.Messages;
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkRefreshPlayerSettlementManagementVM : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string TownId;
+
+    public NetworkRefreshPlayerSettlementManagementVM(string townId)
+    {
+        TownId = townId;
+    }
+}

--- a/source/GameInterface/Services/Buildings/Messages/RefreshPlayerSettlementManagementVM.cs
+++ b/source/GameInterface/Services/Buildings/Messages/RefreshPlayerSettlementManagementVM.cs
@@ -1,0 +1,14 @@
+﻿using Common.Messaging;
+using TaleWorlds.CampaignSystem.Settlements;
+
+namespace GameInterface.Services.Buildings.Messages;
+
+public readonly struct RefreshPlayerSettlementManagementVM : IEvent
+{
+    public readonly Town Town;
+
+    public RefreshPlayerSettlementManagementVM(Town town)
+    {
+        Town = town;
+    }
+}

--- a/source/GameInterface/Services/Buildings/Patches/BuildingsCampaignBehaviorPatches.cs
+++ b/source/GameInterface/Services/Buildings/Patches/BuildingsCampaignBehaviorPatches.cs
@@ -1,4 +1,6 @@
 ﻿using Common;
+using Common.Messaging;
+using GameInterface.Services.Buildings.Messages;
 using GameInterface.Services.Clans.Extensions;
 using HarmonyLib;
 using TaleWorlds.CampaignSystem;
@@ -45,6 +47,12 @@ internal class BuildingsCampaignBehaviorPatches
             if (!town.CurrentBuilding.BuildingType.IsDailyProject)
             {
                 __instance.TickCurrentBuildingForTown(town);
+
+                // Update client's settlement management screen with latest tick
+                // Vanilla is normally paused on this screen so ticks won't update normally
+                var message = new RefreshPlayerSettlementManagementVM(town);
+                MessageBroker.Instance.Publish(__instance, message);
+
                 return false;
             }
             if (town.Governor != null && town.Governor.GetPerkValue(DefaultPerks.Charm.Virile) && MBRandom.RandomFloat <= DefaultPerks.Charm.Virile.SecondaryBonus)

--- a/source/GameInterface/Services/Buildings/Patches/BuildingsCampaignBehaviorPatches.cs
+++ b/source/GameInterface/Services/Buildings/Patches/BuildingsCampaignBehaviorPatches.cs
@@ -28,7 +28,7 @@ internal class BuildingsCampaignBehaviorPatches
 
     [HarmonyPatch(nameof(BuildingsCampaignBehavior.DailyTickSettlement))]
     [HarmonyPrefix]
-    public static bool DailyTickSettlementPrefix(ref BuildingsCampaignBehavior __instance, Settlement settlement)
+    public static bool DailyTickSettlementPrefix(BuildingsCampaignBehavior __instance, Settlement settlement)
     {
         // Skip if village
         if (!settlement.IsFortification) return false;
@@ -48,11 +48,6 @@ internal class BuildingsCampaignBehaviorPatches
             {
                 __instance.TickCurrentBuildingForTown(town);
 
-                // Update client's settlement management screen with latest tick
-                // Vanilla is normally paused on this screen so ticks won't update normally
-                var message = new RefreshPlayerSettlementManagementVM(town);
-                MessageBroker.Instance.Publish(__instance, message);
-
                 return false;
             }
             if (town.Governor != null && town.Governor.GetPerkValue(DefaultPerks.Charm.Virile) && MBRandom.RandomFloat <= DefaultPerks.Charm.Virile.SecondaryBonus)
@@ -70,5 +65,17 @@ internal class BuildingsCampaignBehaviorPatches
 
         // Safe to run normally for non-player clans
         return true;
+    }
+
+    [HarmonyPatch(nameof(BuildingsCampaignBehavior.DailyTickSettlement))]
+    [HarmonyPostfix]
+    public static void DailyTickSettlementPostfix(BuildingsCampaignBehavior __instance, Settlement settlement)
+    {
+        if (!settlement.IsFortification || !settlement.OwnerClan.IsPlayerClan()) return;
+
+        // Update client's settlement management screen with latest tick
+        // Vanilla is normally paused on this screen so ticks won't update normally
+        var message = new RefreshPlayerSettlementManagementVM(settlement.Town);
+        MessageBroker.Instance.Publish(__instance, message);
     }
 }

--- a/source/GameInterface/Services/Buildings/Patches/GauntletMenuTownManagementViewPatches.cs
+++ b/source/GameInterface/Services/Buildings/Patches/GauntletMenuTownManagementViewPatches.cs
@@ -14,4 +14,11 @@ internal class TownManagementViewPatches
     {
         Current = __instance;
     }
+
+    [HarmonyPatch(nameof(GauntletMenuTownManagementView.OnFinalize))]
+    [HarmonyPostfix]
+    public static void OnFinalizePostfix()
+    {
+        Current = null;
+    }
 }

--- a/source/GameInterface/Services/Buildings/Patches/GauntletMenuTownManagementViewPatches.cs
+++ b/source/GameInterface/Services/Buildings/Patches/GauntletMenuTownManagementViewPatches.cs
@@ -1,0 +1,17 @@
+﻿using HarmonyLib;
+using SandBox.GauntletUI.Menu;
+
+namespace GameInterface.Services.Buildings.Patches;
+
+[HarmonyPatch(typeof(GauntletMenuTownManagementView))]
+internal class TownManagementViewPatches
+{
+    public static GauntletMenuTownManagementView Current;
+
+    [HarmonyPatch(nameof(GauntletMenuTownManagementView.OnInitialize))]
+    [HarmonyPostfix]
+    public static void OnInitializePostfix(GauntletMenuTownManagementView __instance)
+    {
+        Current = __instance;
+    }
+}


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The settlement management screen doesn't update on the daily construction tick. This means if a client is watching the progress of a building and it reaches 100%, the building will remain in their queue. When closing the screen, this gets sent to the server and  adds the already constructed building back into the queue.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #3066
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Changed to reject adding buildings to queue if already at max level and refresh clients' settlement management screens when a tick happens modifying the construction queue.

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Fix an issue where a max level building could get stuck in a town's construction queue.
