### PR TITLE
Prevent pre-save world messages during join

### DIFF
--- a/source/Coop.Core/Server/Connections/ConnectionMessageQueue.cs
+++ b/source/Coop.Core/Server/Connections/ConnectionMessageQueue.cs
@@ -20,15 +20,20 @@ namespace Coop.Core.Server.Connections;
 /// runs through here per peer; single-peer handshake and save sends bypass it.
 /// </summary>
 /// <remarks>
-/// Each peer's channel moves through three phases:
+/// Each peer's channel moves through four phases:
 /// <list type="bullet">
 /// <item><b>Dropping</b> (on <see cref="PlayerConnected"/>): pre-save broadcasts are discarded — they
 /// are already in the save the peer is about to load.</item>
 /// <item><b>Queueing</b> (on <see cref="BeginQueueing"/>, just after the save snapshot): broadcasts are
 /// held FIFO — they are not in the save.</item>
 /// <item><b>Open</b> (after the join barrier): held packets are replayed FIFO, a reliable tail marker
-/// is appended, and the peer goes live (a peer with no channel is live).</item>
+/// is appended, and later broadcasts pass through while the client applies the tail.</item>
+/// <item><b>Live</b> (after <see cref="CompleteCatchUp"/>): the retained channel keeps passing broadcasts
+/// through until disconnect.</item>
 /// </list>
+/// A peer with no channel is treated as newly accepted and its world broadcasts are dropped. LiteNetLib
+/// exposes an accepted peer to fan-out before raising <see cref="PlayerConnected"/>, so treating an
+/// unknown peer as live can deliver campaign objects before its save loads.
 /// The drop/queue cut is clean: the save runs in a blocking <c>GameThread.Run</c> on the network
 /// thread, so the poller is parked and nothing races the snapshot. Replay-before-live is held by the
 /// per-peer gate lock (across the whole flush, Open flipped last), not by thread identity or the
@@ -72,6 +77,7 @@ internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposa
         Dropping,
         Queueing,
         Open,
+        Live,
     }
 
     private sealed class PeerChannel
@@ -110,8 +116,9 @@ internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposa
     {
         if (ShouldBypassLoadingQueue(packet)) return false;
 
-        // No channel means a fully-joined (or unknown) peer: send live.
-        if (channels.TryGetValue(peer, out var channel) == false) return false;
+        // LiteNetLib exposes an accepted peer to SendAll before OnPeerConnected installs its channel.
+        // Fail closed during that gap so world objects cannot reach a client before its transfer save.
+        if (channels.TryGetValue(peer, out var channel) == false) return true;
 
         lock (channel.Gate)
         {
@@ -125,9 +132,8 @@ internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposa
                     // Already in the save the peer is about to load; discard.
                     return true;
                 default:
-                    // Open: this peer has already caught up and is a normal live player now, so just
-                    // send the packet. (We only land here for a split second, right after the catch-up
-                    // finishes and before its channel is tidied away.)
+                    // Open and Live peers receive normal world traffic. Retaining the Live channel
+                    // lets an absent channel unambiguously mean a newly accepted peer.
                     return false;
             }
         }
@@ -185,7 +191,7 @@ internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposa
         packetsRemaining = 0;
         if (channels.TryGetValue(peer, out var channel) == false) return false;
 
-        if (channel.Phase == Phase.Dropping) return false;
+        if (channel.Phase == Phase.Dropping || channel.Phase == Phase.Live) return false;
 
         packetsRemaining = Volatile.Read(ref channel.PendingCount) +
                            peer.GetPacketsCountInReliableQueue(0, true) +
@@ -197,11 +203,7 @@ internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposa
     {
         if (tailMarker == null) throw new ArgumentNullException(nameof(tailMarker));
 
-        if (channels.TryGetValue(peer, out var channel) == false)
-        {
-            network.Value.SendImmediate(peer, tailMarker);
-            return;
-        }
+        var channel = channels.GetOrAdd(peer, _ => new PeerChannel());
 
         int replayed;
         lock (channel.Gate)
@@ -225,7 +227,7 @@ internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposa
         lock (channel.Gate)
         {
             if (channel.Phase != Phase.Open) return;
-            channels.TryRemove(peer, out _);
+            channel.Phase = Phase.Live;
         }
     }
 

--- a/source/Coop.Core/Server/Connections/ConnectionMessageQueue.cs
+++ b/source/Coop.Core/Server/Connections/ConnectionMessageQueue.cs
@@ -10,6 +10,7 @@ using Serilog;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace Coop.Core.Server.Connections;
@@ -88,6 +89,15 @@ internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposa
         public int PendingCount;
     }
 
