### PR TITLE
Keep released offline player parties parked

### DIFF
--- a/source/Coop.Core/Server/Connections/ConnectionCollection.cs
+++ b/source/Coop.Core/Server/Connections/ConnectionCollection.cs
@@ -1,6 +1,7 @@
-using Common.Messaging;
+﻿using Common.Messaging;
 using Common.Network.Messages;
 using Coop.Core.Server.Connections.Messages;
+using Coop.Core.Server.Connections.States;
 using LiteNetLib;
 using System;
 using System.Collections;
@@ -18,6 +19,7 @@ namespace Coop.Core.Server.Connections;
 public interface IConnectionCollection : IEnumerable<IConnectionLogic>, IDisposable
 {
     IEnumerable<IConnectionLogic> LoadingPeers { get; }
+    bool HasCompletedCampaignSynchronization(NetPeer peer);
 }
 
 /// <inheritdoc cref="IConnectionCollection"/>
@@ -28,6 +30,10 @@ public class ConnectionCollection : IConnectionCollection
     public IEnumerable<IConnectionLogic> LoadingPeers => ConnectionStates
         .Select(conn => conn.Value)
         .Where(conn => conn.IsLoading);
+
+    public bool HasCompletedCampaignSynchronization(NetPeer peer) =>
+        ConnectionStates.TryGetValue(peer, out var connection) &&
+        (connection.State is CampaignState || connection.State is MissionState);
 
     private readonly IMessageBroker messageBroker;
     private readonly ConnectionContext connectionContext;

--- a/source/Coop.Core/Server/Connections/ConnectionCollection.cs
+++ b/source/Coop.Core/Server/Connections/ConnectionCollection.cs
@@ -31,9 +31,13 @@ public class ConnectionCollection : IConnectionCollection
         .Select(conn => conn.Value)
         .Where(conn => conn.IsLoading);
 
-    public bool HasCompletedCampaignSynchronization(NetPeer peer) =>
-        ConnectionStates.TryGetValue(peer, out var connection) &&
-        (connection.State is CampaignState || connection.State is MissionState);
+    public bool HasCompletedCampaignSynchronization(NetPeer peer)
+    {
+        if (!ConnectionStates.TryGetValue(peer, out var connection)) return false;
+
+        var state = connection.State;
+        return state is CampaignState || state is MissionState;
+    }
 
     private readonly IMessageBroker messageBroker;
     private readonly ConnectionContext connectionContext;

--- a/source/Coop.Core/Server/Services/Players/Handlers/PlayerPartyVisibilityHandler.cs
+++ b/source/Coop.Core/Server/Services/Players/Handlers/PlayerPartyVisibilityHandler.cs
@@ -4,6 +4,7 @@ using Common.Messaging;
 using Common.Network;
 using Common.Network.Messages;
 using Common.Util;
+using Coop.Core.Server.Connections;
 using Coop.Core.Server.Connections.Messages;
 using Coop.Core.Server.Services.Save.Messages;
 using GameInterface.Services.MapEvents.Messages;
@@ -13,6 +14,7 @@ using GameInterface.Services.ObjectManager;
 using GameInterface.Services.PartyBases.Extensions;
 using GameInterface.Services.PartyVisuals.Extensions;
 using GameInterface.Services.PartyVisuals.Messages;
+using GameInterface.Services.PlayerCaptivityService.Messages;
 using GameInterface.Services.Players;
 using GameInterface.Services.Players.Data;
 using GameInterface.Services.SiegeEvents.Interfaces;
@@ -44,6 +46,7 @@ internal class PlayerPartyVisibilityHandler : IHandler
 
     private readonly IMessageBroker messageBroker;
     private readonly IPlayerManager playerManager;
+    private readonly IConnectionCollection connectionCollection;
     private readonly IObjectManager objectManager;
     private readonly INetwork network;
     private readonly ISiegeEventInterface siegeEventInterface;
