### PR TITLE
[3132] Respect the dedicated server battle size setting

### DIFF
--- a/deploy/mod-config.default.json
+++ b/deploy/mod-config.default.json
@@ -80,6 +80,10 @@
     "movementIncomingMiBPerSecond": 1.0,
   },
   "modOptions": {
+    // Total human troops initially allocated across both sides of a battle.
+    // Valid range: 200-1000. Default is 1000.
+    "battleSize": 1000,
+
     // Toggle fast forward (2x speed) being enabled
     // (Default) true: Fast forward is allowed.
     // false: Fast forward is completely disabled.

--- a/source/Coop.Tests/TestComponentBase.cs
+++ b/source/Coop.Tests/TestComponentBase.cs
@@ -7,6 +7,7 @@ using Coop.Core.Server.Services.Kingdoms;
 using Coop.Core.Server.Services.MobileParties;
 using Coop.Tests.Mocks;
 using GameInterface.AutoSync;
+using GameInterface.Configuration;
 using GameInterface.CoopSessionData;
 using GameInterface.Registry;
 using GameInterface.Registry.Auto;
@@ -96,6 +97,7 @@ internal abstract class TestComponentBase
 
         RegisterMock<ILogger>(builder);
         RegisterMock<IGameInterface>(builder);
+        RegisterMock<IModConfig>(builder);
         RegisterMock<IAutoSyncPatchCollector>(builder);
         RegisterMock<IHeroInterface>(builder);
         RegisterMock<IModuleInfoProvider>(builder);

--- a/source/E2E.Tests/Environment/TestEnvironment.cs
+++ b/source/E2E.Tests/Environment/TestEnvironment.cs
@@ -135,7 +135,7 @@ public class TestEnvironment
             this.battleSize = battleSize;
         }
 
-        public int GetBattleSize(TaleWorlds.CampaignSystem.MapEvents.MapEvent mapEvent) => battleSize;
+        public int GetBattleSize() => battleSize;
     }
 }
 

--- a/source/E2E.Tests/Services/Missions/BattleSizeProviderTests.cs
+++ b/source/E2E.Tests/Services/Missions/BattleSizeProviderTests.cs
@@ -1,0 +1,56 @@
+﻿using GameInterface.Configuration;
+using Missions.Battles;
+using Xunit;
+
+namespace E2E.Tests.Services.Missions;
+
+public class BattleSizeProviderTests
+{
+    [Fact]
+    public void MissingSettingUsesDefaultBattleSize()
+    {
+        var provider = CreateProvider(null);
+
+        Assert.Equal(1000, provider.GetBattleSize());
+    }
+
+    [Fact]
+    public void ConfiguredBattleSizeIsUsed()
+    {
+        var provider = CreateProvider(750);
+
+        Assert.Equal(750, provider.GetBattleSize());
+    }
+
+    [Theory]
+    [InlineData(0, 200)]
+    [InlineData(199, 200)]
+    [InlineData(1001, 1000)]
+    [InlineData(5000, 1000)]
+    public void ConfiguredBattleSizeIsClamped(int configured, int expected)
+    {
+        var provider = CreateProvider(configured);
+
+        Assert.Equal(expected, provider.GetBattleSize());
+    }
+
+    private static BattleSizeProvider CreateProvider(int? battleSize)
+    {
+        var config = new TestModConfig
+        {
+            Data = new ModConfigData
+            {
+                ModOptions = new ModOptionsData
+                {
+                    BattleSize = battleSize,
+                },
+            },
+        };
+        return new BattleSizeProvider(config);
+    }
+
+    private sealed class TestModConfig : IModConfig
+    {
+        public ModConfigData Data { get; set; } = new ModConfigData();
+    }
+}

--- a/source/GameInterface.Tests/Configuration/ModConfigTests.cs
+++ b/source/GameInterface.Tests/Configuration/ModConfigTests.cs
@@ -70,9 +70,11 @@ public class ModConfigTests : IDisposable
         Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.BattleDeath);
         Assert.False(config.Difficulty.BirthAndDeath);
         Assert.False(config.Difficulty.AutoAllocateClanMemberPerks);
