### PR TITLE
Restore map event trackers after loading saves

### DIFF
--- a/source/E2E.Tests/Services/MapEvents/MapEventLoadCleanerTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/MapEventLoadCleanerTests.cs
@@ -82,6 +82,83 @@ public class MapEventLoadCleanerTests : MapEventTestBase
     }
 
     [Fact]
+    public void FinalizePlayerMapEvents_CrossLinkedParticipantSide_RepairsAndCompletes()
+    {
+        var mapEventContext = CreateServerMapEvent(commit: false);
+        var heroId = TestEnvironment.CreateRegisteredObject<Hero>();
+        RegisterAsPlayerParty("offline-player-cross-linked-side", heroId, mapEventContext.AttackerPartyId);
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<MapEvent>(mapEventContext.MapEventId, out var mapEvent));
+            Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(mapEventContext.DefenderPartyId, out var defender));
+            Assert.Contains(mapEvent.DefenderSide.Parties, party => ReferenceEquals(party.Party, defender.Party));
+
+            defender.Party._mapEventSide = mapEvent.AttackerSide;
+
+            Server.Resolve<IMessageBroker>().Publish(this, new SavedPlayerRegistrationsRestored());
+            Server.Resolve<IMapEventLoadCleaner>().FinalizePlayerMapEvents();
+
+            Assert.Equal(MapEventState.WaitingRemoval, mapEvent.State);
+            Assert.Empty(mapEvent.AttackerSide.Parties);
+            Assert.Empty(mapEvent.DefenderSide.Parties);
+            Assert.Null(defender.Party.MapEventSide);
+        }, MapEventDisabledMethods);
+    }
+
+    [Fact]
+    public void FinalizePlayerMapEvents_DuplicateParticipantEntry_PrunesAndCompletes()
+    {
+        var mapEventContext = CreateServerMapEvent(commit: false);
+        var heroId = TestEnvironment.CreateRegisteredObject<Hero>();
+        RegisterAsPlayerParty("offline-player-duplicate-entry", heroId, mapEventContext.AttackerPartyId);
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<MapEvent>(mapEventContext.MapEventId, out var mapEvent));
+            Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(mapEventContext.DefenderPartyId, out var defender));
+
+            mapEvent.DefenderSide._battleParties.Add(new MapEventParty(defender.Party));
+            Assert.Equal(2, mapEvent.DefenderSide.Parties.Count(party => ReferenceEquals(party.Party, defender.Party)));
+
+            Server.Resolve<IMessageBroker>().Publish(this, new SavedPlayerRegistrationsRestored());
+            Server.Resolve<IMapEventLoadCleaner>().FinalizePlayerMapEvents();
+
+            Assert.Equal(MapEventState.WaitingRemoval, mapEvent.State);
+            Assert.Empty(mapEvent.AttackerSide.Parties);
+            Assert.Empty(mapEvent.DefenderSide.Parties);
+            Assert.Null(defender.Party.MapEventSide);
+        }, MapEventDisabledMethods);
+    }
+
+    [Fact]
+    public void FinalizePlayerMapEvents_PartyInAnotherEvent_PreservesAuthoritativeMembership()
+    {
+        var loadedEventContext = CreateServerMapEvent(commit: false);
+        var activeEventContext = CreateServerMapEvent(commit: false);
+        var heroId = TestEnvironment.CreateRegisteredObject<Hero>();
+        RegisterAsPlayerParty("offline-player-foreign-event", heroId, loadedEventContext.AttackerPartyId);
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<MapEvent>(loadedEventContext.MapEventId, out var loadedEvent));
+            Assert.True(Server.ObjectManager.TryGetObject<MapEvent>(activeEventContext.MapEventId, out var activeEvent));
+            Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(loadedEventContext.DefenderPartyId, out var defender));
+
+            activeEvent.AttackerSide._battleParties.Add(new MapEventParty(defender.Party));
+            defender.Party._mapEventSide = activeEvent.AttackerSide;
+
+            Server.Resolve<IMessageBroker>().Publish(this, new SavedPlayerRegistrationsRestored());
+            Server.Resolve<IMapEventLoadCleaner>().FinalizePlayerMapEvents();
+
+            Assert.Equal(MapEventState.WaitingRemoval, loadedEvent.State);
+            Assert.DoesNotContain(loadedEvent.InvolvedParties, party => ReferenceEquals(party, defender.Party));
+            Assert.Same(activeEvent.AttackerSide, defender.Party.MapEventSide);
+            Assert.Contains(activeEvent.AttackerSide.Parties, party => ReferenceEquals(party.Party, defender.Party));
+        }, MapEventDisabledMethods);
+    }
+
+    [Fact]
     public void FinalizePlayerMapEvents_UnregisteredPlayerPartyInCampaignObjectManager_FinalizesEvent()
     {
         var mapEventContext = CreateServerMapEvent(commit: false);

--- a/source/E2E.Tests/Services/MapEvents/MapEventLoadCleanerTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/MapEventLoadCleanerTests.cs
@@ -54,6 +54,34 @@ public class MapEventLoadCleanerTests : MapEventTestBase
     }
 
     [Fact]
