### PR TITLE
Revalidate army formation position corrections

### DIFF
--- a/source/GameInterface.Tests/Services/Armies/ArmyFormationPositionConvergenceTests.cs
+++ b/source/GameInterface.Tests/Services/Armies/ArmyFormationPositionConvergenceTests.cs
@@ -35,10 +35,8 @@ public class ArmyFormationPositionConvergenceTests
     }
 
     [Fact]
-    public void DistantCompanion_PositionUpdateDoesNotSatisfyVanillaAttachmentDistance()
+    public void DistantCompanion_DoesNotReportPosition()
     {
-        CampaignVec2 reportedLeaderPosition = Position(12f, 12f);
-        CampaignVec2 distantCompanionPosition = Position(20f, 20f);
         var state = State(
             Position(11f, 12f),
             isArmyLeader: true,
@@ -49,8 +47,37 @@ public class ArmyFormationPositionConvergenceTests
             state,
             hasPreviousPosition: false,
             previousPosition: default));
-        Assert.True(convergence.ShouldApply(state, reportedLeaderPosition));
-        Assert.False(distantCompanionPosition.DistanceSquared(reportedLeaderPosition) < 1.5f);
+    }
+
+    [Fact]
+    public void ReportedPositionWithoutNearbyCompanion_IsRejected()
+    {
+        CampaignVec2 reportedPosition = Position(12f, 12f);
+        var state = State(
+            Position(11f, 12f),
+            isArmyLeader: true,
+            hasConvergingMember: true,
+            hasNearbyConvergingMember: false);
+
+        Assert.False(convergence.ShouldApply(state, reportedPosition));
+    }
+
+    [Fact]
+    public void NearbyCompanion_BoundedCorrectionIsApplied()
+    {
+        CampaignVec2 reportedPosition = Position(12f, 12f);
+        var state = EligibleState(Position(11f, 12f));
+
+        Assert.True(convergence.ShouldApply(state, reportedPosition));
+    }
+
+    [Fact]
+    public void CorrectionBeyondAttachmentDistance_IsRejected()
+    {
+        CampaignVec2 reportedPosition = Position(12f, 12f);
+        var state = EligibleState(Position(10f, 12f));
+
+        Assert.False(convergence.ShouldApply(state, reportedPosition));
     }
 
     [Fact]
@@ -58,9 +85,6 @@ public class ArmyFormationPositionConvergenceTests
     {
         CampaignVec2 reportedPosition = Position(12f, 12f);
 
-        Assert.True(convergence.ShouldApply(
-            EligibleState(Position(11f, 12f)),
-            reportedPosition));
         Assert.False(convergence.ShouldApply(
             EligibleState(reportedPosition),
             reportedPosition));
@@ -130,7 +154,8 @@ public class ArmyFormationPositionConvergenceTests
             isInSettlement: false,
             isCurrentlyAtSea: false,
             hasConvergingMember,
-            hasNearbyConvergingMember ?? hasConvergingMember);
+            hasNearbyConvergingMember ?? hasConvergingMember,
+            attachmentDistanceSquared: 1.5f);
 
     private static CampaignVec2 Position(float x, float y) =>
         new CampaignVec2(new Vec2(x, y), isOnLand: true);

--- a/source/GameInterface/Services/Armies/ArmyFormationPositionConvergence.cs
+++ b/source/GameInterface/Services/Armies/ArmyFormationPositionConvergence.cs
@@ -29,6 +29,7 @@ internal readonly struct ArmyFormationPositionState
     public bool IsCurrentlyAtSea { get; }
     public bool HasConvergingMember { get; }
     public bool HasNearbyConvergingMember { get; }
+    public float AttachmentDistanceSquared { get; }
 
     public ArmyFormationPositionState(
         string leaderPartyId,
@@ -41,7 +42,8 @@ internal readonly struct ArmyFormationPositionState
         bool isInSettlement,
         bool isCurrentlyAtSea,
         bool hasConvergingMember,
-        bool hasNearbyConvergingMember)
+        bool hasNearbyConvergingMember,
+        float attachmentDistanceSquared)
     {
         LeaderPartyId = leaderPartyId;
         Position = position;
@@ -54,6 +56,7 @@ internal readonly struct ArmyFormationPositionState
         IsCurrentlyAtSea = isCurrentlyAtSea;
         HasConvergingMember = hasConvergingMember;
         HasNearbyConvergingMember = hasNearbyConvergingMember;
+        AttachmentDistanceSquared = attachmentDistanceSquared;
     }
 }
 
@@ -78,9 +81,12 @@ internal sealed class ArmyFormationPositionConvergence : IArmyFormationPositionC
     public bool ShouldApply(ArmyFormationPositionState state, CampaignVec2 reportedPosition)
     {
         return IsEligible(state) &&
+            state.HasNearbyConvergingMember &&
+            state.AttachmentDistanceSquared > 0f &&
             reportedPosition.ToVec2().IsValid &&
             reportedPosition.IsOnLand != state.IsCurrentlyAtSea &&
-            reportedPosition != state.Position;
+            reportedPosition != state.Position &&
+            reportedPosition.DistanceSquared(state.Position) <= state.AttachmentDistanceSquared;
     }
 
     public bool CanReport(ArmyFormationPositionState state) =>