+        Assert.Equal(1000, config.ModOptions.BattleSize);
         Assert.True(config.UnknownKeys == null || config.UnknownKeys.Count == 0);
         Assert.True(config.Difficulty.UnknownKeys == null || config.Difficulty.UnknownKeys.Count == 0);
         Assert.True(config.Network.UnknownKeys == null || config.Network.UnknownKeys.Count == 0);
+        Assert.True(config.ModOptions.UnknownKeys == null || config.ModOptions.UnknownKeys.Count == 0);
     }
 
     [Fact]

--- a/source/GameInterface/Configuration/ModConfigData.cs
+++ b/source/GameInterface/Configuration/ModConfigData.cs
@@ -82,6 +82,8 @@ public sealed class NetworkConfigData
 
 public sealed class ModOptionsData
 {
+    public int? BattleSize { get; set; }
+
     public bool? FastForwardEnabled { get; set; }
 
     public bool? AutoPauseEnabled { get; set; }

--- a/source/GameInterface/Services/Party/Commands/LargeBattleRosterFixtureCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/LargeBattleRosterFixtureCommands.cs
@@ -5,6 +5,7 @@ using Common.Messaging;
 using GameInterface.Services.MobileParties.Data;
 using GameInterface.Services.MobileParties.Messages.Behavior;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Players;
 using GameInterface.Utils.Commands;
 using System;
 using System.Collections.Generic;
@@ -55,7 +56,7 @@ internal static class LargeBattleRosterFixtureCommands
             || addedPerParty > 500)
         {
             return "Usage: coop.debug.mobileparty.large_battle_roster_begin " +
-                   "<firstPartyId> <secondPartyId> <troopsPerParty:1-500>";
+                   "<firstPartyOrControllerId> <secondPartyOrControllerId> <troopsPerParty:1-500>";
         }
         if (fixture != null)
             return "A large-battle roster fixture is already pending restoration.";
@@ -116,7 +117,7 @@ internal static class LargeBattleRosterFixtureCommands
             || (healthyPerParty != 5 && healthyPerParty != 900))
         {
             return "Usage: coop.debug.mobileparty.exact_battle_roster_begin " +
-                   "<firstPartyId> <secondPartyId> <healthyPerParty:5|900>";
+                   "<firstPartyOrControllerId> <secondPartyOrControllerId> <healthyPerParty:5|900>";
         }
 
         return BeginExact(args[0], args[1], healthyPerParty, healthyPerParty);
@@ -136,7 +137,7 @@ internal static class LargeBattleRosterFixtureCommands
             || secondHealthyCount > 1000)
         {
             return "Usage: coop.debug.mobileparty.battle_size_roster_begin " +
-                   "<firstPartyId> <secondPartyId> <firstHealthy:1-1000> <secondHealthy:1-1000>";
+                   "<firstPartyOrControllerId> <secondPartyOrControllerId> <firstHealthy:1-1000> <secondHealthy:1-1000>";
         }
 
         return BeginExact(args[0], args[1], firstHealthyCount, secondHealthyCount);
@@ -256,7 +257,7 @@ internal static class LargeBattleRosterFixtureCommands
             return "Run this command on the server.";
         if (args.Count != 2)
         {
-            return $"Usage: {commandName} <firstPartyId> <secondPartyId>";
+            return $"Usage: {commandName} <firstPartyOrControllerId> <secondPartyOrControllerId>";
         }
         if (!TryGetObjectManager(out IObjectManager objectManager))
             return "Unable to resolve ObjectManager.";
@@ -392,7 +393,15 @@ internal static class LargeBattleRosterFixtureCommands
             return true;
         }
 
-        error = $"Unable to resolve party {id}.";
+        if (ContainerProvider.TryResolve<IPlayerManager>(out var playerManager)
+            && playerManager.TryGetPlayer(id, out var player)
+            && objectManager.TryGetObject(player.MobilePartyId, out party))
+        {
+            error = null;
+            return true;
+        }
+
+        error = $"Unable to resolve party or player controller {id}.";
         return false;
     }
 

