### PR TITLE
[3013] Close rejected peace encounters cleanly

### DIFF
--- a/source/E2E.Tests/Services/Barters/BarterClientCompletionTests.cs
+++ b/source/E2E.Tests/Services/Barters/BarterClientCompletionTests.cs
@@ -124,6 +124,57 @@ public class BarterClientCompletionTests : MapEventTestBase
     }
 
     [Fact]
+    public void PeaceBarter_RejectedResult_DoesNotLeavePendingMainPartyMapEvent()
+    {
+        const string contextId = "party-in-pending-map-event";
+        const string requestId = "peace-client-pending-map-event-rejection";
+        var client = Clients.First();
+        var (playerHeroId, playerPartyId, targetHeroId, targetPartyId) = CreateBarterParties(client);
+        var mapEvent = CreateServerMapEvent();
+        SetMockPlayerEncounter(client, targetPartyId);
+
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<MapEvent>(mapEvent.MapEventId, out var activeMapEvent));
+            Assert.True(client.ObjectManager.TryGetObject<MobileParty>(playerPartyId, out var playerParty));
+            var previousMainParty = Campaign.Current.MainParty;
+            var previousMapEventSide = playerParty.Party._mapEventSide;
+            Campaign.Current.MainParty = playerParty;
+            playerParty.Party._mapEventSide = activeMapEvent.AttackerSide;
+
+            try
+            {
+                Assert.Null(PlayerEncounter.Current._mapEvent);
+                Assert.Same(activeMapEvent, MobileParty.MainParty.MapEvent);
+                var barter = CreateBarter(client, playerHeroId, playerPartyId, targetHeroId, targetPartyId);
+                SetStaticField(typeof(PeaceBarterPatch), "pendingBarter", barter);
+                SetStaticField(typeof(PeaceBarterPatch), "pendingUiActive", true);
+                SetStaticField(typeof(PeaceBarterPatch), "pendingRequestId", requestId);
+                SetStaticField(typeof(PeaceBarterPatch), "pendingContext", PeaceConversationContext.MapParty);
+                SetStaticField(typeof(PeaceBarterPatch), "pendingContextId", contextId);
+
+                AssertResultClosesUi(
+                    () => PeaceBarterPatch.CompleteRequest(
+                        new NetworkPeaceBarterResult(
+                            contextId,
+                            accepted: false,
+                            playerGold: 500,
+                            reason: NetworkPeaceBarterResult.InactiveEncounterReason,
+                            requestId: requestId),
+                        new ThrowingBarterClientPresentation()),
+                    expectedAccepted: false,
+                    conversationParty: barter.OtherParty.MobileParty,
+                    expectLeaveEncounter: false);
+            }
+            finally
+            {
+                playerParty.Party._mapEventSide = previousMapEventSide;
+                Campaign.Current.MainParty = previousMainParty;
+            }
+        });
+    }
+
+    [Fact]
     public void BanditBarter_AcceptedResult_ClosesUiBeforePresentationFailure()
     {
         const string banditPartyId = "stale-bandit-party";

--- a/source/E2E.Tests/Services/Barters/BarterClientCompletionTests.cs
+++ b/source/E2E.Tests/Services/Barters/BarterClientCompletionTests.cs
@@ -1,4 +1,4 @@
-using E2E.Tests.Environment.Instance;
+﻿using E2E.Tests.Environment.Instance;
 using E2E.Tests.Services.MapEvents;
 using GameInterface.Services.Bandits.Messages;
 using GameInterface.Services.Bandits.Patches;
@@ -9,6 +9,8 @@ using GameInterface.Services.Entity;
 using HarmonyLib;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.BarterSystem;
+using TaleWorlds.CampaignSystem.Encounters;
+using TaleWorlds.CampaignSystem.MapEvents;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.Core;
 using Xunit.Abstractions;
@@ -18,6 +20,8 @@ namespace E2E.Tests.Services.Barters;
 public class BarterClientCompletionTests : MapEventTestBase
 {
     private static bool barterCloseObserved;
+    private static bool barterClosedObserved;
+    private static MobileParty? conversationPartyOverride;
 
     public BarterClientCompletionTests(ITestOutputHelper output) : base(output)
     {
@@ -40,13 +44,82 @@ public class BarterClientCompletionTests : MapEventTestBase
             SetStaticField(typeof(PeaceBarterPatch), "pendingContext", PeaceConversationContext.Settlement);
             SetStaticField(typeof(PeaceBarterPatch), "pendingContextId", contextId);
 
-            AssertAcceptedResultClosesUi(() => PeaceBarterPatch.CompleteRequest(
-                new NetworkPeaceBarterResult(
-                    contextId,
-                    accepted: true,
-                    playerGold: 500,
-                    requestId: requestId),
-                new ThrowingBarterClientPresentation()));
+            AssertResultClosesUi(
+                () => PeaceBarterPatch.CompleteRequest(
+                    new NetworkPeaceBarterResult(
+                        contextId,
+                        accepted: true,
+                        playerGold: 500,
+                        requestId: requestId),
+                    new ThrowingBarterClientPresentation()),
+                expectedAccepted: true);
+        });
+    }
+
+    [Fact]
+    public void PeaceBarter_RejectedResult_ClosesUi()
+    {
+        const string contextId = "stale-party";
+        const string requestId = "peace-client-rejection";
+        var client = Clients.First();
+        var (playerHeroId, playerPartyId, targetHeroId, targetPartyId) = CreateBarterParties(client);
+        SetMockPlayerEncounter(client, targetPartyId);
+
+        client.Call(() =>
+        {
+            var barter = CreateBarter(client, playerHeroId, playerPartyId, targetHeroId, targetPartyId);
+            SetStaticField(typeof(PeaceBarterPatch), "pendingBarter", barter);
+            SetStaticField(typeof(PeaceBarterPatch), "pendingUiActive", true);
+            SetStaticField(typeof(PeaceBarterPatch), "pendingRequestId", requestId);
+            SetStaticField(typeof(PeaceBarterPatch), "pendingContext", PeaceConversationContext.MapParty);
+            SetStaticField(typeof(PeaceBarterPatch), "pendingContextId", contextId);
+
+            AssertResultClosesUi(
+                () => PeaceBarterPatch.CompleteRequest(
+                    new NetworkPeaceBarterResult(
+                        contextId,
+                        accepted: false,
+                        playerGold: 500,
+                        reason: NetworkPeaceBarterResult.InactiveEncounterReason,
+                        requestId: requestId),
+                    new ThrowingBarterClientPresentation()),
+                expectedAccepted: false,
+                conversationParty: barter.OtherParty.MobileParty,
+                expectLeaveEncounter: true);
+        });
+    }
+
+    [Fact]
+    public void PeaceBarter_RejectedResult_DoesNotLeaveMapEvent()
+    {
+        const string contextId = "party-in-map-event";
+        const string requestId = "peace-client-map-event-rejection";
+        var client = Clients.First();
+        var (playerHeroId, playerPartyId, targetHeroId, targetPartyId) = CreateBarterParties(client);
+        var mapEventId = TestEnvironment.CreateRegisteredObject<MapEvent>();
+        SetMockPlayerEncounter(client, targetPartyId, mapEventId);
+
+        client.Call(() =>
+        {
+            var barter = CreateBarter(client, playerHeroId, playerPartyId, targetHeroId, targetPartyId);
+            SetStaticField(typeof(PeaceBarterPatch), "pendingBarter", barter);
+            SetStaticField(typeof(PeaceBarterPatch), "pendingUiActive", true);
+            SetStaticField(typeof(PeaceBarterPatch), "pendingRequestId", requestId);
+            SetStaticField(typeof(PeaceBarterPatch), "pendingContext", PeaceConversationContext.MapParty);
+            SetStaticField(typeof(PeaceBarterPatch), "pendingContextId", contextId);
+
+            AssertResultClosesUi(
+                () => PeaceBarterPatch.CompleteRequest(
+                    new NetworkPeaceBarterResult(
+                        contextId,
+                        accepted: false,
+                        playerGold: 500,
+                        reason: NetworkPeaceBarterResult.InactiveEncounterReason,
+                        requestId: requestId),
+                    new ThrowingBarterClientPresentation()),
+                expectedAccepted: false,
+                conversationParty: barter.OtherParty.MobileParty,
+                expectLeaveEncounter: false);
         });
     }
 
