### PR TITLE
Resolve starving AI siege stalls

### DIFF
--- a/source/GameInterface.Tests/Services/BesiegerCamps/BesiegerCampAssaultPatchesTests.cs
+++ b/source/GameInterface.Tests/Services/BesiegerCamps/BesiegerCampAssaultPatchesTests.cs
@@ -1,0 +1,32 @@
+﻿using GameInterface.Services.BesiegerCamps.Patches;
+using GameInterface.Services.SiegeEvents;
+using Xunit;
+
+namespace GameInterface.Tests.Services.BesiegerCamps;
+
+[Collection(ModInformationRoleCollection.Name)]
+public class BesiegerCampAssaultPatchesTests
+{
+    [Fact]
+    public void NoContainer_UsesDedicatedHostSafeReadiness()
+    {
+        bool hadPreviousContainer = ContainerProvider.TryGetContainer(out var previousContainer);
+        try
+        {
+            ContainerProvider.Clear();
+
+            Assert.IsType<AiSiegeAssaultReadiness>(BesiegerCampAssaultPatches.ResolveReadiness());
+        }
+        finally
+        {
+            if (hadPreviousContainer)
+            {
+                ContainerProvider.SetContainer(previousContainer);
+            }
+            else
+            {
+                ContainerProvider.Clear();
+            }
+        }
+    }
+}

--- a/source/GameInterface.Tests/Services/SiegeEvents/AiSiegeAssaultReadinessTests.cs
+++ b/source/GameInterface.Tests/Services/SiegeEvents/AiSiegeAssaultReadinessTests.cs
@@ -67,6 +67,23 @@ public class AiSiegeAssaultReadinessTests
         Assert.True(result.IsViable);
     }
 
+    [Fact]
+    public void EmptyAttackAndDefense_IsNotViable()
+    {
+        var result = readiness.Evaluate(new AiSiegeAssaultReadinessInput(
+            attackerStrength: 0f,
+            defenderStrength: 0f,
+            settlementAdvantage: 1f,
+            siegeElapsedHours: 96f,
+            hasRam: true,
+            hasSiegeTower: true,
+            equipmentBuilt: 3,
+            maximumEquipmentProgress: 0f));
+
+        Assert.True(float.IsNaN(result.PowerRatioBeforeEquipment));
+        Assert.False(result.IsViable);
+    }
+
     private static AiSiegeAssaultReadinessInput CreateTimedInput(float siegeElapsedHours)
     {
         return new AiSiegeAssaultReadinessInput(

--- a/source/GameInterface.Tests/Services/SiegeEvents/AiSiegeAssaultReadinessTests.cs
+++ b/source/GameInterface.Tests/Services/SiegeEvents/AiSiegeAssaultReadinessTests.cs
@@ -1,0 +1,82 @@
+﻿using GameInterface.Services.SiegeEvents;
+using Xunit;
+
+namespace GameInterface.Tests.Services.SiegeEvents;
+
+public class AiSiegeAssaultReadinessTests
+{
+    private readonly AiSiegeAssaultReadiness readiness = new AiSiegeAssaultReadiness();
+
+    [Fact]
+    public void StrongPreparedAttack_WithUsableEquipment_IsViable()
+    {
+        var result = readiness.Evaluate(new AiSiegeAssaultReadinessInput(
+            attackerStrength: 200f,
+            defenderStrength: 100f,
+            settlementAdvantage: 1f,
+            siegeElapsedHours: 96f,
+            hasRam: true,
+            hasSiegeTower: true,
+            equipmentBuilt: 3,
+            maximumEquipmentProgress: 0f));
+
+        Assert.True(result.IsViable);
+        Assert.Equal(2f, result.PowerRatioBeforeEquipment);
+        Assert.True(result.AssaultChance > 0f);
+    }
+
+    [Fact]
+    public void StrongAttack_WithoutBuiltEquipment_IsNotYetViable()
+    {
+        var result = readiness.Evaluate(new AiSiegeAssaultReadinessInput(
+            attackerStrength: 200f,
+            defenderStrength: 100f,
+            settlementAdvantage: 1f,
+            siegeElapsedHours: 96f,
+            hasRam: false,
+            hasSiegeTower: false,
+            equipmentBuilt: 0,
+            maximumEquipmentProgress: 0f));
+
+        Assert.False(result.IsViable);
+        Assert.Equal(0f, result.PowerRatioAfterEquipment);
+    }
+
+    [Fact]
+    public void TimeAfterVanillaGracePeriod_ImprovesPowerRatio()
+    {
+        var atGracePeriod = readiness.Evaluate(CreateTimedInput(96f));
+        var oneDayLater = readiness.Evaluate(CreateTimedInput(120f));
+
+        Assert.True(oneDayLater.PowerRatioBeforeEquipment > atGracePeriod.PowerRatioBeforeEquipment);
+    }
+
+    [Fact]
+    public void EmptyDefense_IsViableWithoutDividingPolicyFromVanilla()
+    {
+        var result = readiness.Evaluate(new AiSiegeAssaultReadinessInput(
+            attackerStrength: 100f,
+            defenderStrength: 0f,
+            settlementAdvantage: 2f,
+            siegeElapsedHours: 0f,
+            hasRam: false,
+            hasSiegeTower: false,
+            equipmentBuilt: 0,
+            maximumEquipmentProgress: 0f));
+
+        Assert.True(result.IsViable);
+    }
+
+    private static AiSiegeAssaultReadinessInput CreateTimedInput(float siegeElapsedHours)
+    {
+        return new AiSiegeAssaultReadinessInput(
+            attackerStrength: 150f,
+            defenderStrength: 100f,
+            settlementAdvantage: 2f,
+            siegeElapsedHours,
+            hasRam: true,
+            hasSiegeTower: true,
+            equipmentBuilt: 3,
+            maximumEquipmentProgress: 0f);
+    }
+}

--- a/source/GameInterface.Tests/Services/SiegeEvents/AiSiegeTerminalPolicyTests.cs
+++ b/source/GameInterface.Tests/Services/SiegeEvents/AiSiegeTerminalPolicyTests.cs
@@ -1,0 +1,87 @@
+﻿using GameInterface.Services.SiegeEvents;
+using Moq;
+using Serilog;
+using Xunit;
+
+namespace GameInterface.Tests.Services.SiegeEvents;
+
+public class AiSiegeTerminalPolicyTests
+{
+    private static AiSiegeTerminalPolicy CreatePolicy()
+    {
+        return new AiSiegeTerminalPolicy(
+            new Mock<IAiSiegeAssaultReadiness>().Object,
+            new Mock<ILogger>().Object);
+    }
+
+    [Fact]
+    public void StarvingPreparedViableAiSiege_Assaults()
+    {
+        var decision = CreatePolicy().GetDecision(CreateContext(isAssaultViable: true));
+
+        Assert.Equal(AiSiegeTerminalDecision.Assault, decision);
+    }
+
+    [Fact]
+    public void StarvingPreparedInviableAiSiege_Withdraws()
+    {
+        var decision = CreatePolicy().GetDecision(CreateContext(isAssaultViable: false));
+
+        Assert.Equal(AiSiegeTerminalDecision.Withdraw, decision);
+    }
+
+    [Fact]
+    public void ActiveTransition_DoesNotStartDuplicateTerminalAction()
+    {
+        var decision = CreatePolicy().GetDecision(CreateContext(
+            isAssaultViable: true,
+            hasActiveTransition: true));
+
+        Assert.Equal(AiSiegeTerminalDecision.None, decision);
+    }
+
+    [Fact]
+    public void PlayerLedSiege_IsUnaffected()
+    {
+        var decision = CreatePolicy().GetDecision(CreateContext(
+            isAssaultViable: true,
+            isPlayerLed: true));
+
+        Assert.Equal(AiSiegeTerminalDecision.None, decision);
+    }
+
+    [Fact]
+    public void EndedSiegeState_IsCleanAcrossPolicyInstances()
+    {
+        var context = CreateContext(isAssaultViable: true, isCurrentSiege: false);
+
+        Assert.Equal(AiSiegeTerminalDecision.None, CreatePolicy().GetDecision(context));
+        Assert.Equal(AiSiegeTerminalDecision.None, CreatePolicy().GetDecision(context));
+    }
+
+    [Fact]
+    public void StarvingUnpreparedSiege_Withdraws()
+    {
+        var decision = CreatePolicy().GetDecision(CreateContext(
+            isAssaultViable: true,
+            isPrepared: false));
+
+        Assert.Equal(AiSiegeTerminalDecision.Withdraw, decision);
+    }
+
+    private static AiSiegeTerminalContext CreateContext(
+        bool isAssaultViable,
+        bool isPrepared = true,
+        bool isPlayerLed = false,
+        bool isCurrentSiege = true,
+        bool hasActiveTransition = false)
+    {
+        return new AiSiegeTerminalContext(
+            isFoodProblem: true,
+            isPrepared,
+            isPlayerLed,
+            isCurrentSiege,
+            hasActiveTransition,
+            isAssaultViable);
+    }
+}

--- a/source/GameInterface.Tests/Services/SiegeEvents/AiSiegeTerminalPolicyTests.cs
+++ b/source/GameInterface.Tests/Services/SiegeEvents/AiSiegeTerminalPolicyTests.cs
@@ -1,23 +1,24 @@
-﻿using Common.Messaging;
+﻿using Common;
 using Common.Util;
 using GameInterface.Services.SiegeEvents;
 using Moq;
 using Serilog;
 using System.Collections.Generic;
+using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Siege;
 using Xunit;
 
 namespace GameInterface.Tests.Services.SiegeEvents;
 
+[Collection(ModInformationRoleCollection.Name)]
 public class AiSiegeTerminalPolicyTests
 {
     private static AiSiegeTerminalPolicy CreatePolicy()
     {
         return new AiSiegeTerminalPolicy(
             new Mock<IAiSiegeAssaultReadiness>().Object,
-            new Mock<ILogger>().Object,
-            new Mock<IMessageBroker>().Object);
+            new Mock<ILogger>().Object);
     }
 
     [Fact]
@@ -49,7 +50,7 @@ public class AiSiegeTerminalPolicyTests
     [Fact]
     public void DeferredTransition_IsRetriedOnce()
     {
-        using var policy = CreatePolicy();
+        var policy = CreatePolicy();
         var state = new AiSiegeTerminalTransitionState(
             ObjectHelper.SkipConstructor<MobileParty>(),
             ObjectHelper.SkipConstructor<SiegeEvent>());
@@ -63,6 +64,37 @@ public class AiSiegeTerminalPolicyTests
         var retry = Assert.Single(retried);
         Assert.Same(state.LeaderParty, retry.LeaderParty);
         Assert.Same(state.SiegeEvent, retry.SiegeEvent);
+    }
+
+    [Fact]
+    public void DeferredTransition_SurvivesSaveAndReload()
+    {
+        var records = new Dictionary<string, object>();
+        var state = new AiSiegeTerminalTransitionState(
+            ObjectHelper.SkipConstructor<MobileParty>(),
+            ObjectHelper.SkipConstructor<SiegeEvent>());
+        bool previousRole = ModInformation.IsServer;
+        ModInformation.IsServer = true;
+
+        try
+        {
+            var original = CreatePolicy();
+            original.Defer(state);
+            original.SyncData(new TestDataStore(isSaving: true, records));
+
+            var restored = CreatePolicy();
+            restored.SyncData(new TestDataStore(isSaving: false, records));
+            var retried = new List<AiSiegeTerminalTransitionState>();
+            restored.RetryDeferredTransitions(retried.Add);
+
+            var retry = Assert.Single(retried);
+            Assert.Same(state.LeaderParty, retry.LeaderParty);
+            Assert.Same(state.SiegeEvent, retry.SiegeEvent);
+        }
+        finally
+        {
+            ModInformation.IsServer = previousRole;
+        }
     }
 
     [Fact]
@@ -92,6 +124,33 @@ public class AiSiegeTerminalPolicyTests
             isPrepared: false));
 
         Assert.Equal(AiSiegeTerminalDecision.Withdraw, decision);
