### PR TITLE
Restore nearby AI parties joining player battles

### DIFF
--- a/source/GameInterface.Tests/Services/MapEvents/NearbyPartyReinforcerTests.cs
+++ b/source/GameInterface.Tests/Services/MapEvents/NearbyPartyReinforcerTests.cs
@@ -7,6 +7,7 @@ using GameInterface.Services.MapEvents.Handlers;
 using GameInterface.Services.MapEvents.Messages.Leave;
 using GameInterface.Services.MapEvents.Messages.Start;
 using GameInterface.Services.MapEvents.Patches;
+using GameInterface.Services.MapEventSides.Messages;
 using GameInterface.Services.Players;
 using GameInterface.Services.Players.Data;
 using GameInterface.Tests.Bootstrap;
@@ -41,6 +42,8 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
         typeof(MapEvent).GetField("_sides", BindingFlags.NonPublic | BindingFlags.Instance)!;
     private static readonly FieldInfo BattlePartiesField =
         typeof(MapEventSide).GetField("_battleParties", BindingFlags.NonPublic | BindingFlags.Instance)!;
+    private static readonly FieldInfo MapEventField =
+        typeof(MapEventSide).GetField("_mapEvent", BindingFlags.NonPublic | BindingFlags.Instance)!;
     private static readonly FieldInfo NearbyPartiesField =
         typeof(MapEventSide).GetField("_nearbyPartiesAddedToPlayerMapEvent", BindingFlags.NonPublic | BindingFlags.Instance)!;
 
@@ -307,6 +310,62 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
         reinforcer.RemoveReinforcementsIfNoPlayers(mapEvent, rejoiningPlayer, cleanedSides.Add);
 
         Assert.Equal(4, cleanedSides.Count);
+    }
+
+    [Fact]
+    public void AttachedArmyCleanup_PublishesEveryRecursivelyRemovedParty()
+    {
+        var removedPlayer = CreateMobileParty();
+        var nearbyArmyLeader = CreateMobileParty();
+        var attachedArmyParty = CreateMobileParty();
+        var enemyParty = CreateMobileParty();
+        var mapEvent = CreatePlayerBattle(nearbyArmyLeader, enemyParty);
+        var side = mapEvent.AttackerSide;
+        var leaderMapEventParty = side.Parties[0];
+        var attachedMapEventParty = CreateMapEventParty(attachedArmyParty);
+        side._battleParties.Add(attachedMapEventParty);
+        MapEventField.SetValue(side, mapEvent);
+        nearbyArmyLeader.Party._mapEventSide = side;
+        attachedArmyParty.Party._mapEventSide = side;
+        nearbyArmyLeader._attachedParties = new MBList<MobileParty> { attachedArmyParty };
+        attachedArmyParty._attachedParties = new MBList<MobileParty>();
+        attachedArmyParty._attachedTo = nearbyArmyLeader;
+        var army = (Army)FormatterServices.GetUninitializedObject(typeof(Army));
+        army.LeaderParty = nearbyArmyLeader;
+        nearbyArmyLeader._army = army;
+        attachedArmyParty._army = army;
+        // Keep the uninitialized fixture out of vanilla's post-removal movement reset.
+        nearbyArmyLeader._isCurrentlyUsedByAQuest = true;
+        side._nearbyPartiesAddedToPlayerMapEvent.Add(nearbyArmyLeader);
+        MarkAsPlayerParty(removedPlayer);
+        var publishedRemovals = new List<(object Source, MapEventPartyRemoved Message)>();
+        var messageBroker = new Mock<IMessageBroker>();
+        messageBroker
+            .Setup(broker => broker.Publish(
+                It.IsAny<object>(),
+                It.IsAny<MapEventPartyRemoved>()))
+            .Callback<object, MapEventPartyRemoved>((source, message) =>
+                publishedRemovals.Add((source, message)));
+        var reinforcer = new NearbyPartyReinforcer(messageBroker.Object);
+
+        reinforcer.RemoveReinforcementsIfNoPlayers(mapEvent, removedPlayer);
+
+        Assert.Null(nearbyArmyLeader.MapEventSide);
+        Assert.Null(attachedArmyParty.MapEventSide);
+        Assert.DoesNotContain(leaderMapEventParty, side.Parties);
+        Assert.DoesNotContain(attachedMapEventParty, side.Parties);
+        Assert.Collection(
+            publishedRemovals,
+            removal =>
+            {
+                Assert.Same(side, removal.Source);
+                Assert.Same(leaderMapEventParty, removal.Message.MapEventParty);
+            },
+            removal =>
+            {
+                Assert.Same(side, removal.Source);
+                Assert.Same(attachedMapEventParty, removal.Message.MapEventParty);
+            });
     }
 
     [Fact]

--- a/source/GameInterface.Tests/Services/MapEvents/NearbyPartyReinforcerTests.cs
+++ b/source/GameInterface.Tests/Services/MapEvents/NearbyPartyReinforcerTests.cs
@@ -15,6 +15,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Encounters;
 using TaleWorlds.CampaignSystem.MapEvents;
@@ -45,14 +46,11 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
             .GetValue(null)!;
     private readonly List<object> controlledObjects = new();
     private readonly bool previousIsServer;
-    private readonly int previousGameThreadId;
 
     public NearbyPartyReinforcerTests()
     {
         previousIsServer = ModInformation.IsServer;
-        previousGameThreadId = GameThread.Instance.GameThreadId;
         ModInformation.IsServer = true;
-        GameThread.Instance.MarkGameThread();
     }
 
     public void Dispose()
@@ -61,7 +59,6 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
             playerObjects.Remove(controlledObject);
 
         ModInformation.IsServer = previousIsServer;
-        GameThread.Instance.RestoreGameThread(previousGameThreadId);
     }
 
     [Fact]
@@ -243,17 +240,30 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
     public void PlayerBattleAnnouncement_OpensWindowBeforeImmediateGameThreadScan()
     {
         var mapEvent = (MapEvent)FormatterServices.GetUninitializedObject(typeof(MapEvent));
-        var reinforcer = new RecordingReinforcer(mapEvent);
+        using var reinforcer = new RecordingReinforcer(mapEvent);
         using var messageBroker = new MessageBroker();
         using var handler = new NearbyPartyReinforcementHandler(messageBroker, reinforcer);
 
-        using (new AllowedThread())
+        bool ownsGameThreadMark = GameThread.Instance.GameThreadId == 0;
+        if (ownsGameThreadMark)
+            GameThread.Instance.MarkGameThread();
+
+        try
         {
-            InteractionPatches.OpenAiJoinWindowAndPublish(
-                mapEvent,
-                () => messageBroker.Publish(mapEvent, new PlayerJoinedBattle()));
+            using (new AllowedThread())
+            {
+                InteractionPatches.OpenAiJoinWindowAndPublish(
+                    mapEvent,
+                    () => messageBroker.Publish(mapEvent, new PlayerJoinedBattle()));
+            }
+        }
+        finally
+        {
+            if (ownsGameThreadMark)
+                GameThread.Instance.RestoreGameThread(0);
         }
 
+        Assert.True(reinforcer.WaitForImmediateScan());
         Assert.Equal(1, reinforcer.ImmediateScanCount);
     }
 
@@ -297,9 +307,10 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
         controlledObjects.Add(mobileParty);
     }
 
-    private sealed class RecordingReinforcer : INearbyPartyReinforcer
+    private sealed class RecordingReinforcer : INearbyPartyReinforcer, IDisposable
     {
         private readonly MapEvent expectedMapEvent;
+        private readonly ManualResetEventSlim immediateScanCompleted = new(false);
 
         public RecordingReinforcer(MapEvent expectedMapEvent)
         {
@@ -315,10 +326,18 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
             Assert.False(AllowedThread.IsThisThreadAllowed());
             Assert.True(InteractionPatches.IsWithinAiJoinWindow(mapEvent));
             ImmediateScanCount++;
+            immediateScanCompleted.Set();
         }
 
         public void ReinforceOpenPlayerBattles()
         {
+        }
+
+        public bool WaitForImmediateScan() => immediateScanCompleted.Wait(TimeSpan.FromSeconds(5));
+
+        public void Dispose()
+        {
+            immediateScanCompleted.Dispose();
         }
     }
 }

--- a/source/GameInterface.Tests/Services/MapEvents/NearbyPartyReinforcerTests.cs
+++ b/source/GameInterface.Tests/Services/MapEvents/NearbyPartyReinforcerTests.cs
@@ -11,6 +11,7 @@ using GameInterface.Services.Players.Data;
 using GameInterface.Tests.Bootstrap;
 using GameInterface.Tests.Services.SiegeEvents;
 using HarmonyLib;
+using Moq;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -71,7 +72,7 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
         MarkAsPlayerParty(playerParty);
         InteractionPatches.OpenAiJoinWindowAndPublish(mapEvent, () => { });
         var joins = new List<(MapEventSide Side, MobileParty Party)>();
-        var reinforcer = new NearbyPartyReinforcer();
+        var reinforcer = CreateReinforcer();
         var previousMainParty = Campaign.Current.MainParty;
         var previousEncounter = Campaign.Current.PlayerEncounter;
 
@@ -104,7 +105,7 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
         MarkAsPlayerParty(playerParty);
         InteractionPatches.OpenAiJoinWindowAndPublish(mapEvent, () => { });
         var selectorCalled = false;
