### PR TITLE
Allow attacking other players' parties/caravans

### DIFF
--- a/source/GameInterface/Services/Heroes/Patches/HeroHelperPatches.cs
+++ b/source/GameInterface/Services/Heroes/Patches/HeroHelperPatches.cs
@@ -21,7 +21,7 @@ internal class HeroHelperPatches
         __result = hero != null && 
             ((hero.MapFaction != null && hero.MapFaction.Leader == Hero.MainHero) 
             || (hero.IsNotable && hero.HomeSettlement.OwnerClan == Clan.PlayerClan) 
-            || hero.CompanionOf != null && hero.CompanionOf == Clan.PlayerClan);
+            || (hero.CompanionOf != null && hero.CompanionOf == Clan.PlayerClan));
 
         return false;
     }

--- a/source/GameInterface/Services/Heroes/Patches/HeroHelperPatches.cs
+++ b/source/GameInterface/Services/Heroes/Patches/HeroHelperPatches.cs
@@ -1,0 +1,28 @@
+﻿using Common;
+using HarmonyLib;
+using Helpers;
+using TaleWorlds.CampaignSystem;
+
+namespace GameInterface.Services.Heroes.Patches;
+
+[HarmonyPatch(typeof(HeroHelper))]
+internal class HeroHelperPatches
+{
+    /// <summary>
+    /// Replace check to compare clans rather than just using IsPlayerCompanion
+    /// </summary>
+    [HarmonyPatch(nameof(HeroHelper.UnderPlayerCommand))]
+    [HarmonyPrefix]
+    public static bool UnderPlayerCommandPrefix(ref bool __result, Hero hero)
+    {
+        // Server doesn't have a hero and can't have another hero under command
+        if (ModInformation.IsServer) return false;
+
+        __result = hero != null && 
+            ((hero.MapFaction != null && hero.MapFaction.Leader == Hero.MainHero) 
+            || (hero.IsNotable && hero.HomeSettlement.OwnerClan == Clan.PlayerClan) 
+            || hero.CompanionOf != null && hero.CompanionOf == Clan.PlayerClan);
+
+        return false;
+    }
+}