+    }
+
+    private sealed class TestDataStore : IDataStore
+    {
+        private readonly Dictionary<string, object> records;
+
+        public bool IsSaving { get; }
+        public bool IsLoading => !IsSaving;
+
+        public TestDataStore(bool isSaving, Dictionary<string, object> records)
+        {
+            IsSaving = isSaving;
+            this.records = records;
+        }
+
+        public bool SyncData<T>(string key, ref T data)
+        {
+            if (IsSaving)
+            {
+                records[key] = data;
+                return true;
+            }
+
+            if (!records.TryGetValue(key, out var value)) return false;
+            data = (T)value;
+            return true;
+        }
     }
 
     private static AiSiegeTerminalContext CreateContext(

--- a/source/GameInterface.Tests/Services/SiegeEvents/AiSiegeTerminalPolicyTests.cs
+++ b/source/GameInterface.Tests/Services/SiegeEvents/AiSiegeTerminalPolicyTests.cs
@@ -1,6 +1,11 @@
-﻿using GameInterface.Services.SiegeEvents;
+﻿using Common.Messaging;
+using Common.Util;
+using GameInterface.Services.SiegeEvents;
 using Moq;
 using Serilog;
+using System.Collections.Generic;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Siege;
 using Xunit;
 
 namespace GameInterface.Tests.Services.SiegeEvents;
@@ -11,7 +16,8 @@ public class AiSiegeTerminalPolicyTests
     {
         return new AiSiegeTerminalPolicy(
             new Mock<IAiSiegeAssaultReadiness>().Object,
-            new Mock<ILogger>().Object);
+            new Mock<ILogger>().Object,
+            new Mock<IMessageBroker>().Object);
     }
 
     [Fact]
@@ -31,13 +37,32 @@ public class AiSiegeTerminalPolicyTests
     }
 
     [Fact]
-    public void ActiveTransition_DoesNotStartDuplicateTerminalAction()
+    public void ActiveTransition_DefersTerminalAction()
     {
         var decision = CreatePolicy().GetDecision(CreateContext(
             isAssaultViable: true,
             hasActiveTransition: true));
 
-        Assert.Equal(AiSiegeTerminalDecision.None, decision);
+        Assert.Equal(AiSiegeTerminalDecision.Defer, decision);
+    }
+
+    [Fact]
+    public void DeferredTransition_IsRetriedOnce()
+    {
+        using var policy = CreatePolicy();
+        var state = new AiSiegeTerminalTransitionState(
+            ObjectHelper.SkipConstructor<MobileParty>(),
+            ObjectHelper.SkipConstructor<SiegeEvent>());
+        var retried = new List<AiSiegeTerminalTransitionState>();
+        policy.Defer(state);
+        policy.Defer(state);
+
+        policy.RetryDeferredTransitions(retried.Add);
+        policy.RetryDeferredTransitions(retried.Add);
+
+        var retry = Assert.Single(retried);
+        Assert.Same(state.LeaderParty, retry.LeaderParty);
+        Assert.Same(state.SiegeEvent, retry.SiegeEvent);
     }
 
     [Fact]

--- a/source/GameInterface.Tests/Services/SiegeEvents/AiSiegeTerminalPolicyTests.cs
+++ b/source/GameInterface.Tests/Services/SiegeEvents/AiSiegeTerminalPolicyTests.cs
@@ -1,8 +1,11 @@
 ﻿using Common;
+using Common.Messaging;
 using Common.Util;
+using GameInterface.Services.MapEvents.Messages.Leave;
 using GameInterface.Services.SiegeEvents;
 using Moq;
 using Serilog;
+using System;
 using System.Collections.Generic;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
