### PR TITLE
[3204] Prevent client freezes during battle reinforcements

### DIFF
--- a/source/E2E.Tests/Services/Missions/BattleReserveReconnectScopeTests.cs
+++ b/source/E2E.Tests/Services/Missions/BattleReserveReconnectScopeTests.cs
@@ -899,7 +899,7 @@ public class BattleReserveReconnectScopeTests : MissionTestEnvironment
         var reserve = Server.EnsureSerializable(new NetworkBattleTroopReserve(
             "rt_battle", (int)BattleSideEnum.Attacker,
             new[] { new PartyReserve("own-party", 0, Array.Empty<TroopReserveEntry>(), isReceiverPlayerParty: true,
-                sideOffset: 7, playerOwnedRank: 2) },
+                sideOffset: 7, playerOwnedRank: 2, playerOwnedPartiesBefore: 2) },
             sideTotalTroops: 42,
             playerOwnedPartyCount: 3,
             allocationRevision: 17,
@@ -914,6 +914,8 @@ public class BattleReserveReconnectScopeTests : MissionTestEnvironment
         Assert.True(party.IsReceiverPlayerParty);
         Assert.Equal(7, party.SideOffset);
         Assert.Equal(2, party.PlayerOwnedRank);
+        Assert.Equal(2, party.PlayerOwnedPartiesBefore);
+        Assert.True(party.HasPlayerOwnedPartiesBefore);
 
         var emptyReserve = Server.EnsureSerializable(new NetworkBattleTroopReserve(
             "rt_battle", (int)BattleSideEnum.Attacker, Array.Empty<PartyReserve>(),

--- a/source/E2E.Tests/Services/Missions/CoopTroopSupplierTests.cs
+++ b/source/E2E.Tests/Services/Missions/CoopTroopSupplierTests.cs
@@ -1,5 +1,7 @@
 ﻿using GameInterface.Services.MapEvents;
 using GameInterface.Services.MapEvents.TroopSupply;
+using ProtoBuf;
+using System.IO;
 using System.Linq;
 using TaleWorlds.Core;
 
@@ -13,6 +15,17 @@ namespace E2E.Tests.Services.Missions;
 /// </summary>
 public class CoopTroopSupplierTests
 {
+    [ProtoContract]
+    private sealed class LegacyPartyReserve
+    {
+        [ProtoMember(1)] public string PartyId { get; set; }
+        [ProtoMember(2)] public int SuppliedCount { get; set; }
+        [ProtoMember(3)] public TroopReserveEntry[] Entries { get; set; }
+        [ProtoMember(4)] public bool IsReceiverPlayerParty { get; set; }
+        [ProtoMember(5)] public int SideOffset { get; set; }
+        [ProtoMember(6)] public int PlayerOwnedRank { get; set; }
+    }
+
     private static TroopReserveEntry[] Entries(int count, int seedBase = 500)
     {
         var entries = new TroopReserveEntry[count];
@@ -22,9 +35,10 @@ public class CoopTroopSupplierTests
     }
 
     private static PartyReserve Party(string id, int count, int supplied = 0, int seedBase = 500,
-        bool isReceiverPlayerParty = false, int sideOffset = 0, int playerOwnedRank = -1)
+        bool isReceiverPlayerParty = false, int sideOffset = 0, int playerOwnedRank = -1,
+        int playerOwnedPartiesBefore = 0)
         => new PartyReserve(id, supplied, Entries(count, seedBase), isReceiverPlayerParty, sideOffset,
-            playerOwnedRank);
+            playerOwnedRank, playerOwnedPartiesBefore);
 
     private static int SuppliedFor(CoopTroopSupplier supplier, string partyId)
         => supplier.GetSuppliedByParty().First(p => p.partyId == partyId).supplied;
@@ -269,10 +283,12 @@ public class CoopTroopSupplierTests
             sideTotal: total, playerOwnedParties: playerParties, authoritativeBattleSize: 1000);
         var middle = new CoopTroopSupplier("M1", BattleSideEnum.Attacker, null, new BattleAgentBudget());
         middle.SetReserve(new[] { Party("M", 300, seedBase: 4000, isReceiverPlayerParty: true,
-            sideOffset: 600, playerOwnedRank: 1) }, sideTotal: total, playerOwnedParties: playerParties, authoritativeBattleSize: 1000);
+            sideOffset: 600, playerOwnedRank: 1, playerOwnedPartiesBefore: 1) }, sideTotal: total,
+            playerOwnedParties: playerParties, authoritativeBattleSize: 1000);
         var smallest = new CoopTroopSupplier("M1", BattleSideEnum.Attacker, null, new BattleAgentBudget());
         smallest.SetReserve(new[] { Party("S", 100, seedBase: 8000, isReceiverPlayerParty: true,
-            sideOffset: 900, playerOwnedRank: 2) }, sideTotal: total, playerOwnedParties: playerParties, authoritativeBattleSize: 1000);
+            sideOffset: 900, playerOwnedRank: 2, playerOwnedPartiesBefore: 2) }, sideTotal: total,
+            playerOwnedParties: playerParties, authoritativeBattleSize: 1000);
 
         var shares = new[]
         {
@@ -329,10 +345,51 @@ public class CoopTroopSupplierTests
 
         var big = new CoopTroopSupplier("M1", BattleSideEnum.Attacker, null, new BattleAgentBudget());
         big.SetReserve(new[] { Party("BIG", 999, seedBase: 4000, isReceiverPlayerParty: true, sideOffset: 1,
-            playerOwnedRank: 1) }, sideTotal: total, playerOwnedParties: playerParties, authoritativeBattleSize: 1000);
+            playerOwnedRank: 1, playerOwnedPartiesBefore: 1) }, sideTotal: total, playerOwnedParties: playerParties, authoritativeBattleSize: 1000);
 
         Assert.Equal(allocation, tiny.OwnedShareOf(allocation) + big.OwnedShareOf(allocation));
         Assert.True(tiny.OwnedShareOf(allocation) >= 1, "the small owner still fields its player");