--- a/source/GameInterface/Services/Heroes/Patches/LordConversationsWandererPatches.cs
+++ b/source/GameInterface/Services/Heroes/Patches/LordConversationsWandererPatches.cs
@@ -1,0 +1,64 @@
+﻿using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.CampaignBehaviors;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Settlements;
+
+namespace GameInterface.Services.Heroes.Patches;
+
+[HarmonyPatch(typeof(LordConversationsCampaignBehavior))]
+internal class LordConversationsWandererPatches
+{
+    /// <summary>
+    /// Override result to check if in the same clan rather than just checking if a player companion
+    /// </summary>
+    [HarmonyPatch(nameof(LordConversationsCampaignBehavior.conversation_wanderer_player_owned_on_condition))]
+    [HarmonyPrefix]
+    public static bool ConversationWandererPlayerOwnedOnConditionPrefix(ref bool __result)
+    {
+        __result = CharacterObject.OneToOneConversationCharacter != null
+            && CharacterObject.OneToOneConversationCharacter.IsHero
+            && Hero.OneToOneConversationHero.CompanionOf != null
+            && Hero.OneToOneConversationHero.Clan == Clan.PlayerClan;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Don't load wanderer dialogue for companions of a different clan, instead treat the dialogue as a lord dialogue.
+    /// All companion dialogue in vanilla assumes they are a companion of the player in the conversation.
+    /// </summary>
+    [HarmonyPatch(nameof(LordConversationsCampaignBehavior.conversation_wanderer_on_condition))]
+    [HarmonyPrefix]
+    public static bool ConversationWandererOnConditionPrefix(ref bool __result)
+    {
+        __result = CharacterObject.OneToOneConversationCharacter != null
+            && CharacterObject.OneToOneConversationCharacter.IsHero
+            && CharacterObject.OneToOneConversationCharacter.Occupation == Occupation.Wanderer
+            && CharacterObject.OneToOneConversationCharacter.HeroObject.HeroState != Hero.CharacterStates.Prisoner
+            && Hero.OneToOneConversationHero.CompanionOf != null
+            && Hero.OneToOneConversationHero.Clan == Clan.PlayerClan;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Override result for companions of a different clan to the player
+    /// This allows players to attack wanderers parties (caravan & lord parties) of other player clans
+    /// </summary>
+    [HarmonyPatch(nameof(LordConversationsCampaignBehavior.conversation_lord_is_threated_neutral_on_condition))]
+    [HarmonyPrefix]
+    public static bool ConversationLordIsTreatedNeutralOnConditionPrefix(ref bool __result)
+    {
+        __result = CharacterObject.OneToOneConversationCharacter.IsHero
+            && !CharacterObject.OneToOneConversationCharacter.HeroObject.IsPrisoner
+            && Campaign.Current.CurrentConversationContext == ConversationContext.PartyEncounter
+            && Settlement.CurrentSettlement == null
+            && CharacterObject.OneToOneConversationCharacter.HeroObject.CompanionOf != null
+            && CharacterObject.OneToOneConversationCharacter.HeroObject.CompanionOf != Clan.PlayerClan
+            && FactionManager.IsNeutralWithFaction(Hero.OneToOneConversationHero.MapFaction, Hero.MainHero.MapFaction)
+            && !MobileParty.MainParty.IsInRaftState;
+
+        return false;
+    }
+}

--- a/source/GameInterface/Services/Heroes/Patches/LordConversationsWandererPatches.cs
+++ b/source/GameInterface/Services/Heroes/Patches/LordConversationsWandererPatches.cs
@@ -36,8 +36,8 @@ internal class LordConversationsWandererPatches
             && CharacterObject.OneToOneConversationCharacter.IsHero
             && CharacterObject.OneToOneConversationCharacter.Occupation == Occupation.Wanderer
             && CharacterObject.OneToOneConversationCharacter.HeroObject.HeroState != Hero.CharacterStates.Prisoner
-            && Hero.OneToOneConversationHero.CompanionOf != null
-            && Hero.OneToOneConversationHero.Clan == Clan.PlayerClan;
+            && (Hero.OneToOneConversationHero.CompanionOf == null
+            || Hero.OneToOneConversationHero.CompanionOf == Clan.PlayerClan);
 
         return false;
     }

--- a/source/GameInterface/Services/Heroes/Patches/LordConversationsWandererPatches.cs
+++ b/source/GameInterface/Services/Heroes/Patches/LordConversationsWandererPatches.cs
@@ -54,7 +54,6 @@ internal class LordConversationsWandererPatches
             && !CharacterObject.OneToOneConversationCharacter.HeroObject.IsPrisoner
             && Campaign.Current.CurrentConversationContext == ConversationContext.PartyEncounter
             && Settlement.CurrentSettlement == null
-            && CharacterObject.OneToOneConversationCharacter.HeroObject.CompanionOf != null
             && CharacterObject.OneToOneConversationCharacter.HeroObject.CompanionOf != Clan.PlayerClan
             && FactionManager.IsNeutralWithFaction(Hero.OneToOneConversationHero.MapFaction, Hero.MainHero.MapFaction)
             && !MobileParty.MainParty.IsInRaftState;


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Dialogue checks for companions not under the the conversing player's command process incorrectly, leading to dialogue like "What are orders for your alley". This is because vanilla uses `IsPlayerCompanion` (which is true for all recruited wanderers regardless of player clan) for some checks and validates the player clan against the wanderer's clan for others.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #3134 
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Patch conversation conditions to load already recruited wanderer conversations as lord conversations if the companion is not of the the same clan as the player. This both makes the meeting dialogue for other player's companions make more sense and unlocks the dialogue option to "deliver your demands".

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Players can now attack each other's caravans and parties led by companions.