@@ -52,18 +55,21 @@ internal class PlayerPartyVisibilityHandler : IHandler
     public PlayerPartyVisibilityHandler(
         IMessageBroker messageBroker,
         IPlayerManager playerManager,
+        IConnectionCollection connectionCollection,
         IObjectManager objectManager,
         INetwork network,
         ISiegeEventInterface siegeEventInterface)
     {
         this.messageBroker = messageBroker;
         this.playerManager = playerManager;
+        this.connectionCollection = connectionCollection;
         this.objectManager = objectManager;
         this.network = network;
         this.siegeEventInterface = siegeEventInterface;
 
         messageBroker.Subscribe<PlayerDisconnected>(Handle_PlayerDisconnected);
         messageBroker.Subscribe<PlayerCampaignSynchronized>(Handle_PlayerCampaignSynchronized);
+        messageBroker.Subscribe<PlayerPartyReleasedFromCaptivity>(Handle_PlayerPartyReleasedFromCaptivity);
         messageBroker.Subscribe<MapEventFinalized>(Handle_MapEventFinalized);
         messageBroker.Subscribe<SavedPlayerRegistrationsRestored>(Handle_SavedPlayerRegistrationsRestored);
     }
@@ -72,6 +78,7 @@ internal class PlayerPartyVisibilityHandler : IHandler
     {
         messageBroker.Unsubscribe<PlayerDisconnected>(Handle_PlayerDisconnected);
         messageBroker.Unsubscribe<PlayerCampaignSynchronized>(Handle_PlayerCampaignSynchronized);
+        messageBroker.Unsubscribe<PlayerPartyReleasedFromCaptivity>(Handle_PlayerPartyReleasedFromCaptivity);
         messageBroker.Unsubscribe<MapEventFinalized>(Handle_MapEventFinalized);
         messageBroker.Unsubscribe<SavedPlayerRegistrationsRestored>(Handle_SavedPlayerRegistrationsRestored);
         deferredMapEventParking.Clear();
@@ -186,11 +193,43 @@ internal class PlayerPartyVisibilityHandler : IHandler
                 return;
             }
 
-            party.IsActive = true;
-            CreateVisual(party, player.MobilePartyId);
-            party.Party.UpdateVisibilityAndInspected(party.Position);
+            ActivateParty(party, player.MobilePartyId);
             Logger.Information("Restored party {PartyId} for reconnected peer {Peer}", party.StringId, peer.Id);
         });
+    }
+
+    private void Handle_PlayerPartyReleasedFromCaptivity(
+        MessagePayload<PlayerPartyReleasedFromCaptivity> payload)
+    {
+        if (ModInformation.IsClient) return;
+
+        var party = payload.What.PlayerParty;
+        if (party == null) return;
+
+        party.IsActive = false;
+        party.IsVisible = false;
+        RemoveVisual(party);
+
+        if (!TryGetPlayer(party, out var player) ||
+            !playerManager.IsConnected(player) ||
+            !playerManager.TryGetPeer(player.ControllerId, out var peer) ||
+            !connectionCollection.HasCompletedCampaignSynchronization(peer))
+        {
+            Logger.Information(
+                "Kept released party {PartyId} parked because its player is offline or synchronizing",
+                party.StringId);
+            return;
+        }
+
+        ActivateParty(party, player.MobilePartyId);
+        Logger.Information("Restored released party {PartyId} for peer {Peer}", party.StringId, peer.Id);
+    }
+
+    private void ActivateParty(MobileParty party, string mobilePartyId)
+    {
+        party.IsActive = true;
+        CreateVisual(party, mobilePartyId);
+        party.Party.UpdateVisibilityAndInspected(party.Position);
     }
 
     private void Handle_MapEventFinalized(MessagePayload<MapEventFinalized> payload)
@@ -291,5 +330,14 @@ internal class PlayerPartyVisibilityHandler : IHandler
 
         return playerManager.TryGetPlayer(peer, out player) &&
             objectManager.TryGetObjectWithLogging(player.MobilePartyId, out party);
