### PR TITLE
Allow defenders to join active slow raids

### DIFF
--- a/source/E2E.Tests/Services/Villages/VillageHostileActionTests.cs
+++ b/source/E2E.Tests/Services/Villages/VillageHostileActionTests.cs
@@ -1995,20 +1995,32 @@ public class VillageHostileActionTests : MapEventTestBase
     }
 
     [Fact]
-    public void SlowRaidMapEvent_DefenderJoinRequest_IsRejected()
+    public void SlowRaidMapEvent_DefenderJoin_ContestsRaidBeforeMissionStart()
     {
         var client = Clients.First();
-        var (_, raiderMobilePartyId) = CreatePlayerHeroParty("PlayerOne");
-        var (_, joinerMobilePartyId) = CreatePlayerHeroParty("PlayerTwo");
+        var (raiderHeroId, raiderMobilePartyId) = CreatePlayerHeroParty("PlayerOne");
+        var (joinerHeroId, joinerMobilePartyId) = CreatePlayerHeroParty("PlayerTwo");
         TestEnvironment.ConnectRegisteredPlayer(client, "PlayerTwo");
         var target = CreateVillageTarget();
+        var raiderPartyId = GetPartyBaseId(raiderMobilePartyId);
         var joinerPartyId = GetPartyBaseId(joinerMobilePartyId);
         string? raidMapEventId = null;
 
         Server.Call(() =>
         {
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(raiderHeroId, out var raiderHero));
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(joinerHeroId, out var joinerHero));
             Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(raiderMobilePartyId, out var raiderParty));
+            Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(joinerMobilePartyId, out var joinerParty));
             Assert.True(Server.ObjectManager.TryGetObject<Settlement>(target.SettlementId, out var settlement));
+
+            using (new AllowedThread())
+            {
+                raiderParty.MemberRoster.AddToCounts(raiderHero.CharacterObject, 1);
+                joinerParty.MemberRoster.AddToCounts(joinerHero.CharacterObject, 1);
+                raiderHero.PartyBelongedTo = raiderParty;
+                joinerHero.PartyBelongedTo = joinerParty;
+            }
 
             var mapEvent = CreateHostileActionMapEvent(raiderParty.Party, settlement.Party, VillageHostileAction.Raid);
 
@@ -2018,28 +2030,145 @@ public class VillageHostileActionTests : MapEventTestBase
 
         Assert.NotNull(raidMapEventId);
 
-        client.Call(() => client.Resolve<INetwork>().SendAll(new NetworkRequestJoinBattle(
-            System.Guid.NewGuid().ToString(),
-            raidMapEventId!,
-            joinerPartyId,
-            BattleSideEnum.Defender)), MapEventDisabledMethods);
+        var disabledMethods = MapEventDisabledMethods
+            .Append(AccessTools.Method(typeof(GameMenu), nameof(GameMenu.ActivateGameMenu), new[] { typeof(string) }))
+            .Append(AccessTools.Method(typeof(GameMenu), nameof(GameMenu.SwitchToMenu), new[] { typeof(string) }))
+            .Append(AccessTools.Method(
+                typeof(E2E.Tests.Environment.TestNetworkRouter),
+                nameof(E2E.Tests.Environment.TestNetworkRouter.SendAll),
+                new[] { typeof(LiteNetLib.NetPeer), typeof(IMessage) }))
+            .ToList();
 
+        client.NetworkSentMessages.Clear();
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<MapEvent>(raidMapEventId!, out var mapEvent));
+            Assert.True(client.ObjectManager.TryGetObject<Hero>(joinerHeroId, out var joinerHero));
+            Assert.True(client.ObjectManager.TryGetObject<MobileParty>(joinerMobilePartyId, out var joinerParty));
+
+            using (new AllowedThread())
+            {
+                Campaign.Current.MainParty = joinerParty;
+                joinerHero.PartyBelongedTo = joinerParty;
+                Game.Current.PlayerTroop = joinerHero.CharacterObject;
+            }
+
+            var encounter = ObjectHelper.SkipConstructor<PlayerEncounter>();
+            encounter._mapEvent = mapEvent;
+            encounter._encounteredParty = mapEvent.AttackerSide.LeaderParty;
+            Campaign.Current.PlayerEncounter = encounter;
+
+            var (defenderShown, defenderArgs) = InvokeRaidJoinEncounterConditionPostfix(
+                "game_menu_join_encounter_help_defenders_on_condition");
+            Assert.True(defenderShown);
+            Assert.True(defenderArgs.IsEnabled);
+
+            var (attackerShown, attackerArgs) = InvokeRaidJoinEncounterConditionPostfix(
+                "game_menu_join_encounter_help_attackers_on_condition");
+            Assert.False(attackerShown);
+            Assert.False(attackerArgs.IsEnabled);
+
+            Assert.False(InvokeRaidJoinEncounterConsequencePrefix(
+                "game_menu_join_encounter_help_defenders_on_consequence"));
+            Assert.True(PlayerEncounter.Current.IsJoinedBattle);
+            Assert.Same(mapEvent, PlayerEncounter.Battle);
+            Assert.Null(joinerParty.MapEvent);
+            Assert.Null(joinerParty.Party.MapEventSide);
+        }, disabledMethods);
+
+        var request = client.NetworkSentMessages.GetMessages<NetworkRequestJoinBattle>().Single();
+        Assert.Equal(raidMapEventId, request.MapEventId);
+        Assert.Equal(joinerPartyId, request.PartyId);
+        Assert.Equal(BattleSideEnum.Defender, request.Side);
+
+        Server.NetworkSentMessages.Clear();
+        Server.SimulateMessage(client.NetPeer, new NetworkRequestJoinBattle(
+            Guid.NewGuid().ToString(),
+            raidMapEventId!,
+            raiderPartyId,
+            BattleSideEnum.Defender));
+
+        Assert.False(Server.NetworkSentMessages.GetMessages<NetworkJoinBattleReply>().Single().Accepted);
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkAddBattleParty>());
         Server.Call(() =>
         {
             Assert.True(Server.ObjectManager.TryGetObject<MapEvent>(raidMapEventId!, out var mapEvent));
-            Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(joinerMobilePartyId, out var joinerParty));
             Assert.True(mapEvent.IsActiveSlowVillageRaid());
-            Assert.Null(joinerParty.MapEvent);
         }, MapEventDisabledMethods);
 
