### PR TITLE
Configurable autosave count

### DIFF
--- a/deploy/mod-config.default.json
+++ b/deploy/mod-config.default.json
@@ -119,5 +119,11 @@
     // This includes player companions and family members.
     // Default is false and won't have any effect if enableHeroExecutions is false.
     "enablePlayerClanMemberExecutions": false,
+
+    // Number of rotating autosave slots the server keeps (default 3).
+    // Each autosave overwrites the next slot in turn, so at most this many saveautoN
+    // files exist. Lowering the count leaves any higher-numbered saveauto files already
+    // on disk untouched. Values below 1 fall back to 3.
+    "autoSaveCount": 3,
   }
 }

--- a/source/Coop.IntegrationTests/Serialization/ModConfigNetworkMessageSerializationTest.cs
+++ b/source/Coop.IntegrationTests/Serialization/ModConfigNetworkMessageSerializationTest.cs
@@ -73,6 +73,7 @@ namespace Coop.IntegrationTests.Serialization
                 PlayerKingdomClanTierRequired = 2,
                 SmithingStaminaRecoveryMultiplier = 2.5f,
                 MaximumLootersMultiplier = 0.25f,
+                AutoSaveCount = 8,
             });
 
             var copy = RoundTrip(new NetworkLoadModConfig(options)).ModOptions;
@@ -86,6 +87,7 @@ namespace Coop.IntegrationTests.Serialization
             Assert.Equal(2, copy.PlayerKingdomClanTierRequired);
             Assert.Equal(2.5f, copy.SmithingStaminaRecoveryMultiplier);
             Assert.Equal(0.25f, copy.MaximumLootersMultiplier);
+            Assert.Equal(8, copy.AutoSaveCount);
 
             // Keys the operator left absent still resolve to the documented defaults, not to zero.
             Assert.True(copy.FastForwardEnabled);
@@ -109,6 +111,7 @@ namespace Coop.IntegrationTests.Serialization
             SmithingStaminaRecoveryOutsideSettlements = false,
             SmithingStaminaRecoveryMultiplier = 0f,
             MaximumLootersMultiplier = 0f,
+            AutoSaveCount = 0,
         });
 
         private static void AssertAllOptionsOff(ModOptions copy)
@@ -127,6 +130,7 @@ namespace Coop.IntegrationTests.Serialization
             Assert.False(copy.SmithingStaminaRecoveryOutsideSettlements);
             Assert.Equal(0f, copy.SmithingStaminaRecoveryMultiplier);
             Assert.Equal(0f, copy.MaximumLootersMultiplier);
+            Assert.Equal(0, copy.AutoSaveCount);
         }
 
         private static T RoundTrip<T>(T original)

--- a/source/GameInterface.Tests/Configuration/ModConfigTests.cs
+++ b/source/GameInterface.Tests/Configuration/ModConfigTests.cs
@@ -1,4 +1,5 @@
 ﻿using GameInterface.Configuration;
+using GameInterface.Services.Save.Patches;
 using System;
 using System.IO;
 using Xunit;
@@ -283,6 +284,7 @@ public class ModConfigTests : IDisposable
         Assert.Equal(0.1f, options.SmithingStaminaRecoveryMultiplier);
         Assert.Equal(1f, options.MaximumLootersMultiplier);
         Assert.Equal(LordDefectionRetryMode.Vanilla, options.LordDefectionRetries);
+        Assert.Equal(3, options.AutoSaveCount);
     }
 
     /// <summary>
@@ -451,5 +453,44 @@ public class ModConfigTests : IDisposable
             Environment.SetEnvironmentVariable("COOP_DATA_DIR", savedData);
             Environment.SetEnvironmentVariable("BANNERLORD_USER_DIR", savedEnv);
         }
+    }
+
+    [Theory]
+    [InlineData(0, 3, 1)]
+    [InlineData(1, 3, 2)]
+    [InlineData(3, 3, 1)]
+    [InlineData(4, 5, 5)]
+    [InlineData(5, 5, 1)]
+    public void NextAutoSaveIndex_WrapsAtCount(int current, int count, int expected)
+    {
+        Assert.Equal(expected, AutoSaveCountPatches.NextAutoSaveIndex(current, count));
+    }
+
+    [Theory]
+    [InlineData("saveauto1", "saveauto", 3, true)]
+    [InlineData("saveauto3", "saveauto", 3, true)]
+    [InlineData("saveauto4", "saveauto", 3, false)]
+    [InlineData("saveauto4", "saveauto", 5, true)]
+    [InlineData("save5", "saveauto", 3, false)]
+    public void IsAutoSaveNameReserved_MatchesPrefixWithinCount(
+        string name, string prefix, int count, bool expected)
+    {
+        Assert.Equal(expected, AutoSaveCountPatches.IsAutoSaveNameReserved(name, prefix, count));
+    }
+
+    [Theory]
+    [InlineData("saveauto3", "saveauto", 3, true, 3)]
+    [InlineData("saveauto4", "saveauto", 3, false, 0)]
+    [InlineData("saveauto9", "saveauto", 12, true, 9)]
+    [InlineData("saveauto0", "saveauto", 3, false, 0)]
+    [InlineData("saveauto", "saveauto", 3, false, 0)]
+    [InlineData("plain", "saveauto", 3, false, 0)]
+    public void TryParseAutoSaveSlot_ParsesIndexWithinCount(
+        string name, string prefix, int count, bool expected, int expectedIndex)
+    {
+        bool parsed = AutoSaveCountPatches.TryParseAutoSaveSlot(name, prefix, count, out int index);
+
+        Assert.Equal(expected, parsed);
+        Assert.Equal(expectedIndex, index);
     }
 }