--- a/source/GameInterface/Services/Party/Commands/LargeBattleRosterFixtureCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/LargeBattleRosterFixtureCommands.cs
@@ -28,7 +28,8 @@ internal static class LargeBattleRosterFixtureCommands
         public Campaign Campaign;
         public PartySnapshot FirstParty;
         public PartySnapshot SecondParty;
-        public int? ExactHealthyCount;
+        public int? FirstExactHealthyCount;
+        public int? SecondExactHealthyCount;
     }
 
     private sealed class PartySnapshot
@@ -102,7 +103,7 @@ internal static class LargeBattleRosterFixtureCommands
 
         return
             $"LARGE_BATTLE_ROSTER_FIXTURE_STARTED troop={FixtureTroopId} addedPerParty={addedPerParty}\n" +
-            FormatState("active", firstParty, secondParty, null);
+            FormatState("active", firstParty, secondParty, null, null);
     }
 
     [CommandLineArgumentFunction("exact_battle_roster_begin", "coop.debug.mobileparty")]
@@ -117,6 +118,36 @@ internal static class LargeBattleRosterFixtureCommands
             return "Usage: coop.debug.mobileparty.exact_battle_roster_begin " +
                    "<firstPartyId> <secondPartyId> <healthyPerParty:5|900>";
         }
+
+        return BeginExact(args[0], args[1], healthyPerParty, healthyPerParty);
+    }
+
+    [CommandLineArgumentFunction("battle_size_roster_begin", "coop.debug.mobileparty")]
+    public static string BeginBattleSize(List<string> args)
+    {
+        if (!ModInformation.IsServer)
+            return "Run this command on the server.";
+        if (args.Count != 4
+            || !int.TryParse(args[2], out int firstHealthyCount)
+            || !int.TryParse(args[3], out int secondHealthyCount)
+            || firstHealthyCount < 1
+            || firstHealthyCount > 1000
+            || secondHealthyCount < 1
+            || secondHealthyCount > 1000)
+        {
+            return "Usage: coop.debug.mobileparty.battle_size_roster_begin " +
+                   "<firstPartyId> <secondPartyId> <firstHealthy:1-1000> <secondHealthy:1-1000>";
+        }
+
+        return BeginExact(args[0], args[1], firstHealthyCount, secondHealthyCount);
+    }
+
+    private static string BeginExact(
+        string firstPartyId,
+        string secondPartyId,
+        int firstHealthyCount,
+        int secondHealthyCount)
+    {
         if (fixture != null)
             return "A large-battle roster fixture is already pending restoration.";
         if (!TryGetObjectManager(out IObjectManager objectManager) ||
@@ -126,7 +157,7 @@ internal static class LargeBattleRosterFixtureCommands
         }
         if (!TryResolveParty(
                 objectManager,
-                args[0],
+                firstPartyId,
                 out MobileParty firstParty,
                 out string firstError))
         {
@@ -134,7 +165,7 @@ internal static class LargeBattleRosterFixtureCommands
         }
         if (!TryResolveParty(
                 objectManager,
-                args[1],
+                secondPartyId,
                 out MobileParty secondParty,
                 out string secondError))
         {
@@ -160,7 +191,7 @@ internal static class LargeBattleRosterFixtureCommands
         PartySnapshot secondSnapshot = Capture(secondParty, secondBehavior);
         if (!TryGetFixtureTroopCount(
                 firstSnapshot,
-                healthyPerParty,
+                firstHealthyCount,
                 out int firstTroops,
                 out firstError))
         {
@@ -168,7 +199,7 @@ internal static class LargeBattleRosterFixtureCommands
         }
         if (!TryGetFixtureTroopCount(
                 secondSnapshot,
-                healthyPerParty,
+                secondHealthyCount,
                 out int secondTroops,
                 out secondError))
         {
@@ -180,7 +211,8 @@ internal static class LargeBattleRosterFixtureCommands
             Campaign = Campaign.Current,
             FirstParty = firstSnapshot,
             SecondParty = secondSnapshot,
-            ExactHealthyCount = healthyPerParty,
+            FirstExactHealthyCount = firstHealthyCount,
+            SecondExactHealthyCount = secondHealthyCount,
         };
         fixture = activeFixture;
         try
@@ -206,9 +238,12 @@ internal static class LargeBattleRosterFixtureCommands
                 $"restored={restored}";
         }
 
-        return
-            $"EXACT_BATTLE_ROSTER_FIXTURE_STARTED troop={FixtureTroopId} healthyPerParty={healthyPerParty}\n" +
-            FormatState("active", firstParty, secondParty, healthyPerParty);
+        string started = firstHealthyCount == secondHealthyCount
+            ? $"EXACT_BATTLE_ROSTER_FIXTURE_STARTED troop={FixtureTroopId} healthyPerParty={firstHealthyCount}"
+            : $"EXACT_BATTLE_ROSTER_FIXTURE_STARTED troop={FixtureTroopId} " +
+              $"firstHealthy={firstHealthyCount} secondHealthy={secondHealthyCount}";
+        return started + "\n" +
+               FormatState("active", firstParty, secondParty, firstHealthyCount, secondHealthyCount);
     }
 
     [CommandLineArgumentFunction("large_battle_roster_status", "coop.debug.mobileparty")]