+    }
+
+    private bool TryGetPlayer(MobileParty party, out Player player)
+    {
+        player = null;
+        if (!objectManager.TryGetIdWithLogging(party, out var partyId)) return false;
+
+        player = playerManager.Players.FirstOrDefault(candidate => candidate.MobilePartyId == partyId);
+        return player != null;
     }
 }

--- a/source/Coop.Tests/Server/Connections/States/ConnectionCollectionTests.cs
+++ b/source/Coop.Tests/Server/Connections/States/ConnectionCollectionTests.cs
@@ -6,6 +6,7 @@ using Coop.Core.Server.Connections.Messages;
 using Coop.Core.Server.Connections.States;
 using Coop.Tests.Mocks;
 using LiteNetLib;
+using Moq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -131,6 +132,34 @@ namespace Coop.Tests.Server.Connections.States
 
             connectionLogic.SetState<CampaignState>();
             Assert.Empty(connectionCollection.LoadingPeers);
+        }
+
+        [Fact]
+        public void HasCompletedCampaignSynchronization_ReadsStateOnce()
+        {
+            var connectPayload = new MessagePayload<PlayerConnected>(this, new PlayerConnected(playerPeer));
+            connectionCollection.PlayerJoiningHandler(connectPayload);
+            var missionState = connectionCollection.ConnectionStates[playerPeer].SetState<MissionState>();
+            var connection = new Mock<IConnectionLogic>();
+            connection.SetupGet(logic => logic.State).Returns(missionState);
+            connectionCollection.ConnectionStates[playerPeer] = connection.Object;
+
+            Assert.True(connectionCollection.HasCompletedCampaignSynchronization(playerPeer));
+            connection.VerifyGet(logic => logic.State, Times.Once);
+        }
+
+        [Fact]
+        public void HasCompletedCampaignSynchronization_AcceptsCampaignAndMissionStates()
+        {
+            var connectPayload = new MessagePayload<PlayerConnected>(this, new PlayerConnected(playerPeer));
+            connectionCollection.PlayerJoiningHandler(connectPayload);
+            var connection = connectionCollection.ConnectionStates[playerPeer];
+
+            connection.SetState<CampaignState>();
+            Assert.True(connectionCollection.HasCompletedCampaignSynchronization(playerPeer));
+
+            connection.SetState<MissionState>();
+            Assert.True(connectionCollection.HasCompletedCampaignSynchronization(playerPeer));
         }
 
         [Fact]

--- a/source/Coop.Tests/Server/Services/Players/PlayerPartyVisibilityHandlerTests.cs
+++ b/source/Coop.Tests/Server/Services/Players/PlayerPartyVisibilityHandlerTests.cs
@@ -2,10 +2,14 @@
 using Common.Network;
 using Common.Network.Messages;
 using Common.Tests.Utils;
+using Coop.Core.Server.Connections;
 using Coop.Core.Server.Connections.Messages;
 using Coop.Core.Server.Services.Players.Handlers;
 using Coop.Core.Server.Services.Save.Messages;
+using GameInterface.Services.MapEvents.Messages;
+using GameInterface.Services.MapEvents.Messages.Leave;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.PlayerCaptivityService.Messages;
 using GameInterface.Services.Players;
 using GameInterface.Services.Players.Data;
 using GameInterface.Services.SiegeEvents.Interfaces;
@@ -15,6 +19,7 @@ using Moq;
 using System;
 using System.Runtime.Serialization;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.MapEvents;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.CampaignSystem.Siege;
@@ -82,6 +87,7 @@ public class PlayerPartyVisibilityHandlerTests : IDisposable
         using var handler = new PlayerPartyVisibilityHandler(
             broker,
             playerManager.Object,
+            Mock.Of<IConnectionCollection>(),
             objectManager.Object,
             Mock.Of<INetwork>(),
             Mock.Of<ISiegeEventInterface>());
@@ -106,6 +112,7 @@ public class PlayerPartyVisibilityHandlerTests : IDisposable
         using var handler = new PlayerPartyVisibilityHandler(
             broker,
             playerManager.Object,
+            Mock.Of<IConnectionCollection>(),
             objectManager.Object,
             Mock.Of<INetwork>(),
             Mock.Of<ISiegeEventInterface>());
