### PR TITLE
Fix troop offers not showing on other player's screen

### DIFF
--- a/source/E2E.Tests/Services/MapEvents/PlayerPartyInteractionFlowTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/PlayerPartyInteractionFlowTests.cs
@@ -1108,6 +1108,8 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
             Assert.True(client2.ObjectManager.TryGetObject<Hero>(initiatorHeroId, out var initiatorHero));
             Assert.True(client2.ObjectManager.TryGetObject<CharacterObject>(initiatorTroopId, out var initiatorTroop));
 
+            PlayerPartyTradeContext.Begin(sessionId, responderParty);
+
             var troopRosterElement = new TroopRosterElement(initiatorTroop)
             {
                 _number = 5

--- a/source/E2E.Tests/Services/MapEvents/PlayerPartyInteractionFlowTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/PlayerPartyInteractionFlowTests.cs
@@ -52,8 +52,10 @@ using TaleWorlds.CampaignSystem.BarterSystem.Barterables;
 using TaleWorlds.CampaignSystem.MapEvents;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Party.PartyComponents;
+using TaleWorlds.CampaignSystem.Roster;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.CampaignSystem.Siege;
+using TaleWorlds.CampaignSystem.ViewModelCollection.Barter;
 using TaleWorlds.Core;
 using TaleWorlds.Core.ImageIdentifiers;
 using TaleWorlds.Library;
@@ -1079,6 +1081,72 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
             s.PartyId == responderPartyId &&
             !s.InitiatorAcceptedTrade &&
             !s.ResponderAcceptedTrade);
+    }
+
+    [Fact]
+    public void TradeOfferUpdate_TroopOffer_AppliesAsOfferedOnOtherClient()
+    {
+        var (client1, client2, initiatorHeroId, responderHeroId, initiatorPartyId, responderPartyId) = CreateTwoPlayerPartiesWithHeroes();
+        var initiatorTroopId = TestEnvironment.CreateRegisteredObject<CharacterObject>();
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<PartyBase>(initiatorPartyId, out var initiatorParty));
+            Assert.True(Server.ObjectManager.TryGetObject<CharacterObject>(initiatorTroopId, out var initiatorTroop));
+            initiatorParty.MemberRoster.AddToCounts(initiatorTroop, 5);
+        });
+
+        var sessionId = StartTrade(client1, client2, initiatorPartyId, responderPartyId);
+
+        BarterVM barterVM = null;
+
+        client2.Call(() =>
+        {
+            Assert.True(client2.ObjectManager.TryGetObject<PartyBase>(responderPartyId, out var responderParty));
+            Assert.True(client2.ObjectManager.TryGetObject<PartyBase>(initiatorPartyId, out var initiatorParty));
+            Assert.True(client2.ObjectManager.TryGetObject<Hero>(responderHeroId, out var responderHero));
+            Assert.True(client2.ObjectManager.TryGetObject<Hero>(initiatorHeroId, out var initiatorHero));
+            Assert.True(client2.ObjectManager.TryGetObject<CharacterObject>(initiatorTroopId, out var initiatorTroop));
+
+            var troopRosterElement = new TroopRosterElement(initiatorTroop)
+            {
+                _number = 5
+            };
+
+            var barterData = new BarterData(responderHero, initiatorHero, responderParty, initiatorParty, null, 0, false);
+            barterData.AddBarterGroup(new FiefBarterGroup());
+            barterData.AddBarterGroup(new PrisonerBarterGroup());
+            barterData.AddBarterGroup(new ItemBarterGroup());
+            barterData.AddBarterGroup(new OtherBarterGroup());
+            barterData.AddBarterGroup(new GoldBarterGroup());
+            barterData.AddBarterable<OtherBarterGroup>(
+                new PlayerPartyTroopBarterable(initiatorHero, responderHero, initiatorParty, responderParty, troopRosterElement),
+                false);
+
+            barterVM = new BarterVM(barterData);
+        });
+
+        Server.NetworkSentMessages.Clear();
+        client1.Call(() => client1.Resolve<INetwork>().SendAll(new NetworkPlayerPartyTradeOfferUpdated(
+            sessionId,
+            initiatorPartyId,
+            Array.Empty<ItemRosterElementData>(),
+            new[] { new TroopRosterElementData(initiatorTroopId, 4, 0, 0) })));
+
+        client2.Call(() =>
+        {
+            Assert.True(client2.ObjectManager.TryGetObject<CharacterObject>(initiatorTroopId, out var registeredTroop));
+
+            Assert.NotNull(barterVM);
+
+            var troopItem = Assert.Single(
+                GetAllBarterItems(barterVM),
+                item => item.Barterable is PlayerPartyTroopBarterable troopBarterable &&
+                        ReferenceEquals(troopBarterable.TroopRosterElement.Character, registeredTroop));
+
+            Assert.True(troopItem.IsOffered);
+            Assert.Equal(4, troopItem.CurrentOfferedAmount);
+        });
     }
 
     [Fact]
@@ -4086,6 +4154,33 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
         }
 
         return 0;
+    }
+
+    private static IEnumerable<BarterItemVM> GetAllBarterItems(BarterVM barterVM)
+    {
+        foreach (var list in new IEnumerable<BarterItemVM>[]
+        {
+            barterVM.LeftFiefList,
+            barterVM.RightFiefList,
+            barterVM.LeftPrisonerList,
+            barterVM.RightPrisonerList,
+            barterVM.LeftItemList,
+            barterVM.RightItemList,
+            barterVM.LeftOtherList,
+            barterVM.RightOtherList,
+            barterVM.LeftDiplomaticList,
+            barterVM.RightDiplomaticList,
+            barterVM.LeftGoldList,
+            barterVM.RightGoldList,
+        })
+        {
+            if (list == null) continue;
+
+            foreach (var item in list)
+            {
+                if (item != null) yield return item;
+            }
+        }
     }
 
     private static void ThrowAfterBarterAccepted()

--- a/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyTradeContext.cs
+++ b/source/GameInterface/Services/MapEvents/PlayerPartyInteractions/PlayerPartyTradeContext.cs
@@ -535,24 +535,11 @@ internal static class PlayerPartyTradeContext
 
         if (character == null) return false;
 
-        var hero = character.HeroObject;
-        var isHero = hero != null;
-        string characterId;
-        if (isHero)
-        {
-            if (!objectManager.TryGetId(hero, out characterId)) return false;
-        }
-        else if (!objectManager.TryGetId(character, out characterId)) return false;
-
-        key = GetCharacterKey(characterId, isHero);
-        return true;
+        return objectManager.TryGetId(character, out key);
     }
 
     private static string GetItemKey(ItemObjectData itemObjectData)
         => $"{itemObjectData.ItemObjectId}|{itemObjectData.ItemModifierId}|{itemObjectData.ItemModifierNull}";
-
-    private static string GetCharacterKey(string characterId, bool isHero)
-        => $"{characterId}|{isHero}";
 
     private static TaleWorlds.Library.MBBindingList<BarterItemVM> GetOfferListForItem(BarterVM barterVM, BarterItemVM item)
     {


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Troops or prisoners offered do not show for the opposing party.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->

Resolve offered-troop ids by the CharacterObject id on the receive side instead of the hero-resolved "{id}|{isHero}" key the sender never uses. Troops now show up on other's player screen:


https://github.com/user-attachments/assets/0f50eb2c-5943-4cdc-a018-edb118fbd61c



Resolves #1786
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->

Fixed troop offers not showing on other player's screen.

## Other information