--- a/source/GameInterface/Configuration/ModConfigData.cs
+++ b/source/GameInterface/Configuration/ModConfigData.cs
@@ -100,6 +100,8 @@ public sealed class ModOptionsData
 
     public bool? EnablePlayerClanMemberExecutions { get; set; }
 
+    public int? AutoSaveCount { get; set; }
+
     [JsonExtensionData]
     public IDictionary<string, JToken> UnknownKeys { get; set; }
 }

--- a/source/GameInterface/Configuration/ModConfigProvider.cs
+++ b/source/GameInterface/Configuration/ModConfigProvider.cs
@@ -54,6 +54,8 @@ public readonly struct ModOptions
     public readonly bool EnableHeroExecutions { get; } = true;
     [ProtoMember(17)]
     public readonly bool EnablePlayerClanMemberExecutions { get; } = false;
+    [ProtoMember(18)]
+    public readonly int AutoSaveCount { get; } = 3;
 
     public ModOptions(ModOptionsData modOptionsData)
     {
@@ -74,5 +76,6 @@ public readonly struct ModOptions
         LordDefectionRetries = modOptionsData.LordDefectionRetries ?? LordDefectionRetries;      
         EnableHeroExecutions = modOptionsData.EnableHeroExecutions ?? EnableHeroExecutions;
         EnablePlayerClanMemberExecutions = modOptionsData.EnablePlayerClanMemberExecutions ?? EnablePlayerClanMemberExecutions;
+        AutoSaveCount = modOptionsData.AutoSaveCount ?? AutoSaveCount;
     }
 }

--- a/source/GameInterface/Services/Save/Patches/AutoSaveCountPatches.cs
+++ b/source/GameInterface/Services/Save/Patches/AutoSaveCountPatches.cs
@@ -1,0 +1,104 @@
+﻿using GameInterface.Configuration;
+using HarmonyLib;
+using TaleWorlds.Core;
+
+namespace GameInterface.Services.Save.Patches;
+
+/// <summary>
+/// Replaces the base game autosave rotation count with the configured count from
+/// ModConfigProvider.ModOptions.AutoSaveCount.
+/// </summary>
+[HarmonyPatch(typeof(MBSaveLoad))]
+internal static class AutoSaveCountPatches
+{
+    private const int DefaultAutoSaveCount = 3;
+
+    private static int AutoSaveCount
+    {
+        get
+        {
+            int count = ModConfigProvider.ModOptions.AutoSaveCount;
+            // A value below 1 is meaningless (an autosave slot must have an index)
+            return count < 1 ? DefaultAutoSaveCount : count;
+        }
+    }
+
+    private static bool IsConfiguredCount() => AutoSaveCount != DefaultAutoSaveCount;
+
+    [HarmonyPrefix]
+    [HarmonyPatch(nameof(MBSaveLoad.IncrementAutoSaveIndex))]
+    private static bool IncrementAutoSaveIndexPrefix()
+    {
+        if (!IsConfiguredCount()) return true;
+
+        MBSaveLoad.AutoSaveIndex = NextAutoSaveIndex(MBSaveLoad.AutoSaveIndex, AutoSaveCount);
+        return false;
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(nameof(MBSaveLoad.InitializeAutoSaveIndex))]
+    private static bool InitializeAutoSaveIndexPrefix(string saveName)
+    {
+        if (!IsConfiguredCount()) return true;
+
+        string text = string.Empty;
+        if (saveName.StartsWith(MBSaveLoad.AutoSaveNamePrefix))
+        {
+            text = saveName;
+        }
+        else
+        {
+            string[] saveFileNames = MBSaveLoad.GetSaveFileNames();
+            foreach (string fileName in saveFileNames)
+            {
+                if (fileName.StartsWith(MBSaveLoad.AutoSaveNamePrefix))
+                {
+                    text = fileName;
+                    break;
+                }
+            }
+        }
+
+        MBSaveLoad.AutoSaveIndex =
+            TryParseAutoSaveSlot(text, MBSaveLoad.AutoSaveNamePrefix, AutoSaveCount, out int index)
+                ? index
+                : 1;
+        return false;
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(nameof(MBSaveLoad.IsSaveFileNameReserved))]
+    private static bool IsSaveFileNameReservedPrefix(string name, ref bool __result)
+    {
+        if (!IsConfiguredCount()) return true;
+
+        __result = IsAutoSaveNameReserved(name, MBSaveLoad.AutoSaveNamePrefix, AutoSaveCount);
+        return false;
+    }
+
+    internal static int NextAutoSaveIndex(int current, int count)
+    {
+        int next = current + 1;
+        return next > count ? 1 : next;
+    }
+
+    internal static bool IsAutoSaveNameReserved(string name, string prefix, int count)
+    {
+        for (int i = 1; i <= count; i++)
+        {
+            if (name == prefix + i)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    internal static bool TryParseAutoSaveSlot(string name, string prefix, int count, out int index)
+    {
+        index = 0;
+        if (string.IsNullOrEmpty(name) || !name.StartsWith(prefix)) return false;
+
+        return int.TryParse(name.Substring(prefix.Length), out index) && index > 0 && index <= count;
+    }
+}


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The number of autosaves is hardcoded to 3 in `TaleWorlds.Core.MBSaveLoad`.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #3081
<!-- Describe functionality added. Add images or videos to show how it works if applies -->

The autosave slot count is now configurable via `modOptions.autoSaveCount` in mod-config.json (default 3). A new `AutoSaveCountPatches` overrides `MBSaveLoad`'s logic to use the configured count.

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->

- Autosave count is now configurable via `autoSaveCount` in mod-config.json (default 3).

## Other information

-