-        var reinforcer = new NearbyPartyReinforcer();
+        var reinforcer = CreateReinforcer();
 
         reinforcer.Reinforce(
             mapEvent,
@@ -128,7 +129,7 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
         MarkAsPlayerParty(playerParty);
         InteractionPatches.OpenAiJoinWindowAndPublish(mapEvent, () => { });
         var joins = new List<MobileParty>();
-        var reinforcer = new NearbyPartyReinforcer();
+        var reinforcer = CreateReinforcer();
 
         reinforcer.Reinforce(
             mapEvent,
@@ -177,7 +178,7 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
         }
         var selectorCalled = false;
         var joins = new List<MobileParty>();
-        var reinforcer = new NearbyPartyReinforcer();
+        var reinforcer = CreateReinforcer();
 
         reinforcer.Reinforce(
             mapEvent,
@@ -202,7 +203,7 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
         InteractionPatches.OpenAiJoinWindowAndPublish(mapEvent, () => { });
         mapEvent._battleState = TaleWorlds.Core.BattleState.AttackerVictory;
         var selectorCalled = false;
-        var reinforcer = new NearbyPartyReinforcer();
+        var reinforcer = CreateReinforcer();
 
         reinforcer.Reinforce(
             mapEvent,
@@ -222,7 +223,7 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
         MarkAsPlayerParty(playerParty);
         InteractionPatches.OpenAiJoinWindowAndPublish(mapEvent, () => { });
         var joins = new List<MobileParty>();
-        var reinforcer = new NearbyPartyReinforcer();
+        var reinforcer = CreateReinforcer();
 
         reinforcer.Reinforce(
             mapEvent,
@@ -234,6 +235,48 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
             (side, party) => joins.Add(party));
 
         Assert.Empty(joins);
+    }
+
+    [Fact]
+    public void LastPlayerLeaves_RemovesTrackedNearbyPartiesFromBothSides()
+    {
+        var removedPlayer = CreateMobileParty();
+        var nearbyAlly = CreateMobileParty();
+        var enemyParty = CreateMobileParty();
+        var mapEvent = CreatePlayerBattle(nearbyAlly, enemyParty);
+        MarkAsPlayerParty(removedPlayer);
+        var cleanedSides = new List<MapEventSide>();
+        var reinforcer = CreateReinforcer();
+
+        reinforcer.RemoveReinforcementsIfNoPlayers(
+            mapEvent,
+            removedPlayer,
+            cleanedSides.Add);
+
+        Assert.Collection(
+            cleanedSides,
+            side => Assert.Same(mapEvent.AttackerSide, side),
+            side => Assert.Same(mapEvent.DefenderSide, side));
+    }
+
+    [Fact]
+    public void AnotherPlayerRemains_DoesNotRemoveTrackedNearbyParties()
+    {
+        var removedPlayer = CreateMobileParty();
+        var remainingPlayer = CreateMobileParty();
+        var enemyParty = CreateMobileParty();
+        var mapEvent = CreatePlayerBattle(remainingPlayer, enemyParty);
+        MarkAsPlayerParty(removedPlayer);
+        MarkAsPlayerParty(remainingPlayer);
+        var cleanedSides = new List<MapEventSide>();
+        var reinforcer = CreateReinforcer();
+
+        reinforcer.RemoveReinforcementsIfNoPlayers(
+            mapEvent,
+            removedPlayer,
+            cleanedSides.Add);
+
+        Assert.Empty(cleanedSides);
     }
 
     [Fact]
@@ -267,12 +310,16 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
         Assert.Equal(1, reinforcer.ImmediateScanCount);
     }
 
+    private static NearbyPartyReinforcer CreateReinforcer()
+        => new NearbyPartyReinforcer(Mock.Of<IMessageBroker>());
+
     private MapEvent CreatePlayerBattle(MobileParty playerParty, MobileParty enemyParty)
     {
         var attackerSide = CreateSide(CreateMapEventParty(playerParty));
         var defenderSide = CreateSide(CreateMapEventParty(enemyParty));
         var mapEvent = (MapEvent)FormatterServices.GetUninitializedObject(typeof(MapEvent));
         SidesField.SetValue(mapEvent, new[] { defenderSide, attackerSide });
+        mapEvent._state = MapEventState.Wait;
         return mapEvent;
     }
 
@@ -330,6 +377,10 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
         }
 
         public void ReinforceOpenPlayerBattles()
+        {
+        }
+
+        public void RemoveReinforcementsIfNoPlayers(MapEvent mapEvent, MobileParty removedParty)
         {
         }
 