@@ -66,13 +139,15 @@ public class BarterClientCompletionTests : MapEventTestBase
             SetStaticField(typeof(BanditBarterPatch), "pendingRequestId", requestId);
             SetStaticField(typeof(BanditBarterPatch), "pendingUiActive", true);
 
-            AssertAcceptedResultClosesUi(() => BanditBarterPatch.CompleteRequest(
-                new NetworkBanditBarterResult(
-                    banditPartyId,
-                    accepted: true,
-                    playerGold: 500,
-                    requestId: requestId),
-                new ThrowingBarterClientPresentation()));
+            AssertResultClosesUi(
+                () => BanditBarterPatch.CompleteRequest(
+                    new NetworkBanditBarterResult(
+                        banditPartyId,
+                        accepted: true,
+                        playerGold: 500,
+                        requestId: requestId),
+                    new ThrowingBarterClientPresentation()),
+                expectedAccepted: true);
         });
     }
 
@@ -121,35 +196,66 @@ public class BarterClientCompletionTests : MapEventTestBase
         return new BarterData(playerHero, targetHero, playerParty.Party, targetParty.Party, null);
     }
 
-    private static void AssertAcceptedResultClosesUi(Action completeRequest)
+    private static void AssertResultClosesUi(
+        Action completeRequest,
+        bool expectedAccepted,
+        MobileParty? conversationParty = null,
+        bool expectLeaveEncounter = false)
     {
         var harmony = new Harmony($"e2e.barter-client-completion.{Guid.NewGuid():N}");
         barterCloseObserved = false;
+        barterClosedObserved = false;
+        if (conversationParty != null)
+            PlayerEncounter.LeaveEncounter = false;
         BarterManager.Instance.LastBarterIsAccepted = false;
+        BarterManager.Instance.Closed += CaptureBarterClosed;
+        conversationPartyOverride = conversationParty;
         harmony.Patch(
             AccessTools.Method(typeof(BarterManager), nameof(BarterManager.Close)),
             prefix: new HarmonyMethod(
                 typeof(BarterClientCompletionTests),
                 nameof(CaptureBarterClose)));
+        if (conversationParty != null)
+        {
+            harmony.Patch(
+                AccessTools.PropertyGetter(typeof(MobileParty), nameof(MobileParty.ConversationParty)),
+                prefix: new HarmonyMethod(
+                    typeof(BarterClientCompletionTests),
+                    nameof(GetConversationParty)));
+        }
 
         try
         {
             completeRequest();
             Assert.True(barterCloseObserved);
-            Assert.True(BarterManager.Instance.LastBarterIsAccepted);
+            Assert.True(barterClosedObserved);
+            Assert.Equal(expectedAccepted, BarterManager.Instance.LastBarterIsAccepted);
+            if (conversationParty != null)
+                Assert.Equal(expectLeaveEncounter, PlayerEncounter.LeaveEncounter);
         }
         finally
         {
             PeaceBarterPatch.ClearPendingRequest();
             BanditBarterPatch.ClearPendingRequest();
             BarterManager.Instance.LastBarterIsAccepted = false;
+            BarterManager.Instance.Closed -= CaptureBarterClosed;
+            conversationPartyOverride = null;
+            if (conversationParty != null)
+            {
+                PlayerEncounter.LeaveEncounter = false;
+                Campaign.Current.PlayerEncounter = null;
+            }
             harmony.UnpatchAll(harmony.Id);
         }
     }
 
