### PR TITLE
Restore server party visibility on activation

### DIFF
--- a/source/Coop.Core/Server/Services/Players/Handlers/PlayerPartyVisibilityHandler.cs
+++ b/source/Coop.Core/Server/Services/Players/Handlers/PlayerPartyVisibilityHandler.cs
@@ -229,7 +229,8 @@ internal class PlayerPartyVisibilityHandler : IHandler
     {
         party.IsActive = true;
         CreateVisual(party, mobilePartyId);
-        party.Party.UpdateVisibilityAndInspected(party.Position);
+        party.IsVisible = true;
+        party.IsInspected = true;
     }
 
     private void Handle_MapEventFinalized(MessagePayload<MapEventFinalized> payload)

--- a/source/Coop.Tests/Server/Services/Players/PlayerPartyVisibilityHandlerTests.cs
+++ b/source/Coop.Tests/Server/Services/Players/PlayerPartyVisibilityHandlerTests.cs
@@ -254,11 +254,11 @@ public class PlayerPartyVisibilityHandlerTests : IDisposable
     }
 
     [Fact]
-    public void CaptivityRelease_SynchronizedOwner_ActivatesParty()
+    public void CaptivityRelease_SynchronizedAtSeaOwner_ActivatesAndShowsParty()
     {
         var player = CreatePlayer();
         var party = CreateParty(isActive: false);
-        party._currentSettlement = (Settlement)FormatterServices.GetUninitializedObject(typeof(Settlement));
+        party._isCurrentlyAtSea = true;
         var peer = (NetPeer)FormatterServices.GetUninitializedObject(typeof(NetPeer));
         var (playerManager, connectionCollection, objectManager) =
             CreateReleaseMocks(player, party, peer, isConnected: true, isSynchronized: true);
@@ -274,6 +274,8 @@ public class PlayerPartyVisibilityHandlerTests : IDisposable
         broker.Publish(this, new PlayerPartyReleasedFromCaptivity(party));
 
         Assert.True(party.IsActive);
+        Assert.True(party.IsVisible);
+        Assert.True(party.IsInspected);
     }
 
     [Fact]


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

`ActivateParty` runs the client-relative native visibility calculation. A dedicated server has no `MobileParty.MainParty`, so a synchronized at-sea release can stop after recreating the visual and leave the party hidden.

Follow-up to https://github.com/Bannerlord-Coop-Team/BannerlordCoop/pull/3180#discussion_r3829610290.

## What is the new behavior?

Activated parties are marked visible and inspected directly on the server. The test covers a synchronized at-sea captivity release.

## How to test

`dotnet test source/Coop.Tests/Coop.Tests.csproj -c Release --filter FullyQualifiedName~PlayerPartyVisibilityHandlerTests -p:NuGetAudit=false`

## Bot Changelog Entry

- Fixed released at-sea player parties remaining hidden on dedicated servers.
