### PR TITLE
Skip equipment polling for agents whose weapon slots are not ready

### DIFF
--- a/source/Missions/Agents/Handlers/AgentMovementHandler.cs
+++ b/source/Missions/Agents/Handlers/AgentMovementHandler.cs
@@ -630,6 +630,16 @@ public class AgentMovementHandler : IAgentMovementHandler
                 capturedMovements.Add(
                     new CapturedMovement(agentInfo, agentData, isPriority));
 
+                // Reading the wielded indices dereferences the agent's MissionEquipment, and an agent
+                // can be alive while that backing array is still incomplete — location scenes (taverns,
+                // settlement interiors) hit this as props and NPCs stream in. Apply already refuses the
+                // native wield path in exactly that window; the sending side has to be as careful,
+                // because the throw escapes OnMissionTick, the frame never finishes, and the client
+                // freezes. Skipping the agent leaves its last known equipment in place rather than
+                // broadcasting an empty loadout.
+                if (!AgentEquipmentData.HasSafeWeaponSlots(agent.Equipment))
+                    continue;
+
                 var equipment = new AgentEquipmentData(agent);
                 if (!lastEquipment.TryGetValue(agentInfo.AgentId, out var previousEquipment))
                 {


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

`AgentMovementHandler.PollMovementAgents` builds an `AgentEquipmentData` for every polled agent. Its constructor reads the wielded indices straight off the agent:

```csharp
MainHandIndex = (int)agent.GetPrimaryWieldedItemIndex();
```

That dereferences the agent's `MissionEquipment`, and an agent can be alive while that backing array is still incomplete. `AgentEquipmentData.Apply` already documents exactly this window and refuses the native wield path through `HasSafeWeaponSlots`, but the sending side has no such guard.

When it happens the read throws out of the mission tick and the frame never completes, so the client freezes:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at TaleWorlds.MountAndBlade.Agent.GetPrimaryWieldedItemIndex()
   at Missions.Agents.Packets.AgentEquipmentData..ctor(Agent agent)
   at Missions.Agents.Handlers.AgentMovementHandler.PollMovementAgents(...)
   at Missions.Agents.Handlers.AgentMovementHandler.PollMovement(Single dt)
   at Missions.CoopMissionController.OnMissionTick(Single dt)
   at Missions.Taverns.CoopLocationsController.OnMissionTick(Single dt)
   at TaleWorlds.MountAndBlade.Mission.OnTick_Patch1(...)
```

The `CoopLocationsController` frame in the trace is the common case: it reproduces on entering settlement interiors, taverns most reliably, while props and NPCs are still streaming in. Two separate players hit it independently, one of them repeatedly on the same town.

## What is the new behavior?

The poll loop reuses the guard that `Apply` already relies on and skips an agent whose weapon slots are not readable this tick:

```csharp
if (!AgentEquipmentData.HasSafeWeaponSlots(agent.Equipment))
    continue;
```

Skipping rather than sending a default-constructed packet is deliberate — the agent keeps its last known equipment on the other clients instead of briefly appearing unarmed. Movement for that agent is unaffected; it is captured earlier in the same iteration.

Verified against a dedicated server: entering towns and villages that previously froze the client now works, with no exceptions in `Coop_client.log` across a full session in settlement interiors.

## Bot Changelog Entry

- Fixed a client freeze when entering towns and other settlement interiors.

## Other information

No tests added: reproducing it needs an agent observed mid-spawn inside a location mission, which the existing mission fixtures do not set up. Pointers welcome if you would like coverage here.
