### PR TITLE
Fix getting stuck in when leaving villages after cancelling hostile actions

### DIFF
--- a/source/GameInterface.Tests/PatchTest.cs
+++ b/source/GameInterface.Tests/PatchTest.cs
@@ -41,6 +41,23 @@ namespace GameInterface.Tests
         }
 
         [Fact]
+        public void PlayerLeaveSettlementPatch_PatchesVillageHostileActionLeaveOptions()
+        {
+            var harmony = new Harmony(nameof(PlayerLeaveSettlementPatch_PatchesVillageHostileActionLeaveOptions));
+            try
+            {
+                var patched = harmony.CreateClassProcessor(typeof(PlayerLeaveSettlementPatch)).Patch();
+
+                Assert.Contains(patched, method => method.Name.Contains("game_menu_village_hostile_action_warn_leave_on_consequence"));
+                Assert.Contains(patched, method => method.Name.Contains("village_looted_leave_on_consequence"));
+            }
+            finally
+            {
+                harmony.UnpatchAll(harmony.Id);
+            }
+        }
+
+        [Fact]
         public void PlayerLeaveSiegeEncounterPatch_NeutralPartyRequestsSynchronizedLeave()
         {
             var party = ObjectHelper.SkipConstructor<MobileParty>();

--- a/source/GameInterface/Services/MobileParties/Patches/PlayerLeaveSettlementPatch.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/PlayerLeaveSettlementPatch.cs
@@ -24,6 +24,7 @@ internal class PlayerLeaveSettlementPatch
         typeof(EncounterGameMenuBehavior).GetMethod("game_menu_castle_outside_leave_on_consequence", BindingFlags.NonPublic | BindingFlags.Instance),
         typeof(EncounterGameMenuBehavior).GetMethod("army_encounter_leave_on_consequence", BindingFlags.NonPublic | BindingFlags.Instance),
         typeof(HideoutCampaignBehavior).GetMethod("game_menu_hideout_leave_on_consequence", BindingFlags.NonPublic | BindingFlags.Instance),
+        typeof(VillageHostileActionCampaignBehavior).GetMethod("game_menu_village_hostile_action_warn_leave_on_consequence", BindingFlags.NonPublic | BindingFlags.Static),
         typeof(VillageHostileActionCampaignBehavior).GetMethod("village_looted_leave_on_consequence", BindingFlags.NonPublic | BindingFlags.Static),
     };
 


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Cancelling a hostile village action before it begins leaves the player's party stuck in the village. This affects raiding, forcing supplies, and forcing volunteers.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->

Resolves #3235

Cancelling a hostile village action now uses the synchronized settlement-leave flow, allowing the player's party to leave the village and continue moving normally.

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->

- Fixed players becoming stuck in villages after cancelling a hostile action, forced supplies, or forced volunteers.

## Other information

Verified in-game for the affected hostile village action cancellation flow. A regression test confirms that the shared hostile-action cancellation callback is patched through the synchronized leave flow.