+    public void FinalizePlayerMapEvents_StaleParticipantSideLink_RepairsAndCompletes()
+    {
+        var mapEventContext = CreateServerMapEvent(commit: false);
+        var heroId = TestEnvironment.CreateRegisteredObject<Hero>();
+        RegisterAsPlayerParty("offline-player-stale-side", heroId, mapEventContext.AttackerPartyId);
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<MapEvent>(mapEventContext.MapEventId, out var mapEvent));
+            Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(mapEventContext.DefenderPartyId, out var defender));
+            Assert.Contains(mapEvent.DefenderSide.Parties, party => ReferenceEquals(party.Party, defender.Party));
+
+            // Reproduce a malformed loaded graph: the side still owns its MapEventParty, but the
+            // PartyBase backing link is gone. Vanilla HandleMapEventEnd otherwise loops forever
+            // because assigning null to an already-null link never removes the side-list entry.
+            defender.Party._mapEventSide = null;
+
+            Server.Resolve<IMessageBroker>().Publish(this, new SavedPlayerRegistrationsRestored());
+            Server.Resolve<IMapEventLoadCleaner>().FinalizePlayerMapEvents();
+
+            Assert.Equal(MapEventState.WaitingRemoval, mapEvent.State);
+            Assert.Empty(mapEvent.AttackerSide.Parties);
+            Assert.Empty(mapEvent.DefenderSide.Parties);
+            Assert.Null(defender.Party.MapEventSide);
+        }, MapEventDisabledMethods);
+    }
+
+    [Fact]
     public void FinalizePlayerMapEvents_UnregisteredPlayerPartyInCampaignObjectManager_FinalizesEvent()
     {
         var mapEventContext = CreateServerMapEvent(commit: false);

--- a/source/E2E.Tests/Services/MapEvents/MapEventRobustnessPatchesTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/MapEventRobustnessPatchesTests.cs
@@ -1,0 +1,80 @@
+﻿using Common.Util;
+using E2E.Tests.Environment.Instance;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.MapEvents;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace E2E.Tests.Services.MapEvents;
+
+/// <summary>
+/// Regression coverage for MapEvent tracker recovery after a save restores a null tracker.
+/// </summary>
+public class MapEventRobustnessPatchesTests : MapEventTestBase
+{
+    public MapEventRobustnessPatchesTests(ITestOutputHelper output) : base(output) { }
+
+    [Fact]
+    public void Server_TroopUpgradeTrackerRecovery_RehydratesEveryClient()
+    {
+        var context = CreateServerMapEvent();
+        string? trackerId = null;
+
+        Server.Call(() =>
+        {
+            var mapEvent = GetMapEvent(Server, context.MapEventId);
+
+            // Emulate the server-only null left by save deserialization without broadcasting null to clients.
+            using (new AllowedThread()) mapEvent.TroopUpgradeTracker = null;
+
+            var restored = mapEvent.TroopUpgradeTracker;
+            Assert.NotNull(restored);
+            Assert.True(Server.ObjectManager.TryGetId(restored, out trackerId));
+            AssertTrackerMatchesSides(mapEvent, restored);
+        }, MapEventDisabledMethods);
+
+        Assert.NotNull(trackerId);
+        foreach (var client in Clients)
+        {
+            client.Call(() =>
+            {
+                var mapEvent = GetMapEvent(client, context.MapEventId);
+                Assert.True(client.ObjectManager.TryGetObject<TroopUpgradeTracker>(trackerId, out var restored));
+                Assert.Same(restored, mapEvent.TroopUpgradeTracker);
+                AssertTrackerMatchesSides(mapEvent, restored);
+            });
+        }
+    }
+
+    [Fact]
+    public void Client_NullTroopUpgradeTracker_WaitsForAuthoritativeReplacement()
+    {
+        var context = CreateServerMapEvent();
+        var client = Clients.First();
+
+        client.Call(() =>
+        {
+            var mapEvent = GetMapEvent(client, context.MapEventId);
+
+            using (new AllowedThread()) mapEvent.TroopUpgradeTracker = null;
+
+            Assert.Null(mapEvent.TroopUpgradeTracker);
+        });
+    }
+
+    private static MapEvent GetMapEvent(EnvironmentInstance instance, string mapEventId)
+    {
+        Assert.True(instance.ObjectManager.TryGetObject<MapEvent>(mapEventId, out var mapEvent));
+        return mapEvent;
+    }
+
+    private static void AssertTrackerMatchesSides(MapEvent mapEvent, TroopUpgradeTracker tracker)
+    {
+        var involvedParties = mapEvent._sides
+            .SelectMany(side => side.Parties)
+            .ToList();
+
+        Assert.Equal(involvedParties.Count, tracker._mapEventParties.Count);
+        Assert.All(involvedParties, party => Assert.Contains(party, tracker._mapEventParties));
+    }
+}

--- a/source/E2E.Tests/Services/MapEvents/MapEventRobustnessPatchesTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/MapEventRobustnessPatchesTests.cs
@@ -62,6 +62,24 @@ public class MapEventRobustnessPatchesTests : MapEventTestBase
         });
     }
 