+    /// <summary>Keys connection generations by peer instance rather than reusable endpoint.</summary>
+    private sealed class NetPeerReferenceComparer : IEqualityComparer<NetPeer>
+    {
+        public static readonly NetPeerReferenceComparer Instance = new NetPeerReferenceComparer();
+
+        public bool Equals(NetPeer x, NetPeer y) => ReferenceEquals(x, y);
+        public int GetHashCode(NetPeer peer) => RuntimeHelpers.GetHashCode(peer);
+    }
+
     private static readonly ILogger Logger = LogManager.GetLogger<ConnectionMessageQueue>();
 
     // Lazy breaks the construction cycle: CoopServer (the INetwork) depends on this queue, and the
@@ -95,7 +105,8 @@ internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposa
     private readonly Lazy<INetwork> network;
     private readonly IMessageBroker messageBroker;
 
-    private readonly ConcurrentDictionary<NetPeer, PeerChannel> channels = new ConcurrentDictionary<NetPeer, PeerChannel>();
+    private readonly ConcurrentDictionary<NetPeer, PeerChannel> channels =
+        new ConcurrentDictionary<NetPeer, PeerChannel>(NetPeerReferenceComparer.Instance);
 
     public ConnectionMessageQueue(Lazy<INetwork> network, IMessageBroker messageBroker)
     {
@@ -203,7 +214,8 @@ internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposa
     {
         if (tailMarker == null) throw new ArgumentNullException(nameof(tailMarker));
 
-        var channel = channels.GetOrAdd(peer, _ => new PeerChannel());
+        // Disconnect can remove the channel after the loading state checks that it is still current.
+        if (channels.TryGetValue(peer, out var channel) == false) return;
 
         int replayed;
         lock (channel.Gate)

--- a/source/Coop.Tests/Server/Connections/ConnectionMessageQueueTests.cs
+++ b/source/Coop.Tests/Server/Connections/ConnectionMessageQueueTests.cs
@@ -60,12 +60,16 @@ public class ConnectionMessageQueueTests
     }
 
     [Fact]
-    public void UntrackedPeer_PassesThroughLive()
+    public void PeerVisibleBeforePlayerConnected_DropsWorldBroadcasts()
     {
         var peer = network.CreatePeer();
 
-        // No channel: a fully-joined or unknown peer receives broadcasts live.
-        Assert.False(queue.TryHandleBroadcast(peer, new FakePacket()));
+        // LiteNetLib adds an accepted peer to fan-out before it raises the connected callback.
+        Assert.True(queue.TryHandleBroadcast(peer, new FakePacket()));
+        Assert.True(NothingSentTo(peer));
+
+        messageBroker.Publish(this, new PlayerConnected(peer));
+        Assert.True(queue.TryHandleBroadcast(peer, new FakePacket()));
     }
 
     [Fact]
@@ -144,12 +148,13 @@ public class ConnectionMessageQueueTests
 
         queue.CompleteCatchUp(peer);
         Assert.False(queue.TryGetCatchUpPacketsRemaining(peer, out _));
+        Assert.False(queue.TryHandleBroadcast(peer, new FakePacket()));
     }
 
     [Fact]
-    public void SessionLobbyChangeBypassesTheLoadQueue()
+    public void SessionLobbyChangeBypassesMissingChannel()
     {
-        var peer = Connect();
+        var peer = network.CreatePeer();
         var serializer = new ProtoBufSerializer(new SerializableTypeMapper());
         var packet = MessagePacket.Create(new NetworkSessionLobbyChanged(123), serializer);
 
@@ -217,7 +222,7 @@ public class ConnectionMessageQueueTests
     }
 
     [Fact]
-    public void DisconnectMidLoad_DropsHeldPackets_AndPeerGoesLive()
+    public void DisconnectMidLoad_DropsHeldAndLatePackets()
     {
         var peer = Connect();
         queue.BeginQueueing(peer);
@@ -225,8 +230,8 @@ public class ConnectionMessageQueueTests
 
         messageBroker.Publish(this, new PlayerDisconnected(peer, default));
 
-        // Untracked again -> live; a late flush finds no channel and replays nothing.
-        Assert.False(queue.TryHandleBroadcast(peer, new FakePacket()));
+        // A late send cannot revive or replay the disconnected peer's held world stream.
+        Assert.True(queue.TryHandleBroadcast(peer, new FakePacket()));
         queue.Flush(peer);
         Assert.True(NothingSentTo(peer));
     }
@@ -262,7 +267,11 @@ public class ConnectionMessageQueueTests
         var loading = Connect();
         queue.BeginQueueing(loading);
 
-        var joined = PeerWithEndpoint("127.0.0.2"); // distinct endpoint, never tracked -> live
+        var joined = PeerWithEndpoint("127.0.0.2");
+        messageBroker.Publish(this, new PlayerConnected(joined));
+        queue.BeginQueueing(joined);
+        queue.OpenWithTail(joined, new NetworkJoinSync(JoinSyncSignal.WorldReady));
+        queue.CompleteCatchUp(joined);
 
         Assert.True(queue.TryHandleBroadcast(loading, new FakePacket()));  // held
         Assert.False(queue.TryHandleBroadcast(joined, new FakePacket()));  // live

