### PR TITLE
[3206] Prevent policy decision menu from reopening

### DIFF
--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -1046,6 +1046,66 @@ public class PlayerKingdomCreationFlowTests : IDisposable
     }
 
     [Fact]
+    public void KingdomDecisionResolution_DoesNotReopenBeforeRemovalApplies()
+    {
+        var client = Clients.First();
+        client.Resolve<IControllerIdProvider>().SetControllerId(ControllerId);
+
+        var player = CreateSyncedPlayerContext(ControllerId, client);
+        var otherPlayer = CreateSyncedPlayerContext("PolicyTimeoutOtherClan", _ => false);
+        var kingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+
+        ConfigureClanInKingdom(player.ClanId, kingdomId);
+        ConfigureClanInKingdom(otherPlayer.ClanId, kingdomId);
+        EnsureKingdomRegisteredEverywhere(kingdomId);
+
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Kingdom>(kingdomId, out var kingdom));
+            Assert.True(client.ObjectManager.TryGetObject<Clan>(player.ClanId, out var proposerClan));
+            PolicyObject policy = PolicyObject.All.First(candidate => !kingdom.ActivePolicies.Contains(candidate));
+            using (new AllowedThread())
+            {
+                kingdom._unresolvedDecisions.Add(new KingdomPolicyDecision(proposerClan, policy, false));
+            }
+
+            var decision = Assert.IsType<KingdomPolicyDecision>(Assert.Single(kingdom.UnresolvedDecisions));
+            var decisionsVm = new KingdomDecisionsVM(() => { });
+            decisionsVm.RefreshWith(decision);
+
+            Assert.NotNull(decisionsVm.CurrentDecision);
+            GetVoteManager(client).ApplyResolved(kingdomId, 0, 0, true);
+
+            Assert.Null(decisionsVm.CurrentDecision);
+            Assert.True(GetVoteManager(client).ShouldSuppressLocalDecision(decision));
+
+            InquiryData reopenedInquiry = null;
+            Action<InquiryData, bool, bool> onShowInquiry = (data, _, _) => reopenedInquiry = data;
+            EventInfo showInquiryEvent = typeof(InformationManager).GetEvent(
+                "OnShowInquiry",
+                BindingFlags.Public | BindingFlags.Static);
+            showInquiryEvent.AddEventHandler(null, onShowInquiry);
+            try
+            {
+                decisionsVm.OnFrameTick();
+
+                Assert.Null(reopenedInquiry);
+                Assert.Null(decisionsVm.CurrentDecision);
+                Assert.Contains(decision, decisionsVm._examinedDecisionsSinceInit);
+            }
+            finally
+            {
+                showInquiryEvent.RemoveEventHandler(null, onShowInquiry);
+            }
+
+            client.SimulateMessage(this, new NetworkRemoveDecision(kingdomId, 0));
+
+            Assert.Empty(kingdom.UnresolvedDecisions);
+            Assert.False(GetVoteManager(client).ShouldSuppressLocalDecision(decision));
+        });
+    }
+
+    [Fact]
     public void KingdomDecisionRoundStatus_DisablesPanelWhenLocalClanAlreadySubmitted()
     {
         var client1 = Clients.First();

--- a/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
+++ b/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
@@ -11,6 +11,7 @@ using GameInterface.Services.Kingdoms.Data;
 using GameInterface.Services.Kingdoms.Messages;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
+using Newtonsoft.Json;
 using SandBox.GauntletUI;
 using Serilog;
 using System;
@@ -24,6 +25,8 @@ using TaleWorlds.CampaignSystem.Election;
 using TaleWorlds.CampaignSystem.GameState;
 using TaleWorlds.CampaignSystem.Party.PartyComponents;
 using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.CampaignSystem.ViewModelCollection.KingdomManagement.Decisions;
+using TaleWorlds.CampaignSystem.ViewModelCollection.KingdomManagement.Decisions.ItemTypes;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
 using TaleWorlds.ScreenSystem;
@@ -37,6 +40,7 @@ namespace GameInterface.Services.Kingdoms.Commands;
 public class KingdomDebugCommand
 {
     private static readonly ILogger Logger = LogManager.GetLogger<KingdomDebugCommand>();
+    private static PolicyTimeoutFixture pendingPolicyTimeoutFixture;
     private enum CollectionTarget
     {
         Armies,
@@ -181,6 +185,233 @@ public class KingdomDebugCommand
             $"clanShown={kingdomScreen?.DataSource?.Clan?.Show ?? false} " +
             $"kingdom={kingdomScreen?.DataSource?.Kingdom?.Name} " +
             $"clans={kingdomScreen?.DataSource?.Clan?.Clans?.Count ?? -1}";
+    }
+
+    [CommandLineArgumentFunction("policy_timeout_capture", "coop.debug.kingdom")]
+    public static string CapturePolicyTimeoutFixture(List<string> args)
+    {
+        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        if (args.Count != 0) return "Usage: coop.debug.kingdom.policy_timeout_capture";
+        if (pendingPolicyTimeoutFixture != null) return "A policy-timeout fixture lifecycle is already active.";
+        if (!TryGetObjectManager(out var objectManager) || !TryGetPlayerManager(out var playerManager))
+            return "Unable to resolve policy-timeout fixture services.";
+        if (!playerManager.TryGetPlayer("testclient", out var player))
+            return "No registered player has controller id 'testclient'.";
+        if (!objectManager.TryGetObject(player.ClanId, out Clan proposerClan) || proposerClan.Kingdom == null)
+            return "The testclient clan is not in a kingdom.";
+
+        Kingdom kingdom = proposerClan.Kingdom;
+        if (kingdom.UnresolvedDecisions.Count > 0)
+            return $"Kingdom {kingdom.StringId} already has an unresolved decision.";
+
+        PolicyObject policy = PolicyObject.All
+            .Where(candidate => !kingdom.ActivePolicies.Contains(candidate))
+            .OrderBy(candidate => candidate.StringId)
+            .FirstOrDefault();
+        if (policy == null) return $"Kingdom {kingdom.StringId} has every policy active.";
+        if (!objectManager.TryGetIdWithLogging(kingdom, out string kingdomId) ||
+            !objectManager.TryGetIdWithLogging(proposerClan, out string proposerClanId) ||
+            !objectManager.TryGetIdWithLogging(policy, out string policyId))
+            return "Unable to resolve policy-timeout fixture ids.";
+
+        return PolicyTimeoutJsonResult(new
+        {
+            success = true,
+            controllerId = player.ControllerId,
+            kingdomId,
+            kingdomName = kingdom.Name.ToString(),
+            proposerClanId,
+            policyId,
+            policyName = policy.Name.ToString(),
+            policyWasActive = false,
+            unresolvedDecisionCount = kingdom.UnresolvedDecisions.Count
+        });
+    }
+
+    [CommandLineArgumentFunction("policy_timeout_stage", "coop.debug.kingdom")]
+    public static string StagePolicyTimeoutFixture(List<string> args)
+    {
+        const string usage = "Usage: coop.debug.kingdom.policy_timeout_stage <kingdomId> <proposerClanId> <policyId> <policyWasActive>";
+        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        if (args.Count != 4 || !bool.TryParse(args[3], out bool policyWasActive)) return usage;
+        if (pendingPolicyTimeoutFixture != null) return "A policy-timeout fixture lifecycle is already active.";
+        if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager";
+        if (!objectManager.TryGetObject(args[0], out Kingdom kingdom)) return $"Kingdom with ID: '{args[0]}' not found";
+        if (!objectManager.TryGetObject(args[1], out Clan proposerClan)) return $"Clan with ID: '{args[1]}' not found";
+        if (!objectManager.TryGetObject(args[2], out PolicyObject policy)) return $"PolicyObject with ID: '{args[2]}' not found";
+        if (proposerClan.Kingdom != kingdom) return $"Clan {args[1]} is not in kingdom {args[0]}.";
+        if (kingdom.UnresolvedDecisions.Count > 0)
+            return $"Kingdom {args[0]} no longer has a clean decision fixture.";
+        if (kingdom.ActivePolicies.Contains(policy) != policyWasActive)
+            return $"Policy {args[2]} changed after fixture capture.";
+
+        var fixture = new PolicyTimeoutFixture(
+            kingdom,
+            proposerClan,
+            policy,
+            args[0],
+            args[1],
+            args[2],
+            policyWasActive);
+        pendingPolicyTimeoutFixture = fixture;
+
+        var decision = new KingdomPolicyDecision(fixture.ProposerClan, fixture.Policy, fixture.PolicyWasActive);
+        fixture.Kingdom.AddDecision(decision, true);
+        fixture.DecisionStaged = true;
+        int decisionIndex = fixture.Kingdom._unresolvedDecisions.IndexOf(decision) + 1;
+        if (decisionIndex <= 0) return "The policy-timeout decision was not added to the kingdom.";
+
+        return PolicyTimeoutJsonResult(new
+        {
+            success = true,
+            fixture.KingdomId,
+            fixture.PolicyId,
+            decisionIndex,
+            votingDurationSeconds = (int)KingdomDecisionVoteManager.VotingRoundDuration.TotalSeconds
+        });
+    }
+
+    [CommandLineArgumentFunction("policy_timeout_state", "coop.debug.kingdom")]
+    public static string GetPolicyTimeoutState(List<string> args)
+    {
+        if (ModInformation.IsServer) return "Command can only be run on a client.";
+        if (args.Count != 0) return "Usage: coop.debug.kingdom.policy_timeout_state";
+
+        var kingdomScreen = ScreenManager.TopScreen as GauntletKingdomScreen;
+        DecisionItemBaseVM decision = kingdomScreen?.DataSource?.Decision?.CurrentDecision;
+        string decisionTitle = decision?.TitleText ?? string.Empty;
+        return PolicyTimeoutJsonResult(new
+        {
+            success = true,
+            kingdomScreenActive = Game.Current?.GameStateManager?.ActiveState is KingdomState,
+            topScreenIsKingdom = kingdomScreen != null,
+            decisionPresent = decision != null,
+            decisionActive = decision?.IsActive ?? false,
+            decisionTitle,
+            hasVotingCountdown = decisionTitle.IndexOf("Voting ends in", StringComparison.OrdinalIgnoreCase) >= 0,
+            inquiryActive = InformationManager.IsAnyInquiryActive()
+        });
+    }
+
+    [CommandLineArgumentFunction("policy_timeout_restore", "coop.debug.kingdom")]
+    public static string RestorePolicyTimeoutFixture(List<string> args)
+    {
+        const string usage = "Usage: coop.debug.kingdom.policy_timeout_restore <kingdomId> <proposerClanId> <policyId> <policyWasActive>";
+        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        if (args.Count != 4 || !bool.TryParse(args[3], out bool policyWasActive)) return usage;
+        if (!TryMatchPendingPolicyTimeoutFixture(args[0], args[1], args[2], policyWasActive, out var fixture, out string error))
+            return error;
+
+        KingdomPolicyDecision stagedDecision = fixture.Kingdom.UnresolvedDecisions
+            .OfType<KingdomPolicyDecision>()
+            .FirstOrDefault(decision => decision.Policy == fixture.Policy);
+        if (stagedDecision != null) fixture.Kingdom.RemoveDecision(stagedDecision);
+
+        bool policyIsActive = fixture.Kingdom.ActivePolicies.Contains(fixture.Policy);
+        if (fixture.PolicyWasActive && !policyIsActive)
+        {
+            fixture.Kingdom.AddPolicy(fixture.Policy);
+        }
+        else if (!fixture.PolicyWasActive && policyIsActive)
+        {
+            fixture.Kingdom.RemovePolicy(fixture.Policy);
+        }
+
+        pendingPolicyTimeoutFixture = null;
+        return PolicyTimeoutJsonResult(new
+        {
+            success = true,
+            fixture.KingdomId,
+            fixture.PolicyId,
+            restoredPolicyActive = fixture.Kingdom.ActivePolicies.Contains(fixture.Policy),
+            unresolvedDecisionCount = fixture.Kingdom.UnresolvedDecisions.Count
+        });
+    }
+
+    [CommandLineArgumentFunction("policy_timeout_verify", "coop.debug.kingdom")]
+    public static string VerifyPolicyTimeoutFixture(List<string> args)
+    {
+        const string usage = "Usage: coop.debug.kingdom.policy_timeout_verify <kingdomId> <policyId> <policyWasActive>";
+        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        if (args.Count != 3 || !bool.TryParse(args[2], out bool policyWasActive)) return usage;
+        if (pendingPolicyTimeoutFixture != null) return "The policy-timeout fixture lifecycle is still active.";
+        if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager";
+        if (!objectManager.TryGetObject(args[0], out Kingdom kingdom)) return $"Kingdom with ID: '{args[0]}' not found";
+        if (!objectManager.TryGetObject(args[1], out PolicyObject policy)) return $"PolicyObject with ID: '{args[1]}' not found";
+
+        bool policyIsActive = kingdom.ActivePolicies.Contains(policy);
+        bool decisionPresent = kingdom.UnresolvedDecisions
+            .OfType<KingdomPolicyDecision>()
+            .Any(decision => decision.Policy == policy);
+        bool success = policyIsActive == policyWasActive && !decisionPresent && kingdom.UnresolvedDecisions.Count == 0;
+        return PolicyTimeoutJsonResult(new
+        {
+            success,
+            kingdomId = args[0],
+            policyId = args[1],
+            expectedPolicyActive = policyWasActive,
+            policyIsActive,
+            decisionPresent,
+            unresolvedDecisionCount = kingdom.UnresolvedDecisions.Count
+        });
+    }
+
+    private static bool TryMatchPendingPolicyTimeoutFixture(
+        string kingdomId,
+        string proposerClanId,
+        string policyId,
+        bool policyWasActive,
+        out PolicyTimeoutFixture fixture,
+        out string error)
+    {
+        fixture = pendingPolicyTimeoutFixture;
+        error = string.Empty;
+        if (fixture == null)
+        {
+            error = "No policy-timeout fixture has been captured.";
+            return false;
+        }
+        if (fixture.KingdomId != kingdomId || fixture.ProposerClanId != proposerClanId ||
+            fixture.PolicyId != policyId || fixture.PolicyWasActive != policyWasActive)
+        {
+            error = "The policy-timeout fixture arguments do not match the captured state.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static string PolicyTimeoutJsonResult(object value) =>
+        "LIVE_TEST_JSON=" + JsonConvert.SerializeObject(value);
+
+    private sealed class PolicyTimeoutFixture
+    {
+        public Kingdom Kingdom { get; }
+        public Clan ProposerClan { get; }
+        public PolicyObject Policy { get; }
+        public string KingdomId { get; }
+        public string ProposerClanId { get; }
+        public string PolicyId { get; }
+        public bool PolicyWasActive { get; }
+        public bool DecisionStaged { get; set; }
+
+        public PolicyTimeoutFixture(
+            Kingdom kingdom,
+            Clan proposerClan,
+            PolicyObject policy,
+            string kingdomId,
+            string proposerClanId,
+            string policyId,
+            bool policyWasActive)
+        {
+            Kingdom = kingdom;
+            ProposerClan = proposerClan;
+            Policy = policy;
+            KingdomId = kingdomId;
+            ProposerClanId = proposerClanId;
+            PolicyId = policyId;
+            PolicyWasActive = policyWasActive;
+        }
     }
 
     // coop.debug.kingdom.create Derthert Vlandia_Reborn

--- a/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
+++ b/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
@@ -175,7 +175,26 @@ public class KingdomDebugCommand
         if (Game.Current.GameStateManager.ActiveState is KingdomState) return "KINGDOM_SCREEN_ALREADY_OPEN";
 
         KingdomState kingdomState = Game.Current.GameStateManager.CreateState<KingdomState>(decision);
-        Game.Current.GameStateManager.PushState(kingdomState, 0);
+        InquiryData inquiry = null;
+        Action<InquiryData, bool, bool> captureInquiry = (data, _, _) => inquiry = data;
+        InformationManager.OnShowInquiry += captureInquiry;
+        try
+        {
+            Game.Current.GameStateManager.PushState(kingdomState, 0);
+        }
+        finally
+        {
+            InformationManager.OnShowInquiry -= captureInquiry;
+        }
+
+        if (inquiry == null || inquiry.AffirmativeAction == null ||
+            !string.Equals(inquiry.TitleText, GameTexts.FindText("str_decision").ToString(), StringComparison.Ordinal))
+        {
+            return "The decision confirmation did not open.";
+        }
+
+        InformationManager.HideInquiry();
+        inquiry.AffirmativeAction();
         return "KINGDOM_DECISION_SCREEN_OPENED";
     }
 

--- a/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
+++ b/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
@@ -150,8 +150,27 @@ public class KingdomDebugCommand
     public static string OpenKingdomDecisionScreen(List<string> args)
     {
         if (!ModInformation.IsClient) return "Command can only be run on a client.";
-        if (!TryGetKingdomDecisionByIndex(args, out Kingdom _, out KingdomDecision decision, out int _, out string message))
+        if (args.Count < 2) return "Usage: <kingdomId> <decisionIndex>";
+
+        KingdomDecision decision;
+        Kingdom playerKingdom = Clan.PlayerClan?.Kingdom;
+        bool isPlayerKingdom = playerKingdom != null &&
+            (string.Equals(playerKingdom.StringId, args[0], StringComparison.Ordinal) ||
+             string.Equals($"{nameof(Kingdom)}_{playerKingdom.StringId}", args[0], StringComparison.Ordinal));
+        if (isPlayerKingdom)
+        {
+            if (!int.TryParse(args[1], out int index)) return $"Decision index is not a number: {args[1]}";
+
+            int zeroBasedIndex = index - 1;
+            if (zeroBasedIndex < 0 || zeroBasedIndex >= playerKingdom._unresolvedDecisions.Count)
+                return "Decision index is out of bounds.";
+
+            decision = playerKingdom._unresolvedDecisions[zeroBasedIndex];
+        }
+        else if (!TryGetKingdomDecisionByIndex(args, out Kingdom _, out decision, out int _, out string message))
+        {
             return message;
+        }
         if (Game.Current?.GameStateManager == null) return "The game-state manager is unavailable.";
         if (Game.Current.GameStateManager.ActiveState is KingdomState) return "KINGDOM_SCREEN_ALREADY_OPEN";
 

--- a/source/GameInterface/Services/Kingdoms/KingdomDecisionVoteManager.cs
+++ b/source/GameInterface/Services/Kingdoms/KingdomDecisionVoteManager.cs
@@ -367,6 +367,7 @@ namespace GameInterface.Services.Kingdoms
         {
             if (decision == null || Clan.PlayerClan == null) return false;
             if (Clan.PlayerClan.Kingdom != decision.Kingdom) return false;
+            if (DecisionStates.TryGetValue(decision, out KingdomDecisionVoteState state) && state.IsResolved) return true;
             return !IsLocalPlayerEligible(decision);
         }
 
@@ -591,9 +592,9 @@ namespace GameInterface.Services.Kingdoms
                 return;
             }
 
+            state.IsResolved = true;
             CampaignEventDispatcher.Instance.OnKingdomDecisionConcluded(decision, outcome, isPlayerDecision);
             PublishDecisionNotification(notificationText);
-            RemoveDecisionState(decision);
             CloseDecision(decision);
         }
 

--- a/source/GameInterface/Services/Kingdoms/Patches/KingdomDecisionVMPatches.cs
+++ b/source/GameInterface/Services/Kingdoms/Patches/KingdomDecisionVMPatches.cs
@@ -58,10 +58,12 @@ namespace GameInterface.Services.Kingdoms.Patches
         private static void OnFrameTickPostfix(KingdomDecisionsVM __instance)
         {
             if (!TryGetVoteManager(out var voteManager)) return;
+            DecisionItemBaseVM currentDecision = __instance.CurrentDecision;
+            if (currentDecision == null) return;
 
-            voteManager.RefreshDecisionTitle(__instance.CurrentDecision);
-            string feedback = voteManager.RefreshDecisionWaitingStatus(__instance.CurrentDecision);
-            IReadOnlyList<string> columns = voteManager.GetDecisionWaitingColumns(__instance.CurrentDecision);
+            voteManager.RefreshDecisionTitle(currentDecision);
+            string feedback = voteManager.RefreshDecisionWaitingStatus(currentDecision);
+            IReadOnlyList<string> columns = voteManager.GetDecisionWaitingColumns(currentDecision);
             KingdomDecisionWaitingStatusWidgetPatch.EnsureAttached(__instance);
             KingdomDecisionWaitingStatusWidgetPatch.Refresh(__instance, feedback, columns);
         }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Letting a kingdom policy decision voting timer expire closes the timed menu, then can reopen the same decision without a timer and leave the player unable to continue.

## What is the new behavior?

Resolves #3206

Letting the timer expire now closes the policy decision and keeps it closed while the resolved decision is removed, so the Kingdom screen remains usable.

## Bot Changelog Entry

- Fixed an issue where the same Kingdom Policy Decision could pop up twice, with the second menu being a soft lock