@@ -137,6 +144,7 @@ public class PlayerPartyVisibilityHandlerTests : IDisposable
         using var handler = new PlayerPartyVisibilityHandler(
             broker,
             playerManager.Object,
+            Mock.Of<IConnectionCollection>(),
             objectManager.Object,
             Mock.Of<INetwork>(),
             siegeEventInterface.Object);
@@ -172,6 +180,7 @@ public class PlayerPartyVisibilityHandlerTests : IDisposable
         using var handler = new PlayerPartyVisibilityHandler(
             broker,
             playerManager.Object,
+            Mock.Of<IConnectionCollection>(),
             objectManager.Object,
             Mock.Of<INetwork>(),
             Mock.Of<ISiegeEventInterface>());
@@ -207,6 +216,7 @@ public class PlayerPartyVisibilityHandlerTests : IDisposable
         using var handler = new PlayerPartyVisibilityHandler(
             broker,
             playerManager.Object,
+            Mock.Of<IConnectionCollection>(),
             objectManager.Object,
             Mock.Of<INetwork>(),
             Mock.Of<ISiegeEventInterface>());
@@ -216,6 +226,146 @@ public class PlayerPartyVisibilityHandlerTests : IDisposable
 
         Assert.False(party.IsActive);
         objectManager.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public void CaptivityRelease_OfflineOwner_LeavesPartyInactiveHiddenAndWithoutVisual()