--- a/source/GameInterface.Tests/Services/MapEvents/NearbyPartyReinforcerTests.cs
+++ b/source/GameInterface.Tests/Services/MapEvents/NearbyPartyReinforcerTests.cs
@@ -1,0 +1,209 @@
+﻿using GameInterface.Services.Entity;
+using GameInterface.Services.MapEvents;
+using GameInterface.Services.MapEvents.Patches;
+using GameInterface.Services.Players;
+using GameInterface.Services.Players.Data;
+using GameInterface.Tests.Bootstrap;
+using GameInterface.Tests.Services.SiegeEvents;
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Encounters;
+using TaleWorlds.CampaignSystem.MapEvents;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.Library;
+using Xunit;
+using FormatterServices = System.Runtime.Serialization.FormatterServices;
+
+namespace GameInterface.Tests.Services.MapEvents;
+
+[Collection(nameof(CampaignCurrentCollection))]
+public sealed class NearbyPartyReinforcerTests : IDisposable
+{
+    static NearbyPartyReinforcerTests()
+    {
+        GameBootStrap.Initialize();
+    }
+
+    private static readonly FieldInfo SidesField =
+        typeof(MapEvent).GetField("_sides", BindingFlags.NonPublic | BindingFlags.Instance)!;
+    private static readonly FieldInfo BattlePartiesField =
+        typeof(MapEventSide).GetField("_battleParties", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+    private readonly ConditionalWeakTable<object, ControlledObjectInfo> playerObjects =
+        (ConditionalWeakTable<object, ControlledObjectInfo>)AccessTools
+            .Field(typeof(PlayerManager), "PlayerObjects")
+            .GetValue(null)!;
+    private readonly List<object> controlledObjects = new();
+
+    public void Dispose()
+    {
+        foreach (var controlledObject in controlledObjects)
+            playerObjects.Remove(controlledObject);
+    }
+
+    [Fact]
+    public void PlayerBattleStart_ImmediatelyAddsSelectedNearbyAlly()
+    {
+        var playerParty = CreateMobileParty();
+        var enemyParty = CreateMobileParty();
+        var nearbyAlly = CreateMobileParty();
+        var mapEvent = CreatePlayerBattle(playerParty, enemyParty);
+        MarkAsPlayerParty(playerParty);
+        InteractionPatches.OpenAiJoinWindowAndPublish(mapEvent, () => { });
+        var joins = new List<(MapEventSide Side, MobileParty Party)>();
+        var reinforcer = new NearbyPartyReinforcer();
+        var previousMainParty = Campaign.Current.MainParty;
+        var previousEncounter = Campaign.Current.PlayerEncounter;
+
+        reinforcer.Reinforce(
+            mapEvent,
+            (playerSide, enemySide) =>
+            {
+                Assert.Same(playerParty, MobileParty.MainParty);
+                Assert.Same(mapEvent, PlayerEncounter.Battle);
+                playerSide.Add(nearbyAlly);
+            },
+            (side, party) => joins.Add((side, party)));
+
+        Assert.Same(previousMainParty, Campaign.Current.MainParty);
+        Assert.Same(previousEncounter, Campaign.Current.PlayerEncounter);
+        var join = Assert.Single(joins);
+        Assert.Same(mapEvent.AttackerSide, join.Side);
+        Assert.Same(nearbyAlly, join.Party);
+    }
+
+    [Fact]
+    public void CampaignTick_AddsAllyThatArrivesLaterDuringWindow()
+    {
+        var playerParty = CreateMobileParty();
+        var enemyParty = CreateMobileParty();
+        var lateAlly = CreateMobileParty();
+        var mapEvent = CreatePlayerBattle(playerParty, enemyParty);
+        MarkAsPlayerParty(playerParty);
+        InteractionPatches.OpenAiJoinWindowAndPublish(mapEvent, () => { });
+        var joins = new List<MobileParty>();
+        var reinforcer = new NearbyPartyReinforcer();
+
+        reinforcer.Reinforce(
+            mapEvent,
+            (attackers, defenders) => { },
+            (side, party) => joins.Add(party));
+        reinforcer.Reinforce(
+            mapEvent,
+            (attackers, defenders) => attackers.Add(lateAlly),
+            (side, party) => joins.Add(party));
+
+        Assert.Collection(joins, party => Assert.Same(lateAlly, party));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void OutsideWindowOrFinalizedEvent_DoesNotAddJoiner(bool finalized)
+    {
+        var playerParty = CreateMobileParty();
+        var enemyParty = CreateMobileParty();
+        var nearbyAlly = CreateMobileParty();
+        var mapEvent = CreatePlayerBattle(playerParty, enemyParty);
+        MarkAsPlayerParty(playerParty);
+        if (finalized)
+        {
+            InteractionPatches.OpenAiJoinWindowAndPublish(mapEvent, () => { });
+            mapEvent._state = MapEventState.WaitingRemoval;
+        }
+        var selectorCalled = false;
+        var joins = new List<MobileParty>();
+        var reinforcer = new NearbyPartyReinforcer();
+
+        reinforcer.Reinforce(
+            mapEvent,
+            (attackers, defenders) =>
+            {
+                selectorCalled = true;
+                attackers.Add(nearbyAlly);
+            },
+            (side, party) => joins.Add(party));
+
+        Assert.False(selectorCalled);
+        Assert.Empty(joins);
+    }
+
+    [Fact]
+    public void ConcludedEvent_DoesNotSelectJoiners()
+    {
+        var playerParty = CreateMobileParty();
+        var enemyParty = CreateMobileParty();
+        var mapEvent = CreatePlayerBattle(playerParty, enemyParty);
+        MarkAsPlayerParty(playerParty);
+        InteractionPatches.OpenAiJoinWindowAndPublish(mapEvent, () => { });
+        mapEvent._battleState = TaleWorlds.Core.BattleState.AttackerVictory;
+        var selectorCalled = false;
+        var reinforcer = new NearbyPartyReinforcer();
+
+        reinforcer.Reinforce(
+            mapEvent,
+            (playerSide, enemySide) => selectorCalled = true,
+            (side, party) => { });
+
+        Assert.False(selectorCalled);
+    }
+
+    [Fact]
+    public void PlayerBattleAnnouncement_ObservesOpenAiJoinWindow()
+    {
+        var mapEvent = (MapEvent)FormatterServices.GetUninitializedObject(typeof(MapEvent));
+        var published = false;
+
+        InteractionPatches.OpenAiJoinWindowAndPublish(mapEvent, () =>
+        {
+            published = true;
+            Assert.True(InteractionPatches.IsWithinAiJoinWindow(mapEvent));
+        });
+
+        Assert.True(published);
+    }
+
+    private MapEvent CreatePlayerBattle(MobileParty playerParty, MobileParty enemyParty)
+    {
+        var attackerSide = CreateSide(CreateMapEventParty(playerParty));
+        var defenderSide = CreateSide(CreateMapEventParty(enemyParty));
+        var mapEvent = (MapEvent)FormatterServices.GetUninitializedObject(typeof(MapEvent));
+        SidesField.SetValue(mapEvent, new[] { defenderSide, attackerSide });
+        return mapEvent;
+    }
+
+    private static MapEventSide CreateSide(params MapEventParty[] parties)
+    {
+        var side = (MapEventSide)FormatterServices.GetUninitializedObject(typeof(MapEventSide));
+        BattlePartiesField.SetValue(side, new MBList<MapEventParty>(parties));
+        return side;
+    }
+
+    private static MapEventParty CreateMapEventParty(MobileParty mobileParty)
+    {
+        var mapEventParty = (MapEventParty)FormatterServices.GetUninitializedObject(typeof(MapEventParty));
+        mapEventParty.Party = mobileParty.Party;
+        return mapEventParty;
+    }
+
+    private static MobileParty CreateMobileParty()
+    {
+        var mobileParty = (MobileParty)FormatterServices.GetUninitializedObject(typeof(MobileParty));
+        var party = (PartyBase)FormatterServices.GetUninitializedObject(typeof(PartyBase));
+        party.MobileParty = mobileParty;
+        mobileParty.Party = party;
+        return mobileParty;
+    }
+
+    private void MarkAsPlayerParty(MobileParty mobileParty)
+    {
+        playerObjects.Add(
+            mobileParty,
+            new ControlledObjectInfo("PlayerOne", new ControllerIdProvider()));
+        controlledObjects.Add(mobileParty);
+    }
+}

--- a/source/GameInterface.Tests/Services/MapEvents/NearbyPartyReinforcerTests.cs
+++ b/source/GameInterface.Tests/Services/MapEvents/NearbyPartyReinforcerTests.cs
@@ -4,6 +4,7 @@ using Common.Util;
 using GameInterface.Services.Entity;
 using GameInterface.Services.MapEvents;
 using GameInterface.Services.MapEvents.Handlers;
+using GameInterface.Services.MapEvents.Messages.Leave;
 using GameInterface.Services.MapEvents.Messages.Start;
 using GameInterface.Services.MapEvents.Patches;
 using GameInterface.Services.Players;
@@ -40,6 +41,8 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
         typeof(MapEvent).GetField("_sides", BindingFlags.NonPublic | BindingFlags.Instance)!;
     private static readonly FieldInfo BattlePartiesField =
         typeof(MapEventSide).GetField("_battleParties", BindingFlags.NonPublic | BindingFlags.Instance)!;
+    private static readonly FieldInfo NearbyPartiesField =
+        typeof(MapEventSide).GetField("_nearbyPartiesAddedToPlayerMapEvent", BindingFlags.NonPublic | BindingFlags.Instance)!;
 
     private readonly ConditionalWeakTable<object, ControlledObjectInfo> playerObjects =
         (ConditionalWeakTable<object, ControlledObjectInfo>)AccessTools
@@ -238,20 +241,25 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
     }
 
     [Fact]
-    public void LastPlayerLeaves_RemovesTrackedNearbyPartiesFromBothSides()
+    public void PlayersLeaveInOrder_RemovesReinforcementsOnlyAfterLastPlayer()
     {
-        var removedPlayer = CreateMobileParty();
-        var nearbyAlly = CreateMobileParty();
+        var firstPlayer = CreateMobileParty();
+        var lastPlayer = CreateMobileParty();
         var enemyParty = CreateMobileParty();
-        var mapEvent = CreatePlayerBattle(nearbyAlly, enemyParty);
-        MarkAsPlayerParty(removedPlayer);
+        var mapEvent = CreatePlayerBattle(firstPlayer, enemyParty);
+        AddMapEventParty(mapEvent.AttackerSide, lastPlayer);
+        MarkAsPlayerParty(firstPlayer);
+        MarkAsPlayerParty(lastPlayer);
         var cleanedSides = new List<MapEventSide>();
         var reinforcer = CreateReinforcer();
 
-        reinforcer.RemoveReinforcementsIfNoPlayers(
-            mapEvent,
-            removedPlayer,
-            cleanedSides.Add);
+        RemoveMapEventParty(mapEvent.AttackerSide, firstPlayer);
+        reinforcer.RemoveReinforcementsIfNoPlayers(mapEvent, firstPlayer, cleanedSides.Add);
+
+        Assert.Empty(cleanedSides);
+
+        RemoveMapEventParty(mapEvent.AttackerSide, lastPlayer);
+        reinforcer.RemoveReinforcementsIfNoPlayers(mapEvent, lastPlayer, cleanedSides.Add);
 
         Assert.Collection(
             cleanedSides,
@@ -260,23 +268,73 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
     }
 
     [Fact]
-    public void AnotherPlayerRemains_DoesNotRemoveTrackedNearbyParties()
+    public void TrackedReinforcementLeavesBeforePlayers_RemovesStaleTracking()
     {
-        var removedPlayer = CreateMobileParty();
-        var remainingPlayer = CreateMobileParty();
+        var playerParty = CreateMobileParty();
         var enemyParty = CreateMobileParty();
-        var mapEvent = CreatePlayerBattle(remainingPlayer, enemyParty);
-        MarkAsPlayerParty(removedPlayer);
-        MarkAsPlayerParty(remainingPlayer);
+        var removedReinforcement = CreateMobileParty();
+        var mapEvent = CreatePlayerBattle(playerParty, enemyParty);
+        MarkAsPlayerParty(playerParty);
+        mapEvent.AttackerSide._nearbyPartiesAddedToPlayerMapEvent.Add(removedReinforcement);
         var cleanedSides = new List<MapEventSide>();
         var reinforcer = CreateReinforcer();
 
         reinforcer.RemoveReinforcementsIfNoPlayers(
             mapEvent,
-            removedPlayer,
+            removedReinforcement,
             cleanedSides.Add);
 
+        Assert.Empty(mapEvent.AttackerSide._nearbyPartiesAddedToPlayerMapEvent);
         Assert.Empty(cleanedSides);
+    }
+
+    [Fact]
+    public void PlayerRejoinsAfterCleanup_LastPlayerCleanupRunsAgain()
+    {
+        var firstPlayer = CreateMobileParty();
+        var rejoiningPlayer = CreateMobileParty();
+        var enemyParty = CreateMobileParty();
+        var mapEvent = CreatePlayerBattle(firstPlayer, enemyParty);
+        MarkAsPlayerParty(firstPlayer);
+        MarkAsPlayerParty(rejoiningPlayer);
+        var cleanedSides = new List<MapEventSide>();
+        var reinforcer = CreateReinforcer();
+
+        RemoveMapEventParty(mapEvent.AttackerSide, firstPlayer);
+        reinforcer.RemoveReinforcementsIfNoPlayers(mapEvent, firstPlayer, cleanedSides.Add);
+        AddMapEventParty(mapEvent.AttackerSide, rejoiningPlayer);
+        RemoveMapEventParty(mapEvent.AttackerSide, rejoiningPlayer);
+        reinforcer.RemoveReinforcementsIfNoPlayers(mapEvent, rejoiningPlayer, cleanedSides.Add);
+
+        Assert.Equal(4, cleanedSides.Count);
+    }
+
+    [Fact]
+    public void PartyRemovalAnnouncement_UsesHandlerOwnedReinforcerWithPatchesLive()
+    {
+        var mapEvent = (MapEvent)FormatterServices.GetUninitializedObject(typeof(MapEvent));
+        var removedParty = CreateMobileParty();
+        using var reinforcer = new RecordingReinforcer(mapEvent, removedParty);
+        using var messageBroker = new MessageBroker();
+        using var handler = new NearbyPartyReinforcementHandler(messageBroker, reinforcer);
+
+        bool ownsGameThreadMark = GameThread.Instance.GameThreadId == 0;
+        if (ownsGameThreadMark)
+            GameThread.Instance.MarkGameThread();
+
+        try
+        {
+            using (new AllowedThread())
+                messageBroker.Publish(mapEvent, new PartyRemovedFromMapEvent(removedParty));
+        }
+        finally
+        {
+            if (ownsGameThreadMark)
+                GameThread.Instance.RestoreGameThread(0);
+        }
+
+        Assert.True(reinforcer.WaitForCleanup());
+        Assert.Equal(1, reinforcer.CleanupCount);
     }
 
     [Fact]
@@ -327,7 +385,22 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
     {
         var side = (MapEventSide)FormatterServices.GetUninitializedObject(typeof(MapEventSide));
         BattlePartiesField.SetValue(side, new MBList<MapEventParty>(parties));
+        NearbyPartiesField.SetValue(side, new MBList<MobileParty>());
         return side;
+    }
+
+    private static void AddMapEventParty(MapEventSide side, MobileParty mobileParty)
+    {
+        side._battleParties.Add(CreateMapEventParty(mobileParty));
+    }
+
+    private static void RemoveMapEventParty(MapEventSide side, MobileParty mobileParty)
+    {
+        for (int i = side._battleParties.Count - 1; i >= 0; i--)
+        {
+            if (side._battleParties[i].Party == mobileParty.Party)
+                side._battleParties.RemoveAt(i);
+        }
     }
 
     private static MapEventParty CreateMapEventParty(MobileParty mobileParty)
@@ -357,14 +430,18 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
     private sealed class RecordingReinforcer : INearbyPartyReinforcer, IDisposable
     {
         private readonly MapEvent expectedMapEvent;
+        private readonly MobileParty? expectedRemovedParty;
         private readonly ManualResetEventSlim immediateScanCompleted = new(false);
+        private readonly ManualResetEventSlim cleanupCompleted = new(false);
 
-        public RecordingReinforcer(MapEvent expectedMapEvent)
+        public RecordingReinforcer(MapEvent expectedMapEvent, MobileParty? expectedRemovedParty = null)
         {
             this.expectedMapEvent = expectedMapEvent;
+            this.expectedRemovedParty = expectedRemovedParty;
         }
 
         public int ImmediateScanCount { get; private set; }
+        public int CleanupCount { get; private set; }
 
         public void Reinforce(MapEvent mapEvent)
         {
@@ -382,13 +459,21 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
 
         public void RemoveReinforcementsIfNoPlayers(MapEvent mapEvent, MobileParty removedParty)
         {
+            Assert.Same(expectedMapEvent, mapEvent);
+            Assert.Same(expectedRemovedParty, removedParty);
+            Assert.True(GameThread.Instance.IsGameThread);
+            Assert.False(AllowedThread.IsThisThreadAllowed());
+            CleanupCount++;
+            cleanupCompleted.Set();
         }
 
         public bool WaitForImmediateScan() => immediateScanCompleted.Wait(TimeSpan.FromSeconds(5));
+        public bool WaitForCleanup() => cleanupCompleted.Wait(TimeSpan.FromSeconds(5));
 
         public void Dispose()
         {
             immediateScanCompleted.Dispose();
+            cleanupCompleted.Dispose();
         }
     }
 }

--- a/source/GameInterface.Tests/Services/MapEvents/NearbyPartyReinforcerTests.cs
+++ b/source/GameInterface.Tests/Services/MapEvents/NearbyPartyReinforcerTests.cs
@@ -1,6 +1,7 @@
 ﻿using Common;
 using Common.Messaging;
 using Common.Util;
+using GameInterface.Configuration;
 using GameInterface.Services.Entity;
 using GameInterface.Services.MapEvents;
 using GameInterface.Services.MapEvents.Handlers;
@@ -197,6 +198,37 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
 
         Assert.False(selectorCalled);
         Assert.Empty(joins);
+    }
+
+    [Fact]
+    public void ZeroHourWindow_DoesNotSelectJoiners()
+    {
+        var previousOptions = ModConfigProvider.ModOptions;
+        try
+        {
+            ModConfigProvider.LoadModConfig(new ModOptionsData
+            {
+                PlayerBattleAiJoinWindowHours = 0
+            });
+            var playerParty = CreateMobileParty();
+            var enemyParty = CreateMobileParty();
+            var mapEvent = CreatePlayerBattle(playerParty, enemyParty);
+            MarkAsPlayerParty(playerParty);
+            InteractionPatches.OpenAiJoinWindowAndPublish(mapEvent, () => { });
+            var selectorCalled = false;
+            var reinforcer = CreateReinforcer();
+
+            reinforcer.Reinforce(
+                mapEvent,
+                (playerSide, enemySide) => selectorCalled = true,
+                (side, party) => { });
+
+            Assert.False(selectorCalled);
+        }
+        finally
+        {
+            ModConfigProvider.ModOptions = previousOptions;
+        }
     }
 
     [Fact]

--- a/source/GameInterface.Tests/Services/MapEvents/NearbyPartyReinforcerTests.cs
+++ b/source/GameInterface.Tests/Services/MapEvents/NearbyPartyReinforcerTests.cs
@@ -1,5 +1,10 @@
-﻿using GameInterface.Services.Entity;
+﻿using Common;
+using Common.Messaging;
+using Common.Util;
+using GameInterface.Services.Entity;
 using GameInterface.Services.MapEvents;
+using GameInterface.Services.MapEvents.Handlers;
+using GameInterface.Services.MapEvents.Messages.Start;
 using GameInterface.Services.MapEvents.Patches;
 using GameInterface.Services.Players;
 using GameInterface.Services.Players.Data;
@@ -14,6 +19,7 @@ using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Encounters;
 using TaleWorlds.CampaignSystem.MapEvents;
 using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Library;
 using Xunit;
 using FormatterServices = System.Runtime.Serialization.FormatterServices;
@@ -38,11 +44,24 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
             .Field(typeof(PlayerManager), "PlayerObjects")
             .GetValue(null)!;
     private readonly List<object> controlledObjects = new();
+    private readonly bool previousIsServer;
+    private readonly int previousGameThreadId;
+
+    public NearbyPartyReinforcerTests()
+    {
+        previousIsServer = ModInformation.IsServer;
+        previousGameThreadId = GameThread.Instance.GameThreadId;
+        ModInformation.IsServer = true;
+        GameThread.Instance.MarkGameThread();
+    }
 
     public void Dispose()
     {
         foreach (var controlledObject in controlledObjects)
             playerObjects.Remove(controlledObject);
+
+        ModInformation.IsServer = previousIsServer;
+        GameThread.Instance.RestoreGameThread(previousGameThreadId);
     }
 
     [Fact]
@@ -77,6 +96,32 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
     }
 
     [Fact]
