### PR TITLE
Repair all stuck prisoner heroes

### DIFF
--- a/source/GameInterface.Tests/Services/Companions/Patches/Disable/CompanionsCampaignBehaviorPatchesTests.cs
+++ b/source/GameInterface.Tests/Services/Companions/Patches/Disable/CompanionsCampaignBehaviorPatchesTests.cs
@@ -1,0 +1,36 @@
+﻿using Common.Util;
+using GameInterface.Services.Companions.Patches.Disable;
+using System.Collections.Generic;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Party;
+using Xunit;
+
+namespace GameInterface.Tests.Services.Companions.Patches.Disable;
+
+/// <summary>Verifies stale prisoner repair behavior.</summary>
+public class CompanionsCampaignBehaviorPatchesTests
+{
+    [Fact]
+    public void RepairStuckHeroes_MultipleStuckHeroes_RepairsEveryMatch()
+    {
+        var firstStuckHero = CreateHero(Hero.CharacterStates.Prisoner);
+        var validPrisoner = CreateHero(Hero.CharacterStates.Prisoner);
+        validPrisoner.PartyBelongedToAsPrisoner = ObjectHelper.SkipConstructor<PartyBase>();
+        var activeHero = CreateHero(Hero.CharacterStates.Active);
+        var secondStuckHero = CreateHero(Hero.CharacterStates.Prisoner);
+        var repairedHeroes = new List<Hero>();
+
+        CompanionsCampaignBehaviorPatches.RepairStuckHeroes(
+            new[] { firstStuckHero, validPrisoner, activeHero, secondStuckHero },
+            repairedHeroes.Add);
+
+        Assert.Equal(new[] { firstStuckHero, secondStuckHero }, repairedHeroes);
+    }
+
+    private static Hero CreateHero(Hero.CharacterStates state)
+    {
+        var hero = new Hero();
+        hero._heroState = state;
+        return hero;
+    }
+}

--- a/source/GameInterface/Services/Companions/Patches/Disable/DisableCompanionsCampaignBehavior.cs
+++ b/source/GameInterface/Services/Companions/Patches/Disable/DisableCompanionsCampaignBehavior.cs
@@ -152,12 +152,16 @@ internal class CompanionsCampaignBehaviorPatches
     [HarmonyPostfix]
     public static void DailyTickPostfix()
     {
-        foreach (Hero hero in Hero.AllAliveHeroes)
+        RepairStuckHeroes(Hero.AllAliveHeroes, hero => MakeHeroFugitiveAction.Apply(hero, true));
+    }
+
+    internal static void RepairStuckHeroes(IEnumerable<Hero> heroes, Action<Hero> makeHeroFugitive)
+    {
+        foreach (Hero hero in heroes)
         {
             if (hero.IsPrisoner && hero.PartyBelongedToAsPrisoner == null)
             {
-                MakeHeroFugitiveAction.Apply(hero, true);
-                break;
+                makeHeroFugitive(hero);
             }
         }
     }


### PR DESCRIPTION
## What is the current behavior?

The stale prisoner repair added in #3172 stops after the first match, so additional stuck heroes must wait another campaign day.

## What is the new behavior?

Every prisoner hero with no captor party is repaired in the same daily tick. Prisoners with a valid captor and non-prisoner heroes are left unchanged.

## How to test

`dotnet test source\GameInterface.Tests\GameInterface.Tests.csproj -c Release --no-restore`

1,060 passed, 11 skipped, 0 failed.