+    }
+
+    [Fact]
+    public void FullSideAllocation_DoesNotRequestMoreTroopsThanTheReceiverOwns()
+    {
+        var first = new CoopTroopSupplier("M1", BattleSideEnum.Attacker, null, new BattleAgentBudget());
+        first.SetReserve(new[] { Party("P1", 102, isReceiverPlayerParty: true, playerOwnedRank: 0) },
+            sideTotal: 133, playerOwnedParties: 2, authoritativeBattleSize: 1000);
+        var tail = new CoopTroopSupplier("M1", BattleSideEnum.Attacker, null, new BattleAgentBudget());
+        tail.SetReserve(new[] { Party("P2", 31, seedBase: 3000, isReceiverPlayerParty: true,
+            sideOffset: 102, playerOwnedRank: 1, playerOwnedPartiesBefore: 1) },
+            sideTotal: 133, playerOwnedParties: 2, authoritativeBattleSize: 1000);
+
+        Assert.Equal(102, first.OwnedShareOf(133));
+        Assert.Equal(31, tail.OwnedShareOf(133));
+        Assert.Equal(133, first.OwnedShareOf(133) + tail.OwnedShareOf(133));
+    }
+
+    [Fact]
+    public void LegacyReservePayload_UsesTheLegacyIntervalCalculation()
+    {
+        var legacy = new LegacyPartyReserve
+        {
+            PartyId = "P2",
+            Entries = Entries(31, 3000),
+            IsReceiverPlayerParty = true,
+            SideOffset = 102,
+            PlayerOwnedRank = 1,
+        };
+        using var stream = new MemoryStream();
+        Serializer.Serialize(stream, legacy);
+        stream.Position = 0;
+        var reserve = Serializer.Deserialize<PartyReserve>(stream);
+
+        Assert.False(reserve.HasPlayerOwnedPartiesBefore);
+
+        var supplier = new CoopTroopSupplier("M1", BattleSideEnum.Attacker, null, new BattleAgentBudget());
+        supplier.SetReserve(new[] { reserve }, sideTotal: 133, playerOwnedParties: 2,
+            authoritativeBattleSize: 1000);
+
+        Assert.Equal(32, supplier.OwnedShareOf(133));
     }
 
     [Fact]
@@ -346,9 +403,10 @@ public class CoopTroopSupplierTests
             sideTotal: total, playerOwnedParties: playerParties, authoritativeBattleSize: 1000);
         var p2 = new CoopTroopSupplier("M1", BattleSideEnum.Attacker, null, new BattleAgentBudget());
         p2.SetReserve(new[] { Party("P2", 2, seedBase: 3000, isReceiverPlayerParty: true, sideOffset: 1,
-            playerOwnedRank: 1) }, sideTotal: total, playerOwnedParties: playerParties, authoritativeBattleSize: 1000);
+            playerOwnedRank: 1, playerOwnedPartiesBefore: 1) }, sideTotal: total, playerOwnedParties: playerParties, authoritativeBattleSize: 1000);
         var ai = new CoopTroopSupplier("M1", BattleSideEnum.Attacker, null, new BattleAgentBudget());
-        ai.SetReserve(new[] { Party("AI", 997, seedBase: 7000, sideOffset: 3) },
+        ai.SetReserve(new[] { Party("AI", 997, seedBase: 7000, sideOffset: 3,
+            playerOwnedPartiesBefore: 2) },
             sideTotal: total, playerOwnedParties: playerParties, authoritativeBattleSize: 1000);
 
         foreach (var allocation in new[] { 2, 3, 7, 50, 100, 337, 999 })
@@ -369,10 +427,10 @@ public class CoopTroopSupplierTests
             sideTotal: total, playerOwnedParties: playerParties, authoritativeBattleSize: 1000);
         var r1 = new CoopTroopSupplier("M1", BattleSideEnum.Attacker, null, new BattleAgentBudget());
         r1.SetReserve(new[] { Party("R1", 10, seedBase: 3000, isReceiverPlayerParty: true, sideOffset: 10,
-            playerOwnedRank: 1) }, sideTotal: total, playerOwnedParties: playerParties, authoritativeBattleSize: 1000);
+            playerOwnedRank: 1, playerOwnedPartiesBefore: 1) }, sideTotal: total, playerOwnedParties: playerParties, authoritativeBattleSize: 1000);
         var r2 = new CoopTroopSupplier("M1", BattleSideEnum.Attacker, null, new BattleAgentBudget());
         r2.SetReserve(new[] { Party("R2", 10, seedBase: 6000, isReceiverPlayerParty: true, sideOffset: 20,
-            playerOwnedRank: 2) }, sideTotal: total, playerOwnedParties: playerParties, authoritativeBattleSize: 1000);
+            playerOwnedRank: 2, playerOwnedPartiesBefore: 2) }, sideTotal: total, playerOwnedParties: playerParties, authoritativeBattleSize: 1000);
 
         // Two troops, three players: ranks 0 and 1 get them, rank 2 waits for the next wave. Every client
         // reaches the same answer because the ranks come from the server.