@@ -246,7 +281,8 @@ internal static class LargeBattleRosterFixtureCommands
             fixture == null ? "none" : "active",
             firstParty,
             secondParty,
-            fixture?.ExactHealthyCount);
+            fixture?.FirstExactHealthyCount,
+            fixture?.SecondExactHealthyCount);
     }
 
     [CommandLineArgumentFunction("exact_battle_roster_status", "coop.debug.mobileparty")]
@@ -312,7 +348,8 @@ internal static class LargeBattleRosterFixtureCommands
                        "restore-failed",
                        activeFixture.FirstParty.Party,
                        activeFixture.SecondParty.Party,
-                       activeFixture.ExactHealthyCount);
+                       activeFixture.FirstExactHealthyCount,
+                       activeFixture.SecondExactHealthyCount);
         }
 
         fixture = null;
@@ -323,6 +360,7 @@ internal static class LargeBattleRosterFixtureCommands
                 "none",
                 activeFixture.FirstParty.Party,
                 activeFixture.SecondParty.Party,
+                null,
                 null);
     }
 
@@ -563,12 +601,18 @@ internal static class LargeBattleRosterFixtureCommands
         string state,
         MobileParty firstParty,
         MobileParty secondParty,
-        int? exactHealthyCount)
+        int? firstExactHealthyCount,
+        int? secondExactHealthyCount)
     {
         var output = new StringBuilder();
+        string exactHealthy = firstExactHealthyCount == secondExactHealthyCount
+            ? firstExactHealthyCount?.ToString() ?? "none"
+            : "mixed";
         output.AppendLine(
             $"LARGE_BATTLE_ROSTER_FIXTURE state={state}|" +
-            $"exactHealthy={exactHealthyCount?.ToString() ?? "none"}");
+            $"exactHealthy={exactHealthy}|" +
+            $"firstHealthyTarget={firstExactHealthyCount?.ToString() ?? "none"}|" +
+            $"secondHealthyTarget={secondExactHealthyCount?.ToString() ?? "none"}");
         AppendPartyState(output, firstParty);
         AppendPartyState(output, secondParty);
         return output.ToString().TrimEnd();

--- a/source/Missions/Battles/BattleDebugCommands.cs
+++ b/source/Missions/Battles/BattleDebugCommands.cs
@@ -3,6 +3,7 @@ using GameInterface;
 using GameInterface.Services.MapEvents;
 using GameInterface.Services.MapEvents.TroopSupply;
 using Missions.Agents.Packets;
+using Newtonsoft.Json;
 #if DEBUG
 using Missions.Diagnostics;
 #endif
@@ -337,6 +338,47 @@ internal static class BattleDebugCommands
             $"enemyMovedSinceLast={moved} damageReceivedEvents={ownDamageEvents} " +
             $"resultState={result?.BattleState.ToString() ?? "None"} " +
             $"battleResolved={result?.BattleResolved ?? false} playerVictory={result?.PlayerVictory ?? false}";