--- a/source/Coop.Tests/Server/Connections/ConnectionMessageQueueTests.cs
+++ b/source/Coop.Tests/Server/Connections/ConnectionMessageQueueTests.cs
@@ -10,7 +10,6 @@ using Coop.Tests.Extensions;
 using Coop.Tests.Mocks;
 using LiteNetLib;
 using System;
-using System.Runtime.Serialization;
 using Xunit;
 
 namespace Coop.Tests.Server.Connections;
@@ -48,16 +47,6 @@ public class ConnectionMessageQueueTests
     }
 
     private bool NothingSentTo(NetPeer peer) => network.SentPayloads.ContainsKey(peer.Id) == false;
-
-    // NetPeer equality is endpoint-based and TestNetwork.CreatePeer reuses one endpoint, so a second
-    // distinct peer must be given its own endpoint to be a distinct dictionary key.
-    private static int distinctPeerId = 1000;
-    private static NetPeer PeerWithEndpoint(string ip)
-    {
-        var peer = (NetPeer)FormatterServices.GetUninitializedObject(typeof(NetPeer));
-        peer.Setup(distinctPeerId++, ip);
-        return peer;
-    }
 
     [Fact]
     public void PeerVisibleBeforePlayerConnected_DropsWorldBroadcasts()
@@ -237,6 +226,23 @@ public class ConnectionMessageQueueTests
     }
 
     [Fact]
+    public void LateOpenWithTail_DoesNotOpenSameEndpointReconnect()
+    {
+        var disconnected = Connect();
+        queue.BeginQueueing(disconnected);
+        messageBroker.Publish(this, new PlayerDisconnected(disconnected, default));
+
+        queue.OpenWithTail(disconnected, new NetworkJoinSync(JoinSyncSignal.WorldReady));
+
+        var reconnected = Connect();
+        queue.OpenWithTail(disconnected, new NetworkJoinSync(JoinSyncSignal.WorldReady));
+
+        Assert.True(queue.TryHandleBroadcast(reconnected, new FakePacket()));
+        Assert.True(NothingSentTo(disconnected));
+        Assert.True(NothingSentTo(reconnected));
+    }
+
+    [Fact]
     public void RemovalIsIdempotent()
     {
         var peer = network.CreatePeer();
@@ -267,8 +273,7 @@ public class ConnectionMessageQueueTests
         var loading = Connect();
         queue.BeginQueueing(loading);
 
-        var joined = PeerWithEndpoint("127.0.0.2");
-        messageBroker.Publish(this, new PlayerConnected(joined));
+        var joined = Connect();
         queue.BeginQueueing(joined);
         queue.OpenWithTail(joined, new NetworkJoinSync(JoinSyncSignal.WorldReady));
         queue.CompleteCatchUp(joined);

--- a/source/Coop.Tests/Server/Connections/States/LoadingStateTests.cs
+++ b/source/Coop.Tests/Server/Connections/States/LoadingStateTests.cs
@@ -45,6 +45,7 @@ namespace Coop.Tests.Server.Connections.States
             playerPeer = network.CreatePeer();
             differentPeer = network.CreatePeer();
             connectionLogic = container.Resolve<ConnectionLogic>(new TypedParameter(typeof(NetPeer), playerPeer));
+            container.Resolve<IConnectionMessageQueue>().BeginQueueing(playerPeer);
             baselineSender = container.Resolve<Mock<IJoinCampaignBaselineSender>>();
             kingdomBaselineSender = container.Resolve<Mock<IJoinCampaignKingdomBaseLineSender>>();
 


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

LiteNetLib can expose a newly accepted peer to server fan-out before `PlayerConnected` creates its loading channel. World messages can reach the client before its transferred save, leaving duplicate registry objects and causing the join baseline to retry forever.

## What is the new behavior?

Unknown peers drop world broadcasts until their connection lifecycle is registered. Joined peers retain a live channel until disconnect, so missing channels only identify the pre-`PlayerConnected` gap. Campaign time and lobby metadata still bypass the loading gate.

Resolves #3245

## Bot Changelog Entry

- Fixed clients getting stuck on the Synchronizing screen when joining an active server.

## Other information

Tests:
- `dotnet test source/Coop.Tests/Coop.Tests.csproj -c Release --filter FullyQualifiedName~ConnectionMessageQueueTests` (13 passed)
- `dotnet test source/Coop.Tests/Coop.Tests.csproj -c Release --filter FullyQualifiedName~Coop.Tests.Server.Connections` (78 passed)