+    public void SallyOutSelection_UsesMapEventSettlementWithoutPlayerSiege()
+    {
+        var playerParty = CreateMobileParty();
+        var enemyParty = CreateMobileParty();
+        var mapEvent = CreatePlayerBattle(playerParty, enemyParty);
+        var encounterSettlement = (Settlement)FormatterServices.GetUninitializedObject(typeof(Settlement));
+        mapEvent._mapEventType = MapEvent.BattleTypes.SallyOut;
+        mapEvent.MapEventSettlement = encounterSettlement;
+        MarkAsPlayerParty(playerParty);
+        InteractionPatches.OpenAiJoinWindowAndPublish(mapEvent, () => { });
+        var selectorCalled = false;
+        var reinforcer = new NearbyPartyReinforcer();
+
+        reinforcer.Reinforce(
+            mapEvent,
+            (playerSide, enemySide) =>
+            {
+                selectorCalled = true;
+                Assert.Same(encounterSettlement, PlayerEncounter.EncounterSettlement);
+            },
+            (side, party) => { });
+
+        Assert.True(selectorCalled);
+    }
+
+    [Fact]
     public void CampaignTick_AddsAllyThatArrivesLaterDuringWindow()
     {
         var playerParty = CreateMobileParty();
@@ -92,11 +137,29 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
             mapEvent,
             (attackers, defenders) => { },
             (side, party) => joins.Add(party));
