### PR TITLE
Send a leave request when leaving a looted village

### DIFF
--- a/source/GameInterface/Services/MobileParties/Patches/PlayerLeaveSettlementPatch.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/PlayerLeaveSettlementPatch.cs
@@ -24,6 +24,12 @@ internal class PlayerLeaveSettlementPatch
         typeof(EncounterGameMenuBehavior).GetMethod("game_menu_castle_outside_leave_on_consequence", BindingFlags.NonPublic | BindingFlags.Instance),
         typeof(EncounterGameMenuBehavior).GetMethod("army_encounter_leave_on_consequence", BindingFlags.NonPublic | BindingFlags.Instance),
         typeof(HideoutCampaignBehavior).GetMethod("game_menu_hideout_leave_on_consequence", BindingFlags.NonPublic | BindingFlags.Instance),
+        // A village entered while it is looted opens the "village_looted" menu, whose single option is
+        // its own leave route. Without it here the press ran vanilla only: the menu closed and the
+        // player regained map control locally, but no request ever reached the server, so the server
+        // kept the party inside the settlement and never replicated a leave back — the map party stayed
+        // invisible and frozen until coop.unstuck released the settlement server-side by hand.
+        AccessTools.Method(typeof(VillageHostileActionCampaignBehavior), "village_looted_leave_on_consequence"),
     };
 
     private static bool Prefix() => RequestLeave();


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

Entering a village that is currently looted opens the `village_looted` menu, whose single option is its own leave route: `VillageHostileActionCampaignBehavior.village_looted_leave_on_consequence`.

`PlayerLeaveSettlementPatch` hooks four leave consequences — town, castle outside, army encounter, hideout — but not this one. Pressing "Leave" therefore ran vanilla only. Locally that works: the menu closes and the player gets map control back. But no `EndSettlementEncounterAttempted` is ever raised, so `ClientSettlementExitEnterHandler` never sends `NetworkRequestEndSettlementEncounter`, and the server goes on believing the party is still inside the settlement.

The result on the client is a party that is invisible on the campaign map and cannot be moved, while the server still reports the settlement:

```
pulse: ... players=1 ...
Pausing campaign because every connected player is occupied:
  triggerParty="Player438" players=["<id>:party=MobileParty_Player438,settlement=village_V6_1,mapEvent=none"]
```

The client log stays silent for the whole sequence — the leave never becomes a request.

The only recovery was `coop.unstuck`, which calls `PartyLeaveSettlement` on the server directly and bypasses this path entirely:

```
[Unstuck] Removed the party from settlement village_V6_1.
```

`LeaveSettlementAction.ApplyForParty` is not involved either, so `LeaveSettlementActionPatches` does not cover it.

## What is the new behavior?

`village_looted_leave_on_consequence` is added to `PlayerLeaveSettlementPatch.TargetMethods()`, so the looted-village leave takes the same route as every other settlement leave: the press raises `EndSettlementEncounterAttempted`, the request reaches the server, and the approved leave replicates back. The party reappears on the map and moves normally, with no `coop.unstuck` needed.

Reproduced and verified against a dedicated server: before the change the party was stuck on every attempt; after it, leaving a looted village works on the first press.

## Bot Changelog Entry

- Leaving a village that has been raided now works — your party no longer gets stuck invisible on the map.

## Other information

No tests added: the leave route is a game-menu consequence on a vanilla campaign behavior, and the existing settlement tests do not have a fixture that drives menu consequences. Happy to add one if you can point me at the right place.