-        foreach (var instance in Clients)
+        Server.Call(() => Assert.True(ServerBattleModeArbiter.TryClaimMission(raidMapEventId!)));
+        try
         {
-            instance.Call(() =>
+            Server.NetworkSentMessages.Clear();
+            Server.SimulateMessage(client.NetPeer, request);
+
+            Assert.True(Server.NetworkSentMessages.GetMessages<NetworkJoinBattleReply>().Single().Accepted);
+            var joinMessages = Server.NetworkSentMessages.Messages.ToList();
+            var addIndex = joinMessages.FindIndex(message => message is NetworkAddBattleParty);
+            var modeIndex = joinMessages.FindIndex(message => message is NetworkBattleModeSet);
+            Assert.True(addIndex >= 0);
+            Assert.True(modeIndex > addIndex);
+
+            Server.Call(() =>
             {
-                Assert.True(instance.ObjectManager.TryGetObject<MapEvent>(raidMapEventId!, out var _));
-                Assert.True(instance.ObjectManager.TryGetObject<MobileParty>(joinerMobilePartyId, out var joinerParty));
-                Assert.Null(joinerParty.MapEvent);
-            });
+                Assert.True(Server.ObjectManager.TryGetObject<MapEvent>(raidMapEventId!, out var mapEvent));
+                Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(joinerMobilePartyId, out var joinerParty));
+                Assert.Same(mapEvent.DefenderSide, joinerParty.Party.MapEventSide);
+                Assert.Single(mapEvent.DefenderSide.Parties, party => party.Party == joinerParty.Party);
+                Assert.False(mapEvent.IsActiveSlowVillageRaid());
+            }, MapEventDisabledMethods);
+
+            foreach (var instance in Clients)
+            {
+                instance.Call(() =>
+                {
+                    Assert.True(instance.ObjectManager.TryGetObject<MapEvent>(raidMapEventId!, out var mapEvent));
+                    Assert.True(instance.ObjectManager.TryGetObject<MobileParty>(joinerMobilePartyId, out var joinerParty));
+                    Assert.Same(mapEvent.DefenderSide, joinerParty.Party.MapEventSide);
+                    Assert.Single(mapEvent.DefenderSide.Parties, party => party.Party == joinerParty.Party);
+                    Assert.False(mapEvent.IsActiveSlowVillageRaid());
+                });
+            }
+
+            Server.NetworkSentMessages.Clear();
+            Server.SimulateMessage(client.NetPeer, request);
+
+            Assert.False(Server.NetworkSentMessages.GetMessages<NetworkJoinBattleReply>().Single().Accepted);
+            Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkAddBattleParty>());
+            Server.Call(() =>
+            {
+                Assert.True(Server.ObjectManager.TryGetObject<MapEvent>(raidMapEventId!, out var mapEvent));
+                Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(joinerMobilePartyId, out var joinerParty));
+                Assert.Single(mapEvent.DefenderSide.Parties, party => party.Party == joinerParty.Party);
+                Assert.False(mapEvent.IsActiveSlowVillageRaid());
+            }, MapEventDisabledMethods);
+
+            Server.NetworkSentMessages.Clear();
+            Server.SimulateMessage(client.NetPeer, new NetworkRequestJoinBattle(
+                Guid.NewGuid().ToString(),
+                "stale-map-event",
+                joinerPartyId,
+                BattleSideEnum.Defender));
+
+            Assert.False(Server.NetworkSentMessages.GetMessages<NetworkJoinBattleReply>().Single().Accepted);
+            Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkAddBattleParty>());
+
+            Server.NetworkSentMessages.Clear();
+            client.Call(() => client.Resolve<INetwork>().SendAll(new NetworkBattleStartRequest(
+                Guid.NewGuid().ToString(),
+                (int)BattleStartMode.Mission,
+                raidMapEventId!,
+                joinerMobilePartyId)), MapEventDisabledMethods);
+
+            Assert.True(Server.NetworkSentMessages.GetMessages<NetworkBattleStartReply>().Single().Accepted);
+            Assert.Equal(
+                raidMapEventId,
+                Server.NetworkSentMessages.GetMessages<NetworkStartAttackMission>().Single().MapEventId);
+        }
+        finally
+        {
+            Server.Call(() => ServerBattleModeArbiter.Release(raidMapEventId!));
+            client.Call(BattleModeRegistry.End);
         }
     }
 