@@ -18,7 +21,8 @@ public class AiSiegeTerminalPolicyTests
     {
         return new AiSiegeTerminalPolicy(
             new Mock<IAiSiegeAssaultReadiness>().Object,
-            new Mock<ILogger>().Object);
+            new Mock<ILogger>().Object,
+            new Mock<IMessageBroker>().Object);
     }
 
     [Fact]
@@ -90,6 +94,50 @@ public class AiSiegeTerminalPolicyTests
             var retry = Assert.Single(retried);
             Assert.Same(state.LeaderParty, retry.LeaderParty);
             Assert.Same(state.SiegeEvent, retry.SiegeEvent);
+        }
+        finally
+        {
+            ModInformation.IsServer = previousRole;
+        }
+    }
+
+    [Fact]
+    public void MapEventFinalized_QueuesRetryUntilAfterEncounterClose()
+    {
+        using var messageBroker = new MessageBroker();
+        var scheduled = new Queue<Action>();
+        var timeline = new List<string>();
+        var state = new AiSiegeTerminalTransitionState(
+            ObjectHelper.SkipConstructor<MobileParty>(),
+            ObjectHelper.SkipConstructor<SiegeEvent>());
+        bool previousRole = ModInformation.IsServer;
+        ModInformation.IsServer = true;
+
+        try
+        {
+            using var policy = new AiSiegeTerminalPolicy(
+                new Mock<IAiSiegeAssaultReadiness>().Object,
+                new Mock<ILogger>().Object,
+                messageBroker,
+                action =>
+                {
+                    timeline.Add("retry queued");
+                    scheduled.Enqueue(action);
+                },
+                _ => timeline.Add("retry"));
+            policy.Defer(state);
+
+            timeline.Add("finalize started");
+            messageBroker.Publish(this, new MapEventFinalized(null));
+            timeline.Add("old event closed");
+
+            Assert.Equal(
+                new[] { "finalize started", "retry queued", "old event closed" },
+                timeline);
+
+            Assert.Single(scheduled).Invoke();
+
+            Assert.Equal("retry", timeline[3]);
         }
         finally
         {

--- a/source/GameInterface/GameInterfaceModule.cs
+++ b/source/GameInterface/GameInterfaceModule.cs
@@ -85,7 +85,7 @@ public class GameInterfaceModule : Module
         builder.RegisterType<BattleAgentBudget>().As<IBattleAgentBudget>().InstancePerDependency();
         builder.RegisterType<SiegeMapEventLeaderReconciler>().As<ISiegeMapEventLeaderReconciler>().InstancePerDependency();
         builder.RegisterType<AiSiegeAssaultReadiness>().As<IAiSiegeAssaultReadiness>().InstancePerDependency();
-        builder.RegisterType<AiSiegeTerminalPolicy>().As<IAiSiegeTerminalPolicy>().InstancePerDependency();
+        builder.RegisterType<AiSiegeTerminalPolicy>().As<IAiSiegeTerminalPolicy>().InstancePerLifetimeScope();
         builder.RegisterType<MapEventContributionBarrier>().As<IMapEventContributionBarrier>().InstancePerDependency();
         builder.RegisterType<ArmyDisbander>().As<IArmyDisbander>().InstancePerDependency();
         builder.RegisterType<MapEventLoadCleaner>().As<IMapEventLoadCleaner>().InstancePerDependency();

--- a/source/GameInterface/GameInterfaceModule.cs
+++ b/source/GameInterface/GameInterfaceModule.cs
@@ -35,6 +35,7 @@ using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Party;
 using GameInterface.Services.Players;
 using GameInterface.Services.Stances;
+using GameInterface.Services.SiegeEvents;
 using GameInterface.Services.Time;
 using GameInterface.Services.TroopRosters;
 using GameInterface.Services.TroopRosters.Logging;
@@ -83,6 +84,8 @@ public class GameInterfaceModule : Module
         builder.RegisterType<LocationHostRegistry>().As<ILocationHostRegistry>().InstancePerLifetimeScope();
         builder.RegisterType<BattleAgentBudget>().As<IBattleAgentBudget>().InstancePerDependency();
         builder.RegisterType<SiegeMapEventLeaderReconciler>().As<ISiegeMapEventLeaderReconciler>().InstancePerDependency();
+        builder.RegisterType<AiSiegeAssaultReadiness>().As<IAiSiegeAssaultReadiness>().InstancePerDependency();
+        builder.RegisterType<AiSiegeTerminalPolicy>().As<IAiSiegeTerminalPolicy>().InstancePerDependency();
         builder.RegisterType<MapEventContributionBarrier>().As<IMapEventContributionBarrier>().InstancePerDependency();
         builder.RegisterType<ArmyDisbander>().As<IArmyDisbander>().InstancePerDependency();
         builder.RegisterType<MapEventLoadCleaner>().As<IMapEventLoadCleaner>().InstancePerDependency();

--- a/source/GameInterface/Services/Actions/Patches/DisbandArmyActionPatches.cs
+++ b/source/GameInterface/Services/Actions/Patches/DisbandArmyActionPatches.cs
@@ -1,6 +1,7 @@
 ﻿using Common;
 using Common.Messaging;
 using GameInterface.Services.Actions.Messages;
+using GameInterface.Services.SiegeEvents;
 using HarmonyLib;
 using System.Linq;
 using TaleWorlds.CampaignSystem;
@@ -22,15 +23,50 @@ internal class DisbandArmyActionPatches
 {
     [HarmonyPatch(typeof(DisbandArmyAction), nameof(DisbandArmyAction.ApplyInternal))]
     [HarmonyPrefix]
-    private static bool ApplyInternalPrefix(Army army, Army.ArmyDispersionReason reason)
+    private static bool ApplyInternalPrefix(
+        Army army,
+        Army.ArmyDispersionReason reason,
+        out AiSiegeTerminalTransitionState __state)
     {
-        if (ModInformation.IsServer) return true;
+        __state = default;
+        if (ModInformation.IsServer)
+        {
+            if (reason == Army.ArmyDispersionReason.FoodProblem)
+            {
+                var leader = army?.LeaderParty;
+                var siegeEvent = leader?.SiegeEvent;
+                if (leader != null && siegeEvent != null)
+                {
+                    __state = new AiSiegeTerminalTransitionState(leader, siegeEvent);
+                }
+            }
+
+            return true;
+        }
+
         if (reason == Army.ArmyDispersionReason.DismissalRequestedWithInfluence)
         {
             var message = new DisbandArmyApplyInternal(army, MobileParty.MainParty);
             MessageBroker.Instance.Publish(army, message);
         }
         return false;
+    }
+
+    [HarmonyPatch(typeof(DisbandArmyAction), nameof(DisbandArmyAction.ApplyInternal))]
+    [HarmonyPostfix]
+    private static void ApplyInternalPostfix(
+        Army.ArmyDispersionReason reason,
+        AiSiegeTerminalTransitionState __state)
+    {
+        if (ModInformation.IsClient
+            || reason != Army.ArmyDispersionReason.FoodProblem
+            || !__state.IsValid
+            || !ContainerProvider.TryResolve<IAiSiegeTerminalPolicy>(out var terminalPolicy))
+        {
+            return;
+        }
+
+        terminalPolicy.ResolveFoodProblem(__state);
     }
     
     public static void DisbandArmyApplyInternal(Army army, MobileParty clientParty)

--- a/source/GameInterface/Services/BesiegerCamps/Patches/BesiegerCampAssaultPatches.cs
+++ b/source/GameInterface/Services/BesiegerCamps/Patches/BesiegerCampAssaultPatches.cs
@@ -1,10 +1,6 @@
-﻿using GameInterface.Services.Heroes.Extensions;
+﻿using GameInterface.Services.SiegeEvents;
 using HarmonyLib;
-using TaleWorlds.CampaignSystem;
-using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Siege;
-using TaleWorlds.Core;
-using TaleWorlds.Library;
 
 namespace GameInterface.Services.BesiegerCamps.Patches;
 
@@ -20,71 +16,13 @@ internal class BesiegerCampAssaultPatches
     [HarmonyPrefix]
     private static bool StartingAssaultIsLogicalPrefix(BesiegerCamp __instance, ref bool __result)
     {
-        var siegeEvent = __instance.SiegeEvent;
-        var settlement = siegeEvent.BesiegedSettlement;
-
-        // The player-inside discount is a constant factor, so one pass collects both.
-        bool playerDefenderInside = false;
-        float defenderStrength = 0f;
-        foreach (var party in settlement.GetInvolvedPartiesForEventType())
+        if (!ContainerProvider.TryResolve<IAiSiegeAssaultReadiness>(out var readiness))
         {
-            if (!party.IsMobile || party.MobileParty.CurrentSettlement != settlement) continue;
-
-            if (party.LeaderHero != null && party.LeaderHero.IsPlayerHero())
-            {
-                playerDefenderInside = true;
-            }
-
-            if (party.MobileParty.Aggressiveness > 0.01f || party.MobileParty.IsMilitia || party.MobileParty.IsGarrison)
-            {
-                defenderStrength += party.CalculateCurrentStrength();
-            }
+            __result = false;
+            return false;
         }
 
-        defenderStrength *= playerDefenderInside ? 0.5f : 1f;
-
-        float attackerStrength = 0f;
-        foreach (var party in siegeEvent.BesiegerCamp.GetInvolvedPartiesForEventType())
-        {
-            attackerStrength += party.CalculateCurrentStrength();
-        }
-
-        bool hasRam = false;
-        bool hasSiegeTower = false;
-        foreach (var engine in siegeEvent.GetSiegeEventSide(BattleSideEnum.Attacker).SiegeEngines.AllSiegeEngines())
-        {
-            if (!engine.IsConstructed) continue;
-
-            if (engine.SiegeEngine == DefaultSiegeEngineTypes.Ram || engine.SiegeEngine == DefaultSiegeEngineTypes.ImprovedRam)
-            {
-                hasRam = true;
-            }
-            else if (engine.SiegeEngine == DefaultSiegeEngineTypes.SiegeTower)
-            {
-                hasSiegeTower = true;
-            }
-        }
-
-        float settlementAdvantage = Campaign.Current.Models.CombatSimulationModel.GetSettlementAdvantage(settlement);
-        float graceHours = (float)CampaignTime.HoursInDay * 4f;
-        float advantageExponent = 0.8f - ((siegeEvent.SiegeStartTime.ElapsedHoursUntilNow > graceHours)
-            ? ((siegeEvent.SiegeStartTime.ElapsedHoursUntilNow - graceHours) * 0.02f)
-            : 0f);
-        if (!hasRam) advantageExponent *= 1.25f;
-        if (!hasSiegeTower) advantageExponent *= 1.25f;
-
-        float powerRatio = attackerStrength / (defenderStrength * MathF.Pow(settlementAdvantage, advantageExponent));
-        __result = false;
-        if (powerRatio > 1f)
-        {
-            int equipmentsBuilt = Campaign.Current.Models.CombatSimulationModel.GetNumberOfEquipmentsBuilt(settlement);
-            powerRatio *= (float)MathF.Min(3, equipmentsBuilt) / 3f;
-            float equipmentProgress = Campaign.Current.Models.CombatSimulationModel.GetMaximumSiegeEquipmentProgress(settlement) + (0.25f * (float)(5 - equipmentsBuilt));
-            powerRatio *= 1f - (0.85f * (equipmentProgress * equipmentProgress));
-            float assaultChance = powerRatio * 0.1f;
-            __result = defenderStrength == 0f || MBRandom.RandomFloat < assaultChance;
-        }
-
+        __result = readiness.ShouldStartAssault(__instance);
         return false;
     }
 }

--- a/source/GameInterface/Services/BesiegerCamps/Patches/BesiegerCampAssaultPatches.cs
+++ b/source/GameInterface/Services/BesiegerCamps/Patches/BesiegerCampAssaultPatches.cs
@@ -12,17 +12,20 @@ namespace GameInterface.Services.BesiegerCamps.Patches;
 [HarmonyPatch(typeof(BesiegerCamp))]
 internal class BesiegerCampAssaultPatches
 {
+    private static readonly IAiSiegeAssaultReadiness fallbackReadiness = new AiSiegeAssaultReadiness();
+
     [HarmonyPatch(nameof(BesiegerCamp.StartingAssaultOnBesiegedSettlementIsLogical))]
     [HarmonyPrefix]
     private static bool StartingAssaultIsLogicalPrefix(BesiegerCamp __instance, ref bool __result)
     {
-        if (!ContainerProvider.TryResolve<IAiSiegeAssaultReadiness>(out var readiness))
-        {
-            __result = false;
-            return false;
-        }
-
-        __result = readiness.ShouldStartAssault(__instance);
+        __result = ResolveReadiness().ShouldStartAssault(__instance);
         return false;
+    }
+
+    internal static IAiSiegeAssaultReadiness ResolveReadiness()
+    {
+        return ContainerProvider.TryResolve<IAiSiegeAssaultReadiness>(out var readiness)
+            ? readiness
+            : fallbackReadiness;
     }
 }

--- a/source/GameInterface/Services/SiegeEvents/AiSiegeAssaultReadiness.cs
+++ b/source/GameInterface/Services/SiegeEvents/AiSiegeAssaultReadiness.cs
@@ -1,0 +1,168 @@
+﻿using GameInterface.Services.Heroes.Extensions;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Siege;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
+
+namespace GameInterface.Services.SiegeEvents;
+
+public readonly struct AiSiegeAssaultReadinessInput
+{
+    public float AttackerStrength { get; }
+    public float DefenderStrength { get; }
+    public float SettlementAdvantage { get; }
+    public float SiegeElapsedHours { get; }
+    public bool HasRam { get; }
+    public bool HasSiegeTower { get; }
+    public int EquipmentBuilt { get; }
+    public float MaximumEquipmentProgress { get; }
+
+    public AiSiegeAssaultReadinessInput(
+        float attackerStrength,
+        float defenderStrength,
+        float settlementAdvantage,
+        float siegeElapsedHours,
+        bool hasRam,
+        bool hasSiegeTower,
+        int equipmentBuilt,
+        float maximumEquipmentProgress)
+    {
+        AttackerStrength = attackerStrength;
+        DefenderStrength = defenderStrength;
+        SettlementAdvantage = settlementAdvantage;
+        SiegeElapsedHours = siegeElapsedHours;
+        HasRam = hasRam;
+        HasSiegeTower = hasSiegeTower;
+        EquipmentBuilt = equipmentBuilt;
+        MaximumEquipmentProgress = maximumEquipmentProgress;
+    }
+}
+
+public readonly struct AiSiegeAssaultReadinessResult
+{
+    public float AttackerStrength { get; }
+    public float DefenderStrength { get; }
+    public float PowerRatioBeforeEquipment { get; }
+    public float PowerRatioAfterEquipment { get; }
+    public float AssaultChance { get; }
+
+    public bool IsViable => DefenderStrength == 0f ||
+        (PowerRatioBeforeEquipment > 1f && AssaultChance > 0f);
+
+    public AiSiegeAssaultReadinessResult(
+        float attackerStrength,
+        float defenderStrength,
+        float powerRatioBeforeEquipment,
+        float powerRatioAfterEquipment,
+        float assaultChance)
+    {
+        AttackerStrength = attackerStrength;
+        DefenderStrength = defenderStrength;
+        PowerRatioBeforeEquipment = powerRatioBeforeEquipment;
+        PowerRatioAfterEquipment = powerRatioAfterEquipment;
+        AssaultChance = assaultChance;
+    }
+}
+
+public interface IAiSiegeAssaultReadiness
+{
+    AiSiegeAssaultReadinessResult Evaluate(BesiegerCamp camp);
+    AiSiegeAssaultReadinessResult Evaluate(AiSiegeAssaultReadinessInput input);
+    bool ShouldStartAssault(BesiegerCamp camp);
+}
+
+/// <summary>Evaluates the inputs used by vanilla's AI siege assault roll.</summary>
+internal class AiSiegeAssaultReadiness : IAiSiegeAssaultReadiness
+{
+    public AiSiegeAssaultReadinessResult Evaluate(BesiegerCamp camp)
+    {
+        var siegeEvent = camp.SiegeEvent;
+        var settlement = siegeEvent.BesiegedSettlement;
+
+        bool playerDefenderInside = false;
+        float defenderStrength = 0f;
+        foreach (var party in settlement.GetInvolvedPartiesForEventType())
+        {
+            if (!party.IsMobile || party.MobileParty.CurrentSettlement != settlement) continue;
+
+            if (party.LeaderHero?.IsPlayerHero() == true)
+            {
+                playerDefenderInside = true;
+            }
+
+            if (party.MobileParty.Aggressiveness > 0.01f || party.MobileParty.IsMilitia || party.MobileParty.IsGarrison)
+            {
+                defenderStrength += party.CalculateCurrentStrength();
+            }
+        }
+
+        defenderStrength *= playerDefenderInside ? 0.5f : 1f;
+
+        float attackerStrength = 0f;
+        foreach (var party in camp.GetInvolvedPartiesForEventType())
+        {
+            attackerStrength += party.CalculateCurrentStrength();
+        }
+
+        bool hasRam = false;
+        bool hasSiegeTower = false;
+        foreach (var engine in camp.SiegeEngines.AllSiegeEngines())
+        {
+            if (!engine.IsConstructed) continue;
+
+            if (engine.SiegeEngine == DefaultSiegeEngineTypes.Ram || engine.SiegeEngine == DefaultSiegeEngineTypes.ImprovedRam)
+            {
+                hasRam = true;
+            }
+            else if (engine.SiegeEngine == DefaultSiegeEngineTypes.SiegeTower)
+            {
+                hasSiegeTower = true;
+            }
+        }
+
+        return Evaluate(new AiSiegeAssaultReadinessInput(
+            attackerStrength,
+            defenderStrength,
+            Campaign.Current.Models.CombatSimulationModel.GetSettlementAdvantage(settlement),
+            siegeEvent.SiegeStartTime.ElapsedHoursUntilNow,
+            hasRam,
+            hasSiegeTower,
+            Campaign.Current.Models.CombatSimulationModel.GetNumberOfEquipmentsBuilt(settlement),
+            Campaign.Current.Models.CombatSimulationModel.GetMaximumSiegeEquipmentProgress(settlement)));
+    }
+
+    public AiSiegeAssaultReadinessResult Evaluate(AiSiegeAssaultReadinessInput input)
+    {
+        float graceHours = (float)CampaignTime.HoursInDay * 4f;
+        float advantageExponent = 0.8f - ((input.SiegeElapsedHours > graceHours)
+            ? ((input.SiegeElapsedHours - graceHours) * 0.02f)
+            : 0f);
+        if (!input.HasRam) advantageExponent *= 1.25f;
+        if (!input.HasSiegeTower) advantageExponent *= 1.25f;
+
+        float powerRatioBeforeEquipment = input.AttackerStrength /
+            (input.DefenderStrength * MathF.Pow(input.SettlementAdvantage, advantageExponent));
+        float powerRatioAfterEquipment = powerRatioBeforeEquipment;
+        if (powerRatioBeforeEquipment > 1f)
+        {
+            powerRatioAfterEquipment *= (float)MathF.Min(3, input.EquipmentBuilt) / 3f;
+            float equipmentProgress = input.MaximumEquipmentProgress + (0.25f * (float)(5 - input.EquipmentBuilt));
+            powerRatioAfterEquipment *= 1f - (0.85f * (equipmentProgress * equipmentProgress));
+        }
+
+        return new AiSiegeAssaultReadinessResult(
+            input.AttackerStrength,
+            input.DefenderStrength,
+            powerRatioBeforeEquipment,
+            powerRatioAfterEquipment,
+            powerRatioAfterEquipment * 0.1f);
+    }
+
+    public bool ShouldStartAssault(BesiegerCamp camp)
+    {
+        var result = Evaluate(camp);
+        if (result.PowerRatioBeforeEquipment <= 1f) return false;
+
+        return result.DefenderStrength == 0f || MBRandom.RandomFloat < result.AssaultChance;
+    }
+}

--- a/source/GameInterface/Services/SiegeEvents/AiSiegeAssaultReadiness.cs
+++ b/source/GameInterface/Services/SiegeEvents/AiSiegeAssaultReadiness.cs
@@ -46,8 +46,8 @@ public readonly struct AiSiegeAssaultReadinessResult
     public float PowerRatioAfterEquipment { get; }
     public float AssaultChance { get; }
 
-    public bool IsViable => DefenderStrength == 0f ||
-        (PowerRatioBeforeEquipment > 1f && AssaultChance > 0f);
+    public bool IsViable => PowerRatioBeforeEquipment > 1f &&
+        (DefenderStrength == 0f || AssaultChance > 0f);
 
     public AiSiegeAssaultReadinessResult(
         float attackerStrength,
@@ -161,7 +161,7 @@ internal class AiSiegeAssaultReadiness : IAiSiegeAssaultReadiness
     public bool ShouldStartAssault(BesiegerCamp camp)
     {
         var result = Evaluate(camp);
-        if (result.PowerRatioBeforeEquipment <= 1f) return false;
+        if (!(result.PowerRatioBeforeEquipment > 1f)) return false;
 
         return result.DefenderStrength == 0f || MBRandom.RandomFloat < result.AssaultChance;
     }

--- a/source/GameInterface/Services/SiegeEvents/AiSiegeTerminalPolicy.cs
+++ b/source/GameInterface/Services/SiegeEvents/AiSiegeTerminalPolicy.cs
@@ -1,0 +1,143 @@
+﻿using GameInterface.Services.MobileParties.Extensions;
+using Serilog;
+using TaleWorlds.CampaignSystem.Actions;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Siege;
+
+namespace GameInterface.Services.SiegeEvents;
+
+public enum AiSiegeTerminalDecision
+{
+    None,
+    Assault,
+    Withdraw,
+}
+
+public readonly struct AiSiegeTerminalContext
+{
+    public bool IsFoodProblem { get; }
+    public bool IsPrepared { get; }
+    public bool IsPlayerLed { get; }
+    public bool IsCurrentSiege { get; }
+    public bool HasActiveTransition { get; }
+    public bool IsAssaultViable { get; }
+
+    public AiSiegeTerminalContext(
+        bool isFoodProblem,
+        bool isPrepared,
+        bool isPlayerLed,
+        bool isCurrentSiege,
+        bool hasActiveTransition,
+        bool isAssaultViable)
+    {
+        IsFoodProblem = isFoodProblem;
+        IsPrepared = isPrepared;
+        IsPlayerLed = isPlayerLed;
+        IsCurrentSiege = isCurrentSiege;
+        HasActiveTransition = hasActiveTransition;
+        IsAssaultViable = isAssaultViable;
+    }
+}
+
+public readonly struct AiSiegeTerminalTransitionState
+{
+    public MobileParty LeaderParty { get; }
+    public SiegeEvent SiegeEvent { get; }
+
+    public bool IsValid => LeaderParty != null && SiegeEvent != null;
+
+    public AiSiegeTerminalTransitionState(MobileParty leaderParty, SiegeEvent siegeEvent)
+    {
+        LeaderParty = leaderParty;
+        SiegeEvent = siegeEvent;
+    }
+}
+
+public interface IAiSiegeTerminalPolicy
+{
+    AiSiegeTerminalDecision GetDecision(AiSiegeTerminalContext context);
+    AiSiegeTerminalDecision ResolveFoodProblem(AiSiegeTerminalTransitionState state);
+}
+
+/// <summary>Resolves an AI siege after vanilla disperses its starving army.</summary>
+internal class AiSiegeTerminalPolicy : IAiSiegeTerminalPolicy
+{
+    private readonly IAiSiegeAssaultReadiness readiness;
+    private readonly ILogger logger;
+
+    public AiSiegeTerminalPolicy(IAiSiegeAssaultReadiness readiness, ILogger logger)
+    {
+        this.readiness = readiness;
+        this.logger = logger;
+    }
+
+    public AiSiegeTerminalDecision GetDecision(AiSiegeTerminalContext context)
+    {
+        // World state is the idempotency marker, so a save cannot retain a stale pending transition.
+        if (!context.IsFoodProblem
+            || context.IsPlayerLed
+            || !context.IsCurrentSiege
+            || context.HasActiveTransition)
+        {
+            return AiSiegeTerminalDecision.None;
+        }
+
+        return context.IsPrepared && context.IsAssaultViable
+            ? AiSiegeTerminalDecision.Assault
+            : AiSiegeTerminalDecision.Withdraw;
+    }
+
+    public AiSiegeTerminalDecision ResolveFoodProblem(AiSiegeTerminalTransitionState state)
+    {
+        if (!state.IsValid) return AiSiegeTerminalDecision.None;
+
+        var leader = state.LeaderParty;
+        var siegeEvent = state.SiegeEvent;
+        var camp = siegeEvent.BesiegerCamp;
+        var settlement = siegeEvent.BesiegedSettlement;
+        bool isCurrentSiege = settlement?.SiegeEvent == siegeEvent
+            && camp?.LeaderParty == leader
+            && leader.BesiegerCamp == camp;
+        bool hasActiveTransition = leader.MapEvent != null || settlement?.Party.MapEvent != null;
+        var readinessResult = isCurrentSiege
+            ? readiness.Evaluate(camp)
+            : default;
+        var context = new AiSiegeTerminalContext(
+            isFoodProblem: true,
+            isPrepared: camp?.IsPreparationComplete == true,
+            isPlayerLed: leader.IsPlayerParty(),
+            isCurrentSiege,
+            hasActiveTransition,
+            readinessResult.IsViable);
+        var decision = GetDecision(context);
+
+        if (decision == AiSiegeTerminalDecision.Assault)
+        {
+            logger.Information(
+                "Starving AI siege at {SettlementId} is starting its viable assault: attacker={AttackerStrength:0.00} defender={DefenderStrength:0.00} ratio={PowerRatio:0.000} chance={AssaultChance:0.000}",
+                settlement.StringId,
+                readinessResult.AttackerStrength,
+                readinessResult.DefenderStrength,
+                readinessResult.PowerRatioBeforeEquipment,
+                readinessResult.AssaultChance);
+            StartBattleAction.ApplyStartAssaultAgainstWalls(leader, settlement);
+        }
+        else if (decision == AiSiegeTerminalDecision.Withdraw)
+        {
+            string reason = camp.IsPreparationComplete
+                ? "an assault is not viable"
+                : "preparations are incomplete";
+            logger.Information(
+                "Starving AI siege at {SettlementId} is withdrawing because {Reason}: attacker={AttackerStrength:0.00} defender={DefenderStrength:0.00} ratio={PowerRatio:0.000} chance={AssaultChance:0.000}",
+                settlement.StringId,
+                reason,
+                readinessResult.AttackerStrength,
+                readinessResult.DefenderStrength,
+                readinessResult.PowerRatioBeforeEquipment,
+                readinessResult.AssaultChance);
+            camp.RemoveAllSiegeParties();
+        }
+
+        return decision;
+    }
+}

--- a/source/GameInterface/Services/SiegeEvents/AiSiegeTerminalPolicy.cs
+++ b/source/GameInterface/Services/SiegeEvents/AiSiegeTerminalPolicy.cs
@@ -1,5 +1,10 @@
-﻿using GameInterface.Services.MobileParties.Extensions;
+﻿using Common;
+using Common.Messaging;
+using GameInterface.Services.MapEvents.Messages.Leave;
+using GameInterface.Services.MobileParties.Extensions;
 using Serilog;
+using System;
+using System.Collections.Generic;
 using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Siege;
@@ -9,6 +14,7 @@ namespace GameInterface.Services.SiegeEvents;
 public enum AiSiegeTerminalDecision
 {
     None,
+    Defer,
     Assault,
     Withdraw,
 }
@@ -60,15 +66,27 @@ public interface IAiSiegeTerminalPolicy
 }
 
 /// <summary>Resolves an AI siege after vanilla disperses its starving army.</summary>
-internal class AiSiegeTerminalPolicy : IAiSiegeTerminalPolicy
+internal class AiSiegeTerminalPolicy : IAiSiegeTerminalPolicy, IDisposable
 {
     private readonly IAiSiegeAssaultReadiness readiness;
     private readonly ILogger logger;
+    private readonly IMessageBroker messageBroker;
+    private readonly List<AiSiegeTerminalTransitionState> deferredTransitions = new();
 
-    public AiSiegeTerminalPolicy(IAiSiegeAssaultReadiness readiness, ILogger logger)
+    public AiSiegeTerminalPolicy(
+        IAiSiegeAssaultReadiness readiness,
+        ILogger logger,
+        IMessageBroker messageBroker)
     {
         this.readiness = readiness;
         this.logger = logger;
+        this.messageBroker = messageBroker;
+        messageBroker.Subscribe<MapEventFinalized>(Handle_MapEventFinalized);
+    }
+
+    public void Dispose()
+    {
+        messageBroker.Unsubscribe<MapEventFinalized>(Handle_MapEventFinalized);
     }
 
     public AiSiegeTerminalDecision GetDecision(AiSiegeTerminalContext context)
@@ -76,11 +94,12 @@ internal class AiSiegeTerminalPolicy : IAiSiegeTerminalPolicy
         // World state is the idempotency marker, so a save cannot retain a stale pending transition.
         if (!context.IsFoodProblem
             || context.IsPlayerLed
-            || !context.IsCurrentSiege
-            || context.HasActiveTransition)
+            || !context.IsCurrentSiege)
         {
             return AiSiegeTerminalDecision.None;
         }
+
+        if (context.HasActiveTransition) return AiSiegeTerminalDecision.Defer;
 
         return context.IsPrepared && context.IsAssaultViable
             ? AiSiegeTerminalDecision.Assault
@@ -111,7 +130,11 @@ internal class AiSiegeTerminalPolicy : IAiSiegeTerminalPolicy
             readinessResult.IsViable);
         var decision = GetDecision(context);
 
-        if (decision == AiSiegeTerminalDecision.Assault)
+        if (decision == AiSiegeTerminalDecision.Defer)
+        {
+            Defer(state);
+        }
+        else if (decision == AiSiegeTerminalDecision.Assault)
         {
             logger.Information(
                 "Starving AI siege at {SettlementId} is starting its viable assault: attacker={AttackerStrength:0.00} defender={DefenderStrength:0.00} ratio={PowerRatio:0.000} chance={AssaultChance:0.000}",
@@ -139,5 +162,35 @@ internal class AiSiegeTerminalPolicy : IAiSiegeTerminalPolicy
         }
 
         return decision;
+    }
+
+    internal void Defer(AiSiegeTerminalTransitionState state)
+    {
+        foreach (var pending in deferredTransitions)
+        {
+            if (pending.LeaderParty == state.LeaderParty && pending.SiegeEvent == state.SiegeEvent)
+                return;
+        }
+
+        deferredTransitions.Add(state);
+    }
+
+    private void Handle_MapEventFinalized(MessagePayload<MapEventFinalized> _)
+    {
+        if (ModInformation.IsClient) return;
+
+        RetryDeferredTransitions(state => { ResolveFoodProblem(state); });
+    }
+
+    internal void RetryDeferredTransitions(Action<AiSiegeTerminalTransitionState> resolve)
+    {
+        if (deferredTransitions.Count == 0) return;
+
+        var pending = deferredTransitions.ToArray();
+        deferredTransitions.Clear();
+        foreach (var state in pending)
+        {
+            resolve(state);
+        }
     }
 }