@@ -455,7 +513,8 @@ public class CoopTroopSupplierTests
 
         supplier.SetReserve(new[]
         {
-            Party("P1", 50, supplied: 7, isReceiverPlayerParty: true, sideOffset: 150, playerOwnedRank: 1),
+            Party("P1", 50, supplied: 7, isReceiverPlayerParty: true, sideOffset: 150, playerOwnedRank: 1,
+                playerOwnedPartiesBefore: 1),
         }, sideTotal: 200, playerOwnedParties: 2, snapshotRevision: 3, authoritativeBattleSize: 1000);
         var generationThree = supplier.CaptureAllocationSnapshot();
 

--- a/source/GameInterface/Services/MapEvents/Commands/BattleTeamKillCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/BattleTeamKillCommands.cs
@@ -483,7 +483,7 @@ coop battle LOSS.";
         return killed;
     }
 
-    private static void Kill(Agent agent)
+    internal static void Kill(Agent agent)
     {
         var blow = new Blow(agent.Index)
         {

--- a/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
@@ -2093,6 +2093,10 @@ public class MapEventDebugCommands
             return $"Late-join fixture {mapEventId} did not create the required field battle.";
         }
 
+#if DEBUG
+        LateJoinModeFixtureBattleSizeOverride.Set(mapEvent, 64);
+#endif
+
         // Route the first player's Attack through the real server handler. The resulting mission-start and mode
         // broadcasts reach PlayerTwo before its party belongs to the event, reproducing the missed-claim timing.
         messageBroker.Publish(firstPeer, new NetworkBattleStartRequest(
@@ -2409,8 +2413,14 @@ public class MapEventDebugCommands
 
         messageBroker.Publish(typeof(MapEventDebugCommands), new NetworkRequestLeaveBattle(fixture.JoiningPlayerPartyId));
         messageBroker.Publish(typeof(MapEventDebugCommands), new NetworkRequestLeaveBattle(fixture.FirstPlayerPartyId));
-        if (objectManager.TryGetObject<MapEvent>(fixture.MapEventId, out var mapEvent) && !mapEvent.IsFinalized)
-            mapEvent.FinalizeEvent();
+        if (objectManager.TryGetObject<MapEvent>(fixture.MapEventId, out var mapEvent))
+        {
+#if DEBUG
+            LateJoinModeFixtureBattleSizeOverride.Clear(mapEvent);
+#endif
+            if (!mapEvent.IsFinalized)
+                mapEvent.FinalizeEvent();
+        }
         ServerBattleModeArbiter.Release(fixture.MapEventId);
 
         var restored = RestorePartyBehavior(
@@ -3309,6 +3319,36 @@ public class MapEventDebugCommands
 }
 
 #if DEBUG
+/// <summary>Holds the temporary battle-size limit for the active late-join live-test fixture.</summary>
+public static class LateJoinModeFixtureBattleSizeOverride
+{
+    private static readonly object Gate = new object();
+    private static readonly Dictionary<MapEvent, int> BattleSizes = new Dictionary<MapEvent, int>();
+
+    public static void Set(MapEvent mapEvent, int battleSize)
+    {
+        if (mapEvent == null) throw new ArgumentNullException(nameof(mapEvent));
+        if (battleSize <= 0) throw new ArgumentOutOfRangeException(nameof(battleSize));
+
+        lock (Gate)
+            BattleSizes[mapEvent] = battleSize;
+    }
+
+    public static bool TryGet(MapEvent mapEvent, out int battleSize)
+    {
+        lock (Gate)
+            return BattleSizes.TryGetValue(mapEvent, out battleSize);
+    }
+
+    public static void Clear(MapEvent mapEvent)
+    {
+        if (mapEvent == null) return;
+
+        lock (Gate)
+            BattleSizes.Remove(mapEvent);
+    }
+}
+
 /// <summary>[Server -&gt; Client] Ends a live-test fixture mission without resolving its campaign battle.</summary>
 [ProtoContract(SkipConstructor = true)]
 internal readonly struct NetworkEndLateJoinModeFixtureMission : IEvent

--- a/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
@@ -2093,10 +2093,6 @@ public class MapEventDebugCommands
             return $"Late-join fixture {mapEventId} did not create the required field battle.";
         }
 
-#if DEBUG
-        LateJoinModeFixtureBattleSizeOverride.Set(mapEvent, 64);
-#endif
-
         // Route the first player's Attack through the real server handler. The resulting mission-start and mode
         // broadcasts reach PlayerTwo before its party belongs to the event, reproducing the missed-claim timing.
         messageBroker.Publish(firstPeer, new NetworkBattleStartRequest(
@@ -2413,14 +2409,8 @@ public class MapEventDebugCommands
 
         messageBroker.Publish(typeof(MapEventDebugCommands), new NetworkRequestLeaveBattle(fixture.JoiningPlayerPartyId));
         messageBroker.Publish(typeof(MapEventDebugCommands), new NetworkRequestLeaveBattle(fixture.FirstPlayerPartyId));
-        if (objectManager.TryGetObject<MapEvent>(fixture.MapEventId, out var mapEvent))
-        {
-#if DEBUG
-            LateJoinModeFixtureBattleSizeOverride.Clear(mapEvent);
-#endif
-            if (!mapEvent.IsFinalized)
-                mapEvent.FinalizeEvent();
-        }
+        if (objectManager.TryGetObject<MapEvent>(fixture.MapEventId, out var mapEvent) && !mapEvent.IsFinalized)
+            mapEvent.FinalizeEvent();
         ServerBattleModeArbiter.Release(fixture.MapEventId);
 
         var restored = RestorePartyBehavior(
@@ -3319,36 +3309,6 @@ public class MapEventDebugCommands
 }
 
 #if DEBUG
-/// <summary>Holds the temporary battle-size limit for the active late-join live-test fixture.</summary>
-public static class LateJoinModeFixtureBattleSizeOverride
-{
-    private static readonly object Gate = new object();
-    private static readonly Dictionary<MapEvent, int> BattleSizes = new Dictionary<MapEvent, int>();
-
-    public static void Set(MapEvent mapEvent, int battleSize)
-    {
-        if (mapEvent == null) throw new ArgumentNullException(nameof(mapEvent));
-        if (battleSize <= 0) throw new ArgumentOutOfRangeException(nameof(battleSize));
-
-        lock (Gate)
-            BattleSizes[mapEvent] = battleSize;
-    }
-
-    public static bool TryGet(MapEvent mapEvent, out int battleSize)
-    {
-        lock (Gate)
-            return BattleSizes.TryGetValue(mapEvent, out battleSize);
-    }
-
-    public static void Clear(MapEvent mapEvent)
-    {
-        if (mapEvent == null) return;
-
-        lock (Gate)
-            BattleSizes.Remove(mapEvent);
-    }
-}
-
 /// <summary>[Server -&gt; Client] Ends a live-test fixture mission without resolving its campaign battle.</summary>
 [ProtoContract(SkipConstructor = true)]
 internal readonly struct NetworkEndLateJoinModeFixtureMission : IEvent

--- a/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
@@ -2296,6 +2296,23 @@ public class MapEventDebugCommands
 
         return $"Late-join fixture mission exit requested for {requested} player(s).";
     }
+
+    /// <summary>Returns both fixture clients to campaign and restores the server-side battle state.</summary>
+    [CommandLineArgumentFunction("late_join_mode_restore", "coop.debug.mapevent")]
+    public static string RestoreLateJoinModeFixture(List<string> args)
+    {
+        if (ModInformation.IsClient)
+            return "Run this command on the server.";
+        if (args.Count != 0)
+            return "Usage: coop.debug.mapevent.late_join_mode_restore";
+
+        string exitResult = ExitLateJoinModeFixtureMissions(args);
+        if (lateJoinModeFixture == null)
+            return exitResult;
+
+        string cleanupResult = CleanupLateJoinModeFixture(args);
+        return $"{exitResult} {cleanupResult}";
+    }
 #endif
 
     // coop.debug.mapevent.late_join_mode_state PlayerTwo

--- a/source/GameInterface/Services/MapEvents/Patches/EmptyColumnFormationSpawnPatch.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/EmptyColumnFormationSpawnPatch.cs
@@ -1,0 +1,29 @@
+﻿using HarmonyLib;
+using TaleWorlds.Engine;
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+
+namespace GameInterface.Services.MapEvents.Patches;
+
+/// <summary>Lets the first reinforcement into an emptied column use vanilla's formation spawn frame.</summary>
+[HarmonyPatch(typeof(Formation), nameof(Formation.GetUnitSpawnFrameWithIndex))]
+internal class EmptyColumnFormationSpawnPatch
+{
+    [HarmonyPrefix]
+    private static bool Prefix(
+        Formation __instance,
+        ref WorldPosition? unitSpawnPosition,
+        ref Vec2? unitSpawnDirection)
+    {
+        if (!BattleSpawnConfig.Enabled || !BattleSpawnGate.IsCoopBattleActive)
+            return true;
+        if (!(__instance.Arrangement is ColumnFormation columnFormation))
+            return true;
+        if (columnFormation.GetUnitPositionsOnVanguardFileIndex().Count > 0)
+            return true;
+
+        unitSpawnPosition = null;
+        unitSpawnDirection = null;
+        return false;
+    }
+}

--- a/source/GameInterface/Services/MapEvents/TroopSupply/BattleTroopReserveBuilder.cs
+++ b/source/GameInterface/Services/MapEvents/TroopSupply/BattleTroopReserveBuilder.cs
@@ -141,6 +141,9 @@ public class BattleTroopReserveBuilder : IBattleTroopReserveBuilder
 
             // Only a present player's own party reserves a player slot. Offline or absent registrations fall
             // to the host and must not reduce the allocation available to the players who entered this battle.
+            int playerOwnedPartiesBefore = partySide == BattleSideEnum.Attacker
+                ? attackerPlayerParties
+                : defenderPlayerParties;
             var playerOwnedRank = -1;
             if (entries.Count > 0
                 && ResolveOwningController(partyOwnerController, null, absentControllers) != null)
@@ -162,7 +165,8 @@ public class BattleTroopReserveBuilder : IBattleTroopReserveBuilder
                 entriesArray,
                 isReceiverPlayerParty: IsPartyRegisteredToController(party, controllerId),
                 sideOffset: partyOffset,
-                playerOwnedRank: playerOwnedRank);
+                playerOwnedRank: playerOwnedRank,
+                playerOwnedPartiesBefore: playerOwnedPartiesBefore);
             if (partySide == BattleSideEnum.Attacker)
                 attacker.Add(reserve);
             else

--- a/source/GameInterface/Services/MapEvents/TroopSupply/CoopTroopSupplier.cs
+++ b/source/GameInterface/Services/MapEvents/TroopSupply/CoopTroopSupplier.cs
@@ -36,6 +36,7 @@ public class CoopTroopSupplier : IMissionTroopSupplier
         private readonly int playerOwnedPartyCount;
         private readonly bool ownsReceiverPlayerParty;
         private readonly int receiverPlayerRank;
+        private readonly bool hasPlayerOwnedPartiesBefore;
 
         public long Revision { get; }
         public int BattleSize { get; }
@@ -46,6 +47,7 @@ public class CoopTroopSupplier : IMissionTroopSupplier
         internal AllocationSnapshot(long revision, int battleSize, int sideTotalTroops, int totalTroops,
             int suppliedTroops,
             int playerOwnedPartyCount, bool ownsReceiverPlayerParty, int receiverPlayerRank,
+            bool hasPlayerOwnedPartiesBefore,
             int[] partyOffsets, int[] partyCounts)
         {
             Revision = revision;
@@ -56,6 +58,7 @@ public class CoopTroopSupplier : IMissionTroopSupplier
             this.playerOwnedPartyCount = playerOwnedPartyCount;
             this.ownsReceiverPlayerParty = ownsReceiverPlayerParty;
             this.receiverPlayerRank = receiverPlayerRank;
+            this.hasPlayerOwnedPartiesBefore = hasPlayerOwnedPartiesBefore;
             this.partyOffsets = partyOffsets;
             this.partyCounts = partyCounts;
         }
@@ -66,6 +69,7 @@ public class CoopTroopSupplier : IMissionTroopSupplier
 
             int total = SideTotalTroops;
             if (total <= 0) return 0;
+            sideAllocation = Math.Min(sideAllocation, total);
             if (TotalTroops >= total) return sideAllocation;
 
             if (playerOwnedPartyCount > 0)
@@ -73,9 +77,14 @@ public class CoopTroopSupplier : IMissionTroopSupplier
                 if (sideAllocation < playerOwnedPartyCount)
                     return receiverPlayerRank >= 0 && receiverPlayerRank < sideAllocation ? 1 : 0;
 
-                int share = ApportionByInterval(sideAllocation - playerOwnedPartyCount, total);
+                int apportionmentTotal = hasPlayerOwnedPartiesBefore
+                    ? Math.Max(0, total - playerOwnedPartyCount)
+                    : total;
+                int share = ApportionByInterval(sideAllocation - playerOwnedPartyCount, apportionmentTotal);
                 if (ownsReceiverPlayerParty) share += 1;
-                return Math.Min(share, sideAllocation);
+                return hasPlayerOwnedPartiesBefore
+                    ? Math.Min(share, Math.Min(sideAllocation, TotalTroops))
+                    : Math.Min(share, sideAllocation);
             }
 
             return Math.Min(ApportionByInterval(sideAllocation, total), sideAllocation);