+    {
+        var player = CreatePlayer();
+        var party = CreateParty();
+        var peer = (NetPeer)FormatterServices.GetUninitializedObject(typeof(NetPeer));
+        var (playerManager, connectionCollection, objectManager) =
+            CreateReleaseMocks(player, party, peer, isConnected: false, isSynchronized: false);
+        var network = new Mock<INetwork>();
+        var broker = new TestMessageBroker();
+        using var handler = new PlayerPartyVisibilityHandler(
+            broker,
+            playerManager.Object,
+            connectionCollection.Object,
+            objectManager.Object,
+            network.Object,
+            Mock.Of<ISiegeEventInterface>());
+
+        broker.Publish(this, new PlayerPartyReleasedFromCaptivity(party));
+
+        Assert.False(party.IsActive);
+        Assert.False(party.IsVisible);
+        network.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public void CaptivityRelease_SynchronizedOwner_ActivatesParty()
+    {
+        var player = CreatePlayer();
+        var party = CreateParty(isActive: false);
+        party._currentSettlement = (Settlement)FormatterServices.GetUninitializedObject(typeof(Settlement));
+        var peer = (NetPeer)FormatterServices.GetUninitializedObject(typeof(NetPeer));
+        var (playerManager, connectionCollection, objectManager) =
+            CreateReleaseMocks(player, party, peer, isConnected: true, isSynchronized: true);
+        var broker = new TestMessageBroker();
+        using var handler = new PlayerPartyVisibilityHandler(
+            broker,
+            playerManager.Object,
+            connectionCollection.Object,
+            objectManager.Object,
+            Mock.Of<INetwork>(),
+            Mock.Of<ISiegeEventInterface>());
+
+        broker.Publish(this, new PlayerPartyReleasedFromCaptivity(party));
+
+        Assert.True(party.IsActive);
+    }
+
+    [Fact]
+    public void CaptivityRelease_LoadingOwner_LeavesPartyParked()
+    {
+        var player = CreatePlayer();
+        var party = CreateParty();
+        var peer = (NetPeer)FormatterServices.GetUninitializedObject(typeof(NetPeer));
+        var (playerManager, connectionCollection, objectManager) =
+            CreateReleaseMocks(player, party, peer, isConnected: true, isSynchronized: false);
+        var broker = new TestMessageBroker();
+        using var handler = new PlayerPartyVisibilityHandler(
+            broker,
+            playerManager.Object,
+            connectionCollection.Object,
+            objectManager.Object,
+            Mock.Of<INetwork>(),
+            Mock.Of<ISiegeEventInterface>());
+
+        broker.Publish(this, new PlayerPartyReleasedFromCaptivity(party));
+
+        Assert.False(party.IsActive);
+        Assert.False(party.IsVisible);
+    }
+
+    [Fact]
+    public void CaptivityRelease_LoadingOwner_ActivatesAfterCampaignSynchronization()
+    {
+        var player = CreatePlayer();
+        var party = CreateParty();
+        var peer = (NetPeer)FormatterServices.GetUninitializedObject(typeof(NetPeer));
+        var (playerManager, connectionCollection, objectManager) =
+            CreateReleaseMocks(player, party, peer, isConnected: true, isSynchronized: false);
+        objectManager
+            .Setup(manager => manager.TryGetObjectWithLogging(player.MobilePartyId, out party))
+            .Returns(true);
+        var broker = new TestMessageBroker();
+        using var handler = new PlayerPartyVisibilityHandler(
+            broker,
+            playerManager.Object,
+            connectionCollection.Object,
+            objectManager.Object,
+            Mock.Of<INetwork>(),
+            Mock.Of<ISiegeEventInterface>());
+
+        broker.Publish(this, new PlayerPartyReleasedFromCaptivity(party));
+        Assert.False(party.IsActive);
+
+        broker.Publish(this, new PlayerCampaignSynchronized(peer));
+        GameThread.Run(() => { }, blocking: true);
+
+        Assert.True(party.IsActive);
+    }
+
+    [Fact]
+    public void CaptivityRelease_DeferredMapEventParking_RemainsInactiveAfterFinalization()
+    {
+        var player = CreatePlayer();
+        var party = CreateParty();
+        var peer = (NetPeer)FormatterServices.GetUninitializedObject(typeof(NetPeer));
+        var mapEvent = (MapEvent)FormatterServices.GetUninitializedObject(typeof(MapEvent));
+        var mapEventSide = (MapEventSide)FormatterServices.GetUninitializedObject(typeof(MapEventSide));
+        AccessTools.Field(typeof(MapEventSide), "_mapEvent").SetValue(mapEventSide, mapEvent);
+        party.Party._mapEventSide = mapEventSide;
+
+        var (playerManager, connectionCollection, objectManager) =
+            CreateReleaseMocks(player, party, peer, isConnected: false, isSynchronized: false);
+        objectManager
+            .Setup(manager => manager.TryGetObjectWithLogging(player.MobilePartyId, out party))
+            .Returns(true);
+        var broker = new TestMessageBroker();
+        using var handler = new PlayerPartyVisibilityHandler(
+            broker,
+            playerManager.Object,
+            connectionCollection.Object,
+            objectManager.Object,
+            Mock.Of<INetwork>(),
+            Mock.Of<ISiegeEventInterface>());
+
+        broker.Publish(this, new PlayerDisconnected(peer, default));
+        GameThread.Run(() => { }, blocking: true);
+        Assert.True(party.IsActive);
+        Assert.Single(broker.GetMessagesFromType<PlayerDisconnectedFromMapEvent>());
+
+        party.Party._mapEventSide = null;
+        broker.Publish(this, new PlayerPartyReleasedFromCaptivity(party));
+        Assert.False(party.IsActive);
+
+        broker.Publish(this, new MapEventFinalized(mapEvent));
+
+        Assert.False(party.IsActive);
+        Assert.False(party.IsVisible);
     }
 
     [Fact]
@@ -238,6 +388,7 @@ public class PlayerPartyVisibilityHandlerTests : IDisposable
         using var handler = new PlayerPartyVisibilityHandler(
             broker,
             playerManager.Object,
+            Mock.Of<IConnectionCollection>(),
             objectManager.Object,
             Mock.Of<INetwork>(),
             Mock.Of<ISiegeEventInterface>());
@@ -246,6 +397,32 @@ public class PlayerPartyVisibilityHandlerTests : IDisposable
 
         playerManager.Verify(manager => manager.ClearPeer(peer), Times.Once);
         Assert.Single(broker.GetMessagesFromType<PlayerConnectionStateChanged>());
+    }
+
+    private static (Mock<IPlayerManager>, Mock<IConnectionCollection>, Mock<IObjectManager>)
+        CreateReleaseMocks(
+            Player player,
+            MobileParty party,
+            NetPeer peer,
+            bool isConnected,
+            bool isSynchronized)
+    {
+        var playerManager = new Mock<IPlayerManager>();
+        playerManager.SetupGet(manager => manager.Players).Returns(new[] { player });
+        playerManager.Setup(manager => manager.TryGetPlayer(peer, out player)).Returns(true);
+        playerManager.Setup(manager => manager.TryGetPeer(player.ControllerId, out peer)).Returns(true);
+        playerManager.Setup(manager => manager.IsConnected(player)).Returns(isConnected);
+
+        string partyId = player.MobilePartyId;
+        var objectManager = new Mock<IObjectManager>();
+        objectManager.Setup(manager => manager.TryGetIdWithLogging(party, out partyId)).Returns(true);
+
+        var connectionCollection = new Mock<IConnectionCollection>();
+        connectionCollection
+            .Setup(collection => collection.HasCompletedCampaignSynchronization(peer))
+            .Returns(isSynchronized);
+
+        return (playerManager, connectionCollection, objectManager);
     }
 
     private static Player CreatePlayer() =>

