### PR TITLE
Correlate mission finalization diagnostics

### DIFF
--- a/source/GameInterface.Tests/Services/MapEvents/MissionStateFinalizeDiagnosticsPatchTests.cs
+++ b/source/GameInterface.Tests/Services/MapEvents/MissionStateFinalizeDiagnosticsPatchTests.cs
@@ -1,0 +1,42 @@
+﻿using GameInterface.Services.MapEvents.Patches;
+using System.Runtime.Serialization;
+using TaleWorlds.MountAndBlade;
+using Xunit;
+
+namespace GameInterface.Tests.Services.MapEvents;
+
+/// <summary>Verifies mission lifecycle identifiers survive until finalization.</summary>
+public class MissionStateFinalizeDiagnosticsPatchTests
+{
+    [Fact]
+    public void RecordCorrelation_PreservesSequenceAndMapEventForMissionFinalization()
+    {
+        var mission = (Mission)FormatterServices.GetUninitializedObject(typeof(Mission));
+
+        MissionStateFinalizeDiagnosticsPatch.RecordCorrelation(mission, 42, "map-event-7");
+
+        bool found = MissionStateFinalizeDiagnosticsPatch.TryGetCorrelation(
+            mission,
+            out var sequence,
+            out var mapEventId);
+
+        Assert.True(found);
+        Assert.Equal(42, sequence);
+        Assert.Equal("map-event-7", mapEventId);
+    }
+
+    [Fact]
+    public void TryGetCorrelation_UntrackedMission_ReturnsNoIdentifiers()
+    {
+        var mission = (Mission)FormatterServices.GetUninitializedObject(typeof(Mission));
+
+        bool found = MissionStateFinalizeDiagnosticsPatch.TryGetCorrelation(
+            mission,
+            out var sequence,
+            out var mapEventId);
+
+        Assert.False(found);
+        Assert.Equal(0, sequence);
+        Assert.Null(mapEventId);
+    }
+}

--- a/source/GameInterface/Services/MapEvents/Handlers/BattleMissionStartHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/BattleMissionStartHandler.cs
@@ -7,6 +7,7 @@ using GameInterface.Services.MapEvents.Extensions;
 using GameInterface.Services.MapEvents.Logging;
 using GameInterface.Services.MapEvents.Messages.Leave;
 using GameInterface.Services.MapEvents.Messages.Start;
+using GameInterface.Services.MapEvents.Patches;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
 using LiteNetLib;
@@ -645,6 +646,7 @@ internal class BattleMissionStartHandler : IHandler
                 if (mission != null)
                 {
                     spawnGateEngaged = false; // the attached mission lifecycle owns EndBattle from here
+                    MissionStateFinalizeDiagnosticsPatch.RecordCorrelation(mission, sequence, mapEventId);
                     Logger.Information(
                         "[BattleMissionLifecycle] Attack mission opened: sequence={Sequence} mapEvent={MapEventId} scene={Scene} missionStatePresent={MissionStatePresent} missionPresent={MissionPresent}",
                         sequence,

--- a/source/GameInterface/Services/MapEvents/Patches/MissionStateFinalizeDiagnosticsPatch.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/MissionStateFinalizeDiagnosticsPatch.cs
@@ -1,6 +1,7 @@
 ﻿using Common.Logging;
 using HarmonyLib;
 using Serilog;
+using System.Runtime.CompilerServices;
 using TaleWorlds.MountAndBlade;
 
 namespace GameInterface.Services.MapEvents.Patches;
@@ -10,16 +11,53 @@ namespace GameInterface.Services.MapEvents.Patches;
 internal class MissionStateFinalizeDiagnosticsPatch
 {
     private static readonly ILogger Logger = LogManager.GetLogger<MissionStateFinalizeDiagnosticsPatch>();
+    private static readonly ConditionalWeakTable<Mission, MissionCorrelation> Correlations = new();
+
+    internal static void RecordCorrelation(Mission mission, long sequence, string mapEventId)
+    {
+        Correlations.Remove(mission);
+        Correlations.Add(mission, new MissionCorrelation(sequence, mapEventId));
+    }
+
+    internal static bool TryGetCorrelation(Mission mission, out long sequence, out string mapEventId)
+    {
+        if (mission != null && Correlations.TryGetValue(mission, out var correlation))
+        {
+            sequence = correlation.Sequence;
+            mapEventId = correlation.MapEventId;
+            return true;
+        }
+
+        sequence = 0;
+        mapEventId = null;
+        return false;
+    }
 
     [HarmonyPrefix]
     private static void Prefix(MissionState __instance)
     {
         var mission = __instance.CurrentMission;
+        bool hasCorrelation = TryGetCorrelation(mission, out var sequence, out var mapEventId);
         Logger.Information(
-            "[BattleMissionLifecycle] Mission finalizing: missionName={MissionName} scene={Scene} missionPresent={MissionPresent} missionEnded={MissionEnded}",
+            "[BattleMissionLifecycle] Mission finalizing: sequence={Sequence} mapEvent={MapEventId} missionName={MissionName} scene={Scene} missionPresent={MissionPresent} missionEnded={MissionEnded}",
+            hasCorrelation ? sequence : (long?)null,
+            mapEventId,
             __instance.MissionName,
             mission?.SceneName,
             mission != null,
             mission?.MissionEnded);
+    }
+
+    /// <summary>Identifies the attack-mission start that created a mission.</summary>
+    private sealed class MissionCorrelation
+    {
+        public long Sequence { get; }
+        public string MapEventId { get; }
+
+        public MissionCorrelation(long sequence, string mapEventId)
+        {
+            Sequence = sequence;
+            MapEventId = mapEventId;
+        }
     }
 }


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

Mission finalization diagnostics omit the lifecycle sequence and map-event ID, so repeated transitions into the same scene cannot be matched reliably to the mission that finalized.

## What is the new behavior?

The attack-mission sequence and map-event ID are associated with the opened mission and included in its finalization diagnostic. Untracked missions continue to log safely with empty correlation fields.

Follow-up to #3192.

## Bot Changelog Entry

## Other information

Validated with the complete GameInterface.Tests suite: 1,061 passed, 11 skipped, 0 failed.