--- a/source/GameInterface/Services/Armies/Handlers/ArmyFormationPositionHandler.cs
+++ b/source/GameInterface/Services/Armies/Handlers/ArmyFormationPositionHandler.cs
@@ -57,7 +57,11 @@ internal sealed class ArmyFormationPositionHandler : IHandler
         if (ModInformation.IsServer) return;
 
         MobileParty leaderParty = payload.What.LeaderParty;
-        if (!TryCreateState(leaderParty, leaderParty?.IsControlledByThisInstance() == true, out var state))
+        if (!TryCreateState(
+                leaderParty,
+                leaderParty?.IsControlledByThisInstance() == true,
+                leaderParty?.Position ?? CampaignVec2.Invalid,
+                out var state))
             return;
 
         if (!convergence.CanReport(state))
@@ -91,7 +95,12 @@ internal sealed class ArmyFormationPositionHandler : IHandler
             if (!PeerControlsParty(peer, request.LeaderPartyId)) return;
             if (!objectManager.TryGetObjectWithLogging(request.LeaderPartyId, out MobileParty leaderParty))
                 return;
-            if (!TryCreateState(leaderParty, isControlled: true, out var state)) return;
+            // Recheck attachment proximity at the requested position after the game-thread handoff.
+            if (!TryCreateState(
+                    leaderParty,
+                    isControlled: true,
+                    request.Position,
+                    out var state)) return;
             if (!convergence.ShouldApply(state, request.Position)) return;
 
             CampaignVec2 previousPosition = leaderParty.Position;
@@ -123,6 +132,7 @@ internal sealed class ArmyFormationPositionHandler : IHandler
     private bool TryCreateState(
         MobileParty leaderParty,
         bool isControlled,
+        CampaignVec2 candidateLeaderPosition,
         out ArmyFormationPositionState state)
     {
         state = default;
@@ -134,14 +144,16 @@ internal sealed class ArmyFormationPositionHandler : IHandler
         bool isArmyLeader = army?.LeaderParty == leaderParty;
         bool hasConvergingMember = false;
         bool hasNearbyConvergingMember = false;
+        float attachmentDistanceSquared = 0f;
         if (isArmyLeader && Campaign.Current?.Models?.EncounterModel != null)
         {
-            float attachmentDistanceSquared = leaderParty.IsCurrentlyAtSea
+            attachmentDistanceSquared = leaderParty.IsCurrentlyAtSea
                 ? Campaign.Current.Models.EncounterModel.MaximumAllowedNavalDistanceForEncounteringMobilePartyInArmy
                 : Campaign.Current.Models.EncounterModel.MaximumAllowedLandDistanceForEncounteringMobilePartyInArmy;
             hasConvergingMember = HasConvergingMember(
                 army,
                 leaderParty,
+                candidateLeaderPosition,
                 attachmentDistanceSquared,
                 out hasNearbyConvergingMember);
         }
@@ -157,18 +169,21 @@ internal sealed class ArmyFormationPositionHandler : IHandler
             leaderParty.CurrentSettlement != null,
             leaderParty.IsCurrentlyAtSea,
             hasConvergingMember,
-            hasNearbyConvergingMember);
+            hasNearbyConvergingMember,
+            attachmentDistanceSquared);
         return true;
     }
 
     private static bool HasConvergingMember(
         Army army,
         MobileParty leaderParty,
+        CampaignVec2 candidateLeaderPosition,
         float attachmentDistanceSquared,
         out bool hasNearbyConvergingMember)
     {
         hasNearbyConvergingMember = false;
         bool hasConvergingMember = false;
+        bool hasValidCandidatePosition = candidateLeaderPosition.ToVec2().IsValid;
         // Mirror Army.Tick's non-distance gates so ordinary army travel never sends corrections.
         foreach (MobileParty member in army.Parties)
         {
@@ -181,7 +196,8 @@ internal sealed class ArmyFormationPositionHandler : IHandler
                 continue;
 
             hasConvergingMember = true;
-            if ((member.Position - leaderParty.Position).LengthSquared < attachmentDistanceSquared)
+            if (hasValidCandidatePosition &&
+                (member.Position - candidateLeaderPosition).LengthSquared < attachmentDistanceSquared)
                 hasNearbyConvergingMember = true;
         }
 


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

A queued army-leader position convergence request can still be applied when no gathering member is near the reported position. The correction is also not bounded by the vanilla army attachment distance.

## What is the new behavior?

The server rechecks gathering-member proximity at the reported position after the game-thread handoff and rejects corrections beyond the vanilla attachment distance.

Follow-up to #3183.

## Bot Changelog Entry

- Fixed stale formation updates moving player-led army leaders away from their gathering parties.

## Other information

Tests: 11 army convergence unit tests, 1,062 GameInterface tests, and 8 army E2E tests passed.