### PR TITLE
Fix village hostile actions not declaring war on hero

### DIFF
--- a/source/E2E.Tests/Services/Villages/VillageHostileActionTests.cs
+++ b/source/E2E.Tests/Services/Villages/VillageHostileActionTests.cs
@@ -85,6 +85,34 @@ public class VillageHostileActionTests : MapEventTestBase
         Assert.Equal(VillageHostileActionDeniedReason.Invalid, result.Reason);
     }
 
+    [Fact]
+    public void ApplyHostileAction_WhileAtPeace_DeclaresWarOnAllInstances()
+    {
+        var (_, mobilePartyId) = CreatePlayerHeroParty("PlayerOne");
+        var target = CreateVillageTarget();
+
+        Server.NetworkSentMessages.Clear();
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(mobilePartyId, out var mobileParty));
+            Assert.True(Server.ObjectManager.TryGetObject<Settlement>(target.SettlementId, out var settlement));
+            Assert.False(FactionManager.IsAtWarAgainstFaction(mobileParty.MapFaction, settlement.MapFaction));
+
+            Server.Resolve<IVillageHostileActionInterface>().ApplyHostileAction(mobileParty, settlement, VillageHostileAction.Raid);
+        }, new[] { AccessTools.Method(typeof(BeHostileAction), nameof(BeHostileAction.ApplyEncounterHostileAction)) });
+
+        var warDeclared = Server.NetworkSentMessages.GetMessages<NetworkDeclareWar>().Single();
+        Assert.Equal(GetMobilePartyMapFactionId(Server, mobilePartyId), warDeclared.Faction1Id);
+        Assert.Equal(target.OwnerFactionId, warDeclared.Faction2Id);
+
+        AssertWarDeclared(Server, mobilePartyId, target.OwnerFactionId);
+        foreach (var client in Clients)
+        {
+            AssertWarDeclared(client, mobilePartyId, target.OwnerFactionId);
+        }
+    }
+
     [Theory]
     [InlineData(VillageHostileAction.ForceVolunteers)]
     [InlineData(VillageHostileAction.ForceSupplies)]

--- a/source/GameInterface/Services/Villages/Interfaces/VillageHostileActionInterface.cs
+++ b/source/GameInterface/Services/Villages/Interfaces/VillageHostileActionInterface.cs
@@ -213,6 +213,9 @@ internal class VillageHostileActionInterface : IVillageHostileActionInterface
     public void ApplyHostileAction(MobileParty mobileParty, Settlement settlement, VillageHostileAction action)
     {
         BeHostileAction.ApplyEncounterHostileAction(mobileParty.Party, settlement.Party);
+
+        if (!FactionManager.IsAtWarAgainstFaction(mobileParty.MapFaction, settlement.MapFaction))
+            DeclareWarAction.ApplyByPlayerHostility(mobileParty.MapFaction, settlement.MapFaction);
     }
 
     public void ApplyForceActionOutcome(MapEvent mapEvent, VillageHostileAction action)


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Hostile actions against villages can start without declaring war between the attacking party's faction and the village's faction.

## What is the new behavior?

Resolves #3242

Approved hostile actions against villages now declare war when the attacking and defending factions are at peace. The declaration is performed by the server and synchronized to all clients.

A regression test verifies that the server and all connected clients enter the war state.

## Bot Changelog Entry

- Fixed hostile actions against villages not triggering war.

## Other information

Validated by building `GameInterface` and `E2E.Tests` with zero errors. The targeted E2E regression test passes.