--- a/source/GameInterface/Services/SiegeEvents/AiSiegeTerminalPolicy.cs
+++ b/source/GameInterface/Services/SiegeEvents/AiSiegeTerminalPolicy.cs
@@ -1,4 +1,6 @@
 ﻿using Common;
+using Common.Messaging;
+using GameInterface.Services.MapEvents.Messages.Leave;
 using GameInterface.Services.MobileParties.Extensions;
 using Serilog;
 using System;
@@ -67,21 +69,53 @@ public interface IAiSiegeTerminalPolicy
 }
 
 /// <summary>Resolves an AI siege after vanilla disperses its starving army.</summary>
-internal class AiSiegeTerminalPolicy : IAiSiegeTerminalPolicy
+internal class AiSiegeTerminalPolicy : IAiSiegeTerminalPolicy, IDisposable
 {
     private const string DeferredLeaderSaveKey = "_coop_ai_siege_terminal_leaders";
     private const string DeferredSiegeEventSaveKey = "_coop_ai_siege_terminal_events";
 
     private readonly IAiSiegeAssaultReadiness readiness;
     private readonly ILogger logger;
+    private readonly IMessageBroker messageBroker;
+    private readonly Action<Action> enqueueDeferred;
+    private readonly Action<AiSiegeTerminalTransitionState> resolveTransition;
     private readonly List<AiSiegeTerminalTransitionState> deferredTransitions = new();
 
     public AiSiegeTerminalPolicy(
         IAiSiegeAssaultReadiness readiness,
-        ILogger logger)
+        ILogger logger,
+        IMessageBroker messageBroker)
+        : this(
+            readiness,
+            logger,
+            messageBroker,
+            action => GameThread.EnqueueSafe(action, context: nameof(AiSiegeTerminalPolicy)),
+            null)
+    {
+    }
+
+    internal AiSiegeTerminalPolicy(
+        IAiSiegeAssaultReadiness readiness,
+        ILogger logger,
+        IMessageBroker messageBroker,
+        Action<Action> enqueueDeferred,
+        Action<AiSiegeTerminalTransitionState> resolveTransition)
     {
         this.readiness = readiness;
         this.logger = logger;
+        this.messageBroker = messageBroker;
+        this.enqueueDeferred = enqueueDeferred;
+        if (resolveTransition == null)
+            this.resolveTransition = state => { ResolveFoodProblem(state); };
+        else
+            this.resolveTransition = resolveTransition;
+
+        messageBroker.Subscribe<MapEventFinalized>(Handle_MapEventFinalized);
+    }
+
+    public void Dispose()
+    {
+        messageBroker.Unsubscribe<MapEventFinalized>(Handle_MapEventFinalized);
     }
 
     public AiSiegeTerminalDecision GetDecision(AiSiegeTerminalContext context)
