### PR TITLE
Bind the dedicated server listen port from ManagedServerConfig

### DIFF
--- a/source/Coop.Core/Common/Session/ManagedServerConfig.cs
+++ b/source/Coop.Core/Common/Session/ManagedServerConfig.cs
@@ -27,6 +27,13 @@ public static class ManagedServerConfig
     /// <summary>Optional connection password supplied on the server command line.</summary>
     public static string Password { get; set; } = string.Empty;
 
+    /// <summary>UDP port the dedicated server binds for coop clients. Default 4200.</summary>
+    public const int DefaultPort = 4200;
+
+    public static int Port { get; set; } = DefaultPort;
+
+    public static bool IsValidPort(int port) => port >= 1 && port <= 65535;
+
     /// <summary>Who can discover this server through Steam.</summary>
     public static ServerVisibility Visibility { get; set; } = ServerVisibility.Public;
 }

--- a/source/Coop.Core/CoopartiveMultiplayerExperience.cs
+++ b/source/Coop.Core/CoopartiveMultiplayerExperience.cs
@@ -438,6 +438,9 @@ namespace Coop.Core
                     $"The server password cannot exceed {ConnectionPassword.MaxLength} characters");
             if (!Enum.IsDefined(typeof(ServerVisibility), visibility))
                 throw new ArgumentOutOfRangeException(nameof(visibility));
+            if (!ManagedServerConfig.IsValidPort(ManagedServerConfig.Port))
+                throw new ArgumentOutOfRangeException(nameof(ManagedServerConfig.Port),
+                    "The server port must be between 1 and 65535");
 
             DestroyContainer();
             setCrashPhase("starting-server");
@@ -447,7 +450,11 @@ namespace Coop.Core
             ContainerBuilder builder = new ContainerBuilder();
             builder.RegisterModule<ServerModule>();
             builder.RegisterModule<GameInterfaceModule>();
-            builder.RegisterInstance(new NetworkConfig { Token = password ?? string.Empty })
+            builder.RegisterInstance(new NetworkConfig
+            {
+                Token = password ?? string.Empty,
+                Port = ManagedServerConfig.Port,
+            })
                 .As<INetworkConfig>()
                 .SingleInstance();
             builder.RegisterInstance(new SessionAdvertisementConfig { Visibility = visibility })

--- a/source/Coop.Tests/Session/ManagedServerConfigTests.cs
+++ b/source/Coop.Tests/Session/ManagedServerConfigTests.cs
@@ -1,0 +1,27 @@
+﻿using Coop.Core.Common.Session;
+using Xunit;
+
+namespace Coop.Tests.Session;
+
+public class ManagedServerConfigTests
+{
+    [Fact]
+    public void Port_DefaultsTo4200AndRejectsOutOfRangeValues()
+    {
+        var previous = ManagedServerConfig.Port;
+        try
+        {
+            ManagedServerConfig.Port = ManagedServerConfig.DefaultPort;
+
+            Assert.Equal(4200, ManagedServerConfig.Port);
+            Assert.True(ManagedServerConfig.IsValidPort(1));
+            Assert.True(ManagedServerConfig.IsValidPort(65535));
+            Assert.False(ManagedServerConfig.IsValidPort(0));
+            Assert.False(ManagedServerConfig.IsValidPort(65536));
+        }
+        finally
+        {
+            ManagedServerConfig.Port = previous;
+        }
+    }
+}


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] New feature (non-breaking change that adds functionality)

## What is the current behavior?

Dedicated servers always bind UDP 4200. There is no way to pick another join port.

## What is the new behavior?

Resolves #2728

`StartAsServer` now binds `ManagedServerConfig.Port` (default 4200). An out-of-range port refuses to host. In-game Host spawn still uses 4200.

Needs https://github.com/Bannerlord-Coop-Team/BannerlordCoop.DedicatedServer/pull/53, which adds `"port"` to `server-config.json`. Ship both together: DedicatedServer compiles against the deployed Coop.Core.dll.

## How to test

- Dedicated server with no `port` key still listens on 4200
- `"port": 4255` in `server-config.json` binds 4255 and clients join on that port
- `"port": 0` or `65536` refuses to host
- In-game Host spawn still uses 4200
- `-p` / `--port` is still the engine custom-server port, not this

## Bot Changelog Entry

- Dedicated servers can listen on a custom UDP join port set in server-config.json (default 4200)