@@ -111,6 +120,10 @@ public class CoopTroopSupplier : IMissionTroopSupplier
         public int SideOffset;
         /// <summary>Its position among the side's player-owned parties, or -1; see <see cref="PartyReserve.PlayerOwnedRank"/>.</summary>
         public int PlayerOwnedRank;
+        /// <summary>Player-owned parties before this party in the complete side order.</summary>
+        public int PlayerOwnedPartiesBefore;
+        /// <summary>Whether the sender supplied the guaranteed-slot offset metadata.</summary>
+        public bool HasPlayerOwnedPartiesBefore;
     }
 
     private readonly object gate = new object();
@@ -195,6 +208,8 @@ public class CoopTroopSupplier : IMissionTroopSupplier
                         Supplied = supplied,
                         SideOffset = party.SideOffset,
                         PlayerOwnedRank = party.PlayerOwnedRank,
+                        PlayerOwnedPartiesBefore = party.PlayerOwnedPartiesBefore,
+                        HasPlayerOwnedPartiesBefore = party.HasPlayerOwnedPartiesBefore,
                     };
                     // Allocate this client's own party first. Otherwise an army's AI parties can fill the
                     // render cap before the local hero is reserved, leaving deployment without a player agent.
@@ -256,12 +271,19 @@ public class CoopTroopSupplier : IMissionTroopSupplier
             int receiverPlayerRank = -1;
             var partyOffsets = new int[parties.Count];
             var partyCounts = new int[parties.Count];
