### PR TITLE
Allow stuck family members to be freed

### DIFF
--- a/source/GameInterface/Services/Companions/Patches/Disable/DisableCompanionsCampaignBehavior.cs
+++ b/source/GameInterface/Services/Companions/Patches/Disable/DisableCompanionsCampaignBehavior.cs
@@ -145,7 +145,7 @@ internal class CompanionsCampaignBehaviorPatches
     }
 
     /// <summary>
-    /// Add a check to allow stuck companions to become fugitive if they didn't properly get released.
+    /// Add a check to allow stuck heroes to become fugitive if they didn't properly get released.
     /// This is primarily for older saves where some players would have companions stuck as prisoners.
     /// </summary>
     [HarmonyPatch(nameof(CompanionsCampaignBehavior.DailyTick))]
@@ -154,7 +154,7 @@ internal class CompanionsCampaignBehaviorPatches
     {
         foreach (Hero hero in Hero.AllAliveHeroes)
         {
-            if (hero.IsWanderer && hero.CompanionOf != null && hero.IsPrisoner && hero.PartyBelongedToAsPrisoner == null)
+            if (hero.IsPrisoner && hero.PartyBelongedToAsPrisoner == null)
             {
                 MakeHeroFugitiveAction.Apply(hero, true);
                 break;


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #3160
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Not a root cause fix but should be sufficient enough to free stuck heroes on existing and new saves in a time frame that isn't noticable. This just uses the existing fix for stuck companions.

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Fixed family members permanently becoming stuck as prisoners.