@@ -204,9 +238,17 @@ internal class AiSiegeTerminalPolicy : IAiSiegeTerminalPolicy
         }
     }
 
+    private void Handle_MapEventFinalized(MessagePayload<MapEventFinalized> _)
+    {
+        if (ModInformation.IsClient || deferredTransitions.Count == 0) return;
+
+        // Finalization still has old-event destroy and encounter-close work to send after this synchronous event.
+        enqueueDeferred(RetryDeferredTransitions);
+    }
+
     public void RetryDeferredTransitions()
     {
-        RetryDeferredTransitions(state => { ResolveFoodProblem(state); });
+        RetryDeferredTransitions(resolveTransition);
     }
 
     internal void RetryDeferredTransitions(Action<AiSiegeTerminalTransitionState> resolve)

--- a/source/GameInterface/Services/SiegeEvents/AiSiegeTerminalPolicy.cs
+++ b/source/GameInterface/Services/SiegeEvents/AiSiegeTerminalPolicy.cs
@@ -1,10 +1,9 @@
 ﻿using Common;
-using Common.Messaging;
-using GameInterface.Services.MapEvents.Messages.Leave;
 using GameInterface.Services.MobileParties.Extensions;
 using Serilog;
 using System;
 using System.Collections.Generic;
+using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Siege;
@@ -63,30 +62,26 @@ public interface IAiSiegeTerminalPolicy
 {
     AiSiegeTerminalDecision GetDecision(AiSiegeTerminalContext context);
     AiSiegeTerminalDecision ResolveFoodProblem(AiSiegeTerminalTransitionState state);
+    void RetryDeferredTransitions();
+    void SyncData(IDataStore dataStore);
 }
 
 /// <summary>Resolves an AI siege after vanilla disperses its starving army.</summary>