@@ -2933,6 +3062,24 @@ public class VillageHostileActionTests : MapEventTestBase
         method.Invoke(behavior, new object[] { settlement });
     }
 
+    private static (bool result, MenuCallbackArgs args) InvokeRaidJoinEncounterConditionPostfix(string methodName)
+    {
+        var originalMethod = AccessTools.Method(typeof(EncounterGameMenuBehavior), methodName);
+        Assert.NotNull(originalMethod);
+
+        var patchType = AccessTools.TypeByName("GameInterface.Services.MapEvents.Patches.RaidJoinEncounterConditionPatch");
+        var postfix = AccessTools.Method(patchType, "Postfix");
+        Assert.NotNull(postfix);
+
+        var args = new MenuCallbackArgs((MenuContext)null, null)
+        {
+            IsEnabled = true,
+        };
+        var invocationArgs = new object[] { originalMethod, args, true };
+        postfix.Invoke(null, invocationArgs);
+        return ((bool)invocationArgs[2], args);
+    }
+
     private static bool InvokeRaidJoinEncounterConsequencePrefix(string methodName)
     {
         var originalMethod = AccessTools.Method(typeof(EncounterGameMenuBehavior), methodName);
@@ -2944,6 +3091,7 @@ public class VillageHostileActionTests : MapEventTestBase
 
         return (bool)prefix.Invoke(null, new object[] { originalMethod })!;
     }
+
     private static bool InvokeVillageHealRegisterEventsPrefix()
     {
         var patchType = AccessTools.TypeByName("GameInterface.Services.Villages.Patches.DisableVillageHealCampaignBehavior");

--- a/source/GameInterface/Services/MapEvents/Handlers/BattleJoinLeaveHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/BattleJoinLeaveHandler.cs
@@ -229,11 +229,6 @@ internal class BattleJoinLeaveHandler : IHandler
                         Logger.Warning("Ignoring join request: party {PartyId} is already in a map event", data.PartyId);
                         return;
                     }
-                    if (mapEvent.IsActiveSlowVillageRaid() && data.Side == BattleSideEnum.Defender)
-                    {
-                        Logger.Warning("Ignoring defender join request: map event {MapEventId} is an active slow village raid", data.MapEventId);
-                        return;
-                    }
                     var side = mapEvent.GetMapEventSide(data.Side);
                     if (side == null)
                     {

--- a/source/GameInterface/Services/MapEvents/Patches/RaidJoinEncounterPatch.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/RaidJoinEncounterPatch.cs
@@ -1,4 +1,4 @@
-using Common;
+﻿using Common;
 using GameInterface.Policies;
 using HarmonyLib;
 using System.Collections.Generic;
@@ -29,8 +29,11 @@ internal class RaidJoinEncounterConditionPatch
         if (!mapEvent.IsActiveSlowVillageRaid())
             return;
 
-        if (!RaidJoinEncounterPatch.TryGetJoinSide(__originalMethod, out _))
+        if (!RaidJoinEncounterPatch.TryGetJoinSide(__originalMethod, out var side) ||
+            side == BattleSideEnum.Defender)
+        {
             return;
+        }
 
         __result = false;
         args.IsEnabled = false;
@@ -58,14 +61,14 @@ internal class RaidJoinEncounterPatch
         if (!mapEvent.IsRaidHostileAction() || mainParty == null)
             return true;
 
-        if (mapEvent.IsActiveSlowVillageRaid())
+        if (!TryGetJoinSide(__originalMethod, out var side))
+            return true;
+
+        if (mapEvent.IsActiveSlowVillageRaid() && side == BattleSideEnum.Attacker)
         {
             GameMenu.SwitchToMenu("raid_occupied");
             return false;
         }
-
-        if (!TryGetJoinSide(__originalMethod, out var side))
-            return true;
 
         PlayerEncounter.JoinBattle(side);
         SwitchToJoinedEncounterMenu(mapEvent, side);


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

Active slow village raids disable both encounter join options and reject defender join requests, so a player cannot attack an army raiding their village.

## What is the new behavior?

Defenders can join the existing slow raid through the server-authoritative battle join path. The defender membership is replicated before the battle mode/start messages, and the raid becomes contested while attacker behavior stays unchanged.

This addresses the raiding-army part of #2792 only. It does not address the separate lord-capture report.

## How to test

`dotnet test source/E2E.Tests/E2E.Tests.csproj -c Release --filter "FullyQualifiedName~E2E.Tests.Services.Villages.VillageHostileActionTests"`

## Bot Changelog Entry

- Players can now defend villages against armies performing an active raid.