+    }
+
+    [CommandLineArgumentFunction("size_state", "coop.debug.battle")]
+    public static string SizeState(List<string> args)
+    {
+        if (args.Count != 0)
+            return "Usage: coop.debug.battle.size_state";
+
+        Mission mission = Mission.Current;
+        var controller = mission?.GetMissionBehavior<CoopBattleController>();
+        var spawnHandler = mission?.GetMissionBehavior<CoopBattleMissionSpawnHandler>();
+        if (mission == null || controller == null || spawnHandler == null)
+            return "No active coop battle mission";
+        if (!ContainerProvider.TryResolve<IBattleAgentBudget>(out var agentBudget))
+            return "Battle agent budget is unavailable";
+
+        CoopBattleMissionSpawnHandler.BattleSizeState state = spawnHandler.CaptureBattleSizeState();
+        int activeAgents = mission.Agents.Count(agent => agent.IsActive());
+        int targetTotal = state.DefenderTarget + state.AttackerTarget;
+        string structuredState = JsonConvert.SerializeObject(new
+        {
+            controllerId = controller.Session.OwnControllerId,
+            state.IsSized,
+            authoritativeBattleSize = state.BattleSize,
+            state.DefenderTotal,
+            state.AttackerTotal,
+            state.DefenderTarget,
+            state.AttackerTarget,
+            authoritativeTargetTotal = targetTotal,
+            state.AllocationRevision,
+            activeAgents,
+            renderedAgentLimit = agentBudget.MaxRenderedAgents,
+        });
+
+        return
+            $"BATTLE_SIZE_STATE battleSize={state.BattleSize}|" +
+            $"defenderTotal={state.DefenderTotal}|attackerTotal={state.AttackerTotal}|" +
+            $"defenderTarget={state.DefenderTarget}|attackerTarget={state.AttackerTarget}|" +
+            $"targetTotal={targetTotal}|activeAgents={activeAgents}|" +
+            $"renderedAgentLimit={agentBudget.MaxRenderedAgents}\n" +
+            $"LIVE_TEST_JSON={structuredState}";
     }
 
     [CommandLineArgumentFunction("charge_owned_formations", "coop.debug.battle")]