+            bool hasGuaranteedSlotOffsets = true;
+            foreach (var party in parties)
+                hasGuaranteedSlotOffsets &= party.HasPlayerOwnedPartiesBefore;
             for (int i = 0; i < parties.Count; i++)
             {
                 var party = parties[i];
                 int count = party.Entries.Length;
-                partyOffsets[i] = party.SideOffset;
-                partyCounts[i] = count;
+                partyOffsets[i] = hasGuaranteedSlotOffsets
+                    ? Math.Max(0, party.SideOffset - party.PlayerOwnedPartiesBefore)
+                    : party.SideOffset;
+                partyCounts[i] = hasGuaranteedSlotOffsets
+                    ? Math.Max(0, count - (party.PlayerOwnedRank >= 0 ? 1 : 0))
+                    : count;
                 total += count;
                 supplied += party.Supplied;
                 if (party.PartyId != playerPartyId) continue;
@@ -278,6 +300,7 @@ public class CoopTroopSupplier : IMissionTroopSupplier
                 playerOwnedPartyCount,
                 playerPartyId != null,
                 receiverPlayerRank,
+                hasGuaranteedSlotOffsets,
                 partyOffsets,
                 partyCounts);
         }

--- a/source/GameInterface/Services/MapEvents/TroopSupply/CoopTroopSupplier.cs
+++ b/source/GameInterface/Services/MapEvents/TroopSupply/CoopTroopSupplier.cs
@@ -307,6 +307,45 @@ public class CoopTroopSupplier : IMissionTroopSupplier
         }
     }
 