-    private static bool CaptureBarterClose()
+    private static void CaptureBarterClose() => barterCloseObserved = true;
+
+    private static void CaptureBarterClosed() => barterClosedObserved = true;
+
+    private static bool GetConversationParty(ref MobileParty __result)
     {
-        barterCloseObserved = true;
+        __result = conversationPartyOverride!;
         return false;
     }
 

--- a/source/GameInterface/Services/Barters/Handlers/PeaceBarterHandler.cs
+++ b/source/GameInterface/Services/Barters/Handlers/PeaceBarterHandler.cs
@@ -232,7 +232,7 @@ internal sealed class PeaceBarterHandler : IHandler
                 engagement.PartyId != request.ContextId ||
                 engagement.EngagerPartyId != playerPartyId)
             {
-                reason = "The peace encounter is no longer active.";
+                reason = NetworkPeaceBarterResult.InactiveEncounterReason;
                 return false;
             }
 

--- a/source/GameInterface/Services/Barters/Messages/PeaceBarterMessages.cs
+++ b/source/GameInterface/Services/Barters/Messages/PeaceBarterMessages.cs
@@ -96,6 +96,8 @@ internal readonly struct NetworkRequestPeaceBarter : ICommand
 [ProtoContract(SkipConstructor = true)]
 internal readonly struct NetworkPeaceBarterResult : ICommand
 {
+    public const string InactiveEncounterReason = "The peace encounter is no longer active.";
+
     [ProtoMember(1)]
     public readonly string ContextId;
     [ProtoMember(2)]

--- a/source/GameInterface/Services/Barters/Patches/PeaceBarterPatch.cs
+++ b/source/GameInterface/Services/Barters/Patches/PeaceBarterPatch.cs
@@ -113,18 +113,28 @@ internal static class PeaceBarterPatch
         var completedBarter = pendingBarter;
         var completedContext = pendingContext;
         var shouldCompleteUi = pendingUiActive;
+        var encounterIsActive = shouldCompleteUi && completedContext == PeaceConversationContext.MapParty &&
+            PlayerEncounter.Current != null &&
+            completedBarter.OtherParty == MobileParty.ConversationParty?.Party;
         ClearPendingRequest();
         if (!result.Accepted)
         {
+            if (shouldCompleteUi && BarterManager.Instance != null)
+                BarterManager.Instance.Close();
+
+            if (encounterIsActive &&
+                PlayerEncounter.Current._mapEvent == null &&
+                result.Reason == NetworkPeaceBarterResult.InactiveEncounterReason)
+                PlayerEncounter.LeaveEncounter = true;
+
+            if (shouldCompleteUi)
+                ContinueConversationIfInProgress();
+
             ShowMessage(string.IsNullOrWhiteSpace(result.Reason)
                 ? "The server rejected the peace barter."
                 : result.Reason);
             return;
         }
-
-        var encounterIsActive = shouldCompleteUi && completedContext == PeaceConversationContext.MapParty &&
-            PlayerEncounter.Current != null &&
-            completedBarter.OtherParty == MobileParty.ConversationParty?.Party;
 
         if (shouldCompleteUi && BarterManager.Instance != null)
         {
@@ -146,19 +156,24 @@ internal static class PeaceBarterPatch
         if (encounterIsActive)
             PlayerEncounter.LeaveEncounter = true;
 
-        if (shouldCompleteUi && Campaign.Current?.ConversationManager?.IsConversationInProgress == true)
-        {
-            try
-            {
-                Campaign.Current.ConversationManager.ContinueConversation();
-            }
-            catch
-            {
-                // The authoritative result has already closed the barter UI.
-            }
-        }
+        if (shouldCompleteUi)
+            ContinueConversationIfInProgress();
 
         MBInformationManager.AddQuickInformation(GameTexts.FindText("str_offer_accepted"));
+    }
+
+    private static void ContinueConversationIfInProgress()
+    {
+        if (Campaign.Current?.ConversationManager?.IsConversationInProgress != true) return;
+
+        try
+        {
+            Campaign.Current.ConversationManager.ContinueConversation();
+        }
+        catch
+        {
+            // The authoritative result has already closed the barter UI.
+        }
     }
 
     internal static void ClearPendingRequest()

--- a/source/GameInterface/Services/Barters/Patches/PeaceBarterPatch.cs
+++ b/source/GameInterface/Services/Barters/Patches/PeaceBarterPatch.cs
@@ -124,6 +124,7 @@ internal static class PeaceBarterPatch
 
             if (encounterIsActive &&
                 PlayerEncounter.Current._mapEvent == null &&
+                MobileParty.MainParty?.MapEvent == null &&
                 result.Reason == NetworkPeaceBarterResult.InactiveEncounterReason)
                 PlayerEncounter.LeaveEncounter = true;
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

A rejected peace offer can leave the barter screen open with Cancel disabled, trapping the player in an inactive encounter until they restart or reconnect.

## What is the new behavior?

Resolves #3013

Rejected peace offers now close the barter screen and return the player to the conversation. Matching stale peace encounters also exit cleanly without disrupting an active siege or battle encounter.

## Bot Changelog Entry

- Fixed rejected peace offers leaving players stuck in the diplomacy UI.