-        reinforcer.Reinforce(
-            mapEvent,
-            (attackers, defenders) => attackers.Add(lateAlly),
+
+        long firstScanTicks = CampaignTime.Now.NumTicks;
+        var selectorCalls = 0;
+        Action<List<MobileParty>, List<MobileParty>> selectLateAlly = (attackers, defenders) =>
+        {
+            selectorCalls++;
+            attackers.Add(lateAlly);
+        };
+
+        reinforcer.ReinforceOpenPlayerBattles(
+            firstScanTicks,
+            selectLateAlly,
             (side, party) => joins.Add(party));
 
+        Assert.Equal(0, selectorCalls);
+        Assert.Empty(joins);
+
+        reinforcer.ReinforceOpenPlayerBattles(
+            firstScanTicks + NearbyPartyReinforcer.FollowUpScanIntervalTicks,
+            selectLateAlly,
+            (side, party) => joins.Add(party));
+
+        Assert.Equal(1, selectorCalls);
         Assert.Collection(joins, party => Assert.Same(lateAlly, party));
     }
 
@@ -153,18 +216,45 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
     }
 
     [Fact]
-    public void PlayerBattleAnnouncement_ObservesOpenAiJoinWindow()
+    public void EventConcludedDuringSelection_DoesNotAddJoiner()
+    {
+        var playerParty = CreateMobileParty();
+        var enemyParty = CreateMobileParty();
+        var nearbyAlly = CreateMobileParty();
+        var mapEvent = CreatePlayerBattle(playerParty, enemyParty);
+        MarkAsPlayerParty(playerParty);
+        InteractionPatches.OpenAiJoinWindowAndPublish(mapEvent, () => { });
+        var joins = new List<MobileParty>();
+        var reinforcer = new NearbyPartyReinforcer();
+
+        reinforcer.Reinforce(
+            mapEvent,
+            (playerSide, enemySide) =>
+            {
+                playerSide.Add(nearbyAlly);
+                mapEvent._battleState = TaleWorlds.Core.BattleState.AttackerVictory;
+            },
+            (side, party) => joins.Add(party));
+
+        Assert.Empty(joins);
+    }
+
+    [Fact]
+    public void PlayerBattleAnnouncement_OpensWindowBeforeImmediateGameThreadScan()
     {
         var mapEvent = (MapEvent)FormatterServices.GetUninitializedObject(typeof(MapEvent));
-        var published = false;
+        var reinforcer = new RecordingReinforcer(mapEvent);
+        using var messageBroker = new MessageBroker();
+        using var handler = new NearbyPartyReinforcementHandler(messageBroker, reinforcer);
 
-        InteractionPatches.OpenAiJoinWindowAndPublish(mapEvent, () =>
+        using (new AllowedThread())
         {
-            published = true;
-            Assert.True(InteractionPatches.IsWithinAiJoinWindow(mapEvent));
-        });
+            InteractionPatches.OpenAiJoinWindowAndPublish(
+                mapEvent,
+                () => messageBroker.Publish(mapEvent, new PlayerJoinedBattle()));
+        }
 
-        Assert.True(published);
+        Assert.Equal(1, reinforcer.ImmediateScanCount);
     }
 
     private MapEvent CreatePlayerBattle(MobileParty playerParty, MobileParty enemyParty)
@@ -205,5 +295,30 @@ public sealed class NearbyPartyReinforcerTests : IDisposable
             mobileParty,
             new ControlledObjectInfo("PlayerOne", new ControllerIdProvider()));
         controlledObjects.Add(mobileParty);
+    }
+
+    private sealed class RecordingReinforcer : INearbyPartyReinforcer
+    {
+        private readonly MapEvent expectedMapEvent;
+
+        public RecordingReinforcer(MapEvent expectedMapEvent)
+        {
+            this.expectedMapEvent = expectedMapEvent;
+        }
+
+        public int ImmediateScanCount { get; private set; }
+
+        public void Reinforce(MapEvent mapEvent)
+        {
+            Assert.Same(expectedMapEvent, mapEvent);
+            Assert.True(GameThread.Instance.IsGameThread);
+            Assert.False(AllowedThread.IsThisThreadAllowed());
+            Assert.True(InteractionPatches.IsWithinAiJoinWindow(mapEvent));
+            ImmediateScanCount++;
+        }
+
+        public void ReinforceOpenPlayerBattles()
+        {
+        }
     }
 }

--- a/source/GameInterface/GameInterfaceModule.cs
+++ b/source/GameInterface/GameInterfaceModule.cs
@@ -82,6 +82,7 @@ public class GameInterfaceModule : Module
         builder.RegisterType<BattleHostRegistry>().As<IBattleHostRegistry>().InstancePerLifetimeScope();
         builder.RegisterType<LocationHostRegistry>().As<ILocationHostRegistry>().InstancePerLifetimeScope();
         builder.RegisterType<BattleAgentBudget>().As<IBattleAgentBudget>().InstancePerDependency();
+        builder.RegisterType<NearbyPartyReinforcer>().As<INearbyPartyReinforcer>().InstancePerDependency();
         builder.RegisterType<SiegeMapEventLeaderReconciler>().As<ISiegeMapEventLeaderReconciler>().InstancePerDependency();
         builder.RegisterType<MapEventContributionBarrier>().As<IMapEventContributionBarrier>().InstancePerDependency();
         builder.RegisterType<ArmyDisbander>().As<IArmyDisbander>().InstancePerDependency();

--- a/source/GameInterface/Services/MapEventSides/Handlers/MapEventSideDataHandler.cs
+++ b/source/GameInterface/Services/MapEventSides/Handlers/MapEventSideDataHandler.cs
@@ -92,6 +92,8 @@ internal class MapEventSideDataHandler : IHandler
                 using (new AllowedThread())
                 {
                     side._battleParties.Remove(party);
+                    if (party.Party?.MobileParty != null)
+                        side._nearbyPartiesAddedToPlayerMapEvent.Remove(party.Party.MobileParty);
                     if (party.Party?.MapEventSide == side) party.Party._mapEventSide = null;
                 }
             }

--- a/source/GameInterface/Services/MapEvents/Handlers/NearbyPartyReinforcementHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/NearbyPartyReinforcementHandler.cs
@@ -1,0 +1,56 @@
+﻿using Common;
+using Common.Messaging;
+using Common.Util;
+using GameInterface.Services.MapEvents.Messages.Start;
+using GameInterface.Services.PlayerCaptivityService.Messages;
+using TaleWorlds.CampaignSystem.MapEvents;
+
+namespace GameInterface.Services.MapEvents.Handlers;
+
+/// <summary>Scans for nearby AI when players join a battle and while its join window remains open.</summary>
+internal sealed class NearbyPartyReinforcementHandler : IHandler
+{
+    private readonly IMessageBroker messageBroker;
+    private readonly INearbyPartyReinforcer nearbyPartyReinforcer;
+
+    public NearbyPartyReinforcementHandler(
+        IMessageBroker messageBroker,
+        INearbyPartyReinforcer nearbyPartyReinforcer)
+    {
+        this.messageBroker = messageBroker;
+        this.nearbyPartyReinforcer = nearbyPartyReinforcer;
+
+        messageBroker.Subscribe<PlayerJoinedBattle>(Handle_PlayerJoinedBattle);
+        messageBroker.Subscribe<CampaignTick>(Handle_CampaignTick);
+    }
+
+    public void Dispose()
+    {
+        messageBroker.Unsubscribe<PlayerJoinedBattle>(Handle_PlayerJoinedBattle);
+        messageBroker.Unsubscribe<CampaignTick>(Handle_CampaignTick);
+    }
+
+    private void Handle_PlayerJoinedBattle(MessagePayload<PlayerJoinedBattle> payload)
+    {
+        if (!ModInformation.IsServer || payload.Who is not MapEvent mapEvent)
+            return;
+
+        GameThread.RunSafe(() =>
+        {
+            using (AllowedThread.Suspend())
+                nearbyPartyReinforcer.Reinforce(mapEvent);
+        });
+    }
+
+    private void Handle_CampaignTick(MessagePayload<CampaignTick> payload)
+    {
+        if (!ModInformation.IsServer)
+            return;
+
+        GameThread.RunSafe(() =>
+        {
+            using (AllowedThread.Suspend())
+                nearbyPartyReinforcer.ReinforceOpenPlayerBattles();
+        });
+    }
+}

--- a/source/GameInterface/Services/MapEvents/Handlers/NearbyPartyReinforcementHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/NearbyPartyReinforcementHandler.cs
@@ -1,6 +1,7 @@
 ﻿using Common;
 using Common.Messaging;
 using Common.Util;
+using GameInterface.Services.MapEvents.Messages.Leave;
 using GameInterface.Services.MapEvents.Messages.Start;
 using GameInterface.Services.PlayerCaptivityService.Messages;
 using TaleWorlds.CampaignSystem.MapEvents;
@@ -21,12 +22,14 @@ internal sealed class NearbyPartyReinforcementHandler : IHandler
         this.nearbyPartyReinforcer = nearbyPartyReinforcer;
 
         messageBroker.Subscribe<PlayerJoinedBattle>(Handle_PlayerJoinedBattle);
+        messageBroker.Subscribe<PartyRemovedFromMapEvent>(Handle_PartyRemovedFromMapEvent);
         messageBroker.Subscribe<CampaignTick>(Handle_CampaignTick);
     }
 
     public void Dispose()
     {
         messageBroker.Unsubscribe<PlayerJoinedBattle>(Handle_PlayerJoinedBattle);
+        messageBroker.Unsubscribe<PartyRemovedFromMapEvent>(Handle_PartyRemovedFromMapEvent);
         messageBroker.Unsubscribe<CampaignTick>(Handle_CampaignTick);
     }
 