+#if DEBUG
+    /// <summary>Runs a debug allocation decision while reserve refreshes are blocked.</summary>
+    internal TResult WithSupplyPreview<TResult>(
+        int numberToAllocate,
+        Func<List<IAgentOriginBase>, TResult> action)
+    {
+        if (action == null) throw new ArgumentNullException(nameof(action));
+
+        var origins = new List<IAgentOriginBase>();
+        lock (gate)
+        {
+            if (numberToAllocate > 0)
+            {
+                int slotBudget = agentBudget != null
+                    ? agentBudget.RemainingCapacity(agentBudget.CountLiveAgents(Mission.Current))
+                    : int.MaxValue;
+                int allocated = 0;
+                foreach (var party in parties)
+                {
+                    for (int index = party.Supplied;
+                         allocated < numberToAllocate && index < party.Entries.Length;
+                         index++)
+                    {
+                        var origin = CreateOrigin(party.Entries[index], party.PartyId);
+                        int slots = SlotsForOrigin(origin);
+                        if (slots > slotBudget) return action(origins);
+
+                        allocated++;
+                        slotBudget -= slots;
+                        if (origin != null) origins.Add(origin);
+                    }
+                    if (allocated >= numberToAllocate) break;
+                }
+            }
+            return action(origins);
+        }
+    }
+#endif
+
     /// <summary>Whether this authoritative reserve snapshot still contains a party.</summary>
     public bool ContainsParty(string partyId)
     {

--- a/source/GameInterface/Services/MapEvents/TroopSupply/PartyReserve.cs
+++ b/source/GameInterface/Services/MapEvents/TroopSupply/PartyReserve.cs
@@ -56,8 +56,20 @@ public class PartyReserve
     [ProtoMember(6)]
     public int PlayerOwnedRank { get; }
 
+    /// <summary>
+    /// How many guaranteed player slots precede this party. Removing them from <see cref="SideOffset"/> lets
+    /// every owner apportion the non-guaranteed remainder without assigning a party more troops than it holds.
+    /// </summary>
+    [ProtoMember(7)]
+    public int PlayerOwnedPartiesBefore { get; }
+
+    /// <summary>Whether <see cref="PlayerOwnedPartiesBefore"/> was supplied by this protocol version.</summary>
+    [ProtoMember(8)]
+    public bool HasPlayerOwnedPartiesBefore { get; }
+
     public PartyReserve(string partyId, int suppliedCount, TroopReserveEntry[] entries,
-        bool isReceiverPlayerParty = false, int sideOffset = 0, int playerOwnedRank = -1)
+        bool isReceiverPlayerParty = false, int sideOffset = 0, int playerOwnedRank = -1,
+        int playerOwnedPartiesBefore = 0)
     {
         PartyId = partyId;
         SuppliedCount = suppliedCount;
@@ -65,5 +77,7 @@ public class PartyReserve
         IsReceiverPlayerParty = isReceiverPlayerParty;
         SideOffset = sideOffset;
         PlayerOwnedRank = playerOwnedRank;
+        PlayerOwnedPartiesBefore = playerOwnedPartiesBefore;
+        HasPlayerOwnedPartiesBefore = true;
     }
 }

--- a/source/Missions/Battles/BattleDebugCommands.cs
+++ b/source/Missions/Battles/BattleDebugCommands.cs
@@ -1,6 +1,7 @@
 ﻿using Common;
 using GameInterface;
 using GameInterface.Services.MapEvents;
+using GameInterface.Services.MapEvents.Commands;
 using GameInterface.Services.MapEvents.TroopSupply;
 using Missions.Agents.Packets;
 #if DEBUG
@@ -100,6 +101,228 @@ internal static class BattleDebugCommands
     private static Guid wieldTestAgentId;
     private static EquipmentIndex wieldTestOriginalMainHand;
     private static bool wieldTestActive;