-internal class AiSiegeTerminalPolicy : IAiSiegeTerminalPolicy, IDisposable
+internal class AiSiegeTerminalPolicy : IAiSiegeTerminalPolicy
 {
+    private const string DeferredLeaderSaveKey = "_coop_ai_siege_terminal_leaders";
+    private const string DeferredSiegeEventSaveKey = "_coop_ai_siege_terminal_events";
+
     private readonly IAiSiegeAssaultReadiness readiness;
     private readonly ILogger logger;
-    private readonly IMessageBroker messageBroker;
     private readonly List<AiSiegeTerminalTransitionState> deferredTransitions = new();
 
     public AiSiegeTerminalPolicy(
         IAiSiegeAssaultReadiness readiness,
-        ILogger logger,
-        IMessageBroker messageBroker)
+        ILogger logger)
     {
         this.readiness = readiness;
         this.logger = logger;
-        this.messageBroker = messageBroker;
-        messageBroker.Subscribe<MapEventFinalized>(Handle_MapEventFinalized);
-    }
-
-    public void Dispose()
-    {
-        messageBroker.Unsubscribe<MapEventFinalized>(Handle_MapEventFinalized);
     }
 
     public AiSiegeTerminalDecision GetDecision(AiSiegeTerminalContext context)
@@ -175,10 +170,42 @@ internal class AiSiegeTerminalPolicy : IAiSiegeTerminalPolicy, IDisposable
         deferredTransitions.Add(state);
     }
 