@@ -42,6 +45,21 @@ internal sealed class NearbyPartyReinforcementHandler : IHandler
 
             using (AllowedThread.Suspend())
                 nearbyPartyReinforcer.Reinforce(mapEvent);
+        });
+    }
+
+    private void Handle_PartyRemovedFromMapEvent(MessagePayload<PartyRemovedFromMapEvent> payload)
+    {
+        if (!ModInformation.IsServer)
+            return;
+
+        GameThread.RunSafe(() =>
+        {
+            if (payload.Who is not MapEvent mapEvent)
+                return;
+
+            using (AllowedThread.Suspend())
+                nearbyPartyReinforcer.RemoveReinforcementsIfNoPlayers(mapEvent, payload.What.RemovedParty);
         });
     }
 

--- a/source/GameInterface/Services/MapEvents/Handlers/NearbyPartyReinforcementHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/NearbyPartyReinforcementHandler.cs
@@ -32,11 +32,14 @@ internal sealed class NearbyPartyReinforcementHandler : IHandler
 
     private void Handle_PlayerJoinedBattle(MessagePayload<PlayerJoinedBattle> payload)
     {
-        if (!ModInformation.IsServer || payload.Who is not MapEvent mapEvent)
+        if (!ModInformation.IsServer)
             return;
 
         GameThread.RunSafe(() =>
         {
+            if (payload.Who is not MapEvent mapEvent)
+                return;
+
             using (AllowedThread.Suspend())
                 nearbyPartyReinforcer.Reinforce(mapEvent);
         });

--- a/source/GameInterface/Services/MapEvents/Messages/Leave/PartyRemovedFromMapEvent.cs
+++ b/source/GameInterface/Services/MapEvents/Messages/Leave/PartyRemovedFromMapEvent.cs
@@ -1,0 +1,14 @@
+﻿using Common.Messaging;
+using TaleWorlds.CampaignSystem.Party;
+
+namespace GameInterface.Services.MapEvents.Messages.Leave;
+
+internal readonly struct PartyRemovedFromMapEvent : IEvent
+{
+    public MobileParty RemovedParty { get; }
+
+    public PartyRemovedFromMapEvent(MobileParty removedParty)
+    {
+        RemovedParty = removedParty;
+    }
+}

--- a/source/GameInterface/Services/MapEvents/NearbyPartyReinforcer.cs
+++ b/source/GameInterface/Services/MapEvents/NearbyPartyReinforcer.cs
@@ -1,0 +1,164 @@
+﻿using GameInterface.Services.MapEvents.Patches;
+using GameInterface.Services.MobileParties.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Encounters;
+using TaleWorlds.CampaignSystem.MapEvents;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.Core;
+
+namespace GameInterface.Services.MapEvents;
+
+/// <summary>Finds and adds AI parties selected by the native encounter model.</summary>
+internal interface INearbyPartyReinforcer
+{
+    void Reinforce(MapEvent mapEvent);
+    void ReinforceOpenPlayerBattles();
+}
+
+/// <summary>Applies nearby AI reinforcements to open player battles on the server.</summary>
+internal sealed class NearbyPartyReinforcer : INearbyPartyReinforcer
+{
+    public void Reinforce(MapEvent mapEvent)
+    {
+        var encounterModel = Campaign.Current?.Models?.EncounterModel;
+        if (encounterModel == null)
+            return;
+
+        Reinforce(
+            mapEvent,
+            encounterModel.FindNonAttachedNpcPartiesWhoWillJoinPlayerEncounter,
+            (side, party) => side.AddNearbyPartyToPlayerMapEvent(party));
+    }
+
+    public void ReinforceOpenPlayerBattles()
+    {
+        var mapEvents = Campaign.Current?.MapEventManager?.MapEvents;
+        if (mapEvents == null)
+            return;
+
+        foreach (var mapEvent in mapEvents.ToArray())
+            Reinforce(mapEvent);
+    }
+
+    internal void Reinforce(
+        MapEvent mapEvent,
+        Action<List<MobileParty>, List<MobileParty>> selectJoiners,
+        Action<MapEventSide, MobileParty> addJoiner)
+    {
+        if (!CanReinforce(mapEvent) || !TryGetPlayerParty(mapEvent, out var playerParty, out var playerSide))
+            return;
+
+        var enemySide = playerSide.GetOppositeSide();
+        var playerParties = CollectMobileParties(mapEvent, playerSide);
+        var enemyParties = CollectMobileParties(mapEvent, enemySide);
+        int playerPartyCount = playerParties.Count;
+        int enemyPartyCount = enemyParties.Count;
+
+        SelectJoiners(mapEvent, playerParty, playerSide, playerParties, enemyParties, selectJoiners);
+
+        AddJoiners(mapEvent.GetMapEventSide(playerSide), playerParties, playerPartyCount, addJoiner);
+        AddJoiners(mapEvent.GetMapEventSide(enemySide), enemyParties, enemyPartyCount, addJoiner);
+    }
+
+    internal static bool CanReinforce(MapEvent mapEvent)
+    {
+        if (mapEvent == null || mapEvent.IsFinalized || mapEvent.BattleState != BattleState.None)
+            return false;
+
+        if (mapEvent.IsRaid || mapEvent.IsSiegeAssault || mapEvent.IsForcingSupplies ||
+            mapEvent.IsForcingVolunteers || mapEvent.MapEventSettlement?.IsHideout == true)
+            return false;
+
+        return InteractionPatches.IsWithinAiJoinWindow(mapEvent) && mapEvent.ContainsPlayerParty();
+    }
+
+    private static void SelectJoiners(
+        MapEvent mapEvent,
+        MobileParty playerParty,
+        BattleSideEnum playerSide,
+        List<MobileParty> playerParties,
+        List<MobileParty> enemyParties,
+        Action<List<MobileParty>, List<MobileParty>> selectJoiners)
+    {
+        // Vanilla reads these encounter statics, so scope them to the actual client party without creating a host party.
+        var campaign = Campaign.Current;
+        var previousMainParty = campaign.MainParty;
+        var previousEncounter = campaign.PlayerEncounter;
+        var encounter = new PlayerEncounter
+        {
+            _mapEvent = mapEvent,
+            PlayerSide = playerSide,
+            OpponentSide = playerSide.GetOppositeSide()
+        };
+
+        try
+        {
+            campaign.MainParty = playerParty;
+            campaign.PlayerEncounter = encounter;
+            selectJoiners(playerParties, enemyParties);
+        }
+        finally
+        {
+            campaign.PlayerEncounter = previousEncounter;
+            campaign.MainParty = previousMainParty;
+        }
+    }
+
+    private static bool TryGetPlayerParty(
+        MapEvent mapEvent,
+        out MobileParty playerParty,
+        out BattleSideEnum playerSide)
+    {
+        foreach (var side in new[] { BattleSideEnum.Attacker, BattleSideEnum.Defender })
+        {
+            foreach (var mapEventParty in mapEvent.PartiesOnSide(side))
+            {
+                var mobileParty = mapEventParty?.Party?.MobileParty;
+                if (mobileParty?.IsPlayerParty() != true)
+                    continue;
+
+                playerParty = mobileParty;
+                playerSide = side;
+                return true;
+            }
+        }
+
+        playerParty = null;
+        playerSide = BattleSideEnum.None;
+        return false;
+    }
+
+    private static List<MobileParty> CollectMobileParties(MapEvent mapEvent, BattleSideEnum side)
+    {
+        var parties = new List<MobileParty>();
+        foreach (var mapEventParty in mapEvent.PartiesOnSide(side))
+        {
+            if (mapEventParty?.Party?.IsMobile == true)
+                parties.Add(mapEventParty.Party.MobileParty);
+        }
+
+        return parties;
+    }
+
+    private static void AddJoiners(
+        MapEventSide side,
+        List<MobileParty> parties,
+        int existingPartyCount,
+        Action<MapEventSide, MobileParty> addJoiner)
+    {
+        if (side == null)
+            return;
+
+        for (int i = existingPartyCount; i < parties.Count; i++)
+        {
+            var party = parties[i];
+            if (party == null || party.IsPlayerParty())
+                continue;
+
+            addJoiner(side, party);
+        }
+    }
+}

--- a/source/GameInterface/Services/MapEvents/NearbyPartyReinforcer.cs
+++ b/source/GameInterface/Services/MapEvents/NearbyPartyReinforcer.cs
@@ -119,41 +119,65 @@ internal sealed class NearbyPartyReinforcer : INearbyPartyReinforcer
         MobileParty removedParty,
         Action<MapEventSide> removeReinforcements)
     {
-        if (mapEvent == null
-            || mapEvent.State != MapEventState.Wait
-            || removedParty?.IsPlayerParty() != true
+        if (mapEvent == null || removedParty == null)
+            return;
+
+        RemoveTrackedParty(mapEvent.AttackerSide, removedParty);
+        RemoveTrackedParty(mapEvent.DefenderSide, removedParty);
+
+        if (mapEvent.State != MapEventState.Wait
+            || !removedParty.IsPlayerParty()
             || mapEvent.ContainsPlayerParty())
         {
             return;
         }
 
         followUpScans.Remove(mapEvent);
+        RecalculateNextFollowUpScan();
         removeReinforcements(mapEvent.AttackerSide);
         removeReinforcements(mapEvent.DefenderSide);
     }
 
     private void RemoveReinforcements(MapEventSide side)
     {
-        if (side == null) return;
+        if (side == null || side._nearbyPartiesAddedToPlayerMapEvent.Count == 0)
+            return;
 
-        var removedParties = new List<MapEventParty>();
-        foreach (var nearbyParty in side._nearbyPartiesAddedToPlayerMapEvent)
+        var nearbyParties = new List<MobileParty>(side._nearbyPartiesAddedToPlayerMapEvent);
+
+        // Clear first because each authoritative removal re-enters the removal patch.
+        side._nearbyPartiesAddedToPlayerMapEvent.Clear();
+        foreach (var nearbyParty in nearbyParties)
         {
+            if (nearbyParty?.MapEventSide != side)
+                continue;
+
+            MapEventParty removedParty = null;
             foreach (var mapEventParty in side.Parties)
             {
                 if (mapEventParty.Party == nearbyParty.Party)
                 {
-                    removedParties.Add(mapEventParty);
+                    removedParty = mapEventParty;
                     break;
                 }
             }
-        }
 
-        side.RemoveNearbyPartiesFromPlayerMapEvent();
-        foreach (var mapEventParty in removedParties)
-        {
-            messageBroker.Publish(side, new MapEventPartyRemoved(side, mapEventParty));
+            nearbyParty.MapEventSide = null;
+            if (removedParty != null)
+                messageBroker.Publish(side, new MapEventPartyRemoved(side, removedParty));
         }
+    }
+
+    private static void RemoveTrackedParty(MapEventSide side, MobileParty removedParty)
+    {
+        side?._nearbyPartiesAddedToPlayerMapEvent.Remove(removedParty);
+    }
+
+    private void RecalculateNextFollowUpScan()
+    {
+        nextFollowUpScanAtTicks = long.MaxValue;
+        foreach (var state in followUpScans.Values)
+            nextFollowUpScanAtTicks = Math.Min(nextFollowUpScanAtTicks, state.NextScanAtTicks);
     }
 
     internal void Reinforce(

--- a/source/GameInterface/Services/MapEvents/NearbyPartyReinforcer.cs
+++ b/source/GameInterface/Services/MapEvents/NearbyPartyReinforcer.cs
@@ -1,4 +1,6 @@
-﻿using GameInterface.Services.MapEvents.Patches;
+﻿using Common.Messaging;
+using GameInterface.Services.MapEvents.Patches;
+using GameInterface.Services.MapEventSides.Messages;
 using GameInterface.Services.MobileParties.Extensions;
 using System;
 using System.Collections.Generic;
@@ -15,6 +17,7 @@ internal interface INearbyPartyReinforcer
 {
     void Reinforce(MapEvent mapEvent);
     void ReinforceOpenPlayerBattles();
+    void RemoveReinforcementsIfNoPlayers(MapEvent mapEvent, MobileParty removedParty);
 }
 
 /// <summary>Applies nearby AI reinforcements to open player battles on the server.</summary>
@@ -28,9 +31,15 @@ internal sealed class NearbyPartyReinforcer : INearbyPartyReinforcer
         public long NextScanAtTicks { get; set; }
     }
 
+    private readonly IMessageBroker messageBroker;
     private readonly Dictionary<MapEvent, FollowUpScanState> followUpScans = new();
     private readonly List<MapEvent> completedFollowUpScans = new();
     private long nextFollowUpScanAtTicks = long.MaxValue;
+
+    public NearbyPartyReinforcer(IMessageBroker messageBroker)
+    {
+        this.messageBroker = messageBroker;
+    }
 
     public void Reinforce(MapEvent mapEvent)
     {
@@ -99,6 +108,53 @@ internal sealed class NearbyPartyReinforcer : INearbyPartyReinforcer
     }
 
     internal static long FollowUpScanIntervalTicks => CampaignTime.Hours(FollowUpScanIntervalHours).NumTicks;
+
+    public void RemoveReinforcementsIfNoPlayers(MapEvent mapEvent, MobileParty removedParty)
+    {
+        RemoveReinforcementsIfNoPlayers(mapEvent, removedParty, RemoveReinforcements);
+    }
+
+    internal void RemoveReinforcementsIfNoPlayers(
+        MapEvent mapEvent,
+        MobileParty removedParty,
+        Action<MapEventSide> removeReinforcements)
+    {
+        if (mapEvent == null
+            || mapEvent.State != MapEventState.Wait
+            || removedParty?.IsPlayerParty() != true
+            || mapEvent.ContainsPlayerParty())
+        {
+            return;
+        }
+
+        followUpScans.Remove(mapEvent);
+        removeReinforcements(mapEvent.AttackerSide);
+        removeReinforcements(mapEvent.DefenderSide);
+    }
+
+    private void RemoveReinforcements(MapEventSide side)
+    {
+        if (side == null) return;
+
+        var removedParties = new List<MapEventParty>();
+        foreach (var nearbyParty in side._nearbyPartiesAddedToPlayerMapEvent)
+        {
+            foreach (var mapEventParty in side.Parties)
+            {
+                if (mapEventParty.Party == nearbyParty.Party)
+                {
+                    removedParties.Add(mapEventParty);
+                    break;
+                }
+            }
+        }
+
+        side.RemoveNearbyPartiesFromPlayerMapEvent();
+        foreach (var mapEventParty in removedParties)
+        {
+            messageBroker.Publish(side, new MapEventPartyRemoved(side, mapEventParty));
+        }
+    }
 
     internal void Reinforce(
         MapEvent mapEvent,

--- a/source/GameInterface/Services/MapEvents/NearbyPartyReinforcer.cs
+++ b/source/GameInterface/Services/MapEvents/NearbyPartyReinforcer.cs
@@ -2,7 +2,6 @@
 using GameInterface.Services.MobileParties.Extensions;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Encounters;
 using TaleWorlds.CampaignSystem.MapEvents;
@@ -21,6 +20,18 @@ internal interface INearbyPartyReinforcer
 /// <summary>Applies nearby AI reinforcements to open player battles on the server.</summary>
 internal sealed class NearbyPartyReinforcer : INearbyPartyReinforcer
 {
+    // Campaign-time scheduling stops follow-up scans while the map is paused.
+    private const float FollowUpScanIntervalHours = 0.25f;
+
+    private sealed class FollowUpScanState
+    {
+        public long NextScanAtTicks { get; set; }
+    }
+
+    private readonly Dictionary<MapEvent, FollowUpScanState> followUpScans = new();
+    private readonly List<MapEvent> completedFollowUpScans = new();
+    private long nextFollowUpScanAtTicks = long.MaxValue;
+
     public void Reinforce(MapEvent mapEvent)
     {
         var encounterModel = Campaign.Current?.Models?.EncounterModel;
@@ -35,20 +46,86 @@ internal sealed class NearbyPartyReinforcer : INearbyPartyReinforcer
 
     public void ReinforceOpenPlayerBattles()
     {
-        var mapEvents = Campaign.Current?.MapEventManager?.MapEvents;
-        if (mapEvents == null)
+        long currentTicks = CampaignTime.Now.NumTicks;
+        if (currentTicks < nextFollowUpScanAtTicks)
             return;
 
-        foreach (var mapEvent in mapEvents.ToArray())
-            Reinforce(mapEvent);
+        var encounterModel = Campaign.Current?.Models?.EncounterModel;
+        if (encounterModel == null)
+        {
+            nextFollowUpScanAtTicks = currentTicks + FollowUpScanIntervalTicks;
+            return;
+        }
+
+        ReinforceOpenPlayerBattles(
+            currentTicks,
+            encounterModel.FindNonAttachedNpcPartiesWhoWillJoinPlayerEncounter,
+            (side, party) => side.AddNearbyPartyToPlayerMapEvent(party));
     }
+
+    internal void ReinforceOpenPlayerBattles(
+        long currentTicks,
+        Action<List<MobileParty>, List<MobileParty>> selectJoiners,
+        Action<MapEventSide, MobileParty> addJoiner)
+    {
+        if (currentTicks < nextFollowUpScanAtTicks)
+            return;
+
+        completedFollowUpScans.Clear();
+        nextFollowUpScanAtTicks = long.MaxValue;
+
+        foreach (var pair in followUpScans)
+        {
+            var mapEvent = pair.Key;
+            var state = pair.Value;
+            if (!CanReinforce(mapEvent))
+            {
+                completedFollowUpScans.Add(mapEvent);
+                continue;
+            }
+
+            bool scanIsDue = IsFollowUpScanDue(mapEvent, currentTicks);
+            if (scanIsDue)
+                state.NextScanAtTicks = currentTicks + FollowUpScanIntervalTicks;
+
+            nextFollowUpScanAtTicks = Math.Min(nextFollowUpScanAtTicks, state.NextScanAtTicks);
+
+            if (scanIsDue)
+                ReinforceCore(mapEvent, selectJoiners, addJoiner);
+        }
+
+        foreach (var mapEvent in completedFollowUpScans)
+            followUpScans.Remove(mapEvent);
+    }
+
+    internal static long FollowUpScanIntervalTicks => CampaignTime.Hours(FollowUpScanIntervalHours).NumTicks;
 
     internal void Reinforce(
         MapEvent mapEvent,
         Action<List<MobileParty>, List<MobileParty>> selectJoiners,
         Action<MapEventSide, MobileParty> addJoiner)
     {
-        if (!CanReinforce(mapEvent) || !TryGetPlayerParty(mapEvent, out var playerParty, out var playerSide))
+        if (!CanReinforce(mapEvent))
+            return;
+
+        ScheduleFollowUpScan(mapEvent, CampaignTime.Now.NumTicks);
+        ReinforceCore(mapEvent, selectJoiners, addJoiner);
+    }
+
+    internal bool IsFollowUpScanDue(MapEvent mapEvent, long currentTicks)
+    {
+        if (!followUpScans.TryGetValue(mapEvent, out var state) || !CanReinforce(mapEvent))
+            return false;
+
+        return currentTicks >= state.NextScanAtTicks;
+    }
+
+    private void ReinforceCore(
+        MapEvent mapEvent,
+        Action<List<MobileParty>, List<MobileParty>> selectJoiners,
+        Action<MapEventSide, MobileParty> addJoiner)
+    {
+        if (!TryGetPlayerParty(mapEvent, out var playerParty, out var playerSide))
             return;
 
         var enemySide = playerSide.GetOppositeSide();
@@ -59,8 +136,23 @@ internal sealed class NearbyPartyReinforcer : INearbyPartyReinforcer
 
         SelectJoiners(mapEvent, playerParty, playerSide, playerParties, enemyParties, selectJoiners);
 
+        if (!CanReinforce(mapEvent))
+            return;
+
         AddJoiners(mapEvent.GetMapEventSide(playerSide), playerParties, playerPartyCount, addJoiner);
         AddJoiners(mapEvent.GetMapEventSide(enemySide), enemyParties, enemyPartyCount, addJoiner);
+    }
+
+    private void ScheduleFollowUpScan(MapEvent mapEvent, long currentTicks)
+    {
+        if (!followUpScans.TryGetValue(mapEvent, out var state))
+        {
+            state = new FollowUpScanState();
+            followUpScans.Add(mapEvent, state);
+        }
+
+        state.NextScanAtTicks = currentTicks + FollowUpScanIntervalTicks;
+        nextFollowUpScanAtTicks = Math.Min(nextFollowUpScanAtTicks, state.NextScanAtTicks);
     }
 
     internal static bool CanReinforce(MapEvent mapEvent)
@@ -90,6 +182,7 @@ internal sealed class NearbyPartyReinforcer : INearbyPartyReinforcer
         var encounter = new PlayerEncounter
         {
             _mapEvent = mapEvent,
+            EncounterSettlementAux = mapEvent.MapEventSettlement,
             PlayerSide = playerSide,
             OpponentSide = playerSide.GetOppositeSide()
         };

--- a/source/GameInterface/Services/MapEvents/NearbyPartyReinforcer.cs
+++ b/source/GameInterface/Services/MapEvents/NearbyPartyReinforcer.cs
@@ -152,19 +152,15 @@ internal sealed class NearbyPartyReinforcer : INearbyPartyReinforcer
             if (nearbyParty?.MapEventSide != side)
                 continue;
 
-            MapEventParty removedParty = null;
-            foreach (var mapEventParty in side.Parties)
-            {
-                if (mapEventParty.Party == nearbyParty.Party)
-                {
-                    removedParty = mapEventParty;
-                    break;
-                }
-            }
+            // The setter recursively removes attached army parties, so snapshot the whole side.
+            var partiesBeforeRemoval = new List<MapEventParty>(side.Parties);
 
             nearbyParty.MapEventSide = null;
-            if (removedParty != null)
-                messageBroker.Publish(side, new MapEventPartyRemoved(side, removedParty));
+            foreach (var removedParty in partiesBeforeRemoval)
+            {
+                if (!side.Parties.Contains(removedParty))
+                    messageBroker.Publish(side, new MapEventPartyRemoved(side, removedParty));
+            }
         }
     }
 

--- a/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
@@ -92,13 +92,12 @@ internal class MapEventPatches
     private static void Postfix_RemoveInvolvedPartyInternal(MapEvent __instance, MapEventParty mapEventParty)
     {
         if (ModInformation.IsClient
-            || mapEventParty?.Party?.MobileParty is not MobileParty removedParty
-            || !ContainerProvider.TryResolve<INearbyPartyReinforcer>(out var reinforcer))
+            || mapEventParty?.Party?.MobileParty is not MobileParty removedParty)
         {
             return;
         }
 
-        reinforcer.RemoveReinforcementsIfNoPlayers(__instance, removedParty);
+        MessageBroker.Instance.Publish(__instance, new PartyRemovedFromMapEvent(removedParty));
     }
 
     [HarmonyPatch(nameof(MapEvent.FinalizeEventAux))]

--- a/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
@@ -87,6 +87,20 @@ internal class MapEventPatches
         }
     }
 