+    [Fact]
+    public void Server_FinalizedMapEventTrackerRecovery_DoesNotRehydrateDiscardedParties()
+    {
+        var context = CreateServerMapEvent();
+
+        Server.Call(() =>
+        {
+            var mapEvent = GetMapEvent(Server, context.MapEventId);
+            mapEvent.State = MapEventState.WaitingRemoval;
+            using (new AllowedThread()) mapEvent.TroopUpgradeTracker = null;
+
+            var restored = mapEvent.TroopUpgradeTracker;
+
+            Assert.NotNull(restored);
+            Assert.Empty(restored._mapEventParties);
+        }, MapEventDisabledMethods);
+    }
+
     private static MapEvent GetMapEvent(EnvironmentInstance instance, string mapEventId)
     {
         Assert.True(instance.ObjectManager.TryGetObject<MapEvent>(mapEventId, out var mapEvent));

--- a/source/GameInterface/Services/MapEvents/MapEventLoadCleaner.cs
+++ b/source/GameInterface/Services/MapEvents/MapEventLoadCleaner.cs
@@ -8,6 +8,7 @@ using GameInterface.Services.Players;
 using Helpers;
 using Serilog;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Actions;
@@ -105,32 +106,92 @@ internal sealed class MapEventLoadCleaner : IMapEventLoadCleaner
     private void RepairPartySideLinks(MapEvent mapEvent)
     {
         var repairedLinks = 0;
+        var removedEntries = 0;
+        var sides = (mapEvent._sides ?? Array.Empty<MapEventSide>())
+            .Where(side => side != null)
+            .ToArray();
+        var memberships = new Dictionary<PartyBase, List<MapEventSide>>();
 
-        foreach (var side in mapEvent._sides ?? Array.Empty<MapEventSide>())
+        foreach (var side in sides)
         {
-            if (side?.Parties == null)
-                continue;
-
             foreach (var mapEventParty in side.Parties)
             {
                 var party = mapEventParty?.Party;
-                if (party == null || party.MapEventSide != null)
+                if (party == null)
                     continue;
 
-                // HandleMapEventEnd loops until side.Parties is empty and relies on the PartyBase
-                // setter to remove the current entry. A null backing link makes that setter a no-op,
-                // leaving the vanilla loop permanently stuck. Do not rewrite a non-null link because
-                // it may authoritatively belong to another event.
-                party._mapEventSide = side;
-                repairedLinks++;
+                if (!memberships.TryGetValue(party, out var partySides))
+                {
+                    partySides = new List<MapEventSide>();
+                    memberships.Add(party, partySides);
+                }
+
+                if (!partySides.Contains(side))
+                    partySides.Add(side);
             }
         }
 
-        if (repairedLinks > 0)
+        var canonicalSides = new Dictionary<PartyBase, MapEventSide>();
+        foreach (var membership in memberships)
+        {
+            var party = membership.Key;
+            var linkedSide = party.MapEventSide;
+
+            if (linkedSide != null && membership.Value.Contains(linkedSide))
+            {
+                canonicalSides.Add(party, linkedSide);
+                continue;
+            }
+
+            // A link to another live map event is authoritative. Drop this loaded event's stale
+            // membership instead of moving the party out of its current event.
+            if (linkedSide != null && !sides.Contains(linkedSide))
+                continue;
+
+            canonicalSides.Add(party, membership.Value[0]);
+        }
+
+        var retainedParties = new HashSet<PartyBase>();
+        foreach (var side in sides)
+        {
+            for (var i = side._battleParties.Count - 1; i >= 0; i--)
+            {
+                var party = side._battleParties[i]?.Party;
+                if (party != null &&
+                    canonicalSides.TryGetValue(party, out var canonicalSide) &&
+                    ReferenceEquals(canonicalSide, side) &&
+                    retainedParties.Add(party))
+                {
+                    continue;
+                }
+
+                side._battleParties.RemoveAt(i);
+                removedEntries++;
+            }
+
+            if (side._battleParties.Count > 0 &&
+                !side._battleParties.Any(entry => ReferenceEquals(entry?.Party, side.LeaderParty)))
+            {
+                side.LeaderParty = side._battleParties[0].Party;
+                side._mapFaction = side.LeaderParty.MapFaction;
+            }
+        }
+
+        foreach (var membership in canonicalSides)
+        {
+            if (ReferenceEquals(membership.Key.MapEventSide, membership.Value))
+                continue;
+
+            membership.Key._mapEventSide = membership.Value;
+            repairedLinks++;
+        }
+
+        if (repairedLinks > 0 || removedEntries > 0)
         {
             logger.Warning(
-                "Repaired {RepairedLinkCount} missing party-side links in loaded player map event {MapEventId} before finalization",
+                "Repaired {RepairedLinkCount} party-side links and removed {RemovedEntryCount} stale or duplicate participants from loaded player map event {MapEventId} before finalization",
                 repairedLinks,
+                removedEntries,
                 mapEvent.StringId);
         }
     }

--- a/source/GameInterface/Services/MapEvents/MapEventLoadCleaner.cs
+++ b/source/GameInterface/Services/MapEvents/MapEventLoadCleaner.cs
@@ -7,6 +7,7 @@ using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
 using Helpers;
 using Serilog;
+using System;
 using System.Linq;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Actions;
@@ -52,6 +53,8 @@ internal sealed class MapEventLoadCleaner : IMapEventLoadCleaner
 
         foreach (var mapEvent in loadedPlayerMapEvents)
         {
+            RepairPartySideLinks(mapEvent);
+
             var involvedMobileParties = mapEvent.InvolvedParties
                 .Where(party => party.IsMobile && party.MobileParty.IsActive)
                 .Select(party => party.MobileParty)
@@ -96,6 +99,39 @@ internal sealed class MapEventLoadCleaner : IMapEventLoadCleaner
 
                 mobileParty.ResetNavigationToHold();
             }
+        }
+    }
+
+    private void RepairPartySideLinks(MapEvent mapEvent)
+    {
+        var repairedLinks = 0;
+
+        foreach (var side in mapEvent._sides ?? Array.Empty<MapEventSide>())
+        {
+            if (side?.Parties == null)
+                continue;
+
+            foreach (var mapEventParty in side.Parties)
+            {
+                var party = mapEventParty?.Party;
+                if (party == null || party.MapEventSide != null)
+                    continue;
+
+                // HandleMapEventEnd loops until side.Parties is empty and relies on the PartyBase
+                // setter to remove the current entry. A null backing link makes that setter a no-op,
+                // leaving the vanilla loop permanently stuck. Do not rewrite a non-null link because
+                // it may authoritatively belong to another event.
+                party._mapEventSide = side;
+                repairedLinks++;
+            }
+        }
+
+        if (repairedLinks > 0)
+        {
+            logger.Warning(
+                "Repaired {RepairedLinkCount} missing party-side links in loaded player map event {MapEventId} before finalization",
+                repairedLinks,
+                mapEvent.StringId);
         }
     }
 