+    private static Mission columnReinforcementFixtureMission;
+    private static Formation columnReinforcementFixtureFormation;
+    private static MissionBattleSideSpawnContext columnReinforcementFixtureSpawnContext;
+    private static ArrangementOrder columnReinforcementFixtureOriginalOrder;
+    private static BattleSideEnum columnReinforcementFixtureSide;
+    private static int columnReinforcementFixtureFormationIndex;
+    private static int columnReinforcementFixtureKilled;
+
+    private sealed class ColumnReinforcementCandidate
+    {
+        public BattleSideEnum Side { get; set; }
+        public int FormationIndex { get; set; }
+        public Formation Formation { get; set; }
+        public MissionBattleSideSpawnContext SpawnContext { get; set; }
+        public Agent[] Agents { get; set; }
+    }
+
+    [CommandLineArgumentFunction("column_reinforcement_fixture", "coop.debug.battle")]
+    public static string ColumnReinforcementFixture(List<string> args)
+    {
+        if (args.Count != 1)
+            return "Usage: coop.debug.battle.column_reinforcement_fixture <start|state|restore>";
+
+        switch (args[0].ToLowerInvariant())
+        {
+            case "start":
+                return StartColumnReinforcementFixture();
+            case "state":
+                return GetColumnReinforcementFixtureState();
+            case "restore":
+                return RestoreColumnReinforcementFixture();
+            default:
+                return "Usage: coop.debug.battle.column_reinforcement_fixture <start|state|restore>";
+        }
+    }
+
+    private static string StartColumnReinforcementFixture()
+    {
+        if (columnReinforcementFixtureMission != null &&
+            Mission.Current != columnReinforcementFixtureMission)
+        {
+            ClearColumnReinforcementFixture();
+        }
+        if (columnReinforcementFixtureMission != null)
+            return "COLUMN_REINFORCEMENT_FIXTURE already active";
+
+        Mission mission = Mission.Current;
+        CoopBattleController controller = mission?.GetMissionBehavior<CoopBattleController>();
+        DefaultBattleMissionAgentSpawnLogic spawnLogic =
+            mission?.GetMissionBehavior<DefaultBattleMissionAgentSpawnLogic>();
+        if (mission == null || controller == null || spawnLogic == null)
+            return "COLUMN_REINFORCEMENT_FIXTURE no active coop battle";
+        if (!controller.Session.IsLocalHost)
+            return "COLUMN_REINFORCEMENT_FIXTURE run this on the battle-authority client";
+        if (!controller.Deployment.IsActivated)
+            return "COLUMN_REINFORCEMENT_FIXTURE finish deployment first";
+        if (!ContainerProvider.TryResolve<INetworkAgentRegistry>(out var registry))
+            return "COLUMN_REINFORCEMENT_FIXTURE network agent registry is unavailable";
+
+        ColumnReinforcementCandidate candidate = null;
+        foreach (BattleSideEnum side in new[] { BattleSideEnum.Defender, BattleSideEnum.Attacker })
+        {
+            MissionBattleSideSpawnContext spawnContext =
+                spawnLogic._battleSideSpawnContexts[(int)side];
+            if (spawnContext == null)
+                continue;
+
+            candidate = FindColumnReinforcementCandidate(
+                mission,
+                registry,
+                side,
+                spawnContext,
+                spawnContext._reservedTroops);
+            if (candidate == null && spawnContext._troopSupplier is CoopTroopSupplier supplier)
+            {
+                candidate = supplier.WithSupplyPreview(16, preview =>
+                {
+                    var projectedReserve = new List<IAgentOriginBase>(spawnContext._reservedTroops);
+                    projectedReserve.AddRange(preview);
+                    ColumnReinforcementCandidate previewCandidate =
+                        FindColumnReinforcementCandidate(
+                            mission,
+                            registry,
+                            side,
+                            spawnContext,
+                            projectedReserve);
+                    if (previewCandidate == null)
+                        return null;
+
+                    spawnContext.ReserveTroops(16);
+                    return FindColumnReinforcementCandidate(
+                        mission,
+                        registry,
+                        side,
+                        spawnContext,
+                        spawnContext._reservedTroops);
+                });
+            }
+
+            if (candidate != null)
+                break;
+        }
+
+        if (candidate == null)
+        {
+            return "COLUMN_REINFORCEMENT_FIXTURE no reserve is assigned to a non-player formation " +
+                   "whose active human agents are all locally controlled";
+        }
+
+        columnReinforcementFixtureMission = mission;
+        columnReinforcementFixtureFormation = candidate.Formation;
+        columnReinforcementFixtureSpawnContext = candidate.SpawnContext;
+        columnReinforcementFixtureOriginalOrder = candidate.Formation.ArrangementOrder;
+        columnReinforcementFixtureSide = candidate.Side;
+        columnReinforcementFixtureFormationIndex = candidate.FormationIndex;
+        columnReinforcementFixtureKilled = candidate.Agents.Length;
+
+        candidate.Formation.SetArrangementOrder(ArrangementOrder.ArrangementOrderColumn);
+        foreach (Agent agent in candidate.Agents)
+            BattleTeamKillCommands.Kill(agent);
+
+        return "COLUMN_REINFORCEMENT_FIXTURE_STARTED " +
+               $"side={candidate.Side} formation={candidate.FormationIndex} " +
+               $"killed={candidate.Agents.Length} active=0 " +
+               $"reserved={candidate.SpawnContext.ReservedTroopsCount} arrangement=Column";
+    }
+
+    private static ColumnReinforcementCandidate FindColumnReinforcementCandidate(
+        Mission mission,
+        INetworkAgentRegistry registry,
+        BattleSideEnum side,
+        MissionBattleSideSpawnContext spawnContext,
+        List<IAgentOriginBase> reservedTroops)
+    {
+        foreach (var assignment in MissionGameModels.Current.BattleSpawnModel
+                     .GetReinforcementAssignments(side, reservedTroops))
+        {
+            Team team = Mission.GetAgentTeam(assignment.origin, spawnContext.IsPlayerSide);
+            Formation formation = team?.GetFormation((FormationClass)assignment.formationIndex);
+            if (formation == null)
+                continue;
+
+            Agent[] agents = mission.Agents
+                .Where(agent => agent != null
+                    && agent.IsActive()
+                    && agent.IsHuman
+                    && agent.Formation == formation)
+                .ToArray();
+            if (agents.Length == 0 || agents.Contains(Agent.Main))
+                continue;
+            if (agents.Any(agent => !registry.IsLocallyControlled(agent)))
+                continue;
+
+            return new ColumnReinforcementCandidate
+            {
+                Side = side,
+                FormationIndex = assignment.formationIndex,
+                Formation = formation,
+                SpawnContext = spawnContext,
+                Agents = agents,
+            };
+        }
+
+        return null;
+    }
+
+    private static string GetColumnReinforcementFixtureState()
+    {
+        if (columnReinforcementFixtureMission == null)
+            return "COLUMN_REINFORCEMENT_FIXTURE inactive";
+        if (Mission.Current != columnReinforcementFixtureMission ||
+            columnReinforcementFixtureFormation == null ||
+            columnReinforcementFixtureSpawnContext == null)
+        {
+            ClearColumnReinforcementFixture();
+            return "COLUMN_REINFORCEMENT_FIXTURE mission ended";
+        }
+
+        int active = Mission.Current.Agents.Count(agent => agent != null
+            && agent.IsActive()
+            && agent.IsHuman
+            && agent.Formation == columnReinforcementFixtureFormation);
+        int vanguardPositions = columnReinforcementFixtureFormation.Arrangement is ColumnFormation column
+            ? column.GetUnitPositionsOnVanguardFileIndex().Count
+            : -1;
+
+        return "COLUMN_REINFORCEMENT_FIXTURE_STATE " +
+               $"side={columnReinforcementFixtureSide} " +
+               $"formation={columnReinforcementFixtureFormationIndex} " +
+               $"killed={columnReinforcementFixtureKilled} active={active} " +
+               $"replacementObserved={active > 0} " +
+               $"reserved={columnReinforcementFixtureSpawnContext.ReservedTroopsCount} " +
+               $"reinforcementActive={columnReinforcementFixtureSpawnContext.ReinforcementSpawnActive} " +
+               $"arrangement={columnReinforcementFixtureFormation.Arrangement.GetType().Name} " +
+               $"vanguardPositions={vanguardPositions}";
+    }
+
+    private static string RestoreColumnReinforcementFixture()
+    {
+        if (columnReinforcementFixtureMission == null)
+            return "COLUMN_REINFORCEMENT_FIXTURE inactive";
+
+        bool missionActive = Mission.Current == columnReinforcementFixtureMission;
+        if (missionActive && columnReinforcementFixtureFormation != null)
+            columnReinforcementFixtureFormation.SetArrangementOrder(columnReinforcementFixtureOriginalOrder);
+
+        int killed = columnReinforcementFixtureKilled;
+        ClearColumnReinforcementFixture();
+        return "COLUMN_REINFORCEMENT_FIXTURE_RESTORED " +
+               $"arrangementRestored={missionActive} casualtiesRemain={killed}";
+    }
+
+    private static void ClearColumnReinforcementFixture()
+    {
+        columnReinforcementFixtureMission = null;
+        columnReinforcementFixtureFormation = null;
+        columnReinforcementFixtureSpawnContext = null;
+        columnReinforcementFixtureOriginalOrder = default;
+        columnReinforcementFixtureSide = BattleSideEnum.None;
+        columnReinforcementFixtureFormationIndex = -1;
+        columnReinforcementFixtureKilled = 0;
+    }
 
     [CommandLineArgumentFunction("action_performance", "coop.debug.battle")]
     public static string ActionPerformance(List<string> args)