--- a/source/Missions/Battles/BattleHostHandler.cs
+++ b/source/Missions/Battles/BattleHostHandler.cs
@@ -391,7 +391,7 @@ internal class BattleHostHandler : IHandler
     {
         if (receiver == null) return;
         long allocationRevision = ++reserveSnapshotRevision;
-        int battleSize = battleSizeProvider.GetBattleSize(mapEvent);
+        int battleSize = battleSizeProvider.GetBattleSize();
         foreach (var sideReserve in reserves)
             network.Send(receiver, new NetworkBattleTroopReserve(
                 mapEventId, (int)sideReserve.Side, sideReserve.Parties, sideReserve.TotalTroops,

--- a/source/Missions/Battles/BattleSizeProvider.cs
+++ b/source/Missions/Battles/BattleSizeProvider.cs
@@ -1,23 +1,31 @@
 ﻿using System;
-using TaleWorlds.CampaignSystem.MapEvents;
-using TaleWorlds.MountAndBlade;
+using GameInterface.Configuration;
 
 namespace Missions.Battles;
 
 public interface IBattleSizeProvider
 {
-    int GetBattleSize(MapEvent mapEvent);
+    int GetBattleSize();
 }
 
 public class BattleSizeProvider : IBattleSizeProvider
 {
-    public int GetBattleSize(MapEvent mapEvent)
-    {
-        if (mapEvent == null) throw new ArgumentNullException(nameof(mapEvent));
+    internal const int DefaultBattleSize = 1000;
+    internal const int MinimumBattleSize = 200;
+    internal const int MaximumBattleSize = 1000;
 
-        int configuredBattleSize = mapEvent.IsSiegeAssault
-            ? BannerlordConfig.GetRealBattleSizeForSiege()
-            : BannerlordConfig.GetRealBattleSize();
-        return Math.Min(configuredBattleSize, DefaultBattleMissionAgentSpawnLogic.MaxNumberOfTroopsForMission);
+    private readonly IModConfig modConfig;
+
+    public BattleSizeProvider(IModConfig modConfig)
+    {
+        if (modConfig == null) throw new ArgumentNullException(nameof(modConfig));
+
+        this.modConfig = modConfig;
+    }
+
+    public int GetBattleSize()
+    {
+        int configuredBattleSize = modConfig.Data?.ModOptions?.BattleSize ?? DefaultBattleSize;
+        return Math.Max(MinimumBattleSize, Math.Min(MaximumBattleSize, configuredBattleSize));
     }
 }

--- a/source/Missions/Battles/CoopBattleMissionSpawnHandler.cs
+++ b/source/Missions/Battles/CoopBattleMissionSpawnHandler.cs
@@ -248,6 +248,29 @@ public class CoopBattleMissionSpawnHandler : SandBoxMissionSpawnHandler
         _appliedAllocationRevision = MatchingAllocationRevision(defenderSnapshot.Revision, attackerSnapshot.Revision);
     }
 
+    internal BattleSizeState CaptureBattleSizeState()
+    {
+        SideSizing sizing = ReadSizing();
+        var settings = CreateSandBoxBattleWaveSpawnSettings();
+        var targets = ReinforcementFielder.RecoveryTargets.Calculate(
+            sizing.DefenderOwned,
+            sizing.AttackerOwned,
+            sizing.BattleSize,
+            settings.MaximumBattleSideRatio,
+            settings.DefenderAdvantageFactor);
+        var defenderSnapshot = _defenderSupplier.CaptureAllocationSnapshot();
+        var attackerSnapshot = _attackerSupplier.CaptureAllocationSnapshot();
+
+        return new BattleSizeState(
+            _sized,
+            sizing.DefenderOwned,
+            sizing.AttackerOwned,
+            sizing.BattleSize,
+            targets.Defenders,
+            targets.Attackers,
+            MatchingAllocationRevision(defenderSnapshot.Revision, attackerSnapshot.Revision));
+    }
+
     // Reserve refreshes are sent as a reliable-ordered pair. Wait until both suppliers advanced, then resize
     // only the unspent lifetime quota; InitialSpawnNumber/InitialSpawnedNumber keep deployment one-shot.
     private void ReconcileRefreshedAllocation()
@@ -457,5 +480,34 @@ public class CoopBattleMissionSpawnHandler : SandBoxMissionSpawnHandler
 
         /// <summary>Whether a timeout can safely degrade to a one-sided sizing instead of empty/empty.</summary>
         public bool HasAnyOwnedTroops => DefenderOwned + AttackerOwned > 0;
+    }
+
+    internal readonly struct BattleSizeState
+    {
+        public readonly bool IsSized;
+        public readonly int DefenderTotal;
+        public readonly int AttackerTotal;
+        public readonly int BattleSize;
+        public readonly int DefenderTarget;
+        public readonly int AttackerTarget;
+        public readonly long AllocationRevision;
+
+        public BattleSizeState(
+            bool isSized,
+            int defenderTotal,
+            int attackerTotal,
+            int battleSize,
+            int defenderTarget,
+            int attackerTarget,
+            long allocationRevision)
+        {
+            IsSized = isSized;
+            DefenderTotal = defenderTotal;
+            AttackerTotal = attackerTotal;
+            BattleSize = battleSize;
+            DefenderTarget = defenderTarget;
+            AttackerTarget = attackerTarget;
+            AllocationRevision = allocationRevision;
+        }
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Starting a battle on the dedicated server caps the total deployed troops at 400 even when the battle size is set to 1,000.

## What is the new behavior?

Resolves #3132

Dedicated-server battles use the configured `modOptions.battleSize` value, defaulting to 1,000 and accepting values from 200 through 1,000.

## Bot Changelog Entry

- Made battle size configurable in the mod-options JSON file. Dedicated servers now respect the configured battle size instead of capping battles at 400 troops.