-    private void Handle_MapEventFinalized(MessagePayload<MapEventFinalized> _)
+    public void SyncData(IDataStore dataStore)
     {
-        if (ModInformation.IsClient) return;
+        List<MobileParty> leaders = null;
+        List<SiegeEvent> siegeEvents = null;
+        if (dataStore.IsSaving)
+        {
+            leaders = new List<MobileParty>();
+            siegeEvents = new List<SiegeEvent>();
+            if (ModInformation.IsServer)
+            {
+                foreach (var transition in deferredTransitions)
+                {
+                    leaders.Add(transition.LeaderParty);
+                    siegeEvents.Add(transition.SiegeEvent);
+                }
+            }
+        }
 
+        dataStore.SyncData(DeferredLeaderSaveKey, ref leaders);
+        dataStore.SyncData(DeferredSiegeEventSaveKey, ref siegeEvents);
+        if (!dataStore.IsLoading) return;
+
+        deferredTransitions.Clear();
+        if (ModInformation.IsClient || leaders == null || siegeEvents == null) return;
+
+        int count = Math.Min(leaders.Count, siegeEvents.Count);
+        for (int i = 0; i < count; i++)
+        {
+            var transition = new AiSiegeTerminalTransitionState(leaders[i], siegeEvents[i]);
+            if (transition.IsValid)
+                Defer(transition);
+        }
+    }
+
+    public void RetryDeferredTransitions()
+    {
         RetryDeferredTransitions(state => { ResolveFoodProblem(state); });
     }
 

--- a/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
+++ b/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
@@ -10,6 +10,7 @@ using GameInterface.Services.Party.Commands;
 using GameInterface.Services.Players;
 using GameInterface.Services.Settlements.Interfaces;
 using GameInterface.Services.SiegeEngines;
+using GameInterface.Services.SiegeEvents;
 using GameInterface.Services.SiegeEvents.Interfaces;
 using GameInterface.Services.SiegeEvents.Messages;
 using SandBox.View.Map;
@@ -863,6 +864,105 @@ public class SiegeDebugCommand
 
         var mapEventId = objectManager.TryGetId(mapEvent, out string id) ? id : mapEvent.StringId;
         return $"Started AI siege assault by {attacker.Name} against {settlement.Name} (MapEvent {mapEventId})";
+    }
+
+    /// <summary>
+    /// Reports the exact vanilla readiness inputs and the starvation terminal decision. Read-only.
+    /// </summary>
+    [CommandLineArgumentFunction("terminal_status", "coop.debug.siege")]
+    public static string TerminalStatus(List<string> args)
+    {
+        if (args.Count != 1)
+        {
+            return "Usage: coop.debug.siege.terminal_status town_ES1";
+        }
+
+        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)
+            || !ContainerProvider.TryResolve<IAiSiegeAssaultReadiness>(out var readiness)
+            || !ContainerProvider.TryResolve<IAiSiegeTerminalPolicy>(out var terminalPolicy))
+        {
+            return "Unable to resolve AI siege terminal services";
+        }
+
+        if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
+        {
+            return $"Settlement with id {args[0]} not found";
+        }
+
+        var siegeEvent = settlement.SiegeEvent;
+        var camp = siegeEvent?.BesiegerCamp;
+        var leader = camp?.LeaderParty;
+        if (siegeEvent == null || camp == null || leader == null)
+        {
+            return $"{settlement.Name} has no active siege leader";
+        }
+
+        var result = readiness.Evaluate(camp);
+        int starvingParties = 0;
+        int commandGroupParties = 0;
+        if (leader.Army?.LeaderParty == leader)
+        {
+            commandGroupParties = leader.Army.LeaderPartyAndAttachedPartiesCount;
+            starvingParties = leader.Party.IsStarving ? 1 : 0;
+            starvingParties += leader.AttachedParties.Count(party => party.Party.IsStarving);
+        }
+
+        bool foodProblem = commandGroupParties > 0
+            && (float)starvingParties / (float)commandGroupParties > 0.5f;
+        bool activeTransition = leader.MapEvent != null || settlement.Party.MapEvent != null;
+        var decision = terminalPolicy.GetDecision(new AiSiegeTerminalContext(
+            foodProblem,
+            camp.IsPreparationComplete,
+            leader.IsPlayerParty(),
+            isCurrentSiege: true,
+            activeTransition,
+            result.IsViable));
+
+        return $"settlement={settlement.StringId} leader={leader.StringId} playerLed={leader.IsPlayerParty()} " +
+            $"prepared={camp.IsPreparationComplete} elapsedHours={siegeEvent.SiegeStartTime.ElapsedHoursUntilNow:0.0} " +
+            $"starving={starvingParties}/{commandGroupParties} foodProblem={foodProblem} activeTransition={activeTransition} " +
+            $"attacker={result.AttackerStrength:0.00} defender={result.DefenderStrength:0.00} " +
+            $"powerRatio={result.PowerRatioBeforeEquipment:0.000} adjustedRatio={result.PowerRatioAfterEquipment:0.000} " +
+            $"assaultChance={result.AssaultChance:0.000} viable={result.IsViable} decision={decision}";
+    }
+
+    /// <summary>
+    /// Simulates the vanilla food-problem terminal event for an AI siege. Server only.
+    /// </summary>
+    [CommandLineArgumentFunction("resolve_starvation", "coop.debug.siege")]
+    public static string ResolveStarvation(List<string> args)
+    {
+        if (args.Count != 1)
+        {
+            return "Usage: coop.debug.siege.resolve_starvation town_ES1";
+        }
+
+        if (ModInformation.IsClient)
+        {
+            return "This command can only be used by the server";
+        }
+
+        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)
+            || !ContainerProvider.TryResolve<IAiSiegeTerminalPolicy>(out var terminalPolicy))
+        {
+            return "Unable to resolve AI siege terminal services";
+        }
+
+        if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
+        {
+            return $"Settlement with id {args[0]} not found";
+        }
+
+        var siegeEvent = settlement.SiegeEvent;
+        var leader = siegeEvent?.BesiegerCamp?.LeaderParty;
+        if (siegeEvent == null || leader == null)
+        {
+            return $"{settlement.Name} has no active siege leader";
+        }
+
+        var decision = terminalPolicy.ResolveFoodProblem(
+            new AiSiegeTerminalTransitionState(leader, siegeEvent));
+        return $"Simulated starvation terminal policy at {settlement.Name} ({settlement.StringId}): {decision}";
     }
 
     // coop.debug.siege.list

--- a/source/GameInterface/Services/SiegeEvents/Patches/SiegeEventCampaignBehaviorPatches.cs
+++ b/source/GameInterface/Services/SiegeEvents/Patches/SiegeEventCampaignBehaviorPatches.cs
@@ -43,6 +43,14 @@ internal class SiegeEventCampaignBehaviorPatches
     [HarmonyPrefix]
     private static bool OnPeaceDeclaredPrefix() => ModInformation.IsClient;
 
+    [HarmonyPatch(nameof(SiegeEventCampaignBehavior.SyncData))]
+    [HarmonyPostfix]
+    private static void SyncDataPostfix(IDataStore dataStore)
+    {
+        if (ContainerProvider.TryResolve<IAiSiegeTerminalPolicy>(out var terminalPolicy))
+            terminalPolicy.SyncData(dataStore);
+    }
+
     // Vanilla only reacts to MobileParty.MainParty leaving the besieged settlement, which never
     // matches on the dedicated host; re-derive the trigger as "a player-led party left".
     [HarmonyPatch(nameof(SiegeEventCampaignBehavior.OnSettlementLeft))]
@@ -95,5 +103,19 @@ internal class SiegeEventCampaignBehaviorPatches
 
         siegeEvent.GetSiegeEventSide(side).SetSiegeStrategy(strategy);
         return false;
+    }
+}
+
+// Retry on an hourly campaign turn, after any map-event teardown that deferred the decision has completed.
+[HarmonyPatch(typeof(CampaignEventDispatcher), nameof(CampaignEventDispatcher.HourlyTick))]
+internal class AiSiegeTerminalRetryPatches
+{
+    [HarmonyPostfix]
+    private static void HourlyTickPostfix()
+    {
+        if (ModInformation.IsClient) return;
+        if (!ContainerProvider.TryResolve<IAiSiegeTerminalPolicy>(out var terminalPolicy)) return;
+
+        terminalPolicy.RetryDeferredTransitions();
     }
 }


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

AI siege readiness combines power, equipment state, elapsed time, and a random roll. If the roll never produces an assault before the besieging army starves, vanilla disperses the army for its food problem but leaves the siege objective active, so the remaining leader can keep rebuilding indefinitely.

## What is the new behavior?

Resolves #2735

A server-side terminal policy runs after vanilla disperses an army for a food problem. It starts a prepared assault through `StartBattleAction` only when the current vanilla readiness calculation has a positive assault chance; otherwise it removes the siege parties through the vanilla camp authority so they can replan. Player-led sieges and active map-event transitions are ignored.

## Bot Changelog Entry

- Starving AI siege armies now assault when viable or abandon the siege instead of rebuilding forever.

## Other information

Automated tests:
- `dotnet test source/GameInterface.Tests/GameInterface.Tests.csproj -c Release --filter "FullyQualifiedName~AiSiege"` (10 passed)
- full `GameInterface.Tests` run (1044 passed, 11 skipped)

Manual Danustica check on the server:
1. Run `coop.debug.siege.start town_ES1`.
2. Run `coop.debug.siege.terminal_status town_ES1` to inspect preparation, starvation, power ratio, equipment-adjusted ratio, and the pending decision.
3. Run `coop.debug.siege.resolve_starvation town_ES1` to simulate the food terminal. A viable prepared siege creates the assault map event; an inviable or unprepared siege ends and its parties return to AI planning.