--- a/source/Missions/Battles/BattleSizeProvider.cs
+++ b/source/Missions/Battles/BattleSizeProvider.cs
@@ -1,5 +1,4 @@
-﻿using GameInterface.Services.Villages.Commands;
-using System;
+﻿using System;
 using TaleWorlds.CampaignSystem.MapEvents;
 using TaleWorlds.MountAndBlade;
 
@@ -15,11 +14,6 @@ public class BattleSizeProvider : IBattleSizeProvider
     public int GetBattleSize(MapEvent mapEvent)
     {
         if (mapEvent == null) throw new ArgumentNullException(nameof(mapEvent));
-
-#if DEBUG
-        if (LateJoinModeFixtureBattleSizeOverride.TryGet(mapEvent, out int fixtureBattleSize))
-            return fixtureBattleSize;
-#endif
 
         int configuredBattleSize = mapEvent.IsSiegeAssault
             ? BannerlordConfig.GetRealBattleSizeForSiege()

--- a/source/Missions/Battles/BattleSizeProvider.cs
+++ b/source/Missions/Battles/BattleSizeProvider.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using GameInterface.Services.Villages.Commands;
+using System;
 using TaleWorlds.CampaignSystem.MapEvents;
 using TaleWorlds.MountAndBlade;
 
@@ -14,6 +15,11 @@ public class BattleSizeProvider : IBattleSizeProvider
     public int GetBattleSize(MapEvent mapEvent)
     {
         if (mapEvent == null) throw new ArgumentNullException(nameof(mapEvent));
+
+#if DEBUG
+        if (LateJoinModeFixtureBattleSizeOverride.TryGet(mapEvent, out int fixtureBattleSize))
+            return fixtureBattleSize;
+#endif
 
         int configuredBattleSize = mapEvent.IsSiegeAssault
             ? BannerlordConfig.GetRealBattleSizeForSiege()


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

During a two-player field battle, one client can freeze when casualties empty a formation before reinforcements arrive, leaving that player unable to continue while the other client remains active.

## What is the new behavior?

Resolves #3204

Players remain responsive when reinforcements refill a formation after all of its troops are defeated, and combat continues normally for both clients.

## Bot Changelog Entry

- Fixed a client freeze that could occur mid battle