--- a/source/E2E.Tests/Environment/E2ETestEnvironment.cs
+++ b/source/E2E.Tests/Environment/E2ETestEnvironment.cs
@@ -1,9 +1,13 @@
 ﻿using Common;
 using Common.Logging;
+using Common.Messaging;
 using Common.Network;
 using Common.Network.Coalescing;
 using Common.Tests.Utils;
 using Common.Util;
+using Coop.Core.Server.Connections;
+using Coop.Core.Server.Connections.Messages;
+using Coop.Core.Server.Connections.States;
 using Coop.Core.Server.Services.Time.Handlers;
 using E2E.Tests.Environment.Instance;
 using E2E.Tests.Util;
@@ -121,6 +125,14 @@ public class E2ETestEnvironment : IDisposable
                 $"Player '{controllerId}' must be registered before connecting its peer.");
 
             playerManager.SetPeer(controllerId, client.NetPeer);
+
+            var connections = Server.Resolve<ConnectionCollection>();
+            if (!connections.ConnectionStates.TryGetValue(client.NetPeer, out var connection))
+            {
+                Server.Resolve<IMessageBroker>().Publish(this, new PlayerConnected(client.NetPeer));
+                Assert.True(connections.ConnectionStates.TryGetValue(client.NetPeer, out connection));
+            }
+            connection.SetState<CampaignState>();
 
             Assert.True(
                 playerManager.IsConnected(player),

--- a/source/E2E.Tests/Services/MapEvents/MapEventEnvironmentTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/MapEventEnvironmentTests.cs
@@ -319,6 +319,7 @@ public class MapEventEnvironmentTests : MapEventTestBase
         // Arrange — the player loses a battle and is taken prisoner by the captor party. Capture parks the
         // player party (emptied + deactivated) and makes the hero the captor's prisoner.
         var (heroId, partyId) = CreatePlayerHeroParty("MyControllerId");
+        TestEnvironment.ConnectRegisteredPlayer(Clients.First(), "MyControllerId");
         var captorPartyId = TestEnvironment.CreateRegisteredObject<MobileParty>();
         DefeatPlayerPartyInBattle(heroId, partyId, captorPartyId);
 
@@ -356,6 +357,7 @@ public class MapEventEnvironmentTests : MapEventTestBase
         // lord hero, captured via the companion capture). The player hero itself is added by
         // DefeatPlayerPartyInBattle AFTER this snapshot, hence the explicit +1 below.
         var (heroId, partyId) = CreatePlayerHeroParty("MyControllerId");
+        TestEnvironment.ConnectRegisteredPlayer(Clients.First(), "MyControllerId");
         var captorPartyId = TestEnvironment.CreateRegisteredObject<MobileParty>();
         var capturedTroops = GetPartyNonHeroManCount(Server, partyId);
         var capturedRidingHeroes = GetPartyLiveHeroCount(Server, partyId);
@@ -406,6 +408,7 @@ public class MapEventEnvironmentTests : MapEventTestBase
     public void EscapeFromCaptivity_ProtectsPlayerFromFormerCaptorForTwelveHours()
     {
         var (heroId, partyId) = CreatePlayerHeroParty("MyControllerId");
+        TestEnvironment.ConnectRegisteredPlayer(Clients.First(), "MyControllerId");
         var captorPartyId = TestEnvironment.CreateRegisteredObject<MobileParty>();
         DefeatPlayerPartyInBattle(heroId, partyId, captorPartyId);
 
@@ -477,6 +480,7 @@ public class MapEventEnvironmentTests : MapEventTestBase
     {
         // Arrange — the player party holds the hero plus a stack of regular troops on every instance.
         var (heroId, partyId) = CreatePlayerHeroParty("MyControllerId");
+        TestEnvironment.ConnectRegisteredPlayer(Clients.First(), "MyControllerId");
         var troopCharacterId = TestEnvironment.CreateRegisteredObject<CharacterObject>();
         SeedPartyTroopOnAll(partyId, troopCharacterId, 5);
         var captorPartyId = TestEnvironment.CreateRegisteredObject<MobileParty>();
@@ -532,6 +536,7 @@ public class MapEventEnvironmentTests : MapEventTestBase
     {
         // Arrange — a troopless player is captured.
         var (heroId, partyId) = CreatePlayerHeroParty("MyControllerId");
+        TestEnvironment.ConnectRegisteredPlayer(Clients.First(), "MyControllerId");
         var captorPartyId = TestEnvironment.CreateRegisteredObject<MobileParty>();
         DefeatPlayerPartyInBattle(heroId, partyId, captorPartyId);
 
@@ -554,6 +559,7 @@ public class MapEventEnvironmentTests : MapEventTestBase
         // Arrange — create both player parties and attach the captor hero to its authoritative party so
         // NetworkCompleteDoneLogic resolves the Party screen's right-hand owner and rosters.
         var (playerHeroId, playerPartyId) = CreatePlayerHeroParty("CaptiveControllerId");
+        TestEnvironment.ConnectRegisteredPlayer(Clients.First(), "CaptiveControllerId");
         var (captorHeroId, captorPartyId) = CreatePlayerHeroParty("CaptorControllerId");
 
         Server.Call(() =>
@@ -612,6 +618,7 @@ public class MapEventEnvironmentTests : MapEventTestBase
         // Arrange — capture a player normally, then reproduce the live divergence: the server has already
         // lost the prison-roster element while the captor client still displays it and captivity is active.
         var (playerHeroId, playerPartyId) = CreatePlayerHeroParty("CaptiveControllerId");
+        TestEnvironment.ConnectRegisteredPlayer(Clients.First(), "CaptiveControllerId");
         var (captorHeroId, captorPartyId) = CreatePlayerHeroParty("CaptorControllerId");
 
         Server.Call(() =>

--- a/source/GameInterface/Services/PlayerCaptivityService/Handlers/PlayerCaptivityServerHandler.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Handlers/PlayerCaptivityServerHandler.cs
@@ -504,8 +504,9 @@ internal class PlayerCaptivityServerHandler : IHandler
 
     /// <summary>
     /// Server-authoritative release of a player (client) hero from captivity, shared by the client-requested
-    /// and server-initiated paths. Restores the deactivated player party to the map and clears the captivity
-    /// state — which auto-syncs to the clients through <see cref="Hero.PartyBelongedToAsPrisoner"/>.
+    /// and server-initiated paths. Restores the party's captivity state and release position, then lets the
+    /// server visibility handler decide whether its synchronized owner is ready for map activation. The cleared
+    /// captivity state auto-syncs to the clients through <see cref="Hero.PartyBelongedToAsPrisoner"/>.
     /// Re-implements native <see cref="PlayerCaptivity"/>.EndCaptivityInternal for a hero that is not this
     /// instance's main hero; the menu/encounter cleanup the native version does happens on the owning client
     /// instead (<see cref="PlayerCaptivityClientHandler"/>).
@@ -612,7 +613,6 @@ internal class PlayerCaptivityServerHandler : IHandler
         if (playerHero.IsAlive)
         {
             playerParty.Position = releasePosition;
-            playerParty.IsActive = true;
             playerParty.IgnoreForHours(4);
             if (captorParty?.MobileParty?.IsActive == true)
             {
@@ -638,16 +638,12 @@ internal class PlayerCaptivityServerHandler : IHandler
                 SkillLevelingManager.OnMainHeroReleasedFromCaptivity(PlayerCaptivity.CaptivityStartTime.ElapsedHoursUntilNow);
             }
 
-            if (!playerParty.IsCurrentlyAtSea)
-            {
-                playerParty.Party.UpdateVisibilityAndInspected(playerParty.Position);
-            }
             SyncReleasePosition(playerParty, releasePosition);
 
-            // Rebuild the map mesh after the roster/leader/position are restored, so the freed party's map
-            // figure reflects its (re-mounted) state rather than the stale on-foot captive mesh.
+            // The visibility handler keeps offline/loading owners parked and rebuilds the map figure only
+            // after campaign synchronization has completed.
             playerParty.Party.SetVisualAsDirty();
-            RecreateVisual(playerParty);
+            messageBroker.Publish(this, new PlayerPartyReleasedFromCaptivity(playerParty));
         }
     }
 
@@ -687,33 +683,6 @@ internal class PlayerCaptivityServerHandler : IHandler
         }
 
         network.SendAll(new NetworkDestroyPartyVisual(partyVisualId, mobilePartyId));
-    }
-
-    private void RecreateVisual(MobileParty party)
-    {
-        RemoveVisual(party);
-
-        if (!objectManager.TryGetIdWithLogging(party, out string mobilePartyId)) return;
-
-        using (new AllowedThread())
-        {
-            party.CreateNewPartyVisual();
-        }
-
-        var partyVisual = party.Party.GetPartyVisual();
-        if (partyVisual == null)
-        {
-            Logger.Error("CreateNewPartyVisual did not produce a visual for party {PartyId}", party.StringId);
-            return;
-        }
-
-        if (!objectManager.AddNewObject(partyVisual, out var visualId))
-        {
-            Logger.Error("Failed to register recreated visual for party {PartyId}", party.StringId);
-            return;
-        }
-
-        network.SendAll(new NetworkCreatePartyVisual(visualId, mobilePartyId));
     }
 
     /// <summary>

--- a/source/GameInterface/Services/PlayerCaptivityService/Messages/PlayerPartyReleasedFromCaptivity.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Messages/PlayerPartyReleasedFromCaptivity.cs
@@ -1,0 +1,15 @@
+﻿using Common.Messaging;
+using TaleWorlds.CampaignSystem.Party;
+
+namespace GameInterface.Services.PlayerCaptivityService.Messages;
+
+/// <summary>Published on the server game thread after a player party's captivity state is restored.</summary>
+public readonly struct PlayerPartyReleasedFromCaptivity : IEvent
+{
+    public readonly MobileParty PlayerParty;
+
+    public PlayerPartyReleasedFromCaptivity(MobileParty playerParty)
+    {
+        PlayerParty = playerParty;
+    }
+}


### PR DESCRIPTION
## PR Checklist
- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?
Captivity release reactivates and recreates an offline or still-loading player's party, making the one-hero party attackable again.

## What is the new behavior?
Resolves #2574

Captivity state and release position are restored immediately, but party visibility is restored only for a connected player that completed campaign synchronization. Offline and loading parties stay inactive and hidden until the existing synchronization handler activates them.

Tested with the full `Coop.Tests` suite in Release: 700 passed, 1 skipped.

## Bot Changelog Entry
- Released offline player parties no longer reappear on the map and get captured repeatedly.