### PR TITLE
[3222] Add regression coverage for uneven field battle joins

### DIFF
--- a/source/E2E.Tests/Services/Missions/BattleTroopReserveBuilderTests.cs
+++ b/source/E2E.Tests/Services/Missions/BattleTroopReserveBuilderTests.cs
@@ -96,6 +96,46 @@ public class BattleTroopReserveBuilderTests : MissionTestEnvironment
     }
 
     [Fact]
+    public void GetOwnedReserves_PlayerGuaranteeMetadataTracksEarlierPlayers()
+    {
+        var (mapEventId, partyIds) = SetupCoopBattle("first", "defender", "joining");
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<MapEvent>(mapEventId, out var mapEvent));
+            Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(partyIds[0], out var firstParty));
+            Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(partyIds[2], out var joiningParty));
+            var troop = Server.CreateRegisteredObject<CharacterObject>("player_guarantee_metadata_troop");
+
+            firstParty.MemberRoster.Clear();
+            firstParty.MemberRoster.AddToCounts(troop, 22);
+            joiningParty.MemberRoster.Clear();
+            joiningParty.MemberRoster.AddToCounts(troop, 19);
+            foreach (var party in mapEvent.AttackerSide.Parties)
+                party.Update();
+
+            var builder = Server.Resolve<IBattleTroopReserveBuilder>();
+            var firstSide = builder.GetOwnedReserves(mapEvent, "first", isHost: false)
+                .Single(reserve => reserve.Side == BattleSideEnum.Attacker);
+            var joiningSide = builder.GetOwnedReserves(mapEvent, "joining", isHost: false)
+                .Single(reserve => reserve.Side == BattleSideEnum.Attacker);
+
+            var firstReserve = Assert.Single(firstSide.Parties);
+            var joiningReserve = Assert.Single(joiningSide.Parties);
+            Assert.Equal(0, firstReserve.SideOffset);
+            Assert.Equal(0, firstReserve.PlayerOwnedPartiesBefore);
+            Assert.Equal(0, firstReserve.PlayerOwnedRank);
+            Assert.Equal(22, joiningReserve.SideOffset);
+            Assert.Equal(1, joiningReserve.PlayerOwnedPartiesBefore);
+            Assert.Equal(1, joiningReserve.PlayerOwnedRank);
+            Assert.Equal(41, firstSide.TotalTroops);
+            Assert.Equal(41, joiningSide.TotalTroops);
+            Assert.Equal(2, firstSide.PlayerOwnedPartyCount);
+            Assert.Equal(2, joiningSide.PlayerOwnedPartyCount);
+        });
+    }
+
+    [Fact]
     public void GetOwnedReserves_OfflinePlayerPartyDoesNotReserveAPlayerSlot()
     {
         var (mapEventId, _) = SetupCoopBattle("attacker", "offline-defender");

--- a/source/E2E.Tests/Services/Missions/CoopTroopSupplierTests.cs
+++ b/source/E2E.Tests/Services/Missions/CoopTroopSupplierTests.cs
@@ -367,6 +367,34 @@ public class CoopTroopSupplierTests
         Assert.Equal(133, first.OwnedShareOf(133) + tail.OwnedShareOf(133));
     }
 
+    [Theory]
+    [InlineData(22, 19)]
+    [InlineData(19, 22)]
+    public void FullSideAllocation_WithReportedLateJoinReserves_IsExactInEitherOrder(
+        int firstTroops,
+        int joiningTroops)
+    {
+        int total = firstTroops + joiningTroops;
+
+        var first = new CoopTroopSupplier("M1", BattleSideEnum.Attacker, null, new BattleAgentBudget());
+        first.SetReserve(new[] { Party("FIRST", firstTroops, isReceiverPlayerParty: true,
+            playerOwnedRank: 0) }, sideTotal: total, playerOwnedParties: 2,
+            authoritativeBattleSize: 1000);
+
+        var joining = new CoopTroopSupplier("M1", BattleSideEnum.Attacker, null, new BattleAgentBudget());
+        joining.SetReserve(new[] { Party("JOINING", joiningTroops, seedBase: 4000,
+            isReceiverPlayerParty: true, sideOffset: firstTroops, playerOwnedRank: 1,
+            playerOwnedPartiesBefore: 1) }, sideTotal: total, playerOwnedParties: 2,
+            authoritativeBattleSize: 1000);
+
+        int firstShare = first.OwnedShareOf(total);
+        int joiningShare = joining.OwnedShareOf(total);
+
+        Assert.Equal(firstTroops, firstShare);
+        Assert.Equal(joiningTroops, joiningShare);
+        Assert.Equal(total, firstShare + joiningShare);
+    }
+
     [Fact]
     public void LegacyReservePayload_UsesTheLegacyIntervalCalculation()
     {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

A player joining a friend's field battle could remain on the loading screen or arrive in an empty battle when the two same-side parties had uneven troop reserves.

## What is the new behavior?

Resolves #3222

Either player can enter the same nonempty field battle with 22- and 19-troop parties, regardless of which party joins first.

## Bot Changelog Entry