+    [HarmonyPatch(nameof(MapEvent.RemoveInvolvedPartyInternal))]
+    [HarmonyPostfix]
+    private static void Postfix_RemoveInvolvedPartyInternal(MapEvent __instance, MapEventParty mapEventParty)
+    {
+        if (ModInformation.IsClient
+            || mapEventParty?.Party?.MobileParty is not MobileParty removedParty
+            || !ContainerProvider.TryResolve<INearbyPartyReinforcer>(out var reinforcer))
+        {
+            return;
+        }
+
+        reinforcer.RemoveReinforcementsIfNoPlayers(__instance, removedParty);
+    }
+
     [HarmonyPatch(nameof(MapEvent.FinalizeEventAux))]
     [HarmonyPrefix]
     [HarmonyPriority(Priority.First)]

--- a/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
@@ -381,16 +381,19 @@ internal class InteractionPatches
 {
     private sealed class PlayerBattleWindows
     {
+        private readonly bool aiJoinWindowEnabled;
+
         public CampaignTime AiJoinWindowExpiresAt { get; }
         public CampaignTime GoldFoodConsumptionWindowExpiresAt { get; }
 
         public PlayerBattleWindows(int aiJoinWindowHours, int goldFoodConsumptionWindowHours = 24)
         {
+            aiJoinWindowEnabled = aiJoinWindowHours > 0;
             AiJoinWindowExpiresAt = CampaignTime.HoursFromNow(aiJoinWindowHours);
             GoldFoodConsumptionWindowExpiresAt = CampaignTime.HoursFromNow(goldFoodConsumptionWindowHours);
         }
 
-        public bool AiJoinWindowExpired => CampaignTime.Now > AiJoinWindowExpiresAt;
+        public bool AiJoinWindowExpired => !aiJoinWindowEnabled || CampaignTime.Now > AiJoinWindowExpiresAt;
         public bool GoldFoodConsumptionExpired => CampaignTime.Now > GoldFoodConsumptionWindowExpiresAt;
     }
 

--- a/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
@@ -78,6 +78,13 @@ internal class MapEventPatches
             __instance,
             __instance._sides.SelectMany(side => side.Parties).ToList());
         MessageBroker.Instance.Publish(__instance, message);