--- a/source/GameInterface/Services/MapEvents/Patches/MapEventRobustnessPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/MapEventRobustnessPatches.cs
@@ -45,8 +45,14 @@ internal class MapEventRobustnessPatches
             try
             {
                 __result = new TroopUpgradeTracker();
-                PopulateTrackerFromMapEvent(__instance, __result);
+                if (!__instance.IsFinalized)
+                    PopulateTrackerFromMapEvent(__instance, __result);
                 __instance.TroopUpgradeTracker = __result;
+                Logger.Information(
+                    "Restored {Property} for MapEvent {MapEventId} with {PartyCount} tracked parties",
+                    nameof(MapEvent.TroopUpgradeTracker),
+                    __instance.StringId,
+                    __result._mapEventParties.Count);
             }
             finally
             {

--- a/source/GameInterface/Services/MapEvents/Patches/MapEventRobustnessPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/MapEventRobustnessPatches.cs
@@ -1,4 +1,6 @@
-﻿using Common.Logging;
+﻿using Common;
+using Common.Logging;
+using Common.Util;
 using HarmonyLib;
 using GameInterface.Services.MapEvents.Initialization;
 using SandBox.ViewModelCollection.Map;
@@ -22,6 +24,10 @@ internal class MapEventRobustnessPatches
     {
         if (__result is null)
         {
+            // A client must wait for the authoritative registered tracker rather than creating an
+            // unregistered local replacement while a replicated reference is still in flight.
+            if (ModInformation.IsClient) return;
+
             // The assignment below runs the generated AutoSync setter prefix, which reads this getter
             // to compare values. Let that nested read observe null instead of recursively restoring again.
             if (restoringTroopUpgradeTracker) return;
@@ -39,11 +45,47 @@ internal class MapEventRobustnessPatches
             try
             {
                 __result = new TroopUpgradeTracker();
+                PopulateTrackerFromMapEvent(__instance, __result);
                 __instance.TroopUpgradeTracker = __result;
             }
             finally
             {
                 restoringTroopUpgradeTracker = false;
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(MapEvent), nameof(MapEvent.TroopUpgradeTracker), MethodType.Setter)]
+    [HarmonyPostfix]
+    private static void PostfixTroopUpgradeTrackerSet(MapEvent __instance, TroopUpgradeTracker value)
+    {
+        // The initial graph commit repopulates the tracker in FinishClient. Only post-commit,
+        // network-applied replacement references need this local mirror of the server recovery.
+        if (!ModInformation.IsClient || !AllowedThread.IsThisThreadAllowed() || value is null ||
+            value._mapEventParties.Count != 0)
+        {
+            return;
+        }
+
+        if (ContainerProvider.TryResolve<IMapEventInitializationBarrier>(out var barrier) &&
+            barrier.IsPending(__instance))
+        {
+            return;
+        }
+
+        PopulateTrackerFromMapEvent(__instance, value);
+    }
+
+    private static void PopulateTrackerFromMapEvent(MapEvent mapEvent, TroopUpgradeTracker tracker)
+    {
+        if (mapEvent._sides is null) return;
+
+        foreach (var side in mapEvent._sides)
+        {
+            if (side?.Parties is null) continue;
+            foreach (var party in side.Parties)
+            {
+                if (party is not null) tracker.AddParty(party);
             }
         }
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

A campaign saved while an AI battle is underway can load with that battle stuck. The affected lords remain locked in the encounter and connected players can see a battle that no longer advances.

## What is the new behavior?

Loading a save with an in-progress battle now restores its battle state for the host and connected players, allowing the fight to continue and resolve normally instead of leaving parties stuck.

<img width="722" height="316" alt="image" src="https://github.com/user-attachments/assets/2460891a-45ab-4fae-86be-d9371c4efb34" />

## Bot Changelog Entry

- Fixed an issue where a corrupted AI party could brick a save and make it unloadable.