+
+        if (isPlayerJoin && !InteractionPatches.IsInitializingPlayerBattle(__instance))
+        {
+            InteractionPatches.OpenAiJoinWindowAndPublish(
+                __instance,
+                () => MessageBroker.Instance.Publish(__instance, new PlayerJoinedBattle()));
+        }
     }
 
     [HarmonyPatch(nameof(MapEvent.FinalizeEventAux))]
@@ -520,10 +527,17 @@ internal class InteractionPatches
             return;
 
         initializingPlayerBattles.Remove(__instance);
-        playerBattleWindows.GetValue(
+        OpenAiJoinWindowAndPublish(
             __instance,
+            () => MessageBroker.Instance.Publish(__instance, new PlayerJoinedBattle()));
+    }
+
+    internal static void OpenAiJoinWindowAndPublish(MapEvent mapEvent, Action publish)
+    {
+        playerBattleWindows.GetValue(
+            mapEvent,
             _ => new PlayerBattleWindows(ModConfigProvider.ModOptions.PlayerBattleAiJoinWindowHours));
-        MessageBroker.Instance.Publish(__instance, new PlayerJoinedBattle());
+        publish();
     }
 
     [HarmonyPatch(typeof(MapEvent), nameof(MapEvent.Initialize))]


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

Co-op blocks the client-side nearby-party scan because it mutates the shared map event locally, but the server never replaces it. Nearby friendly lords and armies therefore stop instead of joining a player's battle.

## What is the new behavior?

Part of #2670

The server runs the native encounter-model selection when a player joins and on campaign ticks while the AI join window is open. The window is opened before the synchronous join trigger, and selected AI parties are added authoritatively on the game thread with sync patches active.

## How to test

`dotnet test source/GameInterface.Tests/GameInterface.Tests.csproj -c Release --filter FullyQualifiedName~NearbyPartyReinforcerTests`

## Bot Changelog Entry

- Nearby AI lords and armies can join player battles again.

<!-- issue-2670-split-scope -->
## Scope within #2670

This PR fixes #2670's nearby-AI combat-join/disengagement symptom. PR #3181 owns the separate siege-target-retargeting symptom that occurs when a player enters the intended settlement. Keep #2670 open until both implementations merge and both